### PR TITLE
Recent corrections

### DIFF
--- a/web/www/horas/English/Martyrologium/07-27.txt
+++ b/web/www/horas/English/Martyrologium/07-27.txt
@@ -6,7 +6,8 @@ Also, the holy brethren Hermippus and Hermocrates, who, after many sufferings, w
 At Nola, the holy martyrs Felix, Julia, and Jucunda. 
 At Biseglia, in Apulia, the holy martyrs Maurus, Bishop [of that see,] Pantaleemon, and Sergius, who suffered under Trajan. 
 On the same day are commemorated the holy martyrs whom the tyrant Dunaan caused to be burnt in Yemen, in Arabia, because they believed in Christ. 
-On this day also were born into the better life  At Cordova, in Spain, in the persecution under the Arabs, the holy martyrs George the Deacon, Felix, Aurelius, Natalia, and Liliosa. 
+On this day also were born into the better life—
+At Cordova, in Spain, in the persecution under the Arabs, the holy martyrs George the Deacon, Felix, Aurelius, Natalia, and Liliosa. 
 At Ephesus, the Seven Holy Sleepers, Maximian, Malchus, Martinian, Denis, John, Serapian, and Constantine. 
 At Auxerre, [in the sixth century,] deceased the blessed Confessor Etherius, Bishop [of that see.] 
 At Constantinople, the blessed Virgin Anthusa, who was scourged, under the Emperor Constantine Copronymus, for honouring the holy images, and was sent into exile, where she fell asleep in the Lord. 

--- a/web/www/horas/English/Tempora/Pent02-5.txt
+++ b/web/www/horas/English/Tempora/Pent02-5.txt
@@ -210,7 +210,7 @@ V. This he said, signifying what death he should die.
 R. I will draw all men unto me.
 
 [Lectio8]
-!Of the mystical life, Chap. 30
+!Of the mystical vine, Chap. 30
 Because we are now come to the sweet Heart of Jesus, and because it is good for us to be here, let us not too soon turn away therefrom. O how good and joyful a thing it is to dwell in this Heart. What a good treasure, what a precious pearl, is thy Heart, O most excellent Jesu, which we have found hidden in the pit which hath been dug in this field, namely, in thy body. Who would cast away such a pearl? Nay, rather, for this same I would give all my pearls. I will sell all my thoughts and affections, and buy the same for myself, turning all my thoughts to the Heart of the good Jesus, and without fail it will support me. Therefore, o most sweet Jesu, finding this Heart that is thine and mine, I will pray to thee, my God: admit my prayers into the shrine of hearkening: and draw me even more altogether into thy Heart.
 
 [Responsory8]

--- a/web/www/horas/English/Tempora/Pent02-5.txt
+++ b/web/www/horas/English/Tempora/Pent02-5.txt
@@ -210,7 +210,7 @@ V. This he said, signifying what death he should die.
 R. I will draw all men unto me.
 
 [Lectio8]
-!Of the mystical vine, Chap. 30
+!Of the mystical vine, Chap. 3
 Because we are now come to the sweet Heart of Jesus, and because it is good for us to be here, let us not too soon turn away therefrom. O how good and joyful a thing it is to dwell in this Heart. What a good treasure, what a precious pearl, is thy Heart, O most excellent Jesu, which we have found hidden in the pit which hath been dug in this field, namely, in thy body. Who would cast away such a pearl? Nay, rather, for this same I would give all my pearls. I will sell all my thoughts and affections, and buy the same for myself, turning all my thoughts to the Heart of the good Jesus, and without fail it will support me. Therefore, o most sweet Jesu, finding this Heart that is thine and mine, I will pray to thee, my God: admit my prayers into the shrine of hearkening: and draw me even more altogether into thy Heart.
 
 [Responsory8]

--- a/web/www/horas/Italiano/Martyrologium/02-20.txt
+++ b/web/www/horas/Italiano/Martyrologium/02-20.txt
@@ -4,6 +4,6 @@ A Tiro, nella Fenicia, commemorazione dei beati Martiri, il cui numero è noto so
 A Costantinópoli sant'Eleutério, Vescovo e Martire.
 In Pèrsia il natale di san Sadot Vescovo, e di altri centoventotto, i quali sotto Sàpore, Re dei Persiani, avendo rifiutato di adorare il Sole, con morte crudele si guadagnarono gloriose corone.
 In Cipro i santi Martiri Potàmio e Nemèsio.
