### PR TITLE
Typos and UTF-8 recognition problem

### DIFF
--- a/web/www/horas/English/Sancti/08-30.txt
+++ b/web/www/horas/English/Sancti/08-30.txt
@@ -17,7 +17,7 @@ smell of her perfumes, worthily themselves to become a sweet savour unto Christ.
 $Qui tecum
 
 [Commemoratio]
-!Commemoration of Ss. Felix and Companions Martyrs
+!Commemoration of St Felix and his Companion Martyrs
 @Commune/C3:Oratio proper
 $Oremus
 We humbly beseech thy Majesty, O Lord, that as Thou dost make us exceeding glad~

--- a/web/www/horas/Latin/Sancti/03-19.txt
+++ b/web/www/horas/Latin/Sancti/03-19.txt
@@ -341,7 +341,7 @@ R. Et florebit in aeternum ante Dominum.
 
 [Capitulum Nona]
 !Sap l0:10
-v. Prefugum justum deduxit Sapientia per vias rectas, et ostendit illi regnum Dei, et dedit illi scientiam sanctorum: honestavit illum in laboribus, et complevit labores illius.
+v. Profugum justum deduxit Sapientia per vias rectas, et ostendit illi regnum Dei, et dedit illi scientiam sanctorum: honestavit illum in laboribus, et complevit labores illius.
 $Deo gratias 
 
 [Responsory Nona]

--- a/web/www/horas/Latin/Sancti/05-11r.txt
+++ b/web/www/horas/Latin/Sancti/05-11r.txt
@@ -1,4 +1,4 @@
-[Rank]
+﻿[Rank]
 Ss. Philippi et Jacobi Apostolorum;;Duplex II classis;;5.1;;ex C1
 
 [Rank1960]

--- a/web/www/horas/Latin/Sancti/12-26.txt
+++ b/web/www/horas/Latin/Sancti/12-26.txt
@@ -1,4 +1,4 @@
-﻿[Rank]
+[Rank]
 S. Stephani Protomartyris;;Duplex II class cum octava simplici;;5.4;;ex C2
 
 [Rank1960]

--- a/web/www/horas/Latin/Tempora/Quad1-0.txt
+++ b/web/www/horas/Latin/Tempora/Quad1-0.txt
@@ -56,8 +56,8 @@ R. Ut non vituperétur ministérium nostrum.
 5 Nam et, cum venissemus in Macedoniam, nullam requiem habuit caro nostra, sed omnem tribulationem passi sumus: foris pugnæ, intus timores.
 6 Sed qui consolatur humiles, consolatus est nos Deus in adventu Titi.
 7 Non solum autem in adventu ejus, sed etiam in consolatione, qua consolatus est in vobis, referens nobis vestrum desiderium, vestrum fletum, vestram æmulationem pro me, ita ut magis gauderem.
-8 Quoniam etsi contristavi vos in epistola, non me pœ́nitet: etsi pœ́niteret, videns quod epistola illa (etsi ad horam) vos contristavit;
-9 nunc gaudeo: non quia contristati estis, sed quia contristati estis ad pœ́nitentiam.
+8 Quoniam etsi contristavi vos in epistola, non me pœ́nitet: etsi pœnitéret, videns quod epistola illa (etsi ad horam) vos contristavit;
+9 nunc gaudeo: non quia contristati estis, sed quia contristati estis ad pœniténtiam.
 
 [Responsory3]
 R. In jejúnio et flétu orábunt sacerdótes, dicéntes:


### PR DESCRIPTION
Most of these are typos, and uncontroversial. One could differ about the following changes:

* Regarding Sancti/08-30.txt, one could phrase the title in different ways, but since there's only one companion martyr, the plural was definitely wrong. The companion's name is unknown, and so he is called in Latin "Adauctus," the one who was added.
* The change to Sancti/12-26.txt removes a [BOM](http://en.wikipedia.org/wiki/Byte_order_mark) from the beginning of the file. Without this, [Rank] was unrecognized. Since 4889a8a, this may no longer be necessary, but it was already part of my commit.
* I more recently did the opposite to Santi/05-11.txt, adding a BOM to the beginning: without the BOM this file is not recognized as UTF-8, and so the word "fœnum" in lectio 2 is garbled (see [here](http://divinumofficium.com/cgi-bin/horas/Pofficium.pl?date1=05-11-2015&command=prayMatutinum&version=Rubrics%201960&testmode=regular&lang2=English&votive=)). It might be better to fix the UTF-8 recognition code rather than the case that's making it fail.
