### PR TITLE
Cleanup of French translations of psalms

### DIFF
--- a/web/www/horas/Francais/psalms1/Psalm103.txt
+++ b/web/www/horas/Francais/psalms1/Psalm103.txt
@@ -23,7 +23,7 @@
 103:22 Le soleil se lève : ils se retirent, * et se couchent dans leurs tanières.
 103:23 L'homme sort alors pour sa tâche, * et pour son travail jusqu'au soir.
 103:24 Que Vos œuvres sont nombreuses, Yahweh ! * Vous les avez toutes faites avec sagesse; La terre est remplie de Vos biens.
-103:25 Voici la mer, large et vaste : * là fourmillent sans nombre 
+103:25 Voici la mer, large et vaste : * là fourmillent sans nombre
 103:26 des animaux petits et grands; * là se promènent les navires,
 103:27 et le léviathan que Vous avez formé pour se jouer dans les flots. * Tous attendent de Vous que Vous leur donniez la nourriture en son temps.
 103:28 Vous la leur donnez, et ils la recueillent; * Vous ouvrez Votre main, et ils se rassasient de Vos biens.

--- a/web/www/horas/Francais/psalms1/Psalm105.txt
+++ b/web/www/horas/Francais/psalms1/Psalm105.txt
@@ -20,7 +20,7 @@
 105:19 Ils firent un veau au mont Horeb, * ils se prosternèrent devant une image de métal fondu;
 105:20 Ils échangèrent leur gloire * contre la figure d'un bœuf qui mange l'herbe.
 105:21 Ils oublièrent Dieu, leur sauveur, * qui avait fait de grandes choses en Egypte, des miracles dans le pays de Cham, des prodiges à la mer Rouge.
-105:22 Il parlait de les exterminer, * si Moïse, son élu, ne se fût tenu sur la brèche devant Lui, 
+105:22 Il parlait de les exterminer, * si Moïse, son élu, ne se fût tenu sur la brèche devant Lui,
 105:23 pour empêcher Sa colère de les détruire. * Ils dédaignèrent la terre de délices,
 105:24 ils ne crurent pas à la parole de Yahweh; ils murmurèrent dans leurs tentes, * et n'obéirent pas à sa voix.
 105:25 Alors Il leva la main contre eux, * jurant de les faire périr dans le désert,

--- a/web/www/horas/Francais/psalms1/Psalm106.txt
+++ b/web/www/horas/Francais/psalms1/Psalm106.txt
@@ -21,7 +21,7 @@
 106:21 Qu'ils louent Yahweh pour Sa bonté, * et pour Ses merveilles en faveur des fils de l'homme !
 106:22 Qu'ils offrent des sacrifices d'actions de grâce, * et qu'ils publient Ses œuvres avec des cris de joie !
 106:23 Ils étaient descendus sur la mer dans des navires, * pour faire le négoce sur les vastes eaux :
-106:24 ceux là ont vu les œuvres de Yahweh, * et Ses merveilles au milieu de l'abîme 
+106:24 ceux là ont vu les œuvres de Yahweh, * et Ses merveilles au milieu de l'abîme
 106:25 Il dit, et Il fit lever un vent de tempête, * qui souleva les flots de la mer.
 106:26 Ils montaient jusqu'aux cieux, ils descendaient dans les abîmes; * leur âme défaillait dans la peine.
 106:27 Saisis de vertige, ils chancelaient comme un homme ivre, * et toute leur sagesse était anéantie.

--- a/web/www/horas/Francais/psalms1/Psalm137.txt
+++ b/web/www/horas/Francais/psalms1/Psalm137.txt
@@ -1,5 +1,5 @@
 137:1 Je veux Vous louer de tout mon cœur, * Vous chanter sur la harpe, en présence des dieux.
-137:2 Je veux me prosterner dans Votre saint temple, * et célébrer Votre nom, à cause de Votre bonté 
+137:2 Je veux me prosterner dans Votre saint temple, * et célébrer Votre nom, à cause de Votre bonté
 137:3 et de Votre fidélité, parce que Vous avez fait une promesse magnifique, * au-dessus de toutes les gloires de Votre nom.
 137:3 Le jour où je Vous ai invoqué, Vous m'avez exaucé, * Vous avez rendu à mon âme la force et le courage.
 137:4 Tous les rois de la terre Vous loueront, Yahweh, * quand ils auront appris les oracles de Votre bouche.

--- a/web/www/horas/Francais/psalms1/Psalm143.txt
+++ b/web/www/horas/Francais/psalms1/Psalm143.txt
@@ -8,7 +8,7 @@
 143:8 Etendez Vos mains d'en haut, délivrez-moi et sauvez-moi des grandes eaux, * de la main des fils de l'étranger,
 143:8 dont la bouche profère le mensonge, * et dont la droite est une droite parjure.
 143:9 O Dieu, je Vous chanterai un cantique nouveau, * je Vous célébrerai sur le luth à dix  cordes.
-143:10 Vous qui donnez aux rois la victoire, * qui sauvez du glaive meurtrier David, Votre serviteur, délivrez-moi 
+143:10 Vous qui donnez aux rois la victoire, * qui sauvez du glaive meurtrier David, Votre serviteur, délivrez-moi
 143:11 et sauvez-moi de la main des fils de l'étranger, dont la bouche profère le mensonge, * et dont la droite est une droite parjure.
 143:12 Que nos fils, comme des plants vigoureux, * grandissent en leur jeunesse !
 143:13 Que nos filles soient comme les colonnes angulaires, * sculptées à la façon de celles d'un temple !

--- a/web/www/horas/Francais/psalms1/Psalm144.txt
+++ b/web/www/horas/Francais/psalms1/Psalm144.txt
@@ -11,7 +11,7 @@
 144:11 Ils disent la gloire de Votre règne, * et proclament Votre puissance,
 144:12 afin de faire connaître aux fils des hommes Ses prodiges, * et le glorieux éclat de Son règne.
 144:13 Votre règne est un règne éternel, * et Votre domination subsiste dans tous les âges.
-144:14 Le Seigneur est fidèle dans toutes Ses paroles, * et saint dans toutes Ses œuvres. 
+144:14 Le Seigneur est fidèle dans toutes Ses paroles, * et saint dans toutes Ses œuvres.
 144:15 Yahweh soutient tous ceux qui tombent, * Il redresse tous ceux qui sont courbés.
 144:16 Les yeux de tous les êtres sont tournés vers Vous dans l'attente, * et Vous leur donnez leur nourriture en son temps.
 144:17 Vous ouvrez Votre main, * et Vous rassasiez de Vos biens tout ce qui respire.

--- a/web/www/horas/Francais/psalms1/Psalm17.txt
+++ b/web/www/horas/Francais/psalms1/Psalm17.txt
@@ -1,20 +1,20 @@
 17:1 Il dit : Je Vous aime, Yahweh, ma force ! * Yahweh mon rocher, ma forteresse, mon libérateur,
-17:2 mon Dieu, mon roc * où je trouve un asile, 
+17:2 mon Dieu, mon roc * où je trouve un asile,
 17:3 mon bouclier, la corne de mon salut, * ma citadelle !
 17:4 J'invoquai celui qui est digne de louange, Yahweh, * et je fus délivré de mes ennemis.
 17:5 Les liens de la mort m'environnaient, * les torrents de Bélial m'épouvantaient,
 17:6 les liens du schéol m'enlaçaient, * les filets de la mort étaient tombés devant moi.
-17:7 Dans ma détresse, j'invoquai Yahweh, * et je criai vers mon Dieu; 
+17:7 Dans ma détresse, j'invoquai Yahweh, * et je criai vers mon Dieu;
 17:8 de son temple Il entendit ma voix, * et mon cri devant Lui parvint à Ses oreilles.
 17:9 La terre fut ébranlée et trembla, * les fondements des montagnes s'agitèrent, et ils furent ébranlés, parce qu'Il était courroucé ;
-17:10 une fumée montait de ses narines, et un feu dévorant sortait de Sa bouche; * il en jaillissait des charbons embrasés. 
+17:10 une fumée montait de ses narines, et un feu dévorant sortait de Sa bouche; * il en jaillissait des charbons embrasés.
 17:11 Il abaissa les cieux, et descendit; * une sombre nuée était sous Ses pieds.
 17:12 Il monta sur un Chérubin, et il volait; * Il planait sur les ailes du vent.
 17:13 Il fit des ténèbres Sa retraite, Sa tente autour de Lui * c'étaient des eaux obscures et de sombres nuages.
 17:14 De l'éclat qui le précédait s'élancèrent ses nuées, * portant la grêle et les charbons ardents.
 17:15 Yahweh tonna dans les cieux, le Très-Haut fit retentir sa voix : * grêle et charbons ardents !
 17:16 Il lança Ses flèches et les dispersa; * Il multiplia ses foudres et Il les confondit.
