### PR TITLE
Missing Responsory Quad6-0

### DIFF
--- a/web/www/horas/English/Tempora/Quad6-0.txt
+++ b/web/www/horas/English/Tempora/Quad6-0.txt
@@ -36,10 +36,10 @@ R. Thou hast pleaded my cause, and hast redeemed me, O Lord my God.
 22 Though thou wash thyself with nitre, and multiply to thyself the herb borith, thou art stained in thy iniquity before me, saith the Lord God.
 
 [Responsory2]
-R. O Lord, in the day that I called upon thee, Thou saidst Fear not.
-* Thou hast pleaded my cause, and hast redeemed me, O Lord my God.
-V. In the day of my trouble I called upon thee, for Thou hast heard me.
-R. Thou hast pleaded my cause, and hast redeemed me, O Lord my God.
+R. My brethren stand afar off from me, and they which have known me
+* Make themselves strange unto me, and leave me.
+V. My neighbours forsake me, and mine acquaintance
+R. Make themselves strange unto me, and leave me me.
 
 [Lectio3]
 !Jer 2:29-32


### PR DESCRIPTION
Responsory 1 repeated as responsory 2. Replaced with correct responsory from English Breviary. This problem also found in the other versions of this file. 6-0r also has Jer. 2:18 as the last verse of lesson 1 and the first of lesson 2; the other two versions do not. Unsure if this is proper.