### PR TITLE
Fix rules affected by æ ligature substitution

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -1708,6 +1708,8 @@ sub papal_antiphon_dum_esset($)
           |
             (?:hoc\s+versus\s+)?omittitur
           |
+            (?:hæc\s+versus\s+)?omittuntur
+          |
             (?:haec\s+versus\s+)?omittuntur
         )
         \b

--- a/web/www/horas/Latin/Sancti/04-22.txt
+++ b/web/www/horas/Latin/Sancti/04-22.txt
@@ -7,7 +7,7 @@ SS. Soteris et Caii Summorum Pontificum et Martyrum;;Semiduplex;;2;;vide C3
 [Rule]
 vide C3;
 9 lectiones
-OPapæM=Sotérem et Cajum;
+OPapaeM=Sotérem et Cajum;
 
 [Lectio4]
 Soter, Fundis in Campania natus, sancivit, ne sacræ virgines vasa sacra et pallas attingerent, neve thuris ministerio in ecclesia uterentur. Idem statuit, ut Christi corpus in Cœna Domini sumeretur ab omnibus, iis exceptis, qui propter grave peccatum id facere prohiberentur. Sedit in pontificatu annos tres, menses undecim, dies decem et octo: Martyrio coronatus sub Marco Aurelio imperatore, et in cœmeterio, quod postea Callisti dictum est, sepelitur, more majorum mense Decembri creatis presbyteris decem et octo, diaconis novem, episcopis per diversa loca undecim.

--- a/web/www/horas/Latin/Sancti/04-26.txt
+++ b/web/www/horas/Latin/Sancti/04-26.txt
@@ -7,7 +7,7 @@ SS. Cleti et Marcellini Summorum Pontificum et Martyrum;;Semiduplex;;2.5;;vide C
 [Rule]
 vide C3;
 9 lectiones
-OPapæM=Cletum et Marcellínum;
+OPapaeM=Cletum et Marcellínum;
 
 [Oratio]
 Beatorum Martyrum, pariterque Pontificum Cleti et Marcellini nos Domine foveat pretiosa confessio: et pia jugiter intercessio tueatur.


### PR DESCRIPTION
Commit 4b35e71 converted all occurrences of "ae" in the Latin Sancti files to the æ ligature. But:

1. "hæc versus ommittuntur" is not recognized as a valid conditional: this PR changes horascommon.pl to recognize it, also allowing "haec" to be used.
2. OPapæM is not recognized as a rule. This PR restores the spelling OPapaeM so that the rule will be recognized.