-17:16 Alors le lit des eaux apparut, * les fondements de la terre furent mis à nu, 
+17:16 Alors le lit des eaux apparut, * les fondements de la terre furent mis à nu,
 17:16 à Votre menace, Yahweh, * au souffle du vent de Vos narines.
 17:17 Il étendit Sa main d'en haut et me saisit, * Il me retira des grandes eaux.
 17:18 Il me délivra de mon ennemi puissant, de ceux qui me haïssaient, * alors qu'ils étaient plus forts que moi.
@@ -36,7 +36,7 @@
 17:34 Qui rend mes pieds semblables à ceux des biches, * et me fait tenir debout sur mes hauteurs;
 17:35 Qui forme mes mains au combat, * et mes bras tendent l'arc d'airain.
 17:36 Vous m'avez donné le bouclier de Votre salut, * et Votre droite me soutient, et Votre douceur me fait grandir.
-17:37 Et vos leçons m'ont corrigé jusqu'à la fin, * et ces leçons continueront de m'instruira. 
+17:37 Et vos leçons m'ont corrigé jusqu'à la fin, * et ces leçons continueront de m'instruira.
 17:38 Vous élargissez mon pas au-dessous de moi, * et mes pieds ne chancellent point.
 17:39 Je poursuis mes ennemis et je les atteins; * je ne reviens pas sans les avoir anéantis.
 17:40 Je les brise, et ils ne se relèvent pas; Ils tombent sous mes pieds.

--- a/web/www/horas/Francais/psalms1/Psalm18.txt
+++ b/web/www/horas/Francais/psalms1/Psalm18.txt
@@ -1,8 +1,8 @@
 18:1 Les cieux racontent la gloire de Dieu, * et le firmament annonce l'œuvre de ses mains.
 18:2 Le jour crie au jour la louange, * la nuit l'apprend à la nuit.
 18:3 Ce n'est pas un langage, ce ne sont pas des paroles; * dont la voix ne soit pas entendue.
-18:4 Leur son parcourt toute la terre, * leurs accents vont jusqu'aux extrémités du monde. 
-18:5 C'est là qu'Il a dressé une tente pour le soleil. * Et lui, semblable à l'époux qui sort de la chambre nuptiale, 
+18:4 Leur son parcourt toute la terre, * leurs accents vont jusqu'aux extrémités du monde.
+18:5 C'est là qu'Il a dressé une tente pour le soleil. * Et lui, semblable à l'époux qui sort de la chambre nuptiale,
 18:6 Il s'élance joyeux, comme un héros, pour fournir sa carrière. * Il part d'une extrémité du ciel,
 18:7 et sa course s'achève à l'autre extrémité : * rien ne se dérobe à sa chaleur.
 18:8 La loi de Yahweh est parfaite : elle restaure l'âme. * Le témoignage de Yahweh est sur : Il donne la sagesse aux simples.
@@ -10,7 +10,7 @@
 18:10 La crainte de Yahweh est sainte : elle subsiste à jamais. * Les décrets de Yahweh sont vrais : ils sont tous justes.
 18:11 Ils sont plus précieux que l'or, que beaucoup d'or fin; * plus doux que le miel, que celui qui coule des rayons.
 18:12 Votre serviteur aussi est éclairé par eux; * grande récompense à qui les observe.
-18:13 Qui connaît ses égarements ? Pardonnez-moi ceux que j'ignore ! * Préservez aussi Votre serviteur des orgueilleux ; 
+18:13 Qui connaît ses égarements ? Pardonnez-moi ceux que j'ignore ! * Préservez aussi Votre serviteur des orgueilleux ;
 18:14 Qu'ils ne dominent point sur moi ! Alors je serai parfait * et je serai pur de grands péchés.
 18:15 Accueillez avec faveur les paroles de ma bouche, * et les sentiments de mon cœur devant Vous,
 18:15 Yahweh, mon rocher * et mon libérateur !

--- a/web/www/horas/Francais/psalms1/Psalm2.txt
+++ b/web/www/horas/Francais/psalms1/Psalm2.txt
@@ -9,5 +9,5 @@
 2:9 Tu les briseras avec un sceptre de fer, * Tu les mettras en pièces comme le vase du potier."
 2:10 Et maintenant, rois, devenez sages; * recevez l'avertissement, juges de la terre.
 2:11 Servez Yahweh avec crainte, * tressaillez de joie avec tremblement.
-2:12 Baisez le Fils, de peur qu'Il ne S'irrite * et que vous ne périssiez dans votre voie; 
+2:12 Baisez le Fils, de peur qu'Il ne S'irrite * et que vous ne périssiez dans votre voie;
 2:13 Car bientôt s'allumerait Sa colère; * heureux tous ceux qui mettent en Lui leur confiance.

--- a/web/www/horas/Francais/psalms1/Psalm21.txt
+++ b/web/www/horas/Francais/psalms1/Psalm21.txt
@@ -14,8 +14,8 @@
 21:15 Je suis comme de l'eau qui s'écoule, * et tous mes os sont disjoints;
 21:16 mon cœur est comme de la cire, * il se fond dans mes entrailles.
 21:17 Ma force s'est desséchée comme un tesson d'argile, et ma langue s'attache à mon palais; * tu me couches dans la poussière de la mort.
-21:18 Car des chiens m'environnent, * une troupe de scélérats rôdent autour de moi ; 
-21:19 ils ont percé mes pieds et mes mains, * je pourrais compter tous mes os. 
+21:18 Car des chiens m'environnent, * une troupe de scélérats rôdent autour de moi ;
+21:19 ils ont percé mes pieds et mes mains, * je pourrais compter tous mes os.
 21:20 Eux, ils m'observent, ils me contemplent ; * ils se partagent mes vêtements, ils tirent au sort ma tunique.
 21:21 Et Vous, Yahweh, ne Vous éloignez pas ! Vous qui êtes ma force, * venez en hâte à mon secours !
 21:22 Délivrez mon âme de l'épée, * ma vie du pouvoir du chien !
@@ -30,5 +30,5 @@
 21:30 et toutes les familles des nations * se prosterneront devant sa face.
 21:31 Car à Yahweh appartient l'empire, * Il domine sur les nations.
 21:32 Les puissants de la terre mangeront et se prosterneront; * devant Lui s'inclineront tous ceux qui descendent à la poussière,
-21:32 ceux qui ne peuvent prolonger leur vie. * La postérité le servira; 
+21:32 ceux qui ne peuvent prolonger leur vie. * La postérité le servira;
 21:32 on parlera du Seigneur à la génération future. * Ils viendront et ils annonceront Sa justice, au peuple qui naîtra, ils diront ce qu'Il a fait.

--- a/web/www/horas/Francais/psalms1/Psalm211.txt
+++ b/web/www/horas/Francais/psalms1/Psalm211.txt
@@ -1,6 +1,6 @@
-(Cantique de David * 1 Par. 29:10-13) 
+(Cantique de David * 1 Par. 29:10-13)
 29:10 "Béni soyez-vous, d'éternité en éternité, * Yahweh, Dieu de notre père d'Israël !
-29:11 A Vous, Yahweh, la grandeur, la puissance, * la magnificence, la splendeur 
+29:11 A Vous, Yahweh, la grandeur, la puissance, * la magnificence, la splendeur
 29:12 et la gloire, * car tout, au ciel et sur la terre, Vous appartient;
 29:13 à Vous, Yahweh, la royauté; * à Vous de vous élever souverainement au-dessus de tout.
 29:14 De vous dérivent la richesse et la gloire; * vous dominez sur tout;

--- a/web/www/horas/Francais/psalms1/Psalm213.txt
+++ b/web/www/horas/Francais/psalms1/Psalm213.txt
@@ -1,7 +1,7 @@
 (Canticum Judith * Judith 16:15-22)
 16:15 Chantons un cantique au Seigneur, * chantons au Seigneur un cantique nouveau :
 16:16 Maître souverain, Seigneur, Vous êtes grand, et magnifique dans Votre puissance, * et nul ne peut Vous surpasser.
-16:17 Que toutes Vos créatures Vous servent, * parce que Vous avez parlé, et tout a été fait; 
+16:17 Que toutes Vos créatures Vous servent, * parce que Vous avez parlé, et tout a été fait;
 16:18 Vous avez envoyé votre esprit, et tout a été créé, * et nul ne peut résister à Votre voix.
 16:19 Les montagnes, ainsi que les eaux, sont agitées sur leurs bases, * les pierres se fondent comme la cire, devant Votre face;
 16:20 mais ceux qui Vous craignent * sont grands devant Vous en toutes choses.

