### PR TITLE
Improves the rubrics of the ordo (Ordo/Ordo.txt)

### DIFF
--- a/web/cgi-bin/missa/propers.pl
+++ b/web/cgi-bin/missa/propers.pl
@@ -1146,7 +1146,7 @@ sub Ultimaev : ScriptFunc {
   if ($t && $t !~ /^\s*$/) {
     $t =~ s/\((.*?)\)/setfont($smallfont, $1)/eg;
 	$t =~ s/\n/\n\$Gloria tibi\n/;
-    $t = "\$Dominus vobiscum\n$t\$Deo gratias";
+    $t = "$t\$Deo gratias";
   }
   
   return $t;

--- a/web/www/missa/Deutsch/Ordo/Ordo.txt
+++ b/web/www/missa/Deutsch/Ordo/Ordo.txt
@@ -385,6 +385,8 @@ R. Amen.
 
 !*&CheckUltimaEv
 !Deinde Sacerdos in cornu Evangelii, junctis manibus dicit:
+S. Dóminus vobíscum.  
+M. Et cum spíritu tuo,
 !Et signans signo crucis primum Altare vel librum, deinde se in fronte, ore et pectore, dicit:
 &Ultimaev
 !Finito Evangelio sancti Joannis, discedens ab Altari, pro gratiarum actione dicit Ant. Trium puerórum, cum reliquis, ut habetur in principio Missalis.

--- a/web/www/missa/English/Ordo/Ordo.txt
+++ b/web/www/missa/English/Ordo/Ordo.txt
@@ -378,6 +378,8 @@ S. Amen.
 
 !*&CheckUltimaEv
 !Then turning to the Gospel side of the altar, the priest says:
+P. The Lord be with you. 	
+S. And with thy spirit. 	
 !He then traces the Sign of the Cross, first upon the altar, and then upon his forehead, lips, and breast, and says:
 &Ultimaev
 

--- a/web/www/missa/Italiano/Ordo/Ordo.txt
+++ b/web/www/missa/Italiano/Ordo/Ordo.txt
@@ -391,6 +391,8 @@ R. Amen.
 
 !*&CheckUltimaEv
 !Quindi il Sacerdote nell'angolo del Vangelo
+S. Il Signore sia con voi.
+M. E con il tuo spirito.
 !fa un segno di croce sull’Altare o sulla Cartagloria, poi tre segni di croce su sé stesso: sulla fronte, sulle labbra e sul petto - lo stesso fanno i fedeli -, e dice:
 &Ultimaev
 !Finito il Vangelo di san Giovanni, scendendo dall'Altare, dice per ringraziamento l'Antifona  dei Tre fanciulli con il resto, come scritto all'inizio del Messale.

--- a/web/www/missa/Latin/Ordo/Ordo.txt
+++ b/web/www/missa/Latin/Ordo/Ordo.txt
@@ -133,7 +133,7 @@ v. Munda cor meum, ac labia mea, omnípotens Deus, qui labia Isaíæ Prophétæ 
 !Deinde, conversus ad librum, junctis manibus, dicit: 
 V. Dóminus vobíscum. 
 R. Et cum spíritu tuo.
-!Et pronuntians: Inítium, sive Sequéntia sancti Evangélii, signat librum, et se in fronte, ore et pectore, et legit Evangelium, ut dictum est. Quo finito, respondet Minister: Laus tibi, Christe, et Sacerdos osculatur Evangelium, dicens: per evangelica dicta, ut supra.
+!Et pronuntians: Inítium, sive Sequéntia sancti Evangélii, signat librum, et se in fronte, ore et pectore, et legit Evangelium, ut dictum est. Quo finito, respondet Minister: Laus tibi, Christe.
 &evangelium
 
 # Credo
@@ -211,6 +211,7 @@ _
 v. Sanctus, Sanctus, Sanctus Dóminus, Deus Sábaoth. Pleni sunt coeli et terra glória tua. Hosánna in excélsis. Benedíctus, qui venit in nómine Dómini. Hosánna in excélsis.
 
 # Canon
+!Finita præfatione, sacerdos extendens, elevans aliquantulum et iungens manus, elevansque ad cælum oculos, et statim demittens, profunde inclinatus ante Altare, manibus super eo positis, dicit :
 v. Te igitur, clementíssime Pater, per Jesum Christum, Fílium tuum, Dóminum nostrum, súpplices rogámus, ac pétimus, (osculatur Altare et, junctis manibus ante pectus, dicit:) uti accepta habeas et benedícas, (Signat ter super Hostiam et Calicem simul, dicens:) hæc + dona, hæc + múnera, hæc + sancta sacrifícia illibáta, (Extensis manibus prosequitur:) in primis, quæ tibi offérimus pro Ecclésia tua sancta cathólica: quam pacificáre, custodíre, adunáre et régere dignéris toto orbe terrárum: una cum fámulo tuo Papa nostro N.p et Antístite nostro N.b et ómnibus orthodóxis, atque cathólicæ et apostólicae fídei cultóribus. 
 
 !Commemoratio pro vivis
@@ -235,7 +236,7 @@ _
 !Quibus verbis prolatis, statim Hostiam consecratam genuflexus adorat: surgit, ostendit populo, reponit super Corporale, et genuflexus iterum adorat: nec amplius pollices et indices disjungit, nisi quando Hostia tractanda est, usque ad ablutionem digitorum.
 wait5
 
-(Tunc, detecto Calice, dicit:)~
+(Tunc, detecto Calice, dicit:)
 v. Símili modo postquam coenátum est, (Ambabus manibus accipit Calicem,) accípiens et hunc præclárum Cálicem in sanctas ac venerábiles manus suas: (item Caput inclinat,) tibi grátias agens, (Sinistra tenens Calicem, dextera signat super eum,) bene + dixit, dedítque discípulis suis, dicens: Accípite, et bíbite ex eo omnes.
 
 !Profert verba consecrationis super Calicem, attente, continuate, et secrete, tenens illum parum elevatum.
@@ -264,7 +265,7 @@ v. Nobis quoque peccatóribus (Extensis manibus ut prius, secrete prosequitur:) 
 
 v. Per quem hæc ómnia, Dómine, semper bona creas, (Signat ter super Hostiam, et Calicem simul, dicens:) sancti + ficas, viví + ficas, bene + dícis et præstas nobis.
 !Discooperit Calicem, genuflectit, accipit Hostiam inter pollicem et indicem manus dexteræ: et tenens sinistra Calicem, cum Hostia signat ter a labio ad labium Calicis, dicens:
-v.Per ip + sum, et cum ip + so, et in ip + so, (Cum ipsa Hostia signat bis inter se et Calicem, dicens:) est tibi Deo Patri omnipotenti, in unitáte Spíritus + Sancti, 
+v.Per ip + sum, et cum ip + so, et in ip + so, (Cum ipsa Hostia signat bis inter se et Calicem, dicens:) est tibi Deo Patri + omnipotenti, in unitáte Spíritus + Sancti, 
 !Elevans parum Calicem cum Hostia, dicit:
 omnis honor, et glória.
 !ponit Hostiam, Calicem Palla cooperit, genuflectit, surgit, et dicit intellegibili voce vel cantat:
@@ -272,10 +273,12 @@ v. Per omnia saecula saecolorum.
 R. Amen.
 
 # Preparatio Communionis
+(Iungit manus.)
 v. Orémus: Præcéptis salutáribus móniti, et divína institutione formati audemus dicere:
+(Extendit manus.)
 v. Pater noster, qui es in caelis, Sanctificetur nomen tuum. Adveniat regnum tuum. Fiat voluntas tua, sicut in coelo et in terra. Panem nostrum quotidianum da nobis hodie. Et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris. Et ne nos inducas in tentationem: 
 R. Sed libera nos a malo. 
-S. Amen.
+S. (Sacerdos secrete dicit :) Amen.
 
 !Deinde manu dextera accipit inter indicem et medium digitos Patenam, quam tenens super Altare erectam, dicit secrete:
 v. Líbera nos, quaesumus, Dómine, ab ómnibus malis, prætéritis, præséntibus et futúris: et intercedénte beáta et gloriósa semper Vírgine Dei Genetríce María, cum beátis Apóstolis tuis Petro et Paulo, atque Andréa, et ómnibus Sanctis, (Signat se cum Patena a fronte ad pectus,) da propítius pacem in diébus nostris: (Patenam osculatur,) ut, ope misericórdiæ tuæ adjúti, et a peccáto simus semper líberi et ab omni perturbatióne secúri. 
@@ -354,9 +357,10 @@ v. Corpus tuum, Dómine, quod sumpsi, et Sanguis, quem potávi, adhaereat viscé
 &communio
 
 # Postcommunio
-!Osculatur Altare 
+!Dicta antiphona ad Communionem, osculatur altare, et versus ad populum dicit :
 S. Dóminus vobíscum.
 R. Et cum spíritu tuo.
+!Deinde, reversus ad altare, dicit :
 &postcommunio
 
 # Conclusio
@@ -369,6 +373,7 @@ M. Et cum spíritu tuo,
 &itemissaest
 
 !*&placeattibi
+!Tunc celebrans inclinat se ante medium altaris, et manibus junctis super illud, dicit secrete:
 v. Pláceat tibi, sancta Trínitas, obséquium servitútis meæ: et præsta; ut sacrifícium, quod óculis tuæ majestátis indígnus óbtuli, tibi sit acceptábile, mihíque et ómnibus, pro quibus illud óbtuli, sit, te miseránte, propitiábile. Per Christum, Dóminum nostrum. Amen.
 
 !*&CheckBlessing
@@ -382,7 +387,9 @@ R. Amen.
 !In Missis Defunctorum non datur benedíctio, sed dicto Requiéscant in pace, dicit: Pláceat tibi, sancta Trinitas; deinde osculato Altari, legit Evangelium sancti Joannis. 
 
 !*&CheckUltimaEv
-!Deinde Sacerdos in cornu Evangelii, junctis manibus dicit:
+!Deinde sacerdos in cornu Evangelii, junctis manibus dicit:
+V. Dominus vobiscum.
+R. Et cum spiritu tuo.
 !Et signans signo crucis primum Altare vel librum, deinde se in fronte, ore et pectore, dicit:
 &Ultimaev
 !Finito Evangelio sancti Joannis, discedens ab Altari, pro gratiarum actione dicit Ant. Trium puerórum, cum reliquis, ut habetur in principio Missalis.

--- a/web/www/missa/Magyar/Ordo/Ordo.txt
+++ b/web/www/missa/Magyar/Ordo/Ordo.txt
@@ -376,8 +376,10 @@ S. Ámen.
 !
 
 !*&CheckUltimaEv
-!
-!
+! 
+! 
+P. Az Úr legyen veletek.
+M. És a te lelkeddel.
 &Ultimaev
 
 !*R

--- a/web/www/missa/Polski/Ordo/Ordo.txt
+++ b/web/www/missa/Polski/Ordo/Ordo.txt
@@ -395,6 +395,8 @@ R. Amen.
 
 !*&CheckUltimaEv
 !Następnie Kapłan odwraca się i przechodzi na stronę Ewangelii.
+S. Pan z wami.
+R. I z duchem twoim.
 !Prawym kciukiem czyni znak krzyża na ołtarzu lub na mszale, a następnie na czole, ustach i klatce piersiowej, mówiąc:
 &Ultimaev
 


### PR DESCRIPTION
- propers.pl : removes "Dominus Vobiscum" (which is then added on Ordo.txt)

Why ? In order to have:

"""
    Deinde sacerdos in cornu Evangelii, iunctis manibus dicit:
    V. Dominus vobiscum.
    R. Et cum spiritu tuo.
    Et signans signo crucis primum Altare vel librum, deinde se in fronte, ore et pectore, dicit:
    Initium ✠ sancti Evangélii secúndum Ioánnem.
    R. Gloria tibi, Domine!
"""

and NOT the previous version:

"""
    Deinde sacerdos in cornu Evangelii, iunctis manibus dicit:
    Et signans signo crucis primum Altare vel librum, deinde se in fronte, ore et pectore, dicit:
    V. Dominus vobiscum.
    R. Et cum spiritu tuo.
    Initium ✠ sancti Evangélii secúndum Ioánnem.
    R. Gloria tibi, Domine!
"""