### PR TITLE
Polish - Mass - Adding Maundy Thursday

### DIFF
--- a/web/cgi-bin/horas/dialogcommon.pl
+++ b/web/cgi-bin/horas/dialogcommon.pl
@@ -193,7 +193,7 @@ sub vero($)
 
     # The empty condition is _true_ : safer, since previously conditions were's used.
     return 1 unless $condition;
-
+    $DB::single = 1;
     # aut binds tighter than et
     AUTEM: for ( split /\baut\b/, $condition )
     {

--- a/web/cgi-bin/horas/dialogcommon.pl
+++ b/web/cgi-bin/horas/dialogcommon.pl
@@ -193,7 +193,7 @@ sub vero($)
 
     # The empty condition is _true_ : safer, since previously conditions were's used.
     return 1 unless $condition;
-    $DB::single = 1;
+
     # aut binds tighter than et
     AUTEM: for ( split /\baut\b/, $condition )
     {

--- a/web/www/missa/English/Tempora/Quad6-4.txt
+++ b/web/www/missa/English/Tempora/Quad6-4.txt
@@ -160,7 +160,7 @@ _
 _
 _
 !Antiphona
-!Ps 13:34.
+!John 13:34.
 v. A new commandment I give unto you: That you love one another, as I have loved you, saith the Lord.
 !Ps 118:1
 Blessed are the undefiled in the way: who walk in the law of the Lord.
@@ -169,7 +169,7 @@ v. A new commandment I give unto you: That you love one another, as I have loved
 _
 _
 !Antiphona
-!Ps 13:4, 5, 15.
+!John 13:4, 5, 15.
 v. After our Lord was risen from supper, He put water into a basin, and began to wash the feet of His disciples: to whom He gave this example. 
 !Ps. 47:2
 Great is the Lord, and exceedingly to be praised in the city of our God, in His holy mountain.
@@ -185,7 +185,7 @@ v. Our Lord Jesus, after He had supped with His disciples, washed their feet, an
 _
 _
 !Antiphona
-!Ps 13:6-7, 8
+!John 13:6-7, 8
 v. Lord, dost Thou wash my feet? Jesus answered and said to them: If I shall not wash thy feet, thou shalt have no part with Me. 
 V. He came to Simon Peter, and Peter said to Him: Lord, dost Thou wash my feet? Jesus answered and said to them: If I shall not wash thy feet, thou shalt have no part with Me. 
 V. What I do, thou knowest not now; but thou shalt know hereafter.
@@ -193,6 +193,7 @@ v. Lord, dost Thou wash my feet? Jesus answered and said to them: If I shall not
 _
 _
 !Antiphona
+!John 13:14.
 v. If I your Lord and Master, have washed your feet, how much more ought you to wash one another's feet? 
 !Ps. 48:2
 Hear these things, all ye nations: give ear, ye that inhabit the world.
@@ -200,14 +201,14 @@ v. If I your Lord and Master, have washed your feet, how much more ought you to 
 _
 _
 !Antiphona
-!Ps 13:35.
+!John 13:35.
 v.  By this shall all men know that you are My disciples, if you have love one for another. 
 V. Said Jesus to His disciples.
 v.  By this shall all men know that you are My disciples, if you have love one for another. 
 _
 _
 !Antiphona
-!Ps 13:13
+!1 Cor 13:13.
 v. Let these three, faith, hope, and charity, remain in you; but the greatest of these is charity. 
 V. And now there remain faith, hope and charity, these three; but the greatest of these is charity.
 v. Let these three, faith, hope, and charity, remain in you; but the greatest of these is charity. 

--- a/web/www/missa/English/Tempora/Quad6-4r.txt
+++ b/web/www/missa/English/Tempora/Quad6-4r.txt
@@ -49,7 +49,10 @@ We beseech Thee, O holy Lord, Father almighty, everlasting God, that He Himself 
 $Qui tecum
 
 [Communicantes]
-Communicating and celebrating the most sacred day in which our Lord Jesus Christ was betrayed for us: and also honoring in the first place the memory of the glorious and ever Virgin Mary Genetrícis ejúsdem Dei et Dómini nostri Jesu Christi: sed and of the blessed Apostles and Martyrs Peter and Paul, Andrew, James, John, Thomas, James, Philip, Bartholomew, Matthew, Simon, and Thaddeus; Linus, Cletus, Clement, Xystus, Cornelius, Cyprian, Lawrence, Chrysogonus, John and Paul, Cosmas and Damian, and of all Thy Saints, through whose merits and prayers, grant that we may in all things be defended by the help of Thy protection. (He joins his hands.) Through the same Christ our Lord. Amen. 	
+Communicating and celebrating the most sacred day in which our Lord Jesus Christ was betrayed for us: and also honoring in the first place the memory of the glorious and ever Virgin Mary, mother of our God and Lord Jesus Christ: 
+(rubrica 1960 dicitur)
+as also of the blessed Joseph, her Spouse,
+and of the blessed Apostles and Martyrs Peter and Paul, Andrew, James, John, Thomas, James, Philip, Bartholomew, Matthew, Simon, and Thaddeus; Linus, Cletus, Clement, Xystus, Cornelius, Cyprian, Lawrence, Chrysogonus, John and Paul, Cosmas and Damian, and of all Thy Saints, through whose merits and prayers, grant that we may in all things be defended by the help of Thy protection. (He joins his hands.) Through the same Christ our Lord. Amen. 	
 _
 _
 ! Tenens manus expansas super Oblata, dicit: 
@@ -262,7 +265,7 @@ _
 _
 _
 !Antiphon 1
-!Ps 13:34.
+!John 13:34.
 Ant. A new commandment I give unto you: That you love one another, as I have loved you, saith the Lord.
 !Ps 118:1
 Blessed are the undefiled in the way: who walk in the law of the Lord.
@@ -271,7 +274,7 @@ Ant. A new commandment I give unto you: That you love one another, as I have lov
 _
 _
 !Antiphon 2
-!Ps 13:4, 5, 15.
+!John 13:4, 5, 15.
 Ant. After our Lord was risen from supper, He put water into a basin, and began to wash the feet of His disciples: to whom He gave this example. 
 !Ps. 47:2
 Great is the Lord, and exceedingly to be praised in the city of our God, in His holy mountain.
@@ -287,7 +290,7 @@ Ant. Our Lord Jesus, after He had supped with His disciples, washed their feet, 
 _
 _
 !Antiphon 4
-!Ps 13:6-7, 8
+!John 13:6-7, 8.
 Ant. Lord, dost Thou wash my feet? Jesus answered and said to them: If I shall not wash thy feet, thou shalt have no part with Me. 
 V. He came to Simon Peter, and Peter said to Him: Lord, dost Thou wash my feet? Jesus answered and said to them: If I shall not wash thy feet, thou shalt have no part with Me. 
 V. What I do, thou knowest not now; but thou shalt know hereafter.
@@ -295,6 +298,7 @@ Ant. Lord, dost Thou wash my feet? Jesus answered and said to them: If I shall n
 _
 _
 !Antiphon 5
+!John 13:14.
 Ant. If I your Lord and Master, have washed your feet, how much more ought you to wash one another's feet? 
 !Ps. 48:2
 Hear these things, all ye nations: give ear, ye that inhabit the world.
@@ -302,14 +306,14 @@ Ant. If I your Lord and Master, have washed your feet, how much more ought you t
 _
 _
 !Antiphon 6
-!Ps 13:35.
+!John 13:35.
 Ant.  By this shall all men know that you are My disciples, if you have love one for another. 
 V. Said Jesus to His disciples.
 Ant.  By this shall all men know that you are My disciples, if you have love one for another. 
 _
 _
 !Antiphon 7
-!Ps 13:13
+!1 Cor 13:13.
 Ant. Let these three, faith, hope, and charity, remain in you; but the greatest of these is charity. 
 V. And now there remain faith, hope and charity, these three; but the greatest of these is charity.
 Ant. Let these three, faith, hope, and charity, remain in you; but the greatest of these is charity. 

--- a/web/www/missa/English/Tempora/Quad6-4t.txt
+++ b/web/www/missa/English/Tempora/Quad6-4t.txt
@@ -159,7 +159,7 @@ _
 _
 _
 !Antiphona
-!Ps 13:34.
+!John 13:34.
 v. A new commandment I give unto you: That you love one another, as I have loved you, saith the Lord.
 !Ps 118:1
 Blessed are the undefiled in the way: who walk in the law of the Lord.
@@ -168,7 +168,7 @@ v. A new commandment I give unto you: That you love one another, as I have loved
 _
 _
 !Antiphona
-!Ps 13:4, 5, 15.
+!John 13:4, 5, 15.
 v. After our Lord was risen from supper, He put water into a basin, and began to wash the feet of His disciples: to whom He gave this example. 
 !Ps. 47:2
 Great is the Lord, and exceedingly to be praised in the city of our God, in His holy mountain.
@@ -184,7 +184,7 @@ v. Our Lord Jesus, after He had supped with His disciples, washed their feet, an
 _
 _
 !Antiphona
-!Ps 13:6-7, 8
+!John 13:6-7, 8
 v. Lord, dost Thou wash my feet? Jesus answered and said to them: If I shall not wash thy feet, thou shalt have no part with Me. 
 V. He came to Simon Peter, and Peter said to Him: Lord, dost Thou wash my feet? Jesus answered and said to them: If I shall not wash thy feet, thou shalt have no part with Me. 
 V. What I do, thou knowest not now; but thou shalt know hereafter.
@@ -192,6 +192,7 @@ v. Lord, dost Thou wash my feet? Jesus answered and said to them: If I shall not
 _
 _
 !Antiphona.
+!John 13:14.
 v. If I your Lord and Master, have washed your feet, how much more ought you to wash one another's feet? 
 !Ps. 48:2
 Hear these things, all ye nations: give ear, ye that inhabit the world.
@@ -199,14 +200,14 @@ v. If I your Lord and Master, have washed your feet, how much more ought you to 
 _
 _
 !Antiphona
-!Ps 13:35.
+!John 13:35.
 v.  By this shall all men know that you are My disciples, if you have love one for another. 
 V. Said Jesus to His disciples.
 v.  By this shall all men know that you are My disciples, if you have love one for another. 
 _
 _
 !Antiphona
-!Ps 13:13
+!1 Cor 13:13.
 v. Let these three, faith, hope, and charity, remain in you; but the greatest of these is charity. 
 V. And now there remain faith, hope and charity, these three; but the greatest of these is charity.
 v. Let these three, faith, hope, and charity, remain in you; but the greatest of these is charity. 
@@ -221,7 +222,7 @@ v. Blessed be the Holy Trinity and undivided Unity: We will give praise to Him, 
 _
 _
 !Antiphona.
-!1 Joann. 2; 3; 4.
+!1 John. 2; 3; 4.
 v.  Where charity and love are, there is God. 
 The love of Christ has gathered us together. 
 Let us rejoice in Him and be glad. 

--- a/web/www/missa/Latin/Tempora/Quad6-4.txt
+++ b/web/www/missa/Latin/Tempora/Quad6-4.txt
@@ -162,7 +162,7 @@ _
 _
 _
 !Antiphona
-!Ps 13:34.
+!Joann 13:34.
 v. Mandátum novum do vobis: ut diligátis ínvicem, sicut diléxi vos, dicit Dóminus.
 !Ps 118:1.
 Beáti immaculáti in via: qui ámbulant in lege Dómini.
@@ -170,7 +170,7 @@ v. Mandátum novum do vobis: ut diligátis ínvicem, sicut diléxi vos, dicit D�
 _
 _
 !Antiphona
-!Ps 13:4, 5 et 15.
+!Joann 13:4, 5 et 15.
 v. Postquam surréxit Dóminus a cœna, misit aquam in pelvim, et cœpit laváre pedes discipulórum suórum: hoc exémplum réliquit eis.
 !Ps 47:2.
 Magnus Dóminus, et laudábilis nimis: in civitáte Dei nostri, in monte sancto ejus.
@@ -178,7 +178,7 @@ v. Postquam surréxit Dóminus a cœna, misit aquam in pelvim, et cœpit laváre
 _
 _
 !Antiphona
-!Ps 13:12, 13 et 15.
+!Joann 13:12, 13 et 15.
 v. Dóminus Jesus, postquam cœnávit cum discípulis suis, lavit pedes eórum, et ait illis: Scitis, quid fécerim vobis ego, Dóminus et Magíster? Exémplum dedi vobis, ut et vos ita faciátis.
 !Ps 84:2.
 Benedixísti, Dómine, terram tuam: avertísti captivitátem Jacob.
@@ -186,7 +186,7 @@ v. Dóminus Jesus, postquam cœnávit cum discípulis suis, lavit pedes eórum, 
 _
 _
 !Antiphona
-!Ps 13:6-7 et 8.
+!Joann 13:6-7 et 8.
 v. Dómine, tu mihi lavas pedes? Respóndit Jesus et dixit ei: Si non lávero tibi pedes, non habébis partem mecum.
 V. Venit ergo ad Simónem Petrum, et dixit ei Petrus.
 v. Dómine, tu mihi lavas pedes? Respóndit Jesus et dixit ei: Si non lávero tibi pedes, non habébis partem mecum.
@@ -195,6 +195,7 @@ v. Dómine, tu mihi lavas pedes? Respóndit Jesus et dixit ei: Si non lávero ti
 _
 _
 !Antiphona.
+!Joann 13:14.
 v. Si ego, Dóminus et Magíster vester, lavi vobis pedes: quanto magis debétis alter altérius laváre pedes?
 !Ps 48:2
 Audíte hæc, omnes gentes: áuribus percípite, qui habitátis orbem.
@@ -202,14 +203,14 @@ v. Si ego, Dóminus et Magíster vester, lavi vobis pedes: quanto magis debétis
 _
 _
 !Antiphona
-!Ps 13:35.
+!Joann 13:35.
 v. In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habuéritis ad ínvicem.
 V. Dixit Jesus discípulis suis.
 v. In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habuéritis ad ínvicem.
 _
 _
 !Antiphona
-!Ps 13:13
+!1 Cor 13:13
 v. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas.
 V. Nunc autem manent fides, spes, cáritas, tria hæc: major horum est cáritas.
 v. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas.

--- a/web/www/missa/Latin/Tempora/Quad6-4r.txt
+++ b/web/www/missa/Latin/Tempora/Quad6-4r.txt
@@ -49,7 +49,10 @@ Ipse tibi, quaesumus, Dómine sancte, Pater omnípotens, ætérne Deus, sacrifí
 $Qui tecum
 
 [Communicantes]
-Communicántes et diem sacratíssimum celebrántes, quo Dóminus noster Jesus Christus pro nobis est tráditus: sed et memóriam venerántes, in primis gloriósæ semper Vírginis Maríæ, Genetrícis ejúsdem Dei et Dómini nostri Jesu Christi: sed et beatórum Apostolórum ac Mártyrum tuórum, Petri et Pauli, Andréæ, Jacóbi, Joánnis, Thomæ, Jacóbi, Philíppi, Bartholomaei, Matthaei, Simónis et Thaddaei: Lini, Cleti, Cleméntis, Xysti, Cornélii, Cypriáni, Lauréntii, Chrysógoni, Joánnis et Pauli, Cosmæ et Damiáni: et ómnium Sanctórum tuórum; quorum méritis precibúsque concédas, ut in ómnibus protectiónis tuæ muniámur auxílio. Jungit manus. Per eúndem Christum, Dóminum nostrum. Amen. 
+Communicántes et diem sacratíssimum celebrántes, quo Dóminus noster Jesus Christus pro nobis est tráditus: sed et memóriam venerántes, in primis gloriósæ semper Vírginis Maríæ, Genetrícis ejúsdem Dei et Dómini nostri Jesu Christi: sed 
+(rubrica 1960 dicitur)
+et beati Ioseph, eiusdem Virginis Sponsi,
+et beatórum Apostolórum ac Mártyrum tuórum, Petri et Pauli, Andréæ, Jacóbi, Joánnis, Thomæ, Jacóbi, Philíppi, Bartholomaei, Matthaei, Simónis et Thaddaei: Lini, Cleti, Cleméntis, Xysti, Cornélii, Cypriáni, Lauréntii, Chrysógoni, Joánnis et Pauli, Cosmæ et Damiáni: et ómnium Sanctórum tuórum; quorum méritis precibúsque concédas, ut in ómnibus protectiónis tuæ muniámur auxílio. Jungit manus. Per eúndem Christum, Dóminum nostrum. Amen. 
 _
 _
 ! Tenens manus expansas super Oblata, dicit: 
@@ -338,7 +341,7 @@ Ant. «In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habu
 _
 _
 !Antiphona 7
-!1 Cor 13:13
+!1 Cor 13:13.
 Ant. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas.
 V. Nunc autem manent fides, spes, cáritas, tria hæc: major horum est cáritas.
 Ant. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas.

--- a/web/www/missa/Latin/Tempora/Quad6-4r.txt
+++ b/web/www/missa/Latin/Tempora/Quad6-4r.txt
@@ -285,7 +285,7 @@ _
 _
 _
 !Antiphona 1
-!Ps 13:34.
+!Joann 13:34.
 Ant. Mandátum novum do vobis: ut diligátis ínvicem, sicut diléxi vos, dicit Dóminus.
 !Ps 118:1.
 Beáti immaculáti in via: qui ámbulant in lege Dómini.
@@ -298,7 +298,7 @@ Ant. Mandátum novum do vobis: ut diligátis ínvicem, sicut diléxi vos, dicit 
 _
 _
 !Antiphona 2
-!Ps 13:4, 5 et 15.
+!Joann 13:4, 5 et 15.
 Ant. Postquam surréxit Dóminus a cœna, misit aquam in pelvim, et cœpit laváre pedes discipulórum suórum: hoc exémplum réliquit eis.
 !Ps 47:2.
 Magnus Dóminus, et laudábilis nimis: in civitáte Dei nostri, in monte sancto ejus.
@@ -306,7 +306,7 @@ Ant. Postquam surréxit Dóminus a cœna, misit aquam in pelvim, et cœpit lavá
 _
 _
 !Antiphona 3
-!Ps 13:12, 13 et 15.
+!Joann 13:12, 13 et 15.
 Ant. Dóminus Jesus, postquam cenávit cum discípulis suis, lavit pedes eórum, et ait illis: «Scitis, quid fécerim vobis ego, Dóminus et Magíster? Exémplum dedi vobis, ut et vos ita faciátis».
 !Ps 84:2.
 Benedixísti, Dómine, terram tuam: avertísti captivitátem Jacob.
@@ -314,7 +314,7 @@ Ant. Dóminus Jesus, postquam cenávit cum discípulis suis, lavit pedes eórum,
 _
 _
 !Antiphona 4
-!Ps 13:6-7 et 8.
+!Joann 13:6-7 et 8.
 Ant. «Dómine, tu mihi lavas pedes?» Respóndit Jesus et dixit ei: «Si non lávero tibi pedes, non habébis partem mecum».
 V. Venit ergo ad Simónem Petrum, et dixit ei Petrus.
 Ant. «Dómine, tu mihi lavas pedes?» Respóndit Jesus et dixit ei: «Si non lávero tibi pedes, non habébis partem mecum».
@@ -323,6 +323,7 @@ Ant. «Dómine, tu mihi lavas pedes?» Respóndit Jesus et dixit ei: «Si non l�
 _
 _
 !Antiphona 5
+!Joann 13:14.
 Ant. «Si ego, Dóminus et Magíster vester, lavi vobis pedes: quanto magis debétis alter altérius laváre pedes?»
 !Ps 48:2
 Audíte hæc, omnes gentes: áuribus percípite, qui habitátis orbem.
@@ -330,14 +331,14 @@ Ant. «Si ego, Dóminus et Magíster vester, lavi vobis pedes: quanto magis deb�
 _
 _
 !Antiphona 6
-!Ps 13:35.
+!Joann 13:35.
 Ant. «In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habuéritis ad ínvicem».
 V. Dixit Jesus discípulis suis.
 Ant. «In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habuéritis ad ínvicem».
 _
 _
 !Antiphona 7
-!Ps 13:13
+!1 Cor 13:13
 Ant. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas.
 V. Nunc autem manent fides, spes, cáritas, tria hæc: major horum est cáritas.
 Ant. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas.

--- a/web/www/missa/Latin/Tempora/Quad6-4r.txt
+++ b/web/www/missa/Latin/Tempora/Quad6-4r.txt
@@ -53,10 +53,10 @@ Communicántes et diem sacratíssimum celebrántes, quo Dóminus noster Jesus Ch
 _
 _
 ! Tenens manus expansas super Oblata, dicit: 
-Hanc ígitur oblatiónem servitútis nostræ, sed et cunctæ famíliæ tuæ, quam tibi offérimus ob diem, in qua Dóminus noster Jesus Christus trádidit discípulis suis Córporis et Sánguinis sui mystéria celebránda: quaesumus, Dómine, ut placátus accípias: diésque nostros in tua pace dispónas, atque ab ætérna damnatióne nos éripi et in electórum tuórum júbeas grege numerári. (Jungit manus.) Per eúndem Christum, Dóminum nostrum. Amen. 
+Hanc ígitur oblatiónem servitútis nostræ, sed et cunctæ famíliæ tuæ, quam tibi offérimus ob diem, in qua Dóminus noster Jesus Christus trádidit discípulis suis Córporis et Sánguinis sui mystéria celebránda: quaesumus, Dómine, ut placátus accípias: diésque nostros in tua pace dispónas, atque ab ætérna damnatióne nos éripi et in electórum tuórum júbeas grege numerári. (Jungit manus) Per eúndem Christum, Dóminum nostrum. Amen. 
 _
 _
-Quam oblatiónem tu, Deus, in ómnibus, quaesumus, Signat ter super Oblata, bene + díctam, adscríp + tam, ra + tam, rationábilem acceptabilémque fácere dignéris: Signat semel super Hóstiam, ut nobis Cor + pus, et semel super Cálicem, et San + guis fiat dilectíssimi Fílii tui, Jungit manus, Dómini nostri Jesu Christi. 
+Quam oblatiónem tu, Deus, in ómnibus, quaesumus, Signat ter super Oblata, bene + díctam, adscríp + tam, ra + tam, rationábilem acceptabilémque fácere dignéris: Signat semel super Hóstiam, ut nobis Cor + pus, et semel super Cálicem, et San + guis fiat dilectíssimi Fílii tui, (Jungit manus), Dómini nostri Jesu Christi. 
 _
 _
 Qui prídie, quam pro nostra omniúmque salúte paterétur, hoc est hódie, Accipit Hostiam, accépit panem in sanctas ac venerábiles manus suas, Elevat oculos ad coelum, et elevátis óculis in coelum ad te Deum, Patrem suum omnipoténtem, Caput inclinat, tibi grátias agens, Signat super Hostiam, bene + dixit, fregit, dedítque discípulis suis, dicens: Accípite, et manducáte ex hoc omnes.

--- a/web/www/missa/Latin/Tempora/Quad6-4t.txt
+++ b/web/www/missa/Latin/Tempora/Quad6-4t.txt
@@ -155,7 +155,7 @@ _
 _
 _
 !Antiphona
-!Ps 13:34.
+!Joann 13:34.
 v. Mandátum novum do vobis: ut diligátis ínvicem, sicut diléxi vos, dicit Dóminus
 !Ps 118:1.
 Beáti immaculáti in via: qui ámbulant in lege Dómini.
@@ -163,7 +163,7 @@ v. Mandátum novum do vobis: ut diligátis ínvicem, sicut diléxi vos, dicit Dóminu
 _
 _
 !Antiphona
-!Ps 13:4, 5 et 15.
+!Joann 13:4, 5 et 15.
 v. Postquam surréxit Dóminus a coena, misit aquam in pelvim, et coepit laváre pedes discipulórum suórum: hoc exémplum réliquit eis
 !Ps 47:2.
 Magnus Dóminus, et laudábilis nimis: in civitáte Dei nostri, in monte sancto ejus.
@@ -171,7 +171,7 @@ v. Postquam surréxit Dóminus a coena, misit aquam in pelvim, et coepit laváre pe
 _
 _
 !Antiphona
-!Ps 13:12, 13 et 15.
+!Joann 13:12, 13 et 15.
 v. Dóminus Jesus, postquam coenávit cum discípulis suis, lavit pedes eórum, et ait illis: Scitis, quid fécerim vobis ego, Dóminus et Magíster? Exémplum dedi vobis, ut et vos ita faciátis
 !Ps 84:2.
 Benedixísti, Dómine, terram tuam: avertísti captivitátem Jacob.
@@ -179,7 +179,7 @@ v. Dóminus Jesus, postquam coenávit cum discípulis suis, lavit pedes eórum, et a
 _
 _
 !Antiphona
-!Ps 13:6-7 et 8.
+!Joann 13:6-7 et 8.
 v. Dómine, tu mihi lavas pedes? Respóndit Jesus et dixit ei: Si non lávero tibi pedes, non habébis partem mecum,
 V. Venit ergo ad Simónem Petrum, et dixit ei Petrus.
 v. Dómine, tu mihi lavas pedes? Respóndit Jesus et dixit ei: Si non lávero tibi pedes, non habébis partem mecum,
@@ -188,6 +188,7 @@ v. Dómine, tu mihi lavas pedes? Respóndit Jesus et dixit ei: Si non lávero tibi 
 _
 _
 !Antiphona.
+!Joann 13:14.
 v. Si ego, Dóminus et Magíster vester, lavi vobis pedes: quanto magis debétis alter altérius laváre pedes?
 !Ps 48:2
 Audíte hæc, omnes gentes: áuribus percípite, qui habitátis orbem.
@@ -195,14 +196,14 @@ v. Si ego, Dóminus et Magíster vester, lavi vobis pedes: quanto magis debétis al
 _
 _
 !Antiphona
-!Ps 13:35.
+!Joann 13:35.
 v. In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habuéritis ad ínvicem,
 V. Dixit Jesus discípulis suis.
 v. In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habuéritis ad ínvicem,
 _
 _
 !Antiphona
-!Ps 13:13
+!1 Cor 13:13
 v. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas,
 V. Nunc autem manent fides, spes, cáritas, tria hæc: major horum est cáritas.
 v. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas,

--- a/web/www/missa/Polski/Ordo/Ordo.txt
+++ b/web/www/missa/Polski/Ordo/Ordo.txt
@@ -12,7 +12,7 @@ S. Przystąpię do ołtarza Bożego.
 M. Do Boga, który jest weselem i radością moją.
 !*&Introibo 
 !Potem, na zmianę z Ministrantami, recytuje co następuje: 
-!Ps. 42, 1-5. 
+!Ps 42, 1-5
 S. Wymierz mi, Boże, sprawiedliwość i broń sprawy mojej przeciw ludowi niezbożnemu, wybaw mnie od człowieka podstępnego i niegodziwego.
 M. Ty bowiem, Boże, jesteś mocą moją, czemu mię odrzuciłeś? Czemu chodzę smutny, nękany przez wroga?
 S. Ześlij Swą światłość i wierność Swoją: niech one mnie wiodą, niech mnie przywiodą na górę Twą świętą, do Twoich przybytków.
@@ -172,14 +172,14 @@ v. Za przyczyną świętego Michała Archanioła, stojącego po prawej stronie o
 !Otrzymując trybularz od Diakona, Celebrans okadza chleb i wino, mówiąc:
 v. To kadzidło, któreś pobłogosławił, niech się wzniesie ku Tobie, Panie, a na nas niech zstąpi miłosierdzie Twoje.
 !Następnie okadza ołtarz, mówiąc:
-!Ps. 140, 2-4. 
+!Ps 140, 2-4
 v. Niech się wzbija ku Tobie modlitwa ma, Panie, niby kadzidło, a wznoszenie rąk moich jak ofiara wieczorna. Postaw straż, Panie, przy ustach moich, i stałą wartę przy bramie mych warg. Nie skłaniaj serca mego ku złej sprawie, ku bezbożnemu popełnianiu przestępstw.
 !Oddając kadzielnicę Diakonowi Kapłan mówi:
 v. Niech Pan zapali w nas ogień swej miłości i płomień wiecznego ukochania. Amen.
 !Diakon okadza Celebransa, duchowieństwo i wiernych, którzy biorą udział w ofierze.
 
 !Kapłan po okadzeniu lub zaraz po poleceniu ofiar przechodzi na stronę lekcji i umywa palce rąk, mówiąc:
-!Ps. 25, 6-12. 
+!Ps 25, 6-12
 v. Umywam ręce moje na znak niewinności i obchodzę ołtarz Twój, Panie. By jawnie ogłaszać chwałę i rozpowiadać wszystkie cuda Twoje. Miłuję, Panie, siedzibę Twego domu i miejsce przybytku Twej chwały. Nie zabieraj z grzesznymi mej duszy i życia mego z mężami krwawymi. W ręku ich zbrodnia, a ich prawica pełna jest przekupstwa. Ja zaś postępuję w niewinności mojej. Wyzwól mię, zmiłuj się nade mną. Na drodze równej stoi stopa moja. Na zgromadzeniach będę błogosławił Panu. Chwała Ojcu.
 &Gloria
 

--- a/web/www/missa/Polski/Sancti/01-03n.txt
+++ b/web/www/missa/Polski/Sancti/01-03n.txt
@@ -15,7 +15,7 @@ Imię JEZUS znaczy Zbawiciel. Imię to wybrał sam Bóg i objawił je Maryi i ś
 [Introitus]
 !Flp 2:10-11
 v. Na imię Jezusa niechaj się zgina wszelkie kolano mieszkańców nieba, ziemi i podziemia: i wszelki język niech wyznaje, że Jezus Chrystus jest Panem w chwale Boga Ojca.
-!Ps 8:2.
+!Ps 8:2
 O Panie, Panie nasz, jak przedziwne Twe imię po wszystkiej ziemi.
 &Gloria
 v. Na imię Jezusa niechaj się zgina wszelkie kolano mieszkańców nieba, ziemi i podziemia: i wszelki język niech wyznaje, że Jezus Chrystus jest Panem w chwale Boga Ojca.

--- a/web/www/missa/Polski/Sancti/02-02.txt
+++ b/web/www/missa/Polski/Sancti/02-02.txt
@@ -66,9 +66,9 @@ Ant. Światło na objawienie dla pogan i chwałę ludu Twego, Izraela.
 _
 _
 ! Następnie chór śpiewa:
-!Antyfona Ps 43:26.
+!Antyfona Ps 43:26
 Ant. Na pomoc nam powstań o Panie i wyzwól nas dla chwały imienia Twego.
-!Ps 43:2.
+!Ps 43:2
 Boże, słyszeliśmy na własne uszy, ojcowie nasi nam opowiedzieli.
 &Gloria
 Ant. Na pomoc nam powstań o Panie i wyzwól nas dla chwały imienia Twego.
@@ -153,9 +153,9 @@ Ant. Światło na objawienie dla pogan i chwałę ludu Twego, Izraela.
 _
 _
 ! Następnie chór śpiewa:
-!Antyfona Ps 43:26.
+!Antyfona Ps 43:26
 Ant. Na pomoc nam powstań o Panie i wyzwól nas dla chwały imienia Twego.
-!Ps 43:2.
+!Ps 43:2
 Boże, słyszeliśmy na własne uszy, ojcowie nasi nam opowiedzieli.
 &Gloria
 Ant. Na pomoc nam powstań o Panie i wyzwól nas dla chwały imienia Twego.
@@ -228,7 +228,7 @@ A oto był w Jerozolimie człowiek imieniem Symeon, a ten był sprawiedliwym i b
 «Teraz, o Panie, według Twego słowa, uwalniasz sługę Twego w pokoju, bo moje oczy ujrzały Twoje zbawienie, któreś zgotował dla wszystkich narodów: Światło na objawienie dla pogan i chwałę ludu Twego, Izraela».
 
 [Offertorium]
-!Ps 44:3.
+!Ps 44:3
 Wdzięk rozlał się na Twoich wargach, przeto Bóg pobłogosławił Cię na wieki.
 
 [Secreta]

--- a/web/www/missa/Polski/Sancti/02-24.txt
+++ b/web/www/missa/Polski/Sancti/02-24.txt
@@ -19,7 +19,7 @@ Lekcja dzisiejszej Mszy podaje opis wyboru św. Macieja na Apostoła w miejsce J
 [Introitus]
 !Ps 138:17
 v. Ogromnie zaszczyceni są w oczach moich przyjaciele Twoi, Boże; na zawsze jest utrwalone ich władanie.
-!Ps 138:1-2.
+!Ps 138:1-2
 Panie, Ty mnie przenikasz i znasz; Ty wiesz o moim spoczynku i o mym powstaniu.
 &Gloria
 v. Ogromnie zaszczyceni są w oczach moich przyjaciele Twoi, Boże; na zawsze jest utrwalone ich władanie.
@@ -30,33 +30,33 @@ $Per Dominum
 
 [Lectio]
 Czytanie z Dziejów Apostolskich.
-!Dz 1, 15-26.
+!Dz 1, 15-26
 W one dni powstał Piotr wpośród braci ((a był poczet osób zebranych około stu dwudziestu)) i rzekł: «Mężowie bracia! Musiało się wypełnić Pismo, które Duch Święty zapowiedział przez usta Dawida o Judaszu, przywódcy tych, co pojmali Jezusa. Należał on do naszego grona i miał współuczestnictwo w tym posługiwaniu. Ten tedy nabył pole z zapłaty niegodziwości, a powiesiwszy się, rozpękł się na dwoje i wypłynęły wszystkie jego wnętrzności. I stało się to wiadome wszystkim mieszkańcom Jerozolimy, tak że i pole owo nazwano w ich języku Hakeldama, to jest pole krwi.
 Napisane jest bowiem w Księdze Psalmów: Niech mieszkanie ich stanie się pustkowiem i niech się nie znajdzie, kto by w nim zamieszkał: oraz biskupstwo jego niech zabierze inny. Potrzeba tedy, aby jeden z tych mężów, którzy się z nami zbierali przez cały czas, kiedy Pan Jezus przebywał między nami, począwszy od chrztu Janowego aż do dnia Wniebowstąpienia, stał się wraz z nami świadkiem Jego zmartwychwstania».
 I stawiono dwóch: Józefa, zwanego Barsabą, który miał przydomek Justus, i Macieja. A modląc się mówili: «Ty, Panie, który znasz serca wszystkich, okaż, kogoś z tych dwóch wybrał, aby zajął miejsce tego posługiwania i apostolstwa, któremu sprzeniewierzył się Judasz, aby odejść na miejsce swoje». I rozdano im losy. A los padł na Macieja i przyłączony był do jedenastu Apostołów.
 
 [Graduale]
-!Ps 138:17-18.
+!Ps 138:17-18
 Ogromnie zaszczyceni są w oczach moich przyjaciele Twoi, Boże; na zawsze jest utrwalone ich władanie.
 V. Gdybym ich przeliczył, więcej ich niż piasku.
 
 [Tractus]
-!Ps 138:17-18.
+!Ps 138:17-18
 Ogromnie zaszczyceni są w oczach moich przyjaciele Twoi, Boże; na zawsze jest utrwalone ich władanie.
 V. Gdybym ich przeliczył, więcej ich niż piasku.
-!Ps 20:3-4.
+!Ps 20:3-4
 Spełniłeś pragnienie jego serca, prośbie ust jego nie odmówiłeś.
 V. Uprzedziłeś go hojnym błogosławieństwem.
 V. Włożyłeś mu na głowę koronę z drogich kamieni.
 
 [Evangelium]
 Ciąg dalszy ++ Ewangelii świętej według Mateusza.
-!Mt 11:25-30.
+!Mt 11:25-30
 Onego czasu: Odpowiadając Jezus rzekł: «Wysławiam Cię, Ojcze, Panie nieba i ziemi, iżeś te rzeczy zakrył przed mądrymi i przewidującymi, a objawiłeś je maluczkim. Tak, Ojcze, bo tak się spodobało Tobie. Wszystko dane mi jest od Ojca mego. I nikt nie zna Syna, jeno Ojciec, ani Ojca nikt nie zna, jeno Syn i komu by Syn zechciał objawić.
 Pójdźcie do mnie wszyscy, którzy pracujecie i uginacie się pod ciężarem, a ja was pokrzepię. Weźmijcie jarzmo moje na siebie i uczcie się ode mnie, żem jest cichy i pokornego serca, a znajdziecie odpocznienie dla dusz waszych. Albowiem jarzmo moje słodkie jest, a brzemię moje lekkie».
 
 [Offertorium]
-!Ps 44:17-18.
+!Ps 44:17-18
 Ustanowisz ich książętami po całej ziemi, przez wszystkie pokolenia głosić będą Twe imię, o Panie.
 
 [Secreta]
@@ -64,7 +64,7 @@ Panie, niech ta modlitwa św. Apostoła Twojego Macieja towarzyszy darom, które
 $Per Dominum
 
 [Communio]
-!Mt 19:28.
+!Mt 19:28
 Wy, którzy za mną poszli, zasiądziecie na stolicach, sądząc dwanaście pokoleń Izraela.
 
 [Postcommunio]

--- a/web/www/missa/Polski/Sancti/12-21.txt
+++ b/web/www/missa/Polski/Sancti/12-21.txt
@@ -16,7 +16,7 @@ Szaty czerwone
 Św. Tomasz Apostoł nie chciał uwierzyć w zmartwychwstanie, póki osobiście nie przekonał się o powrocie Chrystusa do życia. Ta ostrożność dodaje znaczenia jego świadectwu. Umocniony w wierze głosił Ewangelię w Małej Azji poza granicami Cesarstwa Rzymskiego. Według tradycji miał dotrzeć do Indii i tam ponieść śmierć koło Madras. Szczegółów jego życia nie znamy. Ukryty jak kamień fundamentu leży u początków budowy Kościoła Chrystusowego (lekcja). Chętnie powtarzamy jegy wyznanie wiary: «Pan mój i Bóg mój», które Kościół obdarzył odpustem.
 
 [Introitus]
-!Ps 138:17.
+!Ps 138:17
 v. Ogromnie zaszczyceni są w oczach moich przyjaciele Twoi, Boże; na zawsze jest utrwalone ich władanie.
 !Ps 138:1-2
 Panie, Ty mnie przenikasz i znasz; Ty wiesz o moim spoczynku i o mym powstaniu.
@@ -33,7 +33,7 @@ Czytanie z Listu świętego Pawła Apostoła do Efezjan.
 Bracia: Nie jesteście już obcymi i przychodniami, ale współobywatelami Świętych i domownikami Boga, wzniesieni na fundamencie Apostołów i Proroków, którego kamieniem węgielnym jest sam Chrystus Jezus. W Nim wszystko budowanie z sobą spojone rośnie w Kościół święty w Panu, do którego i wasza budowa należy na mieszkanie Boże w Duchu.
 
 [Graduale]
-!Ps 138:17-18.
+!Ps 138:17-18
 Ogromnie zaszczyceni są w oczach moich przyjaciele Twoi, Boże; na zawsze jest utrwalone ich władanie.
 V. Gdybym ich przeliczył, więcej ich niż piasku. Alleluja, alleluja
 !Ps 32:1
@@ -68,7 +68,7 @@ V. Włożyłeś mu na głowę koronę z drogich kamieni.
 
 [GradualeP]
 V. Alleluja, alleluja
-!Ps 32:1.
+!Ps 32:1
 Sprawiedliwi, weselcie się w Panu: prawym przystoi Go chwalić. Alleluja.
-!Ps 88:6.
+!Ps 88:6
 V. Niebiosa wielbią cuda Twoje, Panie, a wierność Twoją zgromadzenie świętych. Alleluja.

--- a/web/www/missa/Polski/Sancti/12-26.txt
+++ b/web/www/missa/Polski/Sancti/12-26.txt
@@ -59,9 +59,9 @@ V. Włożyłeś mu na głowę koronę z drogich kamieni.
 
 [GradualeP]
 Alleluja, alleluja
-!Dz 7:55.
+!Dz 7:55
 Widzę niebiosa otwarte i Jezusa stojącego po prawicy mocy Bożej. Alleluja,
-!Ps 20:4.
+!Ps 20:4
 V. Włożyłeś mu na głowę koronę z drogich kamieni. Alleluja.
 
 [Evangelium]

--- a/web/www/missa/Polski/Sancti/12-28.txt
+++ b/web/www/missa/Polski/Sancti/12-28.txt
@@ -17,7 +17,7 @@ Szaty czerwone
 Św. Jan pisze o Panu Jezusie: «Przyszedł do swej własności, a swoi Go nie przyjęli». Jeszcze w niemowlęcym wieku spotkał się Pan Jezus ze sprzeciwem. Aby utrącić rzekomego pretendenta do tronu, Herod wydał okrutny rozkaz wymordowania betlejemskich młodzianków. Oddając życie za Pana Jezusa otrzymali oni Chrzest krwi i osiągnęli podwójną aureolę: dziewictwa i męczeństwa. We Mszy dzisiejszej sławimy Boga za chwałę, jakiej udzielił świętym dzieciom (antyfona na wejście, lekcja, graduał), i opłakujemy zbrodnię Heroda wymierzoną przeciw Zbawicielowi (traktus, antyfona na komunię). W średniowieczu obchodzono w dniu dzisiejszym święto patronalne kościelnych chórów chłopięcych.
 
 [Introitus]
-!Ps 8:3.
+!Ps 8:3
 v. Z ust dzieci i niemowląt zgotowałeś sobie chwałę, Boże, wbrew przeciwnikom Twoim.
 !Ps 8:2
 O Panie, Panie nasz, jak przedziwne Twe imię po wszystkiej ziemi.

--- a/web/www/missa/Polski/Sancti/12-28o.txt
+++ b/web/www/missa/Polski/Sancti/12-28o.txt
@@ -17,7 +17,7 @@ Szaty czerwone
 Św. Jan pisze o Panu Jezusie: «Przyszedł do swej własności, a swoi Go nie przyjęli». Jeszcze w niemowlęcym wieku spotkał się Pan Jezus ze sprzeciwem. Aby utrącić rzekomego pretendenta do tronu, Herod wydał okrutny rozkaz wymordowania betlejemskich młodzianków. Oddając życie za Pana Jezusa otrzymali oni Chrzest krwi i osiągnęli podwójną aureolę: dziewictwa i męczeństwa. We Mszy dzisiejszej sławimy Boga za chwałę, jakiej udzielił świętym dzieciom (antyfona na wejście, lekcja, graduał), i opłakujemy zbrodnię Heroda wymierzoną przeciw Zbawicielowi (traktus, antyfona na komunię). W średniowieczu obchodzono w dniu dzisiejszym święto patronalne kościelnych chórów chłopięcych.
 
 [Introitus]
-!Ps 8:3.
+!Ps 8:3
 v. Z ust dzieci i niemowląt zgotowałeś sobie chwałę, Boże, wbrew przeciwnikom Twoim.
 !Ps 8:2
 O Panie, Panie nasz, jak przedziwne Twe imię po wszystkiej ziemi.

--- a/web/www/missa/Polski/Sancti/12-28r.txt
+++ b/web/www/missa/Polski/Sancti/12-28r.txt
@@ -17,7 +17,7 @@ Szaty czerwone
 Św. Jan pisze o Panu Jezusie: «Przyszedł do swej własności, a swoi Go nie przyjęli». Jeszcze w niemowlęcym wieku spotkał się Pan Jezus ze sprzeciwem. Aby utrącić rzekomego pretendenta do tronu, Herod wydał okrutny rozkaz wymordowania betlejemskich młodzianków. Oddając życie za Pana Jezusa otrzymali oni Chrzest krwi i osiągnęli podwójną aureolę: dziewictwa i męczeństwa. We Mszy dzisiejszej sławimy Boga za chwałę, jakiej udzielił świętym dzieciom (antyfona na wejście, lekcja, graduał), i opłakujemy zbrodnię Heroda wymierzoną przeciw Zbawicielowi (traktus, antyfona na komunię). W średniowieczu obchodzono w dniu dzisiejszym święto patronalne kościelnych chórów chłopięcych.
 
 [Introitus]
-!Ps 8:3.
+!Ps 8:3
 v. Z ust dzieci i niemowląt zgotowałeś sobie chwałę, Boże, wbrew przeciwnikom Twoim.
 !Ps 8:2
 O Panie, Panie nasz, jak przedziwne Twe imię po wszystkiej ziemi.

--- a/web/www/missa/Polski/Tempora/Adv1-0.txt
+++ b/web/www/missa/Polski/Tempora/Adv1-0.txt
@@ -14,7 +14,7 @@ Szaty fioletowe
 W liturgii adwentowej ciągle rozbrzmiewa okrzyk «Veni — Przyjdź». Kościół wyprasza przyjście Zbawiciela do dusz swoich wiernych, aby przygotować ich na godny obchód pamiątki Bożego Narodzenia i na ostateczne przyjście Pana. Śpiewy dzisiejszej Mszy są wyjęte z psalmu 24, który doskonale wyraża usposobienie duszy w Adwencie. Czujemy naszą nicość i grzeszność i gorąco pragniemy zbawienia. Pragnienia nasze wyraża kolekta, zwracająca się wprost do Syna Bożego i natarczywie błagająca o nawiedzenie Boże. Lekcja wzywa do współdziałania z łaską Bożą. Ewangelia zapowiada ostateczne przyjście Zbawiciela, które rzuca właściwe światło na całą doczesność. «Podnoście głowy wasze, bo się zbliża odkupienie». W sekrecie modlimy się o dobre przygotowanie na spotkanie się z Bogiem, który jest naszym początkiem i celem.
 
 [Introitus]
-!Ps 24:1-3.
+!Ps 24:1-3
 v. Ku Tobie wznoszę duszę moją, Boże mój, Tobie ufam: niech nie doznam wstydu, niech się nie śmieją ze mnie moi wrogowie. Wszyscy bowiem, co ufają Tobie, wstydu nie doznają.
 !Ps 24:4
 Ukaż mi, Panie, drogi Twoje i naucz mnie Twoich ścieżek.
@@ -34,7 +34,7 @@ Bracia: Wiecie, że pora nam już powstać ze snu. Teraz bowiem bliższe jest zb
 !Ps 24:3; 24:4
 Wszyscy, co ufają Tobie, wstydu nie doznają.
 V. Ukaż mi, Panie, drogi Twoje, i naucz mnie Twoich ścieżek. Alleluja, alleluja.
-!Ps 84:8.
+!Ps 84:8
 V. Okaż nam, Panie, miłosierdzie swoje i daj nam swoje zbawienie. Alleluja.
 
 [Evangelium]
@@ -51,7 +51,7 @@ Panie, niech te święte tajemnice oczyszczą nas swoją potężną mocą i pozw
 $Per Dominum
 
 [Communio]
-!Ps 84:13.
+!Ps 84:13
 Pan użyczy błogosławieństwa, a ziemia nasza wyda swój plon.
 
 [Postcommunio]

--- a/web/www/missa/Polski/Tempora/Adv3-3.txt
+++ b/web/www/missa/Polski/Tempora/Adv3-3.txt
@@ -25,7 +25,7 @@ W dniu dzisiejszym Kościół wspomina tajemnicę Wcielenia, która przygotował
 [Introitus]
 !Iz 45:8.
 v. Niebiosa, spuśćcie rosę z góry, a obłoki niech zleją z deszczem Sprawiedliwego. Niech się otworzy ziemia i zrodzi Zbawiciela.
-!Ps 18:2.
+!Ps 18:2
 Niebiosa głoszą chwałę Boga, dzieło rąk Jego obwieszcza nieboskłon.
 &Gloria
 v. Niebiosa, spuśćcie rosę z góry, a obłoki niech zleją z deszczem Sprawiedliwego. Niech się otworzy ziemia i zrodzi Zbawiciela.

--- a/web/www/missa/Polski/Tempora/Epi1-0.txt
+++ b/web/www/missa/Polski/Tempora/Epi1-0.txt
@@ -46,7 +46,7 @@ Słowo Chrystusowe niech przebywa w was obficie, abyście z wszelką mądrości�
 [Graduale]
 !Ps 26:4
 O jedno proszę Pana, jednego pragnę, bym mógł przebywać w domu Pańskim po wszystkie dni życia mego.
-!Ps 83:5.
+!Ps 83:5
 Szczęśliwi, którzy mieszkają w domu Twoim Panie, gdyż na wieki wieków mogą Cię chwalić. Alleluja, alleluja.
 !Iz 45:15
 Zaprawdę Tyś jest Król ukryty, Bóg Izraela, Zbawiciel. Alleluja.

--- a/web/www/missa/Polski/Tempora/Nat1-0.txt
+++ b/web/www/missa/Polski/Tempora/Nat1-0.txt
@@ -43,7 +43,7 @@ Bracia! Powiadam tedy: Dopóki dziedzic jest dziecięciem, niczym się nie róż
 !Ps 44:3; 44:2
 Postacią Tyś piękniejszy nad synów ludzkich, wdzięk rozlał się na Twoich wargach.
 V. Z mego serca płynie słowo dobre; pieśń moją śpiewam dla Króla; mój język jest jak rylec sprawnego pisarza. Alleluja, alleluja.
-!Ps 92:1.
+!Ps 92:1
 Pan króluje, w majestat się oblókł; odział się Pan w potęgę i przepasał się mocą. Alleluja.
 
 [Evangelium]

--- a/web/www/missa/Polski/Tempora/Nat2-0.txt
+++ b/web/www/missa/Polski/Tempora/Nat2-0.txt
@@ -15,7 +15,7 @@ Imię JEZUS znaczy Zbawiciel. Imię to wybrał sam Bóg i objawił je Maryi i ś
 [Introitus]
 !Flp 2:10-11
 v. Na imię Jezusa niechaj się zgina wszelkie kolano mieszkańców nieba, ziemi i podziemia: i wszelki język niech wyznaje, że Jezus Chrystus jest Panem w chwale Boga Ojca.
-!Ps 8:2.
+!Ps 8:2
 O Panie, Panie nasz, jak przedziwne Twe imię po wszystkiej ziemi.
 &Gloria
 v. Na imię Jezusa niechaj się zgina wszelkie kolano mieszkańców nieba, ziemi i podziemia: i wszelki język niech wyznaje, że Jezus Chrystus jest Panem w chwale Boga Ojca.

--- a/web/www/missa/Polski/Tempora/Quad3-0.txt
+++ b/web/www/missa/Polski/Tempora/Quad3-0.txt
@@ -15,7 +15,7 @@ Szaty fioletowe
 Katechumenom, gotującym się do Chrztu świętego w najbliższą Wielkanoc, i wiernym, którzy ten sakrament przyjęli, Kościół przypomina, że Chrzest wyrywa nas spod władzy szatana i czyni dziećmi światłości (lekcja). Szatan będzie jednak ponawiał swoje ataki na oczyszczoną duszę. Trzeba więc gromadzić siły do walki. Kto lekceważy niebezpieczeństwo i rozprasza dobra nadprzyrodzone, poniesie większą odpowiedzialność niż człowiek nieochrzczony (ewangelia). Dlatego musimy trwać przy ofierze Chrystusa i Jego sakramentach (antyfona na komunię).
 
 [Introitus]
-!Ps 24:15-16.
+!Ps 24:15-16
 v. Oczy moje zawsze ku Panu, gdyż On sam oswobodzi z sideł moje nogi. Wejrzyj na mnie i zmiłuj się nade mną, bo samotny jestem i biedny.
 !Ps 24:1-2
 Ku Tobie wznoszę duszę moją, Panie, Boże mój, Tobie ja ufam, niech nie doznam wstydu.

--- a/web/www/missa/Polski/Tempora/Quad5-0.txt
+++ b/web/www/missa/Polski/Tempora/Quad5-0.txt
@@ -18,7 +18,7 @@ Szaty fioletowe
 Jezus Chrystus, Arcykapłan Nowego Testamentu, gotuje się do złożenia ofiary krzyżowej. Antyfona na wejście, graduał, traktus i antyfona na komunię — to Jego modlitwa w obliczu nadchodzącej męki. W lekcji św. Paweł poucza nas o charakterze śmierci Zbawiciela, która jest jedyną i wieczystą ofiarą Nowego Testamentu. W ewangelii słyszymy z ust Jezusa wyznanie Bóstwa. Podobne wyznanie powtórzone w uroczystej formie przed Sanhedrynem stało się bezpośrednim powodem skazania Zbawiciela na śmierć.
 
 [Introitus]
-!Ps 42:1-2.
+!Ps 42:1-2
 v. Wymierz mi, Boże, sprawiedliwość i broń mojej sprawy przeciw niezbożnemu ludowi, wybaw mię od człowieka podstępnego i niegodziwego, Ty bowiem, Boże, jesteś mocą moją.
 !Ps 42:3
 Ześlij Swą światłość i wierność Swoją: niech one mię wiodą, niech mnie przywiodą na górę Twą świętą i do Twoich przybytków.

--- a/web/www/missa/Polski/Tempora/Quad5-0t.txt
+++ b/web/www/missa/Polski/Tempora/Quad5-0t.txt
@@ -15,7 +15,7 @@ Szaty fioletowe
 Jezus Chrystus, Arcykapłan Nowego Testamentu, gotuje się do złożenia ofiary krzyżowej. Antyfona na wejście, graduał, traktus i antyfona na komunię — to Jego modlitwa w obliczu nadchodzącej męki. W lekcji św. Paweł poucza nas o charakterze śmierci Zbawiciela, która jest jedyną i wieczystą ofiarą Nowego Testamentu. W ewangelii słyszymy z ust Jezusa wyznanie Bóstwa. Podobne wyznanie powtórzone w uroczystej formie przed Sanhedrynem stało się bezpośrednim powodem skazania Zbawiciela na śmierć.
 
 [Introitus]
-!Ps 42:1-2.
+!Ps 42:1-2
 v. Wymierz mi, Boże, sprawiedliwość i broń mojej sprawy przeciw niezbożnemu ludowi, wybaw mię od człowieka podstępnego i niegodziwego, Ty bowiem, Boże, jesteś mocą moją.
 !Ps 42:3
 Ześlij Swą światłość i wierność Swoją: niech one mię wiodą, niech mnie przywiodą na górę Twą świętą i do Twoich przybytków.

--- a/web/www/missa/Polski/Tempora/Quad6-0.txt
+++ b/web/www/missa/Polski/Tempora/Quad6-0.txt
@@ -87,7 +87,7 @@ v. A nazajutrz, który jest dzień po przygotowaniu, zebrali się przedniejsi ka
 @:Evangelium4
 
 [Offertorium]
-!Ps 68:21-22.
+!Ps 68:21-22
 Urąganiem złamane me serce i sił mi zabrakło. Na współczującego czekałem, ale go nie było, i na pocieszających, lecz ich nie znalazłem. Do mego pokarmu domieszali żółci, a kiedym pragnął, poili mnie octem.
 
 [Secreta]

--- a/web/www/missa/Polski/Tempora/Quad6-1.txt
+++ b/web/www/missa/Polski/Tempora/Quad6-1.txt
@@ -18,7 +18,7 @@ Szaty fioletowe
 W szóstym dniu przed Paschą Pan Jezus przybył do Betanii i przyjął zaproszenie na ucztę w domu Szymona Trędowatego. Wypadki, które rozegrały się w czasie posiłku, zapowiadają bliską śmierć Zbawiciela: czyn Marii Pan Jezus nazywa przygotowaniem do pogrzebu, Judasz ukazuje swoją chciwość, która doprowadzi go do zdrady (ewangelia). Śpiewy mszalne wyrażają ludzką trwogę Pana Jezusa przed cierpieniem, która wystąpiła wyraźnie podczas modlitwy w Ogrodzie Oliwnym. Bóg nie odsunął od Chrystusa kielicha męki, ale dał Mu ostateczne zwycięstwo przez zmartwychwstanie.
 
 [Introitus]
-!Ps 34:1-2.
+!Ps 34:1-2
 v. Rozpraw się, Panie, z tymi, co mnie krzywdzą, uderz na tych, co na mnie natarli, chwyć broń i tarczę, a powstań mi na pomoc, Panie, potężny mój Zbawco.
 !Ps 34:3
 Dobądź miecza i poskrom moich prześladowców, powiedz mej duszy: «Jam twoim zbawieniem».
@@ -35,7 +35,7 @@ Czytanie z Księgi proroka Izajasza.
 W one dni: Rzekł Izajasz: Pan Bóg otworzył mi ucho, a ja się nie sprzeciwiam, wstecz nie odszedłem. Wydałem ciało moje bijącym, a szczypiącym policzki moje; nie odwróciłem twarzy mojej od krzyczących i plwających na mnie. Pan Bóg wspomożycielem moim, przetom nie został zawstydzony: dlatego twarz moją uczyniłem jakby skałą najtwardszą i wiem, że zawstydzony nie będę. Obok mnie jest Ten, który mnie usprawiedliwia; któż mi się sprzeciwi? Razem stańmy: któż jest moim przeciwnikiem? Niechaj zbliży się do mnie! Oto Pan Bóg wspomożycielem moim, któż może mnie potępić? Oto wszyscy niby szata będą starci: zniszczy ich mól. Któż z was boi się Boga i słucha głosu sługi Jego? Kto szedł wśród ciemności i brak mu światła, niech w imieniu Pańskim pokłada nadzieję, a polega na Bogu swoim.
 
 [Graduale]
-!Ps 34:23 et 3.
+!Ps 34:23,3
 Przebudź się, o Panie, powstań ku mojej obronie, wglądnij w mą sprawę, Boże mój i Panie.
 V. Dobądź miecza i poskrom moich prześladowców.
 _

--- a/web/www/missa/Polski/Tempora/Quad6-4r.txt
+++ b/web/www/missa/Polski/Tempora/Quad6-4r.txt
@@ -61,7 +61,10 @@ Prosimy Cię, Panie, Ojcze święty, wszechmogący, wieczny Boże, niech ofiarę
 $Qui tecum
 
 [Communicantes]
-Zjednoczeni w świętych obcowaniu obchodzimy uroczyście prześwięty dzień, w którym Pan nasz Jezus Chrystus został za nas wydany, i ze czcią wspominamy najpierw chwalebną zawsze Dziewicę Maryję, Matkę Boga i Pana naszego Jezusa Chrystusa oraz świętych Apostołów i Męczenników Twoich: Piotra i Pawła, Andrzeja, Jakuba, Jana, Tomasza, Jakuba, Filipa, Bartłomieja, Mateusza, Szymona, Tadeusza, Linusa, Kleta, Klemensa, Sykstusa, Korneliusza, Cypriana, Wawrzyńca, Chryzogona, Jana i Pawła, Kosmę i Damiana, i wszystkich Świętych Twoich; dla ich zasług i modlitw racz nas we wszystkim otaczać Swą przemożną opieką. Przez tegoż Chrystusa Pana naszego. Amen.
+Zjednoczeni w świętych obcowaniu obchodzimy uroczyście prześwięty dzień, w którym Pan nasz Jezus Chrystus został za nas wydany, i ze czcią wspominamy najpierw chwalebną zawsze Dziewicę Maryję, Matkę Boga i Pana naszego Jezusa Chrystusa 
+(rubrica 1960 dicitur)
+a także Świętego Józefa, Oblubieńca Najświętszej Dziewicy,
+oraz świętych Apostołów i Męczenników Twoich: Piotra i Pawła, Andrzeja, Jakuba, Jana, Tomasza, Jakuba, Filipa, Bartłomieja, Mateusza, Szymona, Tadeusza, Linusa, Kleta, Klemensa, Sykstusa, Korneliusza, Cypriana, Wawrzyńca, Chryzogona, Jana i Pawła, Kosmę i Damiana, i wszystkich Świętych Twoich; dla ich zasług i modlitw racz nas we wszystkim otaczać Swą przemożną opieką. Przez tegoż Chrystusa Pana naszego. Amen.
 _
 _
 Prosimy Cię przeto, Panie, abyś łaskawie przyjął tę ofiarę od nas, sług Twoich, jak również od całego ludu Twego. Składamy Ci ją na pamiątkę dnia, w którym Pan nasz Jezus Chrystus powierzył swoim uczniom sprawowanie misteriów Ciała i Krwi swojej. Racz dni nasze pokojem swym napełnić, od potępienia wiecznego nas uchronić i do grona wybranych Swoich zaliczyć. (składa ręce) Przez tegoż Chrystusa, Pana naszego. Amen.

--- a/web/www/missa/Polski/Tempora/Quad6-4r.txt
+++ b/web/www/missa/Polski/Tempora/Quad6-4r.txt
@@ -16,7 +16,7 @@ no Ultima Evangelium
 
 [Comment]
 Wielki Czwartek Wieczerzy Pańskiej
-Stacja u Św. Jana na Laterania
+Stacja u Św. Jana na Lateranie
 1 klasy
 Szaty białe
 W pierwszych wiekach istnienia Kościoła odprawiano w Wielki Czwartek trzy Msze święte. Pierwsza łączyła się z obrzędem pojednania publicznych pokutników, druga z poświęceniem olejów świętych, trzecią odprawiano na pamiątkę Ostatniej Wieczerzy. Gdy ustał zwyczaj publicznej pokuty, zaniechano obrzędu pojednania pokutników. Natomiast w katedrach biskupich, oprócz wieczornej Mszy Wieczerzy Pańskiej, odprawia się rano specjalną Mszę świętą połączoną z konsekracją olejów.
@@ -153,195 +153,119 @@ Ant. Dzielą między siebie moje szaty i o suknię moją los rzucają.
 ~(21:13) Otoczyło mnie mnóstwo cielców, * Byki Baszanu mnie osaczają.
 ~(21:14) Rozwierają przeciwko mnie swoje paszcze, * jak lew drapieżny, ryczący.
 ~(21:15) Rozlałem się jak woda * i rozłączyły się wszystkie me kości:
-~(21:15) Factum est cor meum tamquam cera liquéscens * in médio ventris mei.
-~(21:16) Aruit tamquam testa virtus mea, et lingua mea adhæsit fáucibus meis: * et in púlverem mortis deduxísti me.
-~(21:17) Quóniam circumdedérunt me canes multi: * concílium malignántium obsédit me.
-~(21:18) Fodérunt manus meas et pedes meos: * dinumeravérunt ómnia ossa mea.
-~(21:19) Ipsi vero consideravérunt et inspexérunt me: * divisérunt sibi vestiménta mea, et super vestem meam misérunt sortem.
-~(21:20) Tu autem, Dómine, ne elongáveris auxílium tuum a me: * ad defensiónem meam cónspice.
-~(21:21) Erue a frámea, Deus, ánimam meam: * et de manu canis únicam meam:
-~(21:22) Salva me ex ore leónis: * et a córnibus unicórnium humilitátem meam.
-~(21:23) Narrábo nomen tuum frátribus meis: * in médio ecclésiæ laudábo te.
-~(21:24) Qui timétis Dóminum, laudáte eum: * univérsum semen Jacob, glorificáte eum.
-~(21:25) Tímeat eum omne semen Israël: * quóniam non sprevit, neque despéxit deprecatiónem páuperis:
-~(21:25) Nec avértit fáciem suam a me: * et cum clamárem ad eum, exaudívit me.
-~(21:26) Apud te laus mea in ecclésia magna: * vota mea reddam in conspéctu timéntium eum.
-~(21:27) Edent páuperes, et saturabúntur: et laudábunt Dóminum qui requírunt eum: * vivent corda eórum in sǽculum sǽculi.
-~(21:28) Reminiscéntur et converténtur ad Dóminum * univérsi fines terræ:
-~(21:28) Et adorábunt in conspéctu ejus * univérsæ famíliæ géntium.
-~(21:29) Quóniam Dómini est regnum: * et ipse dominábitur géntium.
-~(21:30) Manducavérunt et adoravérunt omnes pingues terræ: * in conspéctu ejus cadent omnes qui descéndunt in terram.
-~(21:31) Et ánima mea illi vivet: * et semen meum sérviet ipsi.
-~(21:32) Annuntiábitur Dómino generátio ventúra: * et annuntiábunt cœli justítiam ejus pópulo qui nascétur, quem fecit Dóminus.
-Ant. Divisérunt sibi vestiménta mea: et super vestem meam misérunt sortem.
-
-! Clerici, si adsunt, prosequuntur recitationem~
-! huius psalmi, usque dum altarium~
-! denudatio peracta sit; alioquin celebrans dicat~
-! antiphonam et primum tantum versum~
-! psalmi ante denudationem altaris maioris.~
-! Celebrans vero cum ministris sacris, vel~
-! ministrantibus, denudat omnia altaria~
-! ecclesiæ, excepto illo in quo Sacramentum~
-! solemniter adoratur.~
-! Altaribus denudatis, redeunt ad altare~
-! maius, et, repetita a celebrante antiphona~
-! Dividunt, revertuntur in sacristiam.
-_
-! Mox in choro dicitur Completorium,~
-! candelis exstinctis et absque cantu.
-_
-! Ad locum autem repositionis sanctissimæ~
-! Eucharistiæ fit publica adoratio, inde~
-! ab expleta Missa in Cena Domini instituenda~
-! et protrahenda saltem usque ad~
-! mediam noctem.
+~(21:15) Jak wosk się stała me serce * we wnętrzu moim topnieje.
+~(21:16) Gardło me wyschło jak skorupa * język mój przywarł do podniebienia, w proch śmierci mnie obróciłeś.
+~(21:17) Bo sfora psów mnie opadła, * osacza mnie zgraja złoczyńców.
+~(21:18) Przebodli ręce i nogi moje, * policzyć mogę wszystkie moje kości.
+~(21:19) A oni się wpatrują, sycą się mym widokiem; między siebie dzielą moje szaty * i los rzucają o moją suknię.
+~(21:20) Ty zaś, o Panie, nie stój z daleka: * pomocy moja, śpiesz mi na ratunek.
+~(21:21) Wyrwij spod miecza mą duszę * i życie me z psich pazurów.
+~(21:22) Wybaw mnie z lwiej paszczęki * i mnie biednego od rogów bawolich.
+~(21:23) Imię Twoje opowiem swym braciom * i chwalić Cię będę pośród zgromadzenia.
+~(21:24) «Chwalcie Go wy, co się Pana boicie; sławcie Go, całe potomstwo Jakuba: * czcijcie Go, całe potomstwo Izraela.
+~(21:25) Bo On nie wzgardził ani nie brzydził się nędzą biedaka.
+~(21:25) Ani nie ukrył przed nim swojego oblicza * i wysłuchał go, kiedy zawołał do Niego».
+~(21:26) Od Ciebie płynie ma pieśń pochwalna w wielkim zgromadzeniu, * śluby me wypełnię wobec bojących się Jego.
+~(21:27) Ubodzy będę jedli i nasycą się, chwalić będą Pana, którzy Go szukają: * «serca wasze niech żyją na wieki».
+~(21:28) Przypomną sobie i wrócą do Pana * wszystkie krańce ziemi;
+~(21:28) I wszystkie szczepy pogańskie * padną na twarz przed Jego obliczem,
+~(21:29) Bo królowanie należy do Pana, * i On panuje nad narodami.
+~(21:30) Jego jedynego uwielbiają wszyscy, co śpią w ziemi, * przed Nim zegną się wszyscy, którzy w proch zstępują.
+~(21:31) A dusza moja żyć będzie dla Niego, * potomstwo moje Jemu będzie służyć,
+~(21:32) Przyszłemu pokoleniu o Panu opowie, * a sprawiedliwość Jego ogłoszą ludowi, co się narodzi: «Pan to uczynił».
+Ant. Dzielą między siebie moje szaty i o suknię moją los rzucają.
 
 [Maundi]
-!! De lotione pedum
-! Post homiliam proceditur, ubi ratio~
-! pastoralis id suadeat, ad lotionem pedum.
-! In medio presbyterii, vel in ipsa aula~
-! ecclesiæ, parata sint sedilia hinc inde pro~
-! duodecim viris, quorum lavabuntur pedes;~
-! cetera quae occurrunt, tempore opportuno,~
-! in mensula parentur.
-! Interim diaconus et subdiaconus, seu~
-! duo maiores ex ministrantibus, inducunt duodecim~
-! viros selectos, binos et binos, ad locum~
-! paratum, dum schola vel ipse clerus~
-! assistens incipit, cantando vel recitando,~
-! antiphonas, psalmos et versus infrascriptos.
-! Duodecim autem viri selecti, facta reverentia~
-! altari ac celebranti, in presbyterio~
-! sedenti, disponuntur per sedilia; tunc ministri~
-! sacri, seu ministrantes, adibunt celebrantem.~
-! Omnes deponunt manipulum, celebrans~
-! vero etiam planetam.
-! Lotione pedum ad finem vergente, incipitur~
-! antiphona 8a cum suis versibus, ceteris,~
-! si opus sit, omissis.
+!! Mandatum, czyli Umywanie Nóg
+! Po kazaniu odbywa się obrzęd umywania nóg, Celebrans zdejmuje ornat, przepasuje się ręcznikiem i umywa nogi dwunastu mężczyznom duchownym lub świeckim, którzy siedzą na przygotowanych miejscach w prezbiterium lub w nawie kościoła. Celebrans przed każdym z nich przyklęka, umywa i ociera prawą stopę.
+! W ten obrazowy sposób Kościół poucza swe dzieci o konieczności wiernego wypełnienia przykazania miłości bliźniego, które Pan Jezus w czasie Ostatniej Wieczerzy nazwał «swoim przykazaniem» i uczynił je znakiem rozpoznawczym swoich uczniów. Oddając za nas własne życie na krzyżu Chrystus wskazał, że musimy być gotowi na poświęcenie dla braci.
 _
 _
-!Antiphona 1
-!Ps 13:34.
-Ant. Mandátum novum do vobis: ut diligátis ínvicem, sicut diléxi vos, dicit Dóminus.
-!Ps 118:1.
-Beáti immaculáti in via: qui ámbulant in lege Dómini.
-! Et repetitur immediate antiphona «Mandatum novum».
-Ant. Mandátum novum do vobis: ut diligátis ínvicem, sicut diléxi vos, dicit Dóminus.
-! Et sic aliæ antiphonæ, quæ~
-! habent psalmos vel versus, repetuntur. Et~
-! de quolibet psalmo dicitur tantum primus~
-! versus.
+!Antyfona 1
+!J 13:34
+Ant. «Przykazanie nowe daję wam, abyście się wzajemnie miłowali, jakom ja was umiłował» – mówi Pan.
+!Ps 118:1
+Błogosławieni, których droga jest niepokalana: którzy postępują zgodnie z prawem Pańskim.
+Ant. «Przykazanie nowe daję wam, abyście się wzajemnie miłowali, jakom ja was umiłował» –
 _
 _
-!Antiphona 2
-!Ps 13:4, 5 et 15.
-Ant. Postquam surréxit Dóminus a cœna, misit aquam in pelvim, et cœpit laváre pedes discipulórum suórum: hoc exémplum réliquit eis.
+!Antyfona 2
+!J 13:4,5,15
+Ant. Gdy Pan wstał od wieczerzy, nalał wody w miednicę i począł umywać nogi swoich uczniów. Ten przykład im zostawił.
 !Ps 47:2.
-Magnus Dóminus, et laudábilis nimis: in civitáte Dei nostri, in monte sancto ejus.
-Ant. Postquam surréxit Dóminus a cœna, misit aquam in pelvim, et cœpit laváre pedes discipulórum suórum: hoc exémplum réliquit eis.
+Wielki jest Pan i godny wszelkiej chwały w mieście Boga naszego, na świętej Jego górze.
+Ant. Gdy Pan wstał od wieczerzy, nalał wody w miednicę i począł umywać nogi swoich uczniów. Ten przykład im zostawił.
 _
 _
-!Antiphona 3
-!Ps 13:12, 13 et 15.
-Ant. Dóminus Jesus, postquam cenávit cum discípulis suis, lavit pedes eórum, et ait illis: «Scitis, quid fécerim vobis ego, Dóminus et Magíster? Exémplum dedi vobis, ut et vos ita faciátis».
+!Antyfona 3
+!J 13:12,13,15
+Ant. Pan Jezus, gdy skończył wieczerzę z uczniami swoimi, umył nogi ich i rzekł: «Czy wiecie, com wam uczynił, ja, Pan i Mistrz? Przykład dałem wam, abyście i wy tak czynili».
 !Ps 84:2.
-Benedixísti, Dómine, terram tuam: avertísti captivitátem Jacob.
-Ant. Dóminus Jesus, postquam cenávit cum discípulis suis, lavit pedes eórum, et ait illis: «Scitis, quid fécerim vobis ego, Dóminus et Magíster? Exémplum dedi vobis, ut et vos ita faciátis».
+Łaskawym okazałeś się, Panie, dla Twej ziemi; na dobre odmieniłeś los Jakuba.
+Ant. Pan Jezus, gdy skończył wieczerzę z uczniami swoimi, umył nogi ich i rzekł: «Czy wiecie, com wam uczynił, ja, Pan i Mistrz? Przykład dałem wam, abyście i wy tak czynili».
 _
 _
-!Antiphona 4
-!Ps 13:6-7 et 8.
-Ant. «Dómine, tu mihi lavas pedes?» Respóndit Jesus et dixit ei: «Si non lávero tibi pedes, non habébis partem mecum».
-V. Venit ergo ad Simónem Petrum, et dixit ei Petrus.
-Ant. «Dómine, tu mihi lavas pedes?» Respóndit Jesus et dixit ei: «Si non lávero tibi pedes, non habébis partem mecum».
-V. «Quod ego fácio, tu nescis modo: scies autem póstea».
-Ant. «Dómine, tu mihi lavas pedes?» Respóndit Jesus et dixit ei: «Si non lávero tibi pedes, non habébis partem mecum».
+!Antyfona 4
+!J 13:6-7,8
+Ant. «Panie, Ty mnie nogi umywasz?» Odpowiedział mu Jezus: «Jeśli cię nie umyję, nie będziesz miał uczestnictwa ze mną».
+V. Zbliża się tedy do Szymona Piotra i rzecze mu Piotr:
+Ant. «Panie, Ty mnie nogi umywasz?» Odpowiedział mu Jezus: «Jeśli cię nie umyję, nie będziesz miał uczestnictwa ze mną».
+V. «Co ja czynię, ty jeszcze nie rozumiesz, ale zrozumiesz potem».
+Ant. «Panie, Ty mnie nogi umywasz?» Odpowiedział mu Jezus: «Jeśli cię nie umyję, nie będziesz miał uczestnictwa ze mną».
 _
 _
-!Antiphona 5
-Ant. «Si ego, Dóminus et Magíster vester, lavi vobis pedes: quanto magis debétis alter altérius laváre pedes?»
+!Antyfona 5
+!J 13:14
+Ant. «Jeśli ja, Pan i Mistrz wasz, umyłem nogi wasze, o ileż bardziej wy powinniście jeden drugiemu nogi umywać?»
 !Ps 48:2
-Audíte hæc, omnes gentes: áuribus percípite, qui habitátis orbem.
-Ant. «Si ego, Dóminus et Magíster vester, lavi vobis pedes: quanto magis debétis alter altérius laváre pedes?»
+Słuchajcie tego, wszystkie narody, nakłońcie uszy, wszyscy mieszkańcy ziemi.
+Ant. «Jeśli ja, Pan i Mistrz wasz, umyłem nogi wasze, o ileż bardziej wy powinniście jeden drugiemu nogi umywać?»
 _
 _
-!Antiphona 6
-!Ps 13:35.
-Ant. «In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habuéritis ad ínvicem».
-V. Dixit Jesus discípulis suis.
-Ant. «In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habuéritis ad ínvicem».
+!Antyfona 6
+!J 13:35
+Ant. «Po tym poznają wszyscy, żeście uczniami moimi, jeśli miłość mieć będziecie jeden ku drugiemu».
+V. Rzekł Jezus uczniom swoim.
+Ant. «Po tym poznają wszyscy, żeście uczniami moimi, jeśli miłość mieć będziecie jeden ku drugiemu».
 _
 _
-!Antiphona 7
-!Ps 13:13
-Ant. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas.
-V. Nunc autem manent fides, spes, cáritas, tria hæc: major horum est cáritas.
-Ant. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas.
+!Antyfona 7
+!1 Kor 13:13
+Ant. Niech trwają w was wiara, nadzieja i miłość: to troje, a z tych największa jest miłość.
+V. Teraz tedy trwają wiara, nadzieja i miłość: to troje, a z tych największa jest miłość.
+Ant. Niech trwają w was wiara, nadzieja i miłość: to troje, a z tych największa jest miłość.
 _
 _
-!Antiphona 8
-! Sequens antiphona cum suis versibus~
-! numquam omittitur; incipitur autem, omissis,~
-! si opus sit, praecedentibus, lotione pedum~
-! ad finem vergente.
-v. Ubi cáritas et amor, Deus ibi est.
-V. Congregávit nos in unum Christi amor.
-V. Exsultémus et in ipso jucundémur.
-V. Timeámus et amémus Deum vivum.
-V. Et ex corde diligámus nos sincéro.
-v. Ubi cáritas et amor, Deus ibi est.
-V. Simul ergo cum in unum congregámur:
-V. Ne nos mente dividámur, caveámus.
-V. Cessent júrgia malígna, cessent lites.
-V. Et in médio nostri sit Christus Deus.
-v. Ubi cáritas et amor, Deus ibi est.
-V. Simul quoque cum Beátis videámus
-V. Gloriánter vultum tuum, Christe Deus:
-V. Gáudium, quod est imménsum atque probum,
-V. Sǽcula per infiníta sæculórum. Amen.
+!Antyfona 8
+! Następująca 8 antyfonę z jej wersetami zawsze należy wykonać. Jeżeli brakuje czasu, można opuścić poprzednie.
+v. Tam, gdzie miłość, ukochanie, tam jest także Bóg.
+V. W jedno nas tu zgromadziła Chrystusowa miłość.
+V. W Nim się tedy cieszmy wszyscy i weselmy.
+V. Boga bójmy się żywego i kochajmy.
+V. I miłujmy się nawzajem sercem szczerym.
+v. Tam, gdzie miłość, ukochanie, tam jest także Bóg.
+V. Gdy się przeto gromadzimy wszyscy razem.
+V. By się duchem nie rozdzielać, pilnie baczmy.
+V. Niech ustaną złe niesnaski, niech ustaną spory.
+V. A pośrodku nas niech stanie Chrystus Bóg.
+v. Tam, gdzie miłość, ukochanie, tam jest także Bóg.
+V. Razem także ze świętymi daj nam widzieć.
+V. Pośród chwały Twe oblicze, Chryste Boże.
+V. Radość, która nie zna miary i szlachetna jest.
+V. Poprzez wszystkie nieskończone wieki wieków. Amen
 _
 _
-! Interim celebrans procedit ad lotionem~
-! pedum, hoc modo: præcingit se linteo,~
-! et per ordinem dispositis iis, qui lavandi~
-! sunt, acolythis pelvim et aquam ministrantibus,~
-! subdiacono singulorum pedem dextrum~
-! tenente, genuflectens singulis, illorum~
-! pedem lavat et extergit, diacono præbente~
-! linteum ad abstergendum.
-! Officia, quae in ritu solemni a diacono~
-! et subdiacono adimplentur, a ministrantibus~
-! peraguntur.
-! Post lotionem celebrans lavat et abstergit~
-! manus, nihil dicens. Deinde omnes~
-! resumunt manipulum, celebrans vero etiam~
-! planetam, et redeunt ante medium altaris,~
-! ubi celebrans, versus populum, dicit:
+! Skończywszy umywanie nóg celebrans wkłada ornat, staje przed środkiem ołtarza i śpiewa następujące modlitwy:
 _
 $Pater noster
-V. Tu mandásti mandáta tua, Dómine.
-R. Custodíri nimis.
-V. Tu lavásti pedes discipulórum tuórum.
-R. Opera mánuum tuárum ne despícias.
-V. Dómine, exáudi oratiónem meam.
-R. Et clamor meus ad te véniat.
-V. Dóminus vobíscum.
-R. Et cum spíritu tuo.
-v. Orémus.
-Adésto, Dómine, quǽsumus, offício servitútis nostræ: et quia tu discípulis tuis pedes laváre dignátus es, ne despícias ópera mánuum tuárum, quæ nobis retinénda mandásti: ut, sicut hic nobis, et a nobis exterióra abluúntur inquinaménta; sic a te ómnium nostrum interióra lavéntur peccáta. Quod ipse præstáre dignéris, qui vivis et regnas Deus: per ómnia sǽcula sæculórum. 
+V. Tyś rozkazał, Panie, przykazania Twoje.
+R. Zachowywać pilnie.
+V. Tyś umył nogi uczniom Twoim.
+R. Nie wzgardzaj dziełem rąk Swoich.
+V. Panie, wysłuchaj modlitwę moją.
+R. A wołanie moje niech do Ciebie przyjdzie.
+V. Pan z wami.
+R. I z duchem twoim.
+v. Módlmy się.
+Wspomóż, prosimy Cię, Panie, naszą posługę i ponieważ sam raczyłeś umyć nogi uczniom swoim, nie gardź czynnością Twoich rąk, którą poleciłeś nam naśladować; gdy sami obmywamy zewnętrzny brud, zmyj, Panie, w duszach naszych grzechowe zmazy. Racz tego dokonać Ty, który żyjesz i królujesz, Bóg przez wszystkie wieki wieków. 
 R. Amen.
-! Oratione completa, duodecim viri, facta~
-! reverentia altari et celebranti, reducuntur~
-! ad loca sua, si sint clerici in presbyterium,~
-! si sint laici in peculiarem locum ad hoc designatum.
-! Ubi vero contingat lotionem pedum~
-! extra Missarum solemnia peragi, observetur~
-! ordo supra descriptus, præmisso, cum~
-! solitis cæremoniis, cantu Evangelii Missæ~
-! Ante diem festum Paschæ, ut supra.
-! Post pedum lotionem, seu, ubi hæc~
-! locum non habuerit, post homiliam, proceditur~
-! in celebratione Missæ, more solito.

--- a/web/www/missa/Polski/Tempora/Quad6-4r.txt
+++ b/web/www/missa/Polski/Tempora/Quad6-4r.txt
@@ -61,171 +61,98 @@ Prosimy Cię, Panie, Ojcze święty, wszechmogący, wieczny Boże, niech ofiarę
 $Qui tecum
 
 [Communicantes]
-Communicántes et diem sacratíssimum celebrántes, quo Dóminus noster Jesus Christus pro nobis est tráditus: sed et memóriam venerántes, in primis gloriósæ semper Vírginis Maríæ, Genetrícis ejúsdem Dei et Dómini nostri Jesu Christi: sed et beatórum Apostolórum ac Mártyrum tuórum, Petri et Pauli, Andréæ, Jacóbi, Joánnis, Thomæ, Jacóbi, Philíppi, Bartholomaei, Matthaei, Simónis et Thaddaei: Lini, Cleti, Cleméntis, Xysti, Cornélii, Cypriáni, Lauréntii, Chrysógoni, Joánnis et Pauli, Cosmæ et Damiáni: et ómnium Sanctórum tuórum; quorum méritis precibúsque concédas, ut in ómnibus protectiónis tuæ muniámur auxílio. Jungit manus. Per eúndem Christum, Dóminum nostrum. Amen. 
+Zjednoczeni w świętych obcowaniu obchodzimy uroczyście prześwięty dzień, w którym Pan nasz Jezus Chrystus został za nas wydany, i ze czcią wspominamy najpierw chwalebną zawsze Dziewicę Maryję, Matkę Boga i Pana naszego Jezusa Chrystusa oraz świętych Apostołów i Męczenników Twoich: Piotra i Pawła, Andrzeja, Jakuba, Jana, Tomasza, Jakuba, Filipa, Bartłomieja, Mateusza, Szymona, Tadeusza, Linusa, Kleta, Klemensa, Sykstusa, Korneliusza, Cypriana, Wawrzyńca, Chryzogona, Jana i Pawła, Kosmę i Damiana, i wszystkich Świętych Twoich; dla ich zasług i modlitw racz nas we wszystkim otaczać Swą przemożną opieką. Przez tegoż Chrystusa Pana naszego. Amen.
 _
 _
-! Tenens manus expansas super Oblata, dicit: 
-Hanc ígitur oblatiónem servitútis nostræ, sed et cunctæ famíliæ tuæ, quam tibi offérimus ob diem, in qua Dóminus noster Jesus Christus trádidit discípulis suis Córporis et Sánguinis sui mystéria celebránda: quaesumus, Dómine, ut placátus accípias: diésque nostros in tua pace dispónas, atque ab ætérna damnatióne nos éripi et in electórum tuórum júbeas grege numerári. (Jungit manus.) Per eúndem Christum, Dóminum nostrum. Amen. 
+Prosimy Cię przeto, Panie, abyś łaskawie przyjął tę ofiarę od nas, sług Twoich, jak również od całego ludu Twego. Składamy Ci ją na pamiątkę dnia, w którym Pan nasz Jezus Chrystus powierzył swoim uczniom sprawowanie misteriów Ciała i Krwi swojej. Racz dni nasze pokojem swym napełnić, od potępienia wiecznego nas uchronić i do grona wybranych Swoich zaliczyć. (składa ręce) Przez tegoż Chrystusa, Pana naszego. Amen.
 _
 _
-Quam oblatiónem tu, Deus, in ómnibus, quaesumus, Signat ter super Oblata, bene + díctam, adscríp + tam, ra + tam, rationábilem acceptabilémque fácere dignéris: Signat semel super Hóstiam, ut nobis Cor + pus, et semel super Cálicem, et San + guis fiat dilectíssimi Fílii tui, Jungit manus, Dómini nostri Jesu Christi. 
+Racz te dary ofiarne, prosimy Cię, Boże, w całej pełni (trzykrotnie czyni nad Ofiarą znak krzyża) pobłogosławić, przyjąć, zatwierdzić, uduchowić i miłymi sobie uczynić, aby się nam stały Ciałem (raz czyni znak krzyża nad Hostią) i Krwią (raz czyni znak krzyża nad Kielichem) najmilszego Syna Twego, (składa ręce) Pana naszego Jezusa Chrystusa.
 _
 _
-Qui prídie, quam pro nostra omniúmque salúte paterétur, hoc est hódie, Accipit Hostiam, accépit panem in sanctas ac venerábiles manus suas, Elevat oculos ad coelum, et elevátis óculis in coelum ad te Deum, Patrem suum omnipoténtem, Caput inclinat, tibi grátias agens, Signat super Hostiam, bene + dixit, fregit, dedítque discípulis suis, dicens: Accípite, et manducáte ex hoc omnes.
+On to w przeddzień męki, to jest dzisiaj, (bierze Hostię) wziął chleb w swoje święte i czcigodne ręce, (podnosi oczy ku niebu) a podniósłszy oczy w niebo ku Tobie Bogu, Ojcu swemu wszechmogącemu, (pochyla głowę) dzięki Ci składając (czyni znak krzyża nad Hostią) pobłogosławił, połamał i rozdał uczniom swoim mówiąc: 
 
 [Communio]
-!Joann 13:12, 13 et 15. 
-Dóminus Jesus, postquam coenávit cum discípulis suis, lavit pedes eórum, et ait illis: Scitis, quid fécerim vobis ego, Dóminus et Magíster? Exemplum dedi vobis, ut et vos ita faciátis.
+!J 13:12,13,15
+Pan Jezus, gdy skończył wieczerzę z uczniami swoimi, umył nogi ich i rzekł: «Czy wiecie, com wam uczynił, ja Pan i Mistrz? Przykład dałem wam, abyście i wy tak czynili».
 
 [Postcommunio]
-Refécti vitálibus aliméntis, quaesumus, Dómine, Deus noster: ut, quod témpore nostræ mortalitátis exséquimur, immortalitátis tuæ múnere consequámur.
+Posileni życiodajnym pokarmem prosimy Cię, Panie Boże nasz, aby najświętsza tajemnica, którą sprawujemy w doczesności, dała nam udział w nieśmiertelnym Twym życiu.
 $Per Dominum
 
 [Post Missam]
-!!Pange Lingua
-! Missa expleta, statim proceditur ad~
-! solemnem translationem et repositionem ~
-! Sacramenti, quod ad Communionem sequenti~
-! die faciendam in pyxide asservatur.
-_
-! Pro solemni Sacramenti repositione~
-! paretur locus aptus in aliquo sacello vel altari~
-! ecclesiæ, ac decenter, quoad fieri potest,~
-! ornetur velis et luminaribus; atque, servatis~
-! Sacræ Rituum Congregationis decretis~
-! de vitandis vel tollendis abusibus in hoc~
-! loco parando, plane commendatur severitas~
-! quæ liturgiæ horum dierum convenit.
-_
-! In translatione et repositione vero~
-! Sacramenti proceditur hoc modo:~
-! Accenduntur intorticia, et fit processio~
-! more solito.~
-! Si haberi potest, alius subdiaconus paratus~
-! ferat crucem; secus unus ex clericis vel~
-! ministrantibus.~
-! Celebrans, stans ante altare, imponit~
-! incensum in duobus thuribulis, absque~
-! benedictione. Deinde, in medio genuflexus, ter~
-! incensat Sacramentum.~
-! Tunc assumit velum humerale albi~
-! coloris, et ascendens altare in medio, facta~
-! genuflexione, stans, accipit pyxidem, quam~
-! diaconus ei porrigit, et extremitatibus veli~
-! cooperit.~
-! Deinde, de altari descendens, procedit~
-! sub baldachino, duobus acolythis, vel~
-! ministrantibus, Sacramentum continue~
-! incensantibus, usque ad locum paratum.~
-! Ministri sacri, vel ministrantes, comitantur~
-! celebrantem, a dextris et a sinistris~
-! procedentes.~
-! Dum fit processio, cantatur hymnus Pange,~
-! lingua, gloriosi Corporis mysterium,~
-! usque ad verba Tantum ergo; si vero opus~
-! sit, idem hymnus repetitur.
+!! Uroczyste Przeniesienie i Złożenie Najświętszego Sakramentu
+! Po skończeniu Mszy św. kapłan zmienia ornat na kapę i okadziwszy Najświętszy Sakrament przenosi Go w uroczystej procesji do przygotowanej specjalnie kaplicy. W czasie procesji śpiewa się hymn.
 
-v. Pange língua, gloriósi
-Córporis mystérium,
-Sanguinísque pretiósi,
-Quem in mundi prétium
-Fructus ventris generósi
-Rex effúdit géntium.
-_   
-v. Nobis datus, nobis natus
-Ex intácta Vírgine,
-Et in mundo conversátus,
-Sparso verbi sémine.
-Sui moras incolátus.
-Miro clausit órdine.           
+!! Hymn Pange Lingua
+v. Sław, języku, tajemnicę
+Ciała i najdroższej Krwi,
+Którą, jako łask krynicę,
+Wylał w czasie ziemskich dni
+Ten, co Matkę miał Dziewicę,
+Król narodów, godzien czci.
 _
-v. In suprémæ nocte cœnae
-Recúmbens cum frátribus,
-Observáta lege plene
-Cibis in legálibus,
-Cibum turbæ duodénæ
-Se dat suis mánibus.           
+v. Z Panny czystej narodzony,
+Posłan zbawić ludzki ród,
+Gdy po świecie, na wsze strony,
+Ziarno słowa rzucił w lud,
+Wtedy cudem niezgłębionym
+Zamknął Swej pielgrzymki trud.
 _
-v. Verbum caro, panem verum
-Verbo carnem éfficit;
-Fitque sanguis Christi merum:
-Et si sensus déficit,
-Ad firmándum cor sincérum
-Sola fides súfficit.
-
-! Cum autem ventum fuerit ad locum~
-! paratum, celebrans, adiuvante, si opus sit,~
-! diacono, deponit pyxidem super altare,~
-! genuflectit, et incensat, thure iterum imposito~
-! interim canitur Tantum ergo.~
-
-v. Tantum ergo Sacraméntum
-Venerémur cérnui:
-Et antíquum documéntum
-Novo cedat ritui:
-Præstet fides supplémentum
-Sénsuum deféctui.
-_   
-v. Genitóri, Genitóque
-Laus et iubilátio:
-Salus, honor, virtus quoque
-Sit et benedíctio
-Procedénti ab utróque
-Compar sit laudátio.
+v. W noc ostatnią przy wieczerzy
+Z tymi, których braćmi zwał,
+Pełniąc wszystko, jak należy,
+Czego przepis prawny chciał,
+Sam dwunastu się powierzył
+I za pokarm z rąk Swych dał.
+_
+v. Słowem więc, wcielone Słowo,
+Chleb zamienia w Ciało Swe,
+Wino Krwią jest Chrystusową,
+Darmo wzrok to widzieć chce.
+Tylko wiara Bożą mową,
+Pewność o tym w serca śle.
+_
+v. Przed tak wielkim Sakramentem
+Upadajmy wszyscy wraz,
+Niech przed Nowym Testamentem
+Starych praw ustąpi czas.
+Co dla zmysłów niepojęte,
+Niech dopełni wiara w nas.
+_
+v. Bogu Ojcu i Synowi
+Hołd po wszystkie nieśmy dni,
+Niech podaje wiek wiekowi
+Hymn triumfu, dzięki, czci,
+A równemu Im Duchowi
+Niechaj wieczna chwała brzmi.
 Amen.
 
-
-! Deinde diaconus, vel ipse celebrans,~
-! reponit pyxidem in tabernaculo seu capsa.
-_
-! Postea, omnes, genibus flexis, per~
-! aliquod temporis spatium in silentio Sacramentum~
-! adorant. Signo dato, celebrans et~
-! ministri sacri, et ministrantes, surgunt,~
-! iterum, genibus flexis, adorant, et revertuntur~
-! in sacristiam, ubi celebrans et ministri sacri~
-! deponunt paramenta albi coloris; deinde~
-! celebrans et diaconus assumunt stolam~
-! violaceam.
-_
-! Si autem plures pyxides transferendæ~
-! sint, idem celebrans (vel, si habeantur, alius~
-! sacerdos, aut diaconus, indutus superpelliceo~
-! stola alba et velo humerali eiusdem~
-! coloris) eas transferat ad locum destinatum,~
-! antequam incipiat altarium denudationem,~
-! forma quidem simplici, scilicet comitantibus~
-! duobus acolythis, vel ministrantibus, cum~
-! cereis accensis, alioque umbellam portante.
+! W kaplicy odbywa się powtórne okadzenie Najświętszego Sakramentu, po czym umieszcza się Go w tabernakulum i rozpoczyna się adoracja, która powinna trwać przynajmniej do północy. Wierni nawiedzający Najświętszy Sakrament w kaplicy uroczystego przechowania mogą uzyskać odpust zupełny pod zwykłymi warunkami.
 _
 _
-!!Denudatione altaris
+!!Obnażenie Ołtarzy
 _
-! Deinde celebrans et ministri, seu~
-! ministrantes, exeunt ante altare maius; facta~
-! eidem reverentia, stantes, incipiunt~
-! denudationem altarium, hoc modo:~
-! Celebrans dicit clara voce sequentem~
-! antiphonam:
+! W pierwszych wiekach Kościoła zawsze po skończeniu Mszy św. zdejmowano z ołtarza obrusy. Dzisiaj jednak czynność ta ma znaczenie symboliczne. Ołtarz, jak wiadomo, przedstawia samego Chrystusa Pana. Uroczyste obnażenie ołtarzy przypomina, że w czasie męki odarto Zbawiciela z szat usiłując zbezcześcić Jego ludzką godność. W czasie obnażania ołtarzy recytuje się psalm 21, który Pan Jezus odmawiał na krzyżu, stwierdzając w ten sposób, że jest on proroczą wizją Jego męki.
 
 
-!Antiphona
+!Antyfona
 !Ps 21:19
-Ant. Divisérunt sibi vestiménta mea: et super vestem meam misérunt sortem.
-~(21:2) Deus, Deus meus, réspice in me: quare me dereliquísti? * longe a salúte mea verba delictórum meórum.
-~(21:3) Deus meus, clamábo per diem, et non exáudies: * et nocte, et non ad insipiéntiam mihi.
-~(21:4) Tu autem in sancto hábitas, * laus Israël.
-~(21:5) In te speravérunt patres nostri: * speravérunt, et liberásti eos.
-~(21:6) Ad te clamavérunt, et salvi facti sunt: * in te speravérunt, et non sunt confúsi.
-~(21:7) Ego autem sum vermis, et non homo: * oppróbrium hóminum, et abjéctio plebis.
-~(21:8) Omnes vidéntes me, derisérunt me: * locúti sunt lábiis, et movérunt caput.
-~(21:9) Sperávit in Dómino, erípiat eum: * salvum fáciat eum, quóniam vult eum.
-~(21:10) Quóniam tu es, qui extraxísti me de ventre: * spes mea ab ubéribus matris meæ. In te projéctus sum ex útero:
-~(21:11) De ventre matris meæ Deus meus es tu, * ne discésseris a me:
-~(21:12) Quóniam tribulátio próxima est: * quóniam non est qui ádjuvet.
-~(21:13) Circumdedérunt me vítuli multi: * tauri pingues obsedérunt me.
-~(21:14) Aperuérunt super me os suum, * sicut leo rápiens et rúgiens.
-~(21:15) Sicut aqua effúsus sum: * et dispérsa sunt ómnia ossa mea.
+Ant. Dzielą między siebie moje szaty i o suknię moją los rzucają.
+~(21:2) Boże mój, Boże mój, czemuś mnie opuścił? * Daleki jesteś od próśb, od słów mojego wołania.
+~(21:3) Boże mój, wołam przez dzień, a nie słuchasz, * wołam i nocą, a nie zważasz na mnie.
+~(21:4) A przecież Ty mieszkasz w świątyni, * Chwało Izraela!
+~(21:5) Tobie zaufali ojcowie nasi, * zaufali, a Tyś ich uwolnił;
+~(21:6) Do Ciebie wołali i zostali zbawieni, * Tobie ufali i nie doznali wstydu.
+~(21:7) Ja zaś jestem robak a nie człowiek, * pośmiewisko ludzi i wzgarda pospólstwa.
+~(21:8) Szydzą ze mnie wszyscy, którzy na mnie patrzą, * wargi rozwierają, potrząsają głową:
+~(21:9) «Zaufał Panu: niechże Go wyzwoli, * niechże Go wyrwie, jeśli Go miłuje».
+~(21:10) Tyś zaiste prowadził mnie od matczynego łona; * Tyś mnie czynił bezpiecznym u piersi mej matki.
+~(21:11) Tobie od urodzenia zostałem oddany, * od łona matki mojej Tyś jest moim Bogiem.
+~(21:12) Nie stój z dala ode mnie, bom jest trapiony, * bądź blisko: bo nie ma wspomożyciela.
+~(21:13) Otoczyło mnie mnóstwo cielców, * Byki Baszanu mnie osaczają.
+~(21:14) Rozwierają przeciwko mnie swoje paszcze, * jak lew drapieżny, ryczący.
+~(21:15) Rozlałem się jak woda * i rozłączyły się wszystkie me kości:
 ~(21:15) Factum est cor meum tamquam cera liquéscens * in médio ventris mei.
 ~(21:16) Aruit tamquam testa virtus mea, et lingua mea adhæsit fáucibus meis: * et in púlverem mortis deduxísti me.
 ~(21:17) Quóniam circumdedérunt me canes multi: * concílium malignántium obsédit me.

--- a/web/www/missa/Polski/Tempora/Quad6-4r.txt
+++ b/web/www/missa/Polski/Tempora/Quad6-4r.txt
@@ -1,0 +1,420 @@
+[Rank]
+Feria Quinta in Coena Domini;;Feria privilegiata Duplex I classis;;7
+
+[Rule]
+Gloria
+Prefatio=Crucis
+Communicantes
+Post Missam
+Maundi
+Ter miserere
+no Pax
+no Qui dixisti
+Benedicamus Domino
+no Benedictio
+no Ultima Evangelium
+
+[Comment]
+Wielki Czwartek Wieczerzy Pańskiej
+Stacja u Św. Jana na Laterania
+1 klasy
+Szaty białe
+W pierwszych wiekach istnienia Kościoła odprawiano w Wielki Czwartek trzy Msze święte. Pierwsza łączyła się z obrzędem pojednania publicznych pokutników, druga z poświęceniem olejów świętych, trzecią odprawiano na pamiątkę Ostatniej Wieczerzy. Gdy ustał zwyczaj publicznej pokuty, zaniechano obrzędu pojednania pokutników. Natomiast w katedrach biskupich, oprócz wieczornej Mszy Wieczerzy Pańskiej, odprawia się rano specjalną Mszę świętą połączoną z konsekracją olejów.
+Wielki Czwartek jest przede wszystkim rocznicą ustanowienia sakramentów Ołtarza i Kapłaństwa. Na pamiątkę Ostatniej Wieczerzy odprawia się uroczystą wieczorną Mszę św., w czasie której kapłani i wierni przyjmują Komunię św. z rąk biskupa lub kapłana odnawiającego przy ołtarzu ofiarę Nowego Zakonu.
+Eucharystia ustanowiona w czasie Ostatniej Wieczerzy jest owocem i uobecnieniem ofiary krzyżowej. Stąd słusznie chlubimy się krzyżem w antyfonie na wejście i w graduale wieczornej Mszy. W lekcji poucza nas św. Paweł, że sprawowanie Eucharystii jest opowiadaniem śmierci Pańskiej. Chleb i wino, które Pan Jezus wybrał na postacie Najświętszego Sakramentu, symbolizują zjednoczenie. Wiele ziaren łączy się w jednym chlebie, sok wielu jagód tworzy wino. W czasie Ostatniej Wieczerzy Pan Jezus podkreślił ważność przykazania miłości bliźniego, a w modlitwie arcykapłańskiej modlił się o wzajemną miłość między członkami Kościoła. W czasie Mszy św. celebrans konsekruje oprócz hostii mszalnej komunikanty przeznaczone do Komunii duchowieństwa i wiernych, a w Polsce także hostię przeznaczoną do wystawienia w Bożym Grobie. Jest życzeniem Kościoła, aby wierni licznie przystępowali w dniu dzisiejszym do Komunii świętej i oddawali się uczynkom miłości chrześcijańskiej.
+
+[Introitus]
+!Gal 6:14
+v. A myśmy się chlubić powinni Krzyżem Pana naszego Jezusa Chrystusa; w Nim jest zbawienie, życie i zmartwychwstanie nasze: przez Niego jesteśmy zbawieni i oswobodzeni.
+!Ps 66:2
+Niech Bóg się zmiłuje nad nami i nam błogosławi: niech nam ukaże pogodne oblicze i zmiłuje się nad nami.
+v. A myśmy się chlubić powinni Krzyżem Pana naszego Jezusa Chrystusa; w Nim jest zbawienie, życie i zmartwychwstanie nasze: przez Niego jesteśmy zbawieni i oswobodzeni.
+
+[Oratio]
+Boże, od Ciebie Judasz otrzymał karę za swoją zbrodnię, a łotr nagrodę za wyznanie winy; daj nam doznać skutków miłosierdzia Twego, a jak w czasie swojej męki Pan nasz Jezus Chrystus obydwom oddał różną zapłatę, tak niech zgładzi w nas zastarzały błąd i udzieli nam łaski zmartwychwstania:
+$Qui tecum
+
+[Lectio]
+Czytanie z Listu świętego Pawła Apostoła do Koryntian.
+!1 Kor 11:20-32
+Bracia: Gdy się tedy wespół schodzicie, nie jest to już pożywanie wieczerzy Pańskiej. Każdy bowiem wieczerzę swoją już uprzednio spożywa i tak jeden jest głodny, a drugi nietrzeźwy. Czyż domów nie macie do jedzenia i picia? Albo okazujecie wzgardę Kościołowi Bożemu i poniewieracie tymi, którzy nic nie mają? Cóż wam powiem? Czy chwalę was? Za to nie chwale.
+Ja bowiem otrzymałem od Pana, co też wam podałem, że Pan Jezus tej nocy, w której był wydany, wziął chleb i dzięki uczyniwszy, łamał i rzekł: «Bierzcie i jedzcie, to jest ciało moje, które za was będzie wydane: to czyńcie na moją pamiątkę». Także i kielich po wieczerzy mówiąc: «Ten kielich jest nowym testamentem we krwi mojej. To czyńcie, ilekroć pić będziecie, na pamiątkę moją».
+Ilekroć bowiem ten chleb pożywać, a kielich pić będziecie, śmierć Pańską będziecie zwiastować, aż przybędzie. Tak więc ktokolwiek by pożywał ten chleb albo pił kielich Pański niegodnie, winien będzie ciała i krwi Pańskiej. Niechajże tedy doświadcza człowiek samego siebie, a tak niechaj pożywa chleba tego i z kielicha pije. Kto bowiem Pozywa i pije niegodnie, potępienie dla siebie pożywa i pije, nie bacząc na ciało Pańskie. Dlatego między wami wielu chorych i słabych i wielu pomarło. Bo gdybyśmy sami siebie sądzili, nie bylibyśmy sądzeni. Lecz gdy nas sądzą, karanie odbieramy od Pana, abyśmy z tym światem potępieni nie byli.
+
+[Graduale]
+!Flp 2:8-9
+Chrystus stał się dla nas posłuszny aż do śmierci, a była to śmierć krzyżowa.
+V. Dlatego i Bóg wywyższył Go: i nadał Mu imię, przewyższające wszelkie imię.
+
+[Evangelium]
+Ciąg dalszy ++ Ewangelii świętej według Jana.
+!J 13:1-15
+Przed świętym dniem Paschy Jezus, wiedząc, że nadeszła godzina Jego, aby odszedł z tego świata do Ojca, umiłowawszy swoich, którzy byli na świecie, aż do końca ich umiłował. I po skończeniu wieczerzy, gdy szatan skusił był serce Judasza Iszkarioty, syna Szymona, aby Go zdradził, ((Jezus)) wiedząc, że Ojciec oddał wszystko w Jego ręce, że od Boga wyszedł i do Boga zdąża, wstaje od wieczerzy, składa szaty swoje, a wziąwszy prześcieradło, przepasuje się. Potem nalewa wody do misy i poczyna umywać nogi uczniom i wycierać prześcieradłem, którym się był przepasał. Zbliża się tedy do Szymona Piotra. I rzecze Mu Piotr. «Panie, Ty mnie nogi umywasz?» Odpowiadając Jezus, rzekł mu: «Co ja czynię, ty jeszcze nie rozumiesz, ale zrozumiesz potem». Rzecze Mu Piotr: «Nigdy mi nóg nie będziesz umywał». Odpowiedział mu Jezus: «Jeśli cię nie umyję, nie będziesz miał uczestnictwa ze mną». Rzecze Mu Szymon Piotr: «Panie, nie tylko nogi moje, ale ręce i głowę». Rzecze mu Jezus: «Kto umyty jest, potrzebuje tylko nogi umyć, a cały jest czysty. Wy też jesteście czyści, ale nie wszyscy». Albowiem wiedział, który to Go miał wydać, dlatego powiedział: «Nie wszyscy jesteście czyści».
+Gdy tedy umył nogi ich i przywdział szaty swoje, zasiadł do stołu i mówił do nich: «Czy wiecie, com wam uczynił? Wy Mnie nazywacie Mistrzem i Panem i dobrze mówicie, bo jestem nim. Jeśli tedy ja, Pan i Mistrz, umyłem nogi wasze i wy powinniście jeden drugiemu nogi umywać. Albowiem dałem wam przykład, abyście jakom ja wam uczynił, tak i wy czynili».
+
+[Offertorium]
+!Ps 117:16 et 17
+Prawica Pańska moc okazała, prawica Pańska mnie dźwignęła; nie umrę, lecz będę żył i głosił dzieła Pana.
+
+[Secreta]
+Prosimy Cię, Panie, Ojcze święty, wszechmogący, wieczny Boże, niech ofiarę naszą uczyni Ci przyjemną Ten, który w dniu dzisiejszym ustanowił i nakazał swoim uczniom sprawować na swoją pamiątkę: Jezus Chrystus, Syn Twój, nasz Pan:
+$Qui tecum
+
+[Communicantes]
+Communicántes et diem sacratíssimum celebrántes, quo Dóminus noster Jesus Christus pro nobis est tráditus: sed et memóriam venerántes, in primis gloriósæ semper Vírginis Maríæ, Genetrícis ejúsdem Dei et Dómini nostri Jesu Christi: sed et beatórum Apostolórum ac Mártyrum tuórum, Petri et Pauli, Andréæ, Jacóbi, Joánnis, Thomæ, Jacóbi, Philíppi, Bartholomaei, Matthaei, Simónis et Thaddaei: Lini, Cleti, Cleméntis, Xysti, Cornélii, Cypriáni, Lauréntii, Chrysógoni, Joánnis et Pauli, Cosmæ et Damiáni: et ómnium Sanctórum tuórum; quorum méritis precibúsque concédas, ut in ómnibus protectiónis tuæ muniámur auxílio. Jungit manus. Per eúndem Christum, Dóminum nostrum. Amen. 
+_
+_
+! Tenens manus expansas super Oblata, dicit: 
+Hanc ígitur oblatiónem servitútis nostræ, sed et cunctæ famíliæ tuæ, quam tibi offérimus ob diem, in qua Dóminus noster Jesus Christus trádidit discípulis suis Córporis et Sánguinis sui mystéria celebránda: quaesumus, Dómine, ut placátus accípias: diésque nostros in tua pace dispónas, atque ab ætérna damnatióne nos éripi et in electórum tuórum júbeas grege numerári. (Jungit manus.) Per eúndem Christum, Dóminum nostrum. Amen. 
+_
+_
+Quam oblatiónem tu, Deus, in ómnibus, quaesumus, Signat ter super Oblata, bene + díctam, adscríp + tam, ra + tam, rationábilem acceptabilémque fácere dignéris: Signat semel super Hóstiam, ut nobis Cor + pus, et semel super Cálicem, et San + guis fiat dilectíssimi Fílii tui, Jungit manus, Dómini nostri Jesu Christi. 
+_
+_
+Qui prídie, quam pro nostra omniúmque salúte paterétur, hoc est hódie, Accipit Hostiam, accépit panem in sanctas ac venerábiles manus suas, Elevat oculos ad coelum, et elevátis óculis in coelum ad te Deum, Patrem suum omnipoténtem, Caput inclinat, tibi grátias agens, Signat super Hostiam, bene + dixit, fregit, dedítque discípulis suis, dicens: Accípite, et manducáte ex hoc omnes.
+
+[Communio]
+!Joann 13:12, 13 et 15. 
+Dóminus Jesus, postquam coenávit cum discípulis suis, lavit pedes eórum, et ait illis: Scitis, quid fécerim vobis ego, Dóminus et Magíster? Exemplum dedi vobis, ut et vos ita faciátis.
+
+[Postcommunio]
+Refécti vitálibus aliméntis, quaesumus, Dómine, Deus noster: ut, quod témpore nostræ mortalitátis exséquimur, immortalitátis tuæ múnere consequámur.
+$Per Dominum
+
+[Post Missam]
+!!Pange Lingua
+! Missa expleta, statim proceditur ad~
+! solemnem translationem et repositionem ~
+! Sacramenti, quod ad Communionem sequenti~
+! die faciendam in pyxide asservatur.
+_
+! Pro solemni Sacramenti repositione~
+! paretur locus aptus in aliquo sacello vel altari~
+! ecclesiæ, ac decenter, quoad fieri potest,~
+! ornetur velis et luminaribus; atque, servatis~
+! Sacræ Rituum Congregationis decretis~
+! de vitandis vel tollendis abusibus in hoc~
+! loco parando, plane commendatur severitas~
+! quæ liturgiæ horum dierum convenit.
+_
+! In translatione et repositione vero~
+! Sacramenti proceditur hoc modo:~
+! Accenduntur intorticia, et fit processio~
+! more solito.~
+! Si haberi potest, alius subdiaconus paratus~
+! ferat crucem; secus unus ex clericis vel~
+! ministrantibus.~
+! Celebrans, stans ante altare, imponit~
+! incensum in duobus thuribulis, absque~
+! benedictione. Deinde, in medio genuflexus, ter~
+! incensat Sacramentum.~
+! Tunc assumit velum humerale albi~
+! coloris, et ascendens altare in medio, facta~
+! genuflexione, stans, accipit pyxidem, quam~
+! diaconus ei porrigit, et extremitatibus veli~
+! cooperit.~
+! Deinde, de altari descendens, procedit~
+! sub baldachino, duobus acolythis, vel~
+! ministrantibus, Sacramentum continue~
+! incensantibus, usque ad locum paratum.~
+! Ministri sacri, vel ministrantes, comitantur~
+! celebrantem, a dextris et a sinistris~
+! procedentes.~
+! Dum fit processio, cantatur hymnus Pange,~
+! lingua, gloriosi Corporis mysterium,~
+! usque ad verba Tantum ergo; si vero opus~
+! sit, idem hymnus repetitur.
+
+v. Pange língua, gloriósi
+Córporis mystérium,
+Sanguinísque pretiósi,
+Quem in mundi prétium
+Fructus ventris generósi
+Rex effúdit géntium.
+_   
+v. Nobis datus, nobis natus
+Ex intácta Vírgine,
+Et in mundo conversátus,
+Sparso verbi sémine.
+Sui moras incolátus.
+Miro clausit órdine.           
+_
+v. In suprémæ nocte cœnae
+Recúmbens cum frátribus,
+Observáta lege plene
+Cibis in legálibus,
+Cibum turbæ duodénæ
+Se dat suis mánibus.           
+_
+v. Verbum caro, panem verum
+Verbo carnem éfficit;
+Fitque sanguis Christi merum:
+Et si sensus déficit,
+Ad firmándum cor sincérum
+Sola fides súfficit.
+
+! Cum autem ventum fuerit ad locum~
+! paratum, celebrans, adiuvante, si opus sit,~
+! diacono, deponit pyxidem super altare,~
+! genuflectit, et incensat, thure iterum imposito~
+! interim canitur Tantum ergo.~
+
+v. Tantum ergo Sacraméntum
+Venerémur cérnui:
+Et antíquum documéntum
+Novo cedat ritui:
+Præstet fides supplémentum
+Sénsuum deféctui.
+_   
+v. Genitóri, Genitóque
+Laus et iubilátio:
+Salus, honor, virtus quoque
+Sit et benedíctio
+Procedénti ab utróque
+Compar sit laudátio.
+Amen.
+
+
+! Deinde diaconus, vel ipse celebrans,~
+! reponit pyxidem in tabernaculo seu capsa.
+_
+! Postea, omnes, genibus flexis, per~
+! aliquod temporis spatium in silentio Sacramentum~
+! adorant. Signo dato, celebrans et~
+! ministri sacri, et ministrantes, surgunt,~
+! iterum, genibus flexis, adorant, et revertuntur~
+! in sacristiam, ubi celebrans et ministri sacri~
+! deponunt paramenta albi coloris; deinde~
+! celebrans et diaconus assumunt stolam~
+! violaceam.
+_
+! Si autem plures pyxides transferendæ~
+! sint, idem celebrans (vel, si habeantur, alius~
+! sacerdos, aut diaconus, indutus superpelliceo~
+! stola alba et velo humerali eiusdem~
+! coloris) eas transferat ad locum destinatum,~
+! antequam incipiat altarium denudationem,~
+! forma quidem simplici, scilicet comitantibus~
+! duobus acolythis, vel ministrantibus, cum~
+! cereis accensis, alioque umbellam portante.
+_
+_
+!!Denudatione altaris
+_
+! Deinde celebrans et ministri, seu~
+! ministrantes, exeunt ante altare maius; facta~
+! eidem reverentia, stantes, incipiunt~
+! denudationem altarium, hoc modo:~
+! Celebrans dicit clara voce sequentem~
+! antiphonam:
+
+
+!Antiphona
+!Ps 21:19
+Ant. Divisérunt sibi vestiménta mea: et super vestem meam misérunt sortem.
+~(21:2) Deus, Deus meus, réspice in me: quare me dereliquísti? * longe a salúte mea verba delictórum meórum.
+~(21:3) Deus meus, clamábo per diem, et non exáudies: * et nocte, et non ad insipiéntiam mihi.
+~(21:4) Tu autem in sancto hábitas, * laus Israël.
+~(21:5) In te speravérunt patres nostri: * speravérunt, et liberásti eos.
+~(21:6) Ad te clamavérunt, et salvi facti sunt: * in te speravérunt, et non sunt confúsi.
+~(21:7) Ego autem sum vermis, et non homo: * oppróbrium hóminum, et abjéctio plebis.
+~(21:8) Omnes vidéntes me, derisérunt me: * locúti sunt lábiis, et movérunt caput.
+~(21:9) Sperávit in Dómino, erípiat eum: * salvum fáciat eum, quóniam vult eum.
+~(21:10) Quóniam tu es, qui extraxísti me de ventre: * spes mea ab ubéribus matris meæ. In te projéctus sum ex útero:
+~(21:11) De ventre matris meæ Deus meus es tu, * ne discésseris a me:
+~(21:12) Quóniam tribulátio próxima est: * quóniam non est qui ádjuvet.
+~(21:13) Circumdedérunt me vítuli multi: * tauri pingues obsedérunt me.
+~(21:14) Aperuérunt super me os suum, * sicut leo rápiens et rúgiens.
+~(21:15) Sicut aqua effúsus sum: * et dispérsa sunt ómnia ossa mea.
+~(21:15) Factum est cor meum tamquam cera liquéscens * in médio ventris mei.
+~(21:16) Aruit tamquam testa virtus mea, et lingua mea adhæsit fáucibus meis: * et in púlverem mortis deduxísti me.
+~(21:17) Quóniam circumdedérunt me canes multi: * concílium malignántium obsédit me.
+~(21:18) Fodérunt manus meas et pedes meos: * dinumeravérunt ómnia ossa mea.
+~(21:19) Ipsi vero consideravérunt et inspexérunt me: * divisérunt sibi vestiménta mea, et super vestem meam misérunt sortem.
+~(21:20) Tu autem, Dómine, ne elongáveris auxílium tuum a me: * ad defensiónem meam cónspice.
+~(21:21) Erue a frámea, Deus, ánimam meam: * et de manu canis únicam meam:
+~(21:22) Salva me ex ore leónis: * et a córnibus unicórnium humilitátem meam.
+~(21:23) Narrábo nomen tuum frátribus meis: * in médio ecclésiæ laudábo te.
+~(21:24) Qui timétis Dóminum, laudáte eum: * univérsum semen Jacob, glorificáte eum.
+~(21:25) Tímeat eum omne semen Israël: * quóniam non sprevit, neque despéxit deprecatiónem páuperis:
+~(21:25) Nec avértit fáciem suam a me: * et cum clamárem ad eum, exaudívit me.
+~(21:26) Apud te laus mea in ecclésia magna: * vota mea reddam in conspéctu timéntium eum.
+~(21:27) Edent páuperes, et saturabúntur: et laudábunt Dóminum qui requírunt eum: * vivent corda eórum in sǽculum sǽculi.
+~(21:28) Reminiscéntur et converténtur ad Dóminum * univérsi fines terræ:
+~(21:28) Et adorábunt in conspéctu ejus * univérsæ famíliæ géntium.
+~(21:29) Quóniam Dómini est regnum: * et ipse dominábitur géntium.
+~(21:30) Manducavérunt et adoravérunt omnes pingues terræ: * in conspéctu ejus cadent omnes qui descéndunt in terram.
+~(21:31) Et ánima mea illi vivet: * et semen meum sérviet ipsi.
+~(21:32) Annuntiábitur Dómino generátio ventúra: * et annuntiábunt cœli justítiam ejus pópulo qui nascétur, quem fecit Dóminus.
+Ant. Divisérunt sibi vestiménta mea: et super vestem meam misérunt sortem.
+
+! Clerici, si adsunt, prosequuntur recitationem~
+! huius psalmi, usque dum altarium~
+! denudatio peracta sit; alioquin celebrans dicat~
+! antiphonam et primum tantum versum~
+! psalmi ante denudationem altaris maioris.~
+! Celebrans vero cum ministris sacris, vel~
+! ministrantibus, denudat omnia altaria~
+! ecclesiæ, excepto illo in quo Sacramentum~
+! solemniter adoratur.~
+! Altaribus denudatis, redeunt ad altare~
+! maius, et, repetita a celebrante antiphona~
+! Dividunt, revertuntur in sacristiam.
+_
+! Mox in choro dicitur Completorium,~
+! candelis exstinctis et absque cantu.
+_
+! Ad locum autem repositionis sanctissimæ~
+! Eucharistiæ fit publica adoratio, inde~
+! ab expleta Missa in Cena Domini instituenda~
+! et protrahenda saltem usque ad~
+! mediam noctem.
+
+[Maundi]
+!! De lotione pedum
+! Post homiliam proceditur, ubi ratio~
+! pastoralis id suadeat, ad lotionem pedum.
+! In medio presbyterii, vel in ipsa aula~
+! ecclesiæ, parata sint sedilia hinc inde pro~
+! duodecim viris, quorum lavabuntur pedes;~
+! cetera quae occurrunt, tempore opportuno,~
+! in mensula parentur.
+! Interim diaconus et subdiaconus, seu~
+! duo maiores ex ministrantibus, inducunt duodecim~
+! viros selectos, binos et binos, ad locum~
+! paratum, dum schola vel ipse clerus~
+! assistens incipit, cantando vel recitando,~
+! antiphonas, psalmos et versus infrascriptos.
+! Duodecim autem viri selecti, facta reverentia~
+! altari ac celebranti, in presbyterio~
+! sedenti, disponuntur per sedilia; tunc ministri~
+! sacri, seu ministrantes, adibunt celebrantem.~
+! Omnes deponunt manipulum, celebrans~
+! vero etiam planetam.
+! Lotione pedum ad finem vergente, incipitur~
+! antiphona 8a cum suis versibus, ceteris,~
+! si opus sit, omissis.
+_
+_
+!Antiphona 1
+!Ps 13:34.
+Ant. Mandátum novum do vobis: ut diligátis ínvicem, sicut diléxi vos, dicit Dóminus.
+!Ps 118:1.
+Beáti immaculáti in via: qui ámbulant in lege Dómini.
+! Et repetitur immediate antiphona «Mandatum novum».
+Ant. Mandátum novum do vobis: ut diligátis ínvicem, sicut diléxi vos, dicit Dóminus.
+! Et sic aliæ antiphonæ, quæ~
+! habent psalmos vel versus, repetuntur. Et~
+! de quolibet psalmo dicitur tantum primus~
+! versus.
+_
+_
+!Antiphona 2
+!Ps 13:4, 5 et 15.
+Ant. Postquam surréxit Dóminus a cœna, misit aquam in pelvim, et cœpit laváre pedes discipulórum suórum: hoc exémplum réliquit eis.
+!Ps 47:2.
+Magnus Dóminus, et laudábilis nimis: in civitáte Dei nostri, in monte sancto ejus.
+Ant. Postquam surréxit Dóminus a cœna, misit aquam in pelvim, et cœpit laváre pedes discipulórum suórum: hoc exémplum réliquit eis.
+_
+_
+!Antiphona 3
+!Ps 13:12, 13 et 15.
+Ant. Dóminus Jesus, postquam cenávit cum discípulis suis, lavit pedes eórum, et ait illis: «Scitis, quid fécerim vobis ego, Dóminus et Magíster? Exémplum dedi vobis, ut et vos ita faciátis».
+!Ps 84:2.
+Benedixísti, Dómine, terram tuam: avertísti captivitátem Jacob.
+Ant. Dóminus Jesus, postquam cenávit cum discípulis suis, lavit pedes eórum, et ait illis: «Scitis, quid fécerim vobis ego, Dóminus et Magíster? Exémplum dedi vobis, ut et vos ita faciátis».
+_
+_
+!Antiphona 4
+!Ps 13:6-7 et 8.
+Ant. «Dómine, tu mihi lavas pedes?» Respóndit Jesus et dixit ei: «Si non lávero tibi pedes, non habébis partem mecum».
+V. Venit ergo ad Simónem Petrum, et dixit ei Petrus.
+Ant. «Dómine, tu mihi lavas pedes?» Respóndit Jesus et dixit ei: «Si non lávero tibi pedes, non habébis partem mecum».
+V. «Quod ego fácio, tu nescis modo: scies autem póstea».
+Ant. «Dómine, tu mihi lavas pedes?» Respóndit Jesus et dixit ei: «Si non lávero tibi pedes, non habébis partem mecum».
+_
+_
+!Antiphona 5
+Ant. «Si ego, Dóminus et Magíster vester, lavi vobis pedes: quanto magis debétis alter altérius laváre pedes?»
+!Ps 48:2
+Audíte hæc, omnes gentes: áuribus percípite, qui habitátis orbem.
+Ant. «Si ego, Dóminus et Magíster vester, lavi vobis pedes: quanto magis debétis alter altérius laváre pedes?»
+_
+_
+!Antiphona 6
+!Ps 13:35.
+Ant. «In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habuéritis ad ínvicem».
+V. Dixit Jesus discípulis suis.
+Ant. «In hoc cognóscent omnes, quia discípuli mei estis, si dilectiónem habuéritis ad ínvicem».
+_
+_
+!Antiphona 7
+!Ps 13:13
+Ant. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas.
+V. Nunc autem manent fides, spes, cáritas, tria hæc: major horum est cáritas.
+Ant. Máneant in vobis fides, spes, cáritas, tria hæc: major autem horum est cáritas.
+_
+_
+!Antiphona 8
+! Sequens antiphona cum suis versibus~
+! numquam omittitur; incipitur autem, omissis,~
+! si opus sit, praecedentibus, lotione pedum~
+! ad finem vergente.
+v. Ubi cáritas et amor, Deus ibi est.
+V. Congregávit nos in unum Christi amor.
+V. Exsultémus et in ipso jucundémur.
+V. Timeámus et amémus Deum vivum.
+V. Et ex corde diligámus nos sincéro.
+v. Ubi cáritas et amor, Deus ibi est.
+V. Simul ergo cum in unum congregámur:
+V. Ne nos mente dividámur, caveámus.
+V. Cessent júrgia malígna, cessent lites.
+V. Et in médio nostri sit Christus Deus.
+v. Ubi cáritas et amor, Deus ibi est.
+V. Simul quoque cum Beátis videámus
+V. Gloriánter vultum tuum, Christe Deus:
+V. Gáudium, quod est imménsum atque probum,
+V. Sǽcula per infiníta sæculórum. Amen.
+_
+_
+! Interim celebrans procedit ad lotionem~
+! pedum, hoc modo: præcingit se linteo,~
+! et per ordinem dispositis iis, qui lavandi~
+! sunt, acolythis pelvim et aquam ministrantibus,~
+! subdiacono singulorum pedem dextrum~
+! tenente, genuflectens singulis, illorum~
+! pedem lavat et extergit, diacono præbente~
+! linteum ad abstergendum.
+! Officia, quae in ritu solemni a diacono~
+! et subdiacono adimplentur, a ministrantibus~
+! peraguntur.
+! Post lotionem celebrans lavat et abstergit~
+! manus, nihil dicens. Deinde omnes~
+! resumunt manipulum, celebrans vero etiam~
+! planetam, et redeunt ante medium altaris,~
+! ubi celebrans, versus populum, dicit:
+_
+$Pater noster
+V. Tu mandásti mandáta tua, Dómine.
+R. Custodíri nimis.
+V. Tu lavásti pedes discipulórum tuórum.
+R. Opera mánuum tuárum ne despícias.
+V. Dómine, exáudi oratiónem meam.
+R. Et clamor meus ad te véniat.
+V. Dóminus vobíscum.
+R. Et cum spíritu tuo.
+v. Orémus.
+Adésto, Dómine, quǽsumus, offício servitútis nostræ: et quia tu discípulis tuis pedes laváre dignátus es, ne despícias ópera mánuum tuárum, quæ nobis retinénda mandásti: ut, sicut hic nobis, et a nobis exterióra abluúntur inquinaménta; sic a te ómnium nostrum interióra lavéntur peccáta. Quod ipse præstáre dignéris, qui vivis et regnas Deus: per ómnia sǽcula sæculórum. 
+R. Amen.
+! Oratione completa, duodecim viri, facta~
+! reverentia altari et celebranti, reducuntur~
+! ad loca sua, si sint clerici in presbyterium,~
+! si sint laici in peculiarem locum ad hoc designatum.
+! Ubi vero contingat lotionem pedum~
+! extra Missarum solemnia peragi, observetur~
+! ordo supra descriptus, præmisso, cum~
+! solitis cæremoniis, cantu Evangelii Missæ~
+! Ante diem festum Paschæ, ut supra.
+! Post pedum lotionem, seu, ubi hæc~
+! locum non habuerit, post homiliam, proceditur~
+! in celebratione Missæ, more solito.

--- a/web/www/missa/Polski/Tempora/Quadp3-3.txt
+++ b/web/www/missa/Polski/Tempora/Quadp3-3.txt
@@ -132,7 +132,7 @@ Spraw, prosimy Cię, Panie, abyśmy należycie się usposobili do ofiarowania To
 $Per Dominum
 
 [Communio]
-!Ps 1:2 et 3. 
+!Ps 1:2,3
 Kto rozważa Prawo Pańskie dniem i nocą, ten wyda owoc w swym czasie.
 
 [Postcommunio]


### PR DESCRIPTION
When doing Polish translation of Maundy Thursday I found two issues existing in original texts:

1. `Tempora/Quad6-4*.txt` – references in antifons involved in the ceremony of washing feet were incorrect. The reference was always **Ps** while it should be **Joann** (in most cases) and **1 Cor** (in one case). The verses' numbers were correct, though.
2. `Tempora/Quad6-4r.txt` - Maundy Thursday has its own `Communicantes` which does not take into account the change added by John XXIII – mention of st. Joseph. I added this mention as conditional `(rubrica 1960 dicitur)`.

I fixed mentioned issues in Latin and English language versions. I'll leave other languages to the respective authors.