-A Catània, nella Sicilia, san Leène Vescovo, che rifulse per virtù e miracoli.
+A Catània, nella Sicilia, san Leone Vescovo, che rifulse per virtù e miracoli.
 Nello stesso giorno sant'Euchério, Vescovo di Orléans, il quale tanto più risplendette per miracoli, quanto più fu perseguitato dalle calunnie degli invidiosi.
 A Tournai, nel Bélgio, sant'Eleutério, Vescovo e Confessore.

--- a/web/www/horas/Italiano/Martyrologium/10-10.txt
+++ b/web/www/horas/Italiano/Martyrologium/10-10.txt
@@ -1,7 +1,7 @@
 10 Ottobre
 _
 San Francésco Bòrgia, Sacerdote della Compagnia di Gesù e Confessore, il cui giorno natalizio è ricordato il trenta Settembre.
-Presso Céuta, nella Mauritania Tingitàna, la passione di sette santi Martiri, dell'Ordine dei Minori, cioè Danièle, Samuèle, Angelo, Leène, Nicòla, Ugolino e Donno, i quali, essendo tutti, eccetto Donno, Sacerdoti, ivi, per la predicazione del Vangelo e per la confutazione della setta Maomettana, patirono dai Saraceni ingiurie, catene e flagelli, e finalmente decapitati conseguirono la palma del martirio.
+Presso Céuta, nella Mauritania Tingitàna, la passione di sette santi Martiri, dell'Ordine dei Minori, cioè Danièle, Samuèle, Angelo, Leone, Nicòla, Ugolino e Donno, i quali, essendo tutti, eccetto Donno, Sacerdoti, ivi, per la predicazione del Vangelo e per la confutazione della setta Maomettana, patirono dai Saraceni ingiurie, catene e flagelli, e finalmente decapitati conseguirono la palma del martirio.
 A Colònia san Gereòne Martire, con altri trecentodiciotto, i quali per la vera religione, nella persecuzione di Massimiàno, offrirono pazientemente i loro colli alle spade.
 Nel territorio della stessa città i santi Vittóre e Compagni Martiri.
 A Bonn, nella Germania, i santi Martiri Càssio e Fiorènzo, con moltissimi altri.

--- a/web/www/horas/Italiano/Martyrologium/11-10.txt
+++ b/web/www/horas/Italiano/Martyrologium/11-10.txt
@@ -9,5 +9,5 @@ Nel territorio di Agde, in Frància, i santi Martiri Tibério, Modèsto e Fiorénza,
 A Ravénna san Probo Vescovo, illustre per miracoli.
 Ad Orléans, in Frància, san Monitóre, Vescovo e Confessore.
 In Inghiltérra san Giusto Vescovo, il quale, insieme con Agostino, Mellito ed altri, mandato in quell'isola dal beato Gregório Papa per predicare il Vangelo, ivi, celebre per santità, si riposò nel Signore.
-Nel castello di Melun, in Frància, san Leène Confessore.
+Nel castello di Melun, in Frància, san Leone Confessore.
 Nell'isola Paro santa Teotiste Vergine.

--- a/web/www/horas/Italiano/Tempora/Quad3-6.txt
+++ b/web/www/horas/Italiano/Tempora/Quad3-6.txt
@@ -16,7 +16,7 @@ Gesù andò al monte Oliveto (Joann. 8,1), al monte fertile, al monte dell'ungue
 @Tempora/Quad3-0:Responsory7
 
 [Lectio2]
-Egli scribi e i farisei gli conducono una donna colta in adulterio, e fattala venire avanti, gli dissero: Maestro, questa donna è stata colta adesso in flagrante adulterio: or Mosè nella ,legge ci ha comandato che una tale venga lapidata: e tu che ne dici? E dicevano questo per tentarlo: per avere onde accusarlo» (Joann. 8,3). Accusarlo di che? Lo avevano forse colto in qualche fallo, o si credeva che quella donna potesse in qualche modo interessarlo?
+Egli scribi e i farisei gli conducono una donna colta in adulterio, e fattala venire avanti, gli dissero: Maestro, questa donna è stata colta adesso in flagrante adulterio: or Mosè nella legge ci ha comandato che una tale venga lapidata: e tu che ne dici? E dicevano questo per tentarlo: per avere onde accusarlo» (Joann. 8,3). Accusarlo di che? Lo avevano forse colto in qualche fallo, o si credeva che quella donna potesse in qualche modo interessarlo?
 
 [Responsory2]
 @Tempora/Quad3-0:Responsory8

--- a/web/www/horas/Italiano/Tempora/Quad3-6t.txt
+++ b/web/www/horas/Italiano/Tempora/Quad3-6t.txt
@@ -16,7 +16,7 @@ Gesù andò al monte Oliveto (Joann. 8,1), al monte fertile, al monte dell'ungue
 @Tempora/Quad3-0:Responsory7
 
 [Lectio2]
-Egli scribi e i farisei gli conducono una donna colta in adulterio, e fattala venire avanti, gli dissero: Maestro, questa donna è stata colta adesso in flagrante adulterio: or Mosè nella ,legge ci ha comandato che una tale venga lapidata: e tu che ne dici? E dicevano questo per tentarlo: per avere onde accusarlo» (Joann. 8,3). Accusarlo di che? Lo avevano forse colto in qualche fallo, o si credeva che quella donna potesse in qualche modo interessarlo?
+Egli scribi e i farisei gli conducono una donna colta in adulterio, e fattala venire avanti, gli dissero: Maestro, questa donna è stata colta adesso in flagrante adulterio: or Mosè nella legge ci ha comandato che una tale venga lapidata: e tu che ne dici? E dicevano questo per tentarlo: per avere onde accusarlo» (Joann. 8,3). Accusarlo di che? Lo avevano forse colto in qualche fallo, o si credeva che quella donna potesse in qualche modo interessarlo?
 
 [Responsory2]
 @Tempora/Quad3-0:Responsory8

--- a/web/www/horas/Latin/Sancti/07-31.txt
+++ b/web/www/horas/Latin/Sancti/07-31.txt
@@ -6,7 +6,7 @@ vide C5;
 9 lectiones;
 
 [Oratio]
-Deus, qui ad majorem tui nominis gloriam propagandam, novo per beatum Ignatium subsidio militantem Ecclesiam roborasti: concede; ut, ejus auxilio et imitatione certantes in terris, coronari cum ipso mereamur in caelis.
+Deus, qui, ad majorem tui nominis gloriam propagandam, novo per beatum Ignatium subsidio militantem Ecclesiam roborasti: concede; ut, ejus auxilio et imitatione certantes in terris, coronari cum ipso mereamur in caelis.
 $Per Dominum
 
 [Lectio4]

--- a/web/www/horas/Latin/Sancti/08-02.txt
+++ b/web/www/horas/Latin/Sancti/08-02.txt
@@ -10,7 +10,7 @@ vide C4a;mtv
 CPapaM=Stéphanum;
 
 [Oratio]
-Deus, qui per beatum Alfonsum Mariam Confessorem tuum atque Pontificem animarum zelo succensum, Ecclesiam tuam nova prole foecundasti: quaesumus; ut ejus salutaribus monitis edocti, et exemplis roborati, ad te pervenire feliciter valeamus.
+Deus, qui per beatum Alfonsum Mariam Confessorem tuum atque Pontificem, animarum zelo succensum, Ecclesiam tuam nova prole foecundasti: quaesumus; ut, ejus salutaribus monitis edocti et exemplis roborati, ad te pervenire feliciter valeamus.
 $Per Dominum.
 
 [Commemoratio]

--- a/web/www/horas/Latin/Tempora/Pent03-1Feria.txt
+++ b/web/www/horas/Latin/Tempora/Pent03-1Feria.txt
@@ -1,4 +1,4 @@
-[Rank]
+﻿[Rank]
 Feria secunda infra Hebdomadam III post Octavam Pentecostes;;Feria;;1
 
 [Rule]


### PR DESCRIPTION
These are almost all corrections to typos. One corrects a mistranslation of "De vite mystica." The only one that could be questioned is adding a BOM to Pent03-1Feria.txt: without this, the file is read as CP-1252, which mangles the word "Israel". Arguably, the code to identify UTF-8 files should be improved instead of patching a single file.
