### PR TITLE
English translation corrections

### DIFF
--- a/web/www/horas/English/Commune/C1p.txt
+++ b/web/www/horas/English/Commune/C1p.txt
@@ -69,7 +69,7 @@ R. The Lord had chosen you for his inheritance, alleluia.
 Behold * how they are numbered among the children of God, and their lot is among the Saints, alleluia.;;46
 ;;60
 ;;63
-V. Eternal light will shine over your saints, O Lord.
+V. Eternal light will shine over your saints, O Lord, alleluia.
 R. And the eternity of times, alleluia.
 Eternal light * will shine over your saints, O Lord, and the eternity of times, alleluia.;;74
 ;;96

--- a/web/www/horas/English/Commune/C7.txt
+++ b/web/www/horas/English/Commune/C7.txt
@@ -80,7 +80,7 @@ R. He hath made her to dwell in His Tabernacle.
 [Lectio1]
 Lesson from the book of Proverbs
 !Prov 31:10-17
-10 Who shall find a valiant woman? far and from the uttermost coasts is the price of her.
+10 Who shall find a valiant woman? Far and from the uttermost coasts is the price of her.
 11 The heart of her husband trusteth in her, and he shall have no need of spoils.
 12 She will render him good, and not evil, all the days of her life.
 13 She hath sought wool and flax, and hath wrought by the counsel of her hands.

--- a/web/www/horas/English/Commune/C7a.txt
+++ b/web/www/horas/English/Commune/C7a.txt
@@ -7,7 +7,7 @@ Antiphonas horas
 
 [Capitulum Vespera]
 !Prov. 31:10-11
-v. Who shall find a valiant woman? far and from the uttermost coasts is the price of her. The heart of her husband trusteth in her, and he shall have no need of spoils.
+v. Who shall find a valiant woman? Far and from the uttermost coasts is the price of her. The heart of her husband trusteth in her, and he shall have no need of spoils.
 $Deo gratias.
 
 [Lectio Prima]


### PR DESCRIPTION
The elimination of proper texts that are just duplicates of the common (and common texts that duplicate others) is causing the commons to be used more frequently. This in turn makes it more evident that they do not have a consistent style. These commits restore an alleluia that disappeared, and capitalize a word, but a more thorough review is needed.

@APMarcello3, I suggest you review the English commons for style. For example, should alleluia be capitalized or not? Should terms like "mother" and virgin" be capitalized?

In particular, take a look at `web/www/horas/English/Commune/C1p.txt`: ætérnitas tempórum is sometimes translated "the eternity of times" and other times "the eternity of *the* times."