--- a/web/www/horas/Francais/psalms1/Psalm214.txt
+++ b/web/www/horas/Francais/psalms1/Psalm214.txt
@@ -2,7 +2,7 @@
 31:10 Nations, écoutez la parole de Yahweh * et annoncez-la aux îles lointaines
 31:11 dites : "Celui qui a dispersé Israël le rassemblera, * et le gardera comme un berger son troupeau.
 31:12 Car Yahweh a racheté Jacob, * Il l'a délivré des mains d'un plus fort que lui."
-31:13 Ils viendront avec des cris de joie sur la hauteur de Sion; * ils afflueront vers les biens de Yahweh, 
+31:13 Ils viendront avec des cris de joie sur la hauteur de Sion; * ils afflueront vers les biens de Yahweh,
 31:14 vers le blé, vers le vin nouveau, vers l'huile, * vers les brebis et les bœufs;
 31:15 leur âme sera comme un jardin arrosé, * et ils ne continueront plus de languir.
 31:16 Alors la jeune fille s'égaiera à la danse, * et les jeunes hommes et les vieillards ensemble;

--- a/web/www/horas/Francais/psalms1/Psalm22.txt
+++ b/web/www/horas/Francais/psalms1/Psalm22.txt
@@ -1,9 +1,9 @@
 22:1 Yahweh est mon pasteur; je ne manquerai de rien. * Il me fait reposer dans de verts pâturages,
 22:2 Il me mène près des eaux rafraîchissantes; * Il restaure mon âme.
 22:3 Il me conduit dans les droits sentiers, * à cause de Son nom.
-22:4 Même quand je marche dans une vallée d'ombre mortelle, je ne crains aucun mal, * car Vous êtes avec moi : 
+22:4 Même quand je marche dans une vallée d'ombre mortelle, je ne crains aucun mal, * car Vous êtes avec moi :
 22:5 Votre houlette et Votre bâton * me rassurent.
-22:6 Vous dressez devant moi une table * en face de mes ennemis; 
+22:6 Vous dressez devant moi une table * en face de mes ennemis;
 22:7 Vous répandez l'huile sur ma tête; * ma coupe est débordante.
-22:8 Oui, le bonheur et la grâce m'accompagneront, * tous les jours de ma vie, 
+22:8 Oui, le bonheur et la grâce m'accompagneront, * tous les jours de ma vie,
 22:9 et j'habiterai dans la maison de Yahweh, * pour de longs jours.

--- a/web/www/horas/Francais/psalms1/Psalm221.txt
+++ b/web/www/horas/Francais/psalms1/Psalm221.txt
@@ -2,7 +2,7 @@
 12:1 Et tu diras en ce jour-là : Je Vous loue, Yahweh, car Vous étiez irrité, * mais Votre colère s'est détournée et Vous me consolez.
 12:2 Voici le Dieu de ma délivrance; j'ai confiance et je ne crains pas;
 12:3 car ma force et ma louange c'est Yahweh, * Yahweh; Il a été pour moi le salut.
-12:4 Vous puiserez des eaux avec joie aux sources du salut, * et vous direz en ce jour-là : Louez Yahweh, invoquez Son nom, 
+12:4 Vous puiserez des eaux avec joie aux sources du salut, * et vous direz en ce jour-là : Louez Yahweh, invoquez Son nom,
 12:5 publiez parmi les peuples ses grandes œuvres, * proclamez que Son nom est élevé.
 12:6 Chantez Yahweh, car Il a fait des choses magnifiques; * qu'on le sache dans toute la terre !
 12:7 Pousse des cris, tressaille d'allégresse, habitante de Sion, * car le Saint d'Israël est grand au milieu de toi !

--- a/web/www/horas/Francais/psalms1/Psalm222.txt
+++ b/web/www/horas/Francais/psalms1/Psalm222.txt
@@ -6,7 +6,7 @@
 38:14 Comme un tisserand, j'ourdissais ma vie; il me retranche du métier ! * Du jour à la nuit tu en auras fini avec moi !
 38:15 Je me suis tu jusqu'au matin; * comme un lion, il brisait tous mes os;
 38:16 du jour à la nuit tu en auras fini avec moi ! * Comme l'hirondelle, comme la grue, je crie; je gémis comme la colombe;
-38:17 mes yeux se sont lassés * à regarder en haut : 
+38:17 mes yeux se sont lassés * à regarder en haut :
 38:18 "Yahweh, on me fait violence; soyez mon garant !" Que dirais-je ? Il m'a dit, Il l'a fait.
 38:19 Je marcherai humblement pendant toutes mes années, * me souvenant de l'amertume de mon âme.
 38:20 Seigneur, c'est en cela qu'est la vie, en tout cela est la vie de mon esprit. Vous me guérissez, vous me rendez la vie : * voici que ma suprême amertume se change en paix !

--- a/web/www/horas/Francais/psalms1/Psalm223.txt
+++ b/web/www/horas/Francais/psalms1/Psalm223.txt
@@ -1,8 +1,8 @@
 (Cantique d'Anne * 1 Sam 2:1-16)
-2:1 Mon cœur tressaille de joie en Yahweh, * ma corne a été élevée par Yahweh, 
+2:1 Mon cœur tressaille de joie en Yahweh, * ma corne a été élevée par Yahweh,
 2:2 ma bouche est ouverte sur mes ennemis, * car je me suis réjouie de Votre secours.
 2:3 Nul n'est saint comme Yahweh, car il n'y a pas d'autre Dieu que Vous; * il n'y a pas de rocher comme notre Dieu.
-2:4 Ne prononcez pas tant de paroles * hautaines, 
+2:4 Ne prononcez pas tant de paroles * hautaines,
 2:5 qu'un langage arrogant ne sorte pas de votre bouche. Car Yahweh est un Dieu qui sait tout, * et les actions de l'homme ne subsistent pas.
 2:6 L'arc des puissants est brisé, * et les faibles ont la force pour ceinture.
 2:7 Ceux qui étaient rassasiés se louent pour du pain, * et ceux qui étaient affamés n'ont plus faim;

--- a/web/www/horas/Francais/psalms1/Psalm225.txt
+++ b/web/www/horas/Francais/psalms1/Psalm225.txt
@@ -4,7 +4,7 @@
 4 dans le cours des âges faites-la connaître ! * Dans Votre colère, souvenez-Vous d'avoir pitié.
 5 Dieu vient de Théman, * et le Saint de la montagne de Pharan.
 6 Sa majesté a couvert les cieux, * et la terre a été remplie de Sa gloire.
-7 C'est un éclat comme la lumière du soleil levant; * des rayons partent de Ses mains; 
+7 C'est un éclat comme la lumière du soleil levant; * des rayons partent de Ses mains;
 8 là se cache Sa puissance. * Devant Lui marche la mortalité,
 9 et la fièvre brûlante est sur Ses pas. * Il s'est arrêté et a fait trembler la terre,
 10 Il a regardé et a secoué les nations; * les montagnes éternelles se sont brisées,

--- a/web/www/horas/Francais/psalms1/Psalm234.txt
+++ b/web/www/horas/Francais/psalms1/Psalm234.txt
@@ -12,7 +12,7 @@ Eternel est le Père, éternel le Fils, * éternel le Saint-Esprit;
 Et cependant, ils ne sont pas trois éternels, * mais un éternel;
 tout comme ils ne sont pas trois incréés, ni trois infinis, * mais un incréé et un infini.
 De même, tout-puissant est le Père, tout-puissant le Fils, * tout-puissant le Saint-Esprit;
-Et cependant ils ne sont pas trois tout-puissants, * mais un tout-puissant. 
+Et cependant ils ne sont pas trois tout-puissants, * mais un tout-puissant.
 Ainsi le Père est Dieu, le Fils est Dieu, * le Saint-Esprit est Dieu;
 Et cependant ils ne sont pas trois Dieux, * mais un Dieu.
 Ainsi le Père est Seigneur, le Fils est Seigneur, * le Saint-Esprit est Seigneur;

--- a/web/www/horas/Francais/psalms1/Psalm24.txt
+++ b/web/www/horas/Francais/psalms1/Psalm24.txt
@@ -4,7 +4,7 @@
 24:4 Yahweh, faites-moi connaître Vos voies, * enseignez-moi Vos sentiers.
 24:5 Conduisez-moi dans Votre vérité, et instruis-moi, * car Vous êtes le Dieu de mon salut; tout le jour en Vous j'espère.
 24:6 Souvenez-Vous de Votre miséricorde, Yahweh, * et de Votre bonté car elles sont éternelles.
-24:7 Ne Vous souvenez pas des péchés de ma jeunesse * ni de mes transgressions; 
+24:7 Ne Vous souvenez pas des péchés de ma jeunesse * ni de mes transgressions;
 24:7 souvenez-Vous de moi selon Votre miséricorde, * à cause de Votre bonté, ô Yahweh,
 24:8 Yahweh est bon et droit; * c'est pourquoi Il indique aux pécheurs la voie.
 24:9 Il fait marcher les humbles dans la justice, * Il enseigne aux humbles sa voie.

--- a/web/www/horas/Francais/psalms1/Psalm26.txt
+++ b/web/www/horas/Francais/psalms1/Psalm26.txt
@@ -1,4 +1,4 @@
-26:1 Yahweh est ma lumière et mon salut : * qui craindrais-je ? 
+26:1 Yahweh est ma lumière et mon salut : * qui craindrais-je ?
 26:2 Yahweh est le rempart de ma vie : * de qui aurais-je peur ?
 26:3 Quand des méchants se sont avancés contre moi, * pour dévorer ma chair;
 26:4 quand mes adversaires et mes ennemis se sont avancés, * ce sont eux qui ont chancelé et qui sont tombés.
@@ -6,7 +6,7 @@
 26:6 que contre moi s'engage le combat, alors même j'aurai confiance.
 26:6 Je demande à Yahweh une chose, je la désire ardemment : * je voudrais habiter dans la maison de Yahweh, tous les jours de ma vie,
 26:6 pour jouir des amabilités de Yahweh, * pour contempler Son sanctuaire.
-26:6 Car Il m'abritera dans Sa demeure au jour de l'adversité, * Il me cachera dans le secret de Sa tente, 
+26:6 Car Il m'abritera dans Sa demeure au jour de l'adversité, * Il me cachera dans le secret de Sa tente,
 26:6 Il m'établira sur un rocher. * Alors ma tête s'élèvera au-dessus des ennemis ; qui sont autour de moi.
 26:6 J'offrirai dans Son tabernacle des sacrifices d'actions de grâces, * je chanterai et je dirai des hymnes à Yahweh.
 26:7 Yahweh, écoutez ma voix, je Vous invoque; * ayez pitié de moi et exaucez-moi !

--- a/web/www/horas/Francais/psalms1/Psalm27.txt
+++ b/web/www/horas/Francais/psalms1/Psalm27.txt
@@ -1,6 +1,6 @@
 27:1 C'est vers Vous, Yahweh, que je crie; mon rocher, ne restez pas sourd à ma voix, * de peur que, si Vous gardez le silence, je ne ressemble à ceux qui descendent dans la fosse.
 27:2 Ecoutez la voix de mes supplications, quand je crie vers Vous, * quand j'élève mes mains vers Votre saint sanctuaire.
-27:3 Ne m'emporte pas avec les méchants * et les artisans d'iniquité, 
+27:3 Ne m'emporte pas avec les méchants * et les artisans d'iniquité,
 27:4 qui parlent de paix à leur prochain, * et qui ont la malice dans le cœur.
 27:5 Rendez-leur selon leurs œuvres, * et selon la malice de leurs actions;
 27:6 Rendez-leur selon l'ouvrage de leurs mains, * donne-leur le salaire qu'ils méritent.

--- a/web/www/horas/Francais/psalms1/Psalm29.txt
+++ b/web/www/horas/Francais/psalms1/Psalm29.txt
@@ -5,10 +5,10 @@
 29:5 Car Sa colère dure un instant, * mais Sa grâce toute la vie;
 29:6 le soir viennent les pleurs, * et le matin l'allégresse.
 29:7 Je disais dans ma sécurité : * "Je ne serai jamais ébranlé !"
-29:8 Yahweh, par Votre grâce, * Vous avez affermi ma montagne ; 
+29:8 Yahweh, par Votre grâce, * Vous avez affermi ma montagne ;
 29:9 Vous avez caché Votre face, * et j'ai été troublé.
 29:10 Yahweh, j'ai crié vers Vous, * j'ai imploré Yahweh :
-29:11 "Que gagnez-Vous à verser mon sang; * à me faire descendre dans la fosse ? 
+29:11 "Que gagnez-Vous à verser mon sang; * à me faire descendre dans la fosse ?
 29:12 La poussière chantera-t-elle Vos louanges, * annoncera-t-elle Votre vérité ?
 29:13 Ecoutez, Yahweh, soyez-moi propice; * Yahweh, venez à mon secours !"
 29:14 Et Vous avez changé mes lamentations en allégresse, * Vous avez délié mon sac et Vous m'avez ceint de joie,

--- a/web/www/horas/Francais/psalms1/Psalm30.txt
+++ b/web/www/horas/Francais/psalms1/Psalm30.txt
@@ -13,7 +13,7 @@
 30:12 ma force est épuisée à cause de mon iniquité, * et mes os dépérissent.
 30:13 Tous mes adversaires m'ont rendu un objet d'opprobre; un fardeau pour mes voisins, * un objet d'effroi pour mes amis.
 30:14 Ceux qui me voient dehors s'enfuient loin de moi. * Je suis en oubli, comme un mort, loin des cœurs;
-30:15 je suis comme un vase brisé. * Car j'ai appris les mauvais propos de la foule, l'épouvante qui règne à l'entour, 
+30:15 je suis comme un vase brisé. * Car j'ai appris les mauvais propos de la foule, l'épouvante qui règne à l'entour,
 30:16 pendant qu'ils tiennent conseil contre moi : * ils ourdissent des complots pour m'ôter la vie.
 30:17 Et moi, je me confie en Vous, Yahweh; * je dis : "Vous êtes mon Dieu !"
 30:18 Mes destinées sont dans Votre main; délivrez-moi de la main de mes ennemis * et de mes persécuteurs !

--- a/web/www/horas/Francais/psalms1/Psalm31.txt
+++ b/web/www/horas/Francais/psalms1/Psalm31.txt
@@ -2,13 +2,13 @@
 31:2 Heureux l'homme à qui Yahweh n'impute pas l'iniquité, * et dans l'esprit duquel il n'y a point de fraude !
 31:3 Tant que je me suis tu, mes os se consumaient dans mon gémissement, * chaque jour.
 31:4 Car jour et nuit Votre main s'appesantissait sur moi; * la sève de ma vie se desséchait aux ardeurs de l'été.
-31:5 Je Vous ai fait connaître mon péché, je n'ai point caché mon iniquité; 
+31:5 Je Vous ai fait connaître mon péché, je n'ai point caché mon iniquité;
 31:6 j'ai dit : "Je veux confesser à Yahweh mes transgressions" * et Vous, Vous as remis l'iniquité de mon péché.
 31:7 Que tout homme pieux te prie donc * au temps favorable !
 31:8 Non ! quand les grandes eaux déborderont, * elles ne l'atteindront point.
 31:9 Vous êtes mon asile, Vous me préserverez de la détresse; * Vous m'entourerez de chants de délivrance.
 31:10 "Je t'instruirai et te montrerai la voie que tu dois suivre; je serai ton conseiller, * mon œil sera sur toi."
-31:11 Ne soyez pas comme le cheval ou le mulet * sans intelligence; 
+31:11 Ne soyez pas comme le cheval ou le mulet * sans intelligence;
 31:12 il faut les gouverner avec le mors et le frein, * autrement, ils n'obéissent pas.
 31:13 De nombreuses douleurs sont la part du méchant, * mais celui qui se confie en Yahweh est environné de Sa grâce.
 31:14 Justes, réjouissez-vous en Yahweh et soyez dans l'allégresse ! * Poussez des cris de joie, vous tous qui avez le cœur droit !

--- a/web/www/horas/Francais/psalms1/Psalm34.txt
+++ b/web/www/horas/Francais/psalms1/Psalm34.txt
@@ -1,18 +1,18 @@
 34:1 Yahweh, combattez ceux qui me combattent, * faites la guerre à ceux qui me font la guerre !
 34:2 Saisissez le petit et le grand bouclier, * et levez-Vous pour me secourir !
 34:3 Tirez la lance et barrez le passage à mes persécuteurs; * dites à mon âme : "Je suis ton salut !"
-34:4 Qu'ils soient honteux et confus * ceux qui en veulent à ma vie; 
+34:4 Qu'ils soient honteux et confus * ceux qui en veulent à ma vie;
 34:5 Qu'ils reculent et rougissent * ceux qui méditent ma perte !
 34:6 Qu'ils soient comme la paille au souffle du vent, * et que l'ange de Yahweh les chasse devant Lui !
 34:7 Que leur voie soit ténébreuse et glissante, * et que l'ange de Yahweh les poursuive !
 34:8 Car sans cause ils ont caché leur filet pour ma ruine, * sans cause ils ont creusé la fosse pour me faire périr.
 34:9 Que la ruine tombe sur lui à l'improviste, que le filet qu'il a caché le saisisse, * qu'il y tombe et périsse !
 34:10 Et mon âme aura de la joie en Yahweh, * de l'allégresse dans Son salut.
-34:10 Tous mes os diront : * "Yahweh, qui est semblable à Vous, 
+34:10 Tous mes os diront : * "Yahweh, qui est semblable à Vous,
 34:10 délivrant le malheureux d'un plus fort que lui, * le malheureux et le pauvre de celui qui le dépouille ?"
 34:11 Des témoins iniques se lèvent; * ils m'accusent de choses que j'ignore.
 34:12 Ils me rendent le mal pour le bien; * mon âme est dans l'abandon.
-34:13 Et moi, quand ils étaient malades, * je revêtais un sac, 
+34:13 Et moi, quand ils étaient malades, * je revêtais un sac,
 34:14 j'affligeais mon âme par le jeûne, * et ma prière retournait sur mon sein.
 34:15 Comme pour un ami, pour un frère, je me traînais lentement; * comme pour le deuil d'une mère, je me courbais avec tristesse.
 34:16 Et maintenant que je chancelle, ils se réjouissent et s'assemblent, * contre moi des calomniateurs s'assemblent à mon insu; ils me déchirent sans relâche.
@@ -26,7 +26,7 @@
 34:23 Eveillez-Vous, levez-Vous pour me faire justice, * mon Dieu et mon Seigneur, pour prendre en main ma cause !
 34:24 Jugez-moi selon Votre justice, Yahweh, mon Dieu, * et qu'ils ne se réjouissent pas à mon sujet !
 34:25 Qu'ils ne disent pas dans leur cœur : "Notre âme est satisfaite !" * qu'ils ne disent pas : "Nous l'avons englouti !"
-34:26 Qu'ils rougissent et soient confondus tous ensemble, * ceux qui se réjouissent de mon malheur ! 
+34:26 Qu'ils rougissent et soient confondus tous ensemble, * ceux qui se réjouissent de mon malheur !
 34:27 Qu'ils soient couverts de honte et d'ignominie, * ceux qui s'élèvent contre moi !
 34:28 Qu'ils soient dans la joie et l'allégresse, ceux qui désirent le triomphe de mon droit; * et que sans cesse ils disent : "Gloire à Yahweh, qui veut la paix de Son serviteur !"
 34:28 Et ma langue célébrera Votre justice, * Votre louange tous les jours.

--- a/web/www/horas/Francais/psalms1/Psalm36.txt
+++ b/web/www/horas/Francais/psalms1/Psalm36.txt
@@ -11,14 +11,14 @@
 36:11 Mais les doux posséderont la terre, * ils goûteront les délices d'une paix profonde.
 36:12 Le méchant forme des projets contre le juste, * il grince les dents contre lui.
 36:13 Le Seigneur se rit du méchant, * car Il voit que son jour arrive.
-36:14 Les méchants tirent le glaive, * ils bandent leur arc; 
+36:14 Les méchants tirent le glaive, * ils bandent leur arc;
 36:15 pour abattre le malheureux et le pauvre, * pour égorger ceux dont la voie est droite.
 36:15 Leur glaive entrera dans leur propre cœur, * et leurs arcs se briseront.
 36:16 Mieux vaut le peu du juste, * que l'abondance de nombreux méchants;
 36:17 car les bras des méchants seront brisés, * et Yahweh soutient les justes.
 36:18 Yahweh connaît les jours des hommes intègres, * et leur héritage dure à jamais.
 36:19 Ils ne sont pas confondus au jour du malheur, et ils sont rassasiés aux jours de la famine. * Car les méchants périssent;
-36:20 les ennemis de Yahweh sont comme la gloire des prairies; * ils s'évanouissent en fumée, ils s'évanouissent. 
+36:20 les ennemis de Yahweh sont comme la gloire des prairies; * ils s'évanouissent en fumée, ils s'évanouissent.
 36:21 Le méchant emprunte, et il ne rend pas; * le juste est compatissant, et il donne.
 36:22 Car ceux que bénit Yahweh possèdent le pays, * et ceux qu'Il maudit sont retranchés.
 36:23 Yahweh affermit les pas de l'homme juste, * et Il prend plaisir à sa voie.
@@ -26,7 +26,7 @@
 36:25 J'ai été jeune, me voilà vieux, * et je n'ai point vu le juste abandonné, ni sa postérité mendiant son pain.
 36:26 Toujours il est compatissant, et il prête, * et sa postérité est en bénédiction.
 36:27 Détourne-toi du mal et fais le bien; * et habite à jamais ta demeure.
-36:28 Car Yahweh aime la justice, et Il n'abandonne pas Ses fidèles. * Ils sont toujours sous Sa garde, 
+36:28 Car Yahweh aime la justice, et Il n'abandonne pas Ses fidèles. * Ils sont toujours sous Sa garde,
 36:29 mais la postérité des méchants * sera retranchée.
 36:29 Les justes posséderont le pays, * et ils y habiteront à jamais.
 36:30 La bouche du juste annonce la sagesse, * et sa langue proclame la justice.

--- a/web/www/horas/Francais/psalms1/Psalm37.txt
+++ b/web/www/horas/Francais/psalms1/Psalm37.txt
@@ -8,7 +8,7 @@
 37:8 Je suis sans force, brisé outre mesure; * le trouble de mon cœur m'arrache des gémissements.
 37:9 Seigneur, tous mes désirs sont devant Vous, * et mes soupirs ne Vous sont pas cachés.
 37:10 Mon cœur palpite, ma force m'abandonne, * et la lumière même de mes yeux n'est plus avec moi.
-37:12 Mes amis et mes compagnons * s'éloignent de ma plaie; 
+37:12 Mes amis et mes compagnons * s'éloignent de ma plaie;
 37:13 et mes proches se tiennent à l'écart. * Ceux qui en veulent à ma vie tendent leurs pièges;
 37:14 ceux qui cherchent mon malheur profèrent des menaces, * et tout le jour ils méditent des embûches.
 37:15 Et moi, je suis comme un sourd, je n'entends pas; * je suis comme un muet, qui n'ouvre pas la bouche.

--- a/web/www/horas/Francais/psalms1/Psalm4.txt
+++ b/web/www/horas/Francais/psalms1/Psalm4.txt
@@ -3,8 +3,8 @@
 4:3 Fils des hommes, jusques à quand Ma gloire sera-t-elle outragée ? * Jusques à quand aimerez-vous la vanité, et rechercherez-vous le mensonge ?
 4:4 Sachez que Yahweh S'est choisi un homme pieux; * Yahweh entend quand je l'invoque.
 4:5 Tremblez, et ne péchez plus ! * Parlez-vous à vous-mêmes sur votre couche, et cessez !
-4:6 Offrez des sacrifices de justice, et confiez-vous en Yahweh. * Beaucoup disent : "Qui nous fera voir le bonheur ?" 
+4:6 Offrez des sacrifices de justice, et confiez-vous en Yahweh. * Beaucoup disent : "Qui nous fera voir le bonheur ?"
 4:7 Faites lever sur nous * la lumière de Votre face, Yahweh !
 4:8 Vous avez mis dans mon cœur plus de joie qu'ils n'en ont * au temps où abondent leur froment et leur vin nouveau.
-4:9 En paix je me coucherai * et je m'endormirai aussitôt; 
+4:9 En paix je me coucherai * et je m'endormirai aussitôt;
 4:10 Car Vous, Yahweh, Vous seul, * Vous me faites habiter dans la sécurité.

--- a/web/www/horas/Francais/psalms1/Psalm41.txt
+++ b/web/www/horas/Francais/psalms1/Psalm41.txt
@@ -6,10 +6,10 @@
 41:6 Pourquoi es-tu abattue, ô mon âme, * et t'agites-tu en moi ?
 41:6 Espère en Dieu, car je le louerai encore, * lui, le salut de ma face et mon Dieu !
 41:7 Mon âme est abattue au dedans de moi;  * aussi je pense à Vous, du pays du Jourdain, de l'Hermon, de la montagne de Misar.
-41:8 Un flot en appelle un autre, * quand grondent Vos cataractes : 
+41:8 Un flot en appelle un autre, * quand grondent Vos cataractes :
 41:9 Ainsi toutes Vos vagues et Vos torrents * passent sur moi.
 41:10 Le jour, Yahweh commandait à Sa grâce de me visiter; * la nuit, son cantique était sur mes lèvres.
-41:11 j'adressais une prière au Dieu de ma vie. * Maintenant je dis à Dieu mon rocher : 
+41:11 j'adressais une prière au Dieu de ma vie. * Maintenant je dis à Dieu mon rocher :
 41:12 "Pourquoi m'oublies-tu ? * Pourquoi me faut-il marcher dans la tristesse, sous l'oppression de l'ennemi ?"
 41:12 Je sens mes os se briser, * quand mes persécuteurs m'insultent,
 41:12 en me disant sans cesse : "Où est ton Dieu ?" Pourquoi es-tu abattue, ô mon âme, et t'agites-tu en moi ?

--- a/web/www/horas/Francais/psalms1/Psalm43.txt
+++ b/web/www/horas/Francais/psalms1/Psalm43.txt
@@ -1,4 +1,4 @@
-43:1 O Dieu, nous avons entendu de nos oreilles, * nos pères nous ont raconté 
+43:1 O Dieu, nous avons entendu de nos oreilles, * nos pères nous ont raconté
 43:2 l'œuvre que Vous avez accomplie de leur temps, * aux jours anciens.
 43:3 De Votre main Vous avez chassé des nations pour les établir, * Vous avez frappé des peuples pour les étendre.
 43:4 Car ce n'est point avec leur épée qu'ils ont conquis le pays, * ce n'est point leur bras qui leur a donné la victoire;
@@ -10,7 +10,7 @@
 43:9 En Dieu nous nous glorifions chaque jour, * et nous célébrons Votre nom à jamais.
 43:10 Cependant Vous nous repoussez et nous couvrez de honte; * Vous ne sortez plus avec nos armées.
 43:11 Vous nous faites reculer devant l'ennemi, * et ceux qui nous haïssent nous dépouillent.
-43:12 Vous nous livrez comme des brebis destinées à la boucherie, * Vous nous dispersez parmi les nations; 
+43:12 Vous nous livrez comme des brebis destinées à la boucherie, * Vous nous dispersez parmi les nations;
 43:13 Vous vendez Votre peuple à vil prix, * Vous ne l'estimez pas à une grande valeur.
 43:14 Vous faites de nous un objet d'opprobre pour nos voisins, * de moquerie et de risée pour ceux qui nous entourent.
 43:15 Vous nous rendez la fable des nations, * et un sujet de hochements de tête parmi les peuples.

--- a/web/www/horas/Francais/psalms1/Psalm44.txt
+++ b/web/www/horas/Francais/psalms1/Psalm44.txt
@@ -2,7 +2,7 @@
 44:2 Ma langue est comme le roseau * rapide du scribe,
 44:3 Tu es le plus beau des fils de l'homme, * la grâce est répandue sur tes lèvres; * c'est pourquoi Dieu t'a béni pour toujours.
 44:4 Ceins ton épée sur ta cuisse, * ô héros,
-44:5 revêts ta splendeur et ta majesté. * Et dans ta majesté avance-toi, monte sur ton char, combats 
+44:5 revêts ta splendeur et ta majesté. * Et dans ta majesté avance-toi, monte sur ton char, combats
 44:6 pour la vérité, la douceur et la justice; * et que ta droite te fasse accomplir des faits merveilleux.
 44:7 Tes flèches sont aiguës; des peuples tomberont à tes pieds; * elles perceront le cœur des ennemis du roi.
 44:8 Ton trône, ô Dieu, est établi pour toujours; * le sceptre de ta royauté est un sceptre de droiture.
@@ -16,5 +16,5 @@
 44:15 En robe de couleurs variées, elle est présentée au roi; * après elles, des jeunes filles ses compagnes, te sont amenées.
 44:16 On les introduit au milieu des réjouissances et de l'allégresse; * elles entrent dans le palais du Roi.
 44:17 Tes enfants prendront la place de tes pères;  * tu les établiras princes sur toute la terre.
-44:18 Je rappellerai ton nom * dans tous les âges; 
+44:18 Je rappellerai ton nom * dans tous les âges;
 44:18 et les peuples te loueront éternellement * et à jamais.

--- a/web/www/horas/Francais/psalms1/Psalm45.txt
+++ b/web/www/horas/Francais/psalms1/Psalm45.txt
@@ -8,4 +8,4 @@
 45:8 Venez, contemplez les œuvres de Yahweh, les dévastations qu'Il a opérées sur la terre ! * Il a fait cesser les combats jusqu'au bout de ta terre,
 45:9 Il a brisé l'arc, Il a rompu la lance, * Il a consumé par le feu les chars de guerre :
 45:10 "Arrêtez et reconnaissez que Je suis Dieu; * Je domine sur les nations, Je domine sur la terre !"
-45:11 Yahweh des armées est avec nous, * le Dieu de Jacob est pour nous une citadelle. 
+45:11 Yahweh des armées est avec nous, * le Dieu de Jacob est pour nous une citadelle.

--- a/web/www/horas/Francais/psalms1/Psalm46.txt
+++ b/web/www/horas/Francais/psalms1/Psalm46.txt
@@ -1,9 +1,9 @@
-1 Vous tous, peuples, battez des mains, * célébrez Dieu par des cris d'allégresse !
-2 Car Yahweh est très haut, redoutable, * grand roi sur toute la terre.
-3 Il nous assujettit les peuples, * Il met les nations sous nos pieds.
-4 Il nous choisit notre héritage, * la gloire de Jacob, Son bien-aimé.
-5 Dieu monte à son sanctuaire au milieu des acclamations; * Yahweh, au son de la trompette.
-6 Chantez à Dieu, chantez ! * chantez à notre Roi, chantez !
-7 Car Dieu est roi de toute la terre; * chantez un cantique de louange.
-8 Dieu règne sur les nations, * Il siège sur Son trône saint.
-9 Les princes des peuples se réunissent pour former aussi un peuple du Dieu d'Abraham; * car à Dieu sont les boucliers de la terre; Il est souverainement élevé.
+46:1 Vous tous, peuples, battez des mains, * célébrez Dieu par des cris d'allégresse !
+46:2 Car Yahweh est très haut, redoutable, * grand roi sur toute la terre.
+46:3 Il nous assujettit les peuples, * Il met les nations sous nos pieds.
+46:4 Il nous choisit notre héritage, * la gloire de Jacob, Son bien-aimé.
+46:5 Dieu monte à son sanctuaire au milieu des acclamations; * Yahweh, au son de la trompette.
+46:6 Chantez à Dieu, chantez ! * chantez à notre Roi, chantez !
+46:7 Car Dieu est roi de toute la terre; * chantez un cantique de louange.
+46:8 Dieu règne sur les nations, * Il siège sur Son trône saint.
+46:9 Les princes des peuples se réunissent pour former aussi un peuple du Dieu d'Abraham; * car à Dieu sont les boucliers de la terre; Il est souverainement élevé.

--- a/web/www/horas/Francais/psalms1/Psalm47.txt
+++ b/web/www/horas/Francais/psalms1/Psalm47.txt
@@ -1,13 +1,13 @@
-1 Yahweh est grand, Il est l'objet de toute louange, * dans la cité de notre Dieu, sur Sa montagne sainte.
-2 Elle s'élève gracieuse, joie de toute la terre, la montagne de Sion, * aux extrémités du septentrion, la cité du grand Roi.
-3 Dieu, dans Ses palais, S'est fait connaître * comme un refuge.
-4 Car voici que les rois s'étaient réunis, * ensemble ils s'étaient avancés.
-5 Ils ont vu, soudain ils ont été dans la stupeur; éperdus, ils ont pris la fuite. * Là un tremblement les a saisis,
-6 une douleur comme celle de la femme qui enfante. * Par le vent d'Orient Vous brisez les vaisseaux de Tharsis.
-7 Ce que nous avions entendu dire, nous l'avons vu * dans la cité de Yahweh des armées; dans la cité de notre Dieu : * Dieu l'affermit pour toujours.
-8 O Dieu nous rappelons la mémoire de Votre bonté, * au milieu de Votre temple.
-9 Comme Votre nom, ô Dieu, ainsi Votre louange arrive jusqu'aux extrémités de la terre. * Votre droite est pleine de justice.
-10 Que la montagne de Sion se réjouisse, que les filles de Juda soient dans l'allégresse, * à cause de Vos jugements !
-11 Parcourez Sion et faites-en le tour, * comptez ses forteresses;
-12 observez son rempart, * examinez ses palais, pour le raconter à la génération future.
-13 Voilà le Dieu qui est notre Dieu à jamais et toujours ; * Il sera notre guide dans tous les siècles.
+47:1 Yahweh est grand, Il est l'objet de toute louange, * dans la cité de notre Dieu, sur Sa montagne sainte.
+47:2 Elle s'élève gracieuse, joie de toute la terre, la montagne de Sion, * aux extrémités du septentrion, la cité du grand Roi.
+47:3 Dieu, dans Ses palais, S'est fait connaître * comme un refuge.
+47:4 Car voici que les rois s'étaient réunis, * ensemble ils s'étaient avancés.
+47:5 Ils ont vu, soudain ils ont été dans la stupeur; éperdus, ils ont pris la fuite. * Là un tremblement les a saisis,
+47:6 une douleur comme celle de la femme qui enfante. * Par le vent d'Orient Vous brisez les vaisseaux de Tharsis.
+47:7 Ce que nous avions entendu dire, nous l'avons vu * dans la cité de Yahweh des armées; dans la cité de notre Dieu : * Dieu l'affermit pour toujours.
+47:8 O Dieu nous rappelons la mémoire de Votre bonté, * au milieu de Votre temple.
+47:9 Comme Votre nom, ô Dieu, ainsi Votre louange arrive jusqu'aux extrémités de la terre. * Votre droite est pleine de justice.
+47:10 Que la montagne de Sion se réjouisse, que les filles de Juda soient dans l'allégresse, * à cause de Vos jugements !
+47:11 Parcourez Sion et faites-en le tour, * comptez ses forteresses;
+47:12 observez son rempart, * examinez ses palais, pour le raconter à la génération future.
+47:13 Voilà le Dieu qui est notre Dieu à jamais et toujours ; * Il sera notre guide dans tous les siècles.

--- a/web/www/horas/Francais/psalms1/Psalm48.txt
+++ b/web/www/horas/Francais/psalms1/Psalm48.txt
@@ -7,7 +7,7 @@
 48:7 Un homme ne peut racheter son frère, * ni payer à Dieu sa rançon.
 48:8 Le rachat de leur vie est trop cher; * il est à jamais impossible, pour qu'il vive éternellement,
 48:9 et qu'il ne voie jamais la fosse. Non, il la verra; les sages meurent, * l'insensé et le stupide périssent également,
-48:10 laissant à d'autres leurs biens. * Ils s'imaginent que leurs maisons seront éternelles, 
+48:10 laissant à d'autres leurs biens. * Ils s'imaginent que leurs maisons seront éternelles,
 48:11 que leurs demeures subsisteront d'âge en âge, * et ils donnent leurs noms à leurs domaines.
 48:12 Mais, même dans sa splendeur, l'homme ne dure pas; * il est semblable aux biches qui périssent.
 48:14 Tel est leur sort, à ces hommes si confiants, * et à ceux qui les suivent en approuvant leurs discours.

--- a/web/www/horas/Francais/psalms1/Psalm5.txt
+++ b/web/www/horas/Francais/psalms1/Psalm5.txt
@@ -1,5 +1,5 @@
 5:1 Prêtez l'oreille à mes paroles, Yahweh, * entendez mes soupirs;
-5:2 Soyez attentif à mes cris, * ô mon Roi et mon Dieu; 
+5:2 Soyez attentif à mes cris, * ô mon Roi et mon Dieu;
 5:3 car c'est à Vous * que j'adresse ma prière.
 5:4 Yahweh, dès le matin, Vous entendez ma voix; * dès le matin, je Vous offre mes vœux et j'attends.
 5:5 Car Vous n'êtes pas un Dieu qui prenne plaisir au mal; * avec Vous le méchant ne saurait habiter.
@@ -7,8 +7,8 @@
 5:7 Vous faites périr les menteurs; * Yahweh abhorre l'homme de sang et de fraude.
 5:8 Pour moi, par Votre grande miséricorde, j'irai dans Votre maison; * je me prosternerai, dans Votre crainte, devant Votre saint temple.
 5:9 Seigneur, conduisez-moi, dans Votre justice, à cause de mes ennemis aplanissez Votre voie sous mes pas.
-5:10 Car il n'y a point de sincérité dans leur bouche; * leur cœur n'est que malice; 
-5:11 leur gosier est un sépulcre ouvert, leur langue se fait caressante. * Châtiez-les, ô Dieu. 
+5:10 Car il n'y a point de sincérité dans leur bouche; * leur cœur n'est que malice;
+5:11 leur gosier est un sépulcre ouvert, leur langue se fait caressante. * Châtiez-les, ô Dieu.
 5:12 Qu'ils échouent dans leurs desseins ! A cause de leurs crimes sans nombre, précipitez-les; * car ils sont en révolte contre Vous.
 5:13 Alors se réjouiront tous ceux qui se confient en Vous; ils seront dans une perpétuelle allégresse, * et Vous les protégerez;
 5:14 ils se livreront à de joyeux transports, * ceux qui aiment Votre nom.

--- a/web/www/horas/Francais/psalms1/Psalm67.txt
+++ b/web/www/horas/Francais/psalms1/Psalm67.txt
@@ -1,8 +1,8 @@
 67:1 Que Dieu Se lève, et que Ses ennemis soient dispersés, * et que ceux qui Le haïssent fuient devant Sa face !
 67:2 Comme se dissipe la fumée, dissipez-les; * comme la cire se fond au feu, que les méchants disparaissent devant Dieu !
 67:3 Mais que les justes se réjouissent et tressaillent devant Dieu; * qu'ils soient transportés d'allégresse !
-67:4 Chantez à Dieu, célébrez Son nom ! * Frayez le chemin à Celui qui s'avance à travers les plaines ! (fit reverentia) Yahweh est Son nom; 
-67:5 tressaillez devant Lui ! * Il est père des orphelins et juge des veuves, 
+67:4 Chantez à Dieu, célébrez Son nom ! * Frayez le chemin à Celui qui s'avance à travers les plaines ! (fit reverentia) Yahweh est Son nom;
+67:5 tressaillez devant Lui ! * Il est père des orphelins et juge des veuves,
 67:6 * Dieu dans Sa sainte demeure. * Aux abandonnés Dieu donne une maison;
 67:7 Il délivre les captifs * et les rend au bonheur; seuls les rebelles restent au désert brûlant.
 67:8 O Dieu, quand Vous sortiez à la tête de Votre peuple, * quand Vous Vous avançiez dans le désert,

--- a/web/www/horas/Francais/psalms1/Psalm68.txt
+++ b/web/www/horas/Francais/psalms1/Psalm68.txt
@@ -13,7 +13,7 @@
 68:13 Je verse des larmes et je jeûne : * on m'en fait un sujet d'opprobre.
 68:13 Je prends un sac pour vêtement, * et je suis l'objet de leurs sarcasmes.
 68:13 Ceux qui sont assis à la porte parlent de moi, * et les buveurs de liqueurs fortes font sur moi des chansons.
-68:13 Et moi, je Vous adresse ma prière, Yahweh; * dans le temps favorable, ô Dieu, 
+68:13 Et moi, je Vous adresse ma prière, Yahweh; * dans le temps favorable, ô Dieu,
 68:14 selon Votre grande bonté, exaucez-moi, * selon la vérité de Votre salut.
 68:15 Retirez-moi de la boue, et que je n'y reste plus enfoncé; * que je sois délivré de mes ennemis et des eaux profondes !
 68:16 Que les flots ne me submergent plus, que l'abîme ne m'engloutisse pas, * que la fosse ne se ferme pas sur moi !

--- a/web/www/horas/Francais/psalms1/Psalm73.txt
+++ b/web/www/horas/Francais/psalms1/Psalm73.txt
@@ -3,7 +3,7 @@
 73:3 que Vous as racheté pour être la tribu de Votre héritage ! * Souvenez-Vous de Votre montagne de Sion où Vous faisiez Votre résidence,
 73:4 portez Vos pas vers ces ruines irréparables; * l'ennemi a tout ravagé dans le sanctuaire.
 73:5 Vos adversaires ont rugi * au milieu de Vos saints parvis;
-73:6 ils ont établi pour emblèmes leurs emblèmes. * On les a vus, pareils au bûcheron, 
+73:6 ils ont établi pour emblèmes leurs emblèmes. * On les a vus, pareils au bûcheron,
 73:7 qui lève la cognée dans une épaisse forêt. Et maintenant, toutes les sculptures ensemble; * ils les ont brisées à coups de hache et de marteau.
 73:8 Ils ont livré au feu Votre sanctuaire; * ils ont abattu et profané la demeure de Votre nom.
 73:9 Ils disaient dans leur cœur : "Détruisons-les tous ensemble !" * Ils ont brûlé dans le pays tous les lieux saints.

--- a/web/www/horas/Francais/psalms1/Psalm77.txt
+++ b/web/www/horas/Francais/psalms1/Psalm77.txt
@@ -1,7 +1,7 @@
 77:1 Ecoute, ô mon peuple, mon enseignement; * prête l'oreille aux paroles de ma bouche.
 77:2 Je vais ouvrir ma bouche pour dire des sentences, * je publierai les mystères des temps anciens.
 77:3 Ce que nous avons entendu, ce que nous avons appris, * ce que nos pères nous ont raconté,
-77:4 nous ne le cacherons pas à leurs enfants; nous dirons à la génération future 
+77:4 nous ne le cacherons pas à leurs enfants; nous dirons à la génération future
 77:5 les louanges de Yahweh, et Sa puissance, * et les prodiges qu'Il a opérés.
 77:6 Il a mis une règle en Jacob, * Il a établi une loi en Israël,
 77:7 qu'Il a enjoint à nos pères d'apprendre à leurs enfants, * pour qu'elles soient connues des générations suivantes,

--- a/web/www/horas/Francais/psalms1/Psalm8.txt
+++ b/web/www/horas/Francais/psalms1/Psalm8.txt
@@ -3,7 +3,7 @@
 8:3 Par la bouche des enfants et de ceux qui sont à la mamelle Vous Vous êtes fondé une force pour confondre Vos ennemis, * pour imposer silence à l'adversaire et au blasphémateur.
 8:4 Quand je contemple Vos cieux, ouvrage de Vos doigts, * la lune et les étoiles que Vous avez créées, je m'écrie :
 8:5 Qu'est-ce que l'homme, pour que Vous Vous souveniez de lui, * et le fils de l'homme, pour que Vous en preniez soin ?
-8:6 Vous l'avez fait de peu inférieur aux anges, Vous l'avez couronné de gloire et d'honneur. * Vous lui as donné l'empire sur les œuvres de Vos mains. 
+8:6 Vous l'avez fait de peu inférieur aux anges, Vous l'avez couronné de gloire et d'honneur. * Vous lui as donné l'empire sur les œuvres de Vos mains.
 8:7 Vous avez mis toutes choses sous ses pieds : * Brebis et bœufs, tous ensemble, et les animaux des champs;
 8:8 Oiseaux du ciel et poissons de la mer, et tout ce qui parcourt les sentiers des mers.
 8:9 Yahweh, notre Seigneur, * que Votre nom est glorieux sur toute la terre !

--- a/web/www/horas/Francais/psalms1/Psalm84.txt
+++ b/web/www/horas/Francais/psalms1/Psalm84.txt
@@ -5,7 +5,7 @@
 84:5 Serez-Vous toujours irrité contre nous, * prolongerez-Vous Votre courroux éternellement ?
 84:6 Ne nous ferez-Vous pas revenir à la vie, * afin que Votre peuple se réjouisse en Vous ?
 84:7 Yahweh, faites-nous voir Votre bonté, * et accordez-nous Votre salut.
-84:8 Je veux écouter ce que dira le Dieu Yahweh : * Il a des paroles de paix pour son peuple 
+84:8 Je veux écouter ce que dira le Dieu Yahweh : * Il a des paroles de paix pour son peuple
 84:9 et pour ses fidèles; * pourvu qu'ils ne retournent pas à leur folie.
 84:10 Oui, Son salut est proche de ceux qui Le craignent, * et la gloire habitera de nouveau dans notre pays.
 84:11 La bonté et la vérité vont se rencontrer, * la justice et la paix s'embrasseront.

--- a/web/www/horas/Francais/psalms1/Psalm9.txt
+++ b/web/www/horas/Francais/psalms1/Psalm9.txt
@@ -4,15 +4,15 @@
 9:4 Car Vous avez fait triompher mon droit et ma cause, * Vous Vous êtes assis sur Votre trône en juste juge.
 9:5 Vous avez châtié les nations, Vous avez fait périr l'impie, * Vous avez effacé leur nom pour toujours et à jamais.
 9:6 L'ennemi est anéanti ! Des ruines pour toujours ! * Des villes que Vous avez renversées !
-9:7 Leur souvenir a disparu !* Mais Yahweh siège à jamais, 
+9:7 Leur souvenir a disparu !* Mais Yahweh siège à jamais,
 9:8 Il a dressé Son trône pour le jugement. Il juge le monde avec justice, * Il juge les peuples avec droiture.
 9:9 Et Yahweh est un refuge pour l'opprimé, * un refuge au temps de la détresse.
 9:10 En Vous se confient tous ceux qui connaissent Votre nom; * car Vous ne délaissez pas ceux qui Vous cherchent, Yahweh.
 9:12 Chantez à Yahweh, qui réside en Sion, * publiez parmi les peuples ses hauts faits.
 9:13 Car Celui qui redemande le sang versé s'en est souvenu, * Il n'a point oublié le cri des affligés.
-9:14 "Ayez pitié de moi, Yahweh, disaient-ils ; voyez l'affliction où m'ont réduit mes ennemis, 
+9:14 "Ayez pitié de moi, Yahweh, disaient-ils ; voyez l'affliction où m'ont réduit mes ennemis,
 9:15 Vous qui me retirez des portes de la mort, * afin que je puisse raconter toutes les louanges, aux portes de la fille de Sion,
-9:16 tressaillir de joie à cause de Votre salut." * Les nations sont tombées dans la fosse qu'elles ont creusée, 
+9:16 tressaillir de joie à cause de Votre salut." * Les nations sont tombées dans la fosse qu'elles ont creusée,
 9:17 dans le lacet qu'elles ont caché * elles se sont pris leur pied.
 9:18 Yahweh S'est montré, Il a exercé le jugement, * dans l'œuvre de Ses mains Il a enlacé l'impie.
 9:19 Les impies retournent au schéol, * toutes les nations qui oublient Dieu.
@@ -23,18 +23,18 @@
 9:23 Quand le méchant s'enorgueillit, les malheureux sont consumés; * ils sont pris dans les intrigues qu'il a conçues.
 9:24 Car le méchant se glorifie de sa convoitise; * le ravisseur maudit, méprise Yahweh.
 9:25 Dans son arrogance, le méchant dit : "Il ne punit pas !" * "Il n'y a pas de Dieu" :
-9:26 Voilà toutes ses pensées. * Ses voies sont prospères en tout temps ! 
+9:26 Voilà toutes ses pensées. * Ses voies sont prospères en tout temps !
 9:27 Vos jugements sont trop élevés pour qu'il s'en inquiète; * tous ses adversaires, il les dissipe d'un souffle.
 9:28 Il dit dans son cœur : * "Je ne serai pas ébranlé, je suis pour toujours à l'abri du malheur."
 9:29 Sa bouche est pleine de malédiction, de tromperie et de violence; * sous sa langue est la malice et l'iniquité.
-9:30 Il se met en embuscade près des hameaux, * dans les lieux couverts il assassine l'innocent. 
+9:30 Il se met en embuscade près des hameaux, * dans les lieux couverts il assassine l'innocent.
 9:31 Ses yeux épient l'homme sans défense, * Il est aux aguets dans le lieu couvert, comme un lion dans son fourré;
-9:32 il est aux aguets pour surprendre le pauvre, 
+9:32 il est aux aguets pour surprendre le pauvre,
 9:32 Il se saisit du pauvre en le tirant dans son filet. * Il se courbe, il se baisse, et les malheureux tombent dans ses griffes.
 9:32 Il dit dans son cœur : "Dieu a oublié ! Il a couvert sa face, Il ne voit jamais rien."
 9:33 Levez-Vous, Yahweh; ô Dieu, levez Votre main ! * N'oubliez pas les affligés.
 9:34 Pourquoi le méchant méprise-t-il Dieu ? * Pourquoi dit-il en son cœur : "Vous ne punissez pas ?"
-9:35 Vous avez vu pourtant; car Vous regardez la peine et la souffrance, * pour prendre en main leur cause. 
+9:35 Vous avez vu pourtant; car Vous regardez la peine et la souffrance, * pour prendre en main leur cause.
 9:36 A Vous s'abandonne le malheureux, * à l'orphelin Vous venez en aide.
 9:37 Brisez le bras du méchant; l'impie, * si Vous cherchez son crime, ne le trouverez-Vous pas ?
 9:38 Yahweh est roi à jamais et pour l'éternité, * les nations seront exterminées de Sa terre.


### PR DESCRIPTION
- Fixed numbering labels in Ps 46 and 47
- Removed remaining spaces from ends of lines

Remaining problem: Ps 1 has 6 verses while the Latin version (https://github.com/DivinumOfficium/divinum-officium/blob/master/web/www/horas/Latin/psalms1/Psalm1.txt) has 7. Can someone fix this?

// I guess you meant Latin has 7 - DL