### PR TITLE
Restore Responsory4 of Latin/Sancti/08-15.txt

### DIFF
--- a/web/www/horas/Latin/Sancti/08-15.txt
+++ b/web/www/horas/Latin/Sancti/08-15.txt
@@ -97,7 +97,10 @@ Sermo sancti Joannis Damasceni.
 Hodie sacra et animata arca Dei viventis, quae suum in utero concepit Creatorem, requiescit in templo Domini, quod nullis est exstructum manibus: et David exsultat ejus parens, et cum eo choros ducunt Angeli, celebrant Archangeli, Virtutes glorificant, Principatus exsultant, Potestates collaetantur, gaudent Dominationes, Throni festum diem agunt, laudant Cherubim, gloriam ejus praedicant Seraphim. Hodie Eden novi Adam paradisum suscipit animatum, in quo soluta est condemnatio, in quo plantatum est lignum vitae, in quo operta fuit nostra nuditas.
 
 [Responsory4]
-@Commune/C11:Responsory6:s/.\&.*/ Unguentum effusum nomen tuum./s
+R. Ornatam monilibus filiam Jerusalem Dominus concupivit:
+* Et videntes eam filiae Sion, beatissimam praedicaverunt, dicentes: Unguentum effusum nomen tuum.
+V. Astitit regina a dextris tuis in vestitu deaurato, circumdata varietate.
+R. Et videntes eam filiae Sion, beatissimam praedicaverunt, dicentes: Unguentum effusum nomen tuum.
 
 [Lectio5]
 Hodie Virgo immaculata, quae nullis terrenis inquinata est affectibus, sed caelestibus educata cogitationibus, non in terram reversa est; sed, cum esset animatum caelum, in caelestibus tabernaculis collocatur. Ex qua enim omnibus vera vita manavit, quomodo illa mortem gustaret? Sed cedit legi latae ab eo quem genuit; et ut filia veteris Adam, veterem sententiam subiit: (nam et ejus Filius, qui est vita ipsa, eam non recusavit) ut autem Dei viventis Mater, ad illum ipsum digne assumitur.

--- a/web/www/horas/Latin/Sancti/08-15.txt
+++ b/web/www/horas/Latin/Sancti/08-15.txt
@@ -97,10 +97,7 @@ Sermo sancti Joannis Damasceni.
 Hodie sacra et animata arca Dei viventis, quae suum in utero concepit Creatorem, requiescit in templo Domini, quod nullis est exstructum manibus: et David exsultat ejus parens, et cum eo choros ducunt Angeli, celebrant Archangeli, Virtutes glorificant, Principatus exsultant, Potestates collaetantur, gaudent Dominationes, Throni festum diem agunt, laudant Cherubim, gloriam ejus praedicant Seraphim. Hodie Eden novi Adam paradisum suscipit animatum, in quo soluta est condemnatio, in quo plantatum est lignum vitae, in quo operta fuit nostra nuditas.
 
 [Responsory4]
-R. Ornatam monilibus filiam Jerusalem Dominus concupivit:
-* Et videntes eam filiae Sion, beatissimam praedicaverunt, dicentes: Unguentum effusum nomen tuum.
-V. Astitit regina a dextris tuis in vestitu deaurato, circumdata varietate.
-R. Et videntes eam filiae Sion, beatissimam praedicaverunt, dicentes: Unguentum effusum nomen tuum.
+@Commune/C11:Responsory6:s/.\&.*/ Unguentum effusum nomen tuum./s s/: \*/:/s
 
 [Lectio5]
 Hodie Virgo immaculata, quae nullis terrenis inquinata est affectibus, sed caelestibus educata cogitationibus, non in terram reversa est; sed, cum esset animatum caelum, in caelestibus tabernaculis collocatur. Ex qua enim omnibus vera vita manavit, quomodo illa mortem gustaret? Sed cedit legi latae ab eo quem genuit; et ut filia veteris Adam, veterem sententiam subiit: (nam et ejus Filius, qui est vita ipsa, eam non recusavit) ut autem Dei viventis Mater, ad illum ipsum digne assumitur.


### PR DESCRIPTION
The attempt of @mbab to replace it with Reponsory 6 of C11 left a spurious asterisk
before the first "Unguentum", thus:

> R. Ornatam monilibus filiam Ierusalem Dominus concupivit:
> \* Et videntes eam filiae Sion, beatissimam praedicaverunt, dicentes: * Unguentum effusum nomen tuum.
> V. Astitit regina a dextris tuis in vestitu deaurato, circumdata varietate.
> R. Et videntes eam filiae Sion, beatissimam praedicaverunt, dicentes: Unguentum effusum nomen tuum.

This commit reverts the change. It may be that a more clever substitution could eliminate the spurious asterisk. That would also be acceptable to me.