### PR TITLE
Reverting commit 5a9dc6b as it causes problems in Mass part

### DIFF
--- a/web/www/horas/Latin/Tabulae/Tr1960.txt
+++ b/web/www/horas/Latin/Tabulae/Tr1960.txt
@@ -1,6 +1,9 @@
 C03-20=Votive/Coronatio;;
 Tempora/Quad5-5=Tempora/Quad5-5Feria;;
 Tempora/Quad6-0=Tempora/Quad6-0r;;
+Tempora/Quad6-4=Tempora/Quad6-4r;;
+Tempora/Quad6-5=Tempora/Quad6-5r;;
+Tempora/Quad6-6=Tempora/Quad6-6r;;
 Tempora/Pasc2-3=Tempora/Pasc2-3Feria;;
 Tempora/Pasc2-4=Tempora/Pasc2-4Feria;;
 Tempora/Pasc2-5=Tempora/Pasc2-5Feria;;

--- a/web/www/horas/Latin/Tempora/Quad6-4r.txt
+++ b/web/www/horas/Latin/Tempora/Quad6-4r.txt
@@ -1,0 +1,1 @@
+@Tempora/Quad6-4

--- a/web/www/horas/Latin/Tempora/Quad6-5r.txt
+++ b/web/www/horas/Latin/Tempora/Quad6-5r.txt
@@ -1,0 +1,1 @@
+@Tempora/Quad6-5

--- a/web/www/horas/Latin/Tempora/Quad6-6r.txt
+++ b/web/www/horas/Latin/Tempora/Quad6-6r.txt
@@ -1,0 +1,1 @@
+@Tempora/Quad6-6


### PR DESCRIPTION
Removing these files results in lack of Polish Mass translation for Maundy Thursday, Good Friday and Easter Vigil. Perhaps Polish files for the Mass can be adjusted to allow deletion of files in question but I'd defer it for time after Easter.

http://divinumofficium.com/cgi-bin/missa/missa.pl?lang2=Polski&Propers=1&date=3-24-2016
http://divinumofficium.com/cgi-bin/missa/missa.pl?lang2=Polski&Propers=1&date=3-25-2016
http://divinumofficium.com/cgi-bin/missa/missa.pl?lang2=Polski&Propers=1&date=3-26-2016