### PR TITLE
Renumbering of verses in Psalm 1

### DIFF
--- a/web/www/horas/Deutsch/psalms1/Psalm1.txt
+++ b/web/www/horas/Deutsch/psalms1/Psalm1.txt
@@ -1,7 +1,7 @@
 1:1 Wie glücklich ist der Mensch, † der niemals mitläuft mit dem Frevlerhaufen und nicht stehen bleibt am Sünderwege, * sich auch nicht niederläßt, wo Missetäter sich versammeln,
 1:2 Der aber Freude hat an dem Gesetze Gottes * und allezeit um sein Gesetz besorgt ist.
 1:3 Ja, der wird wie ein Baum, der seine Wurzeln hat an Wasserbächen, * der reiche Frucht zur richt'gen Zeit hervorbringt,
-1:4 Und dem kein Blättchen abfällt; * und alles, was er unternimmt, hat guten Fortgang.
-1:5 Nicht also kann's den Frevlern gehen, nicht also, * sie sind im Gegenteil wie Spreu, die überm Boden vor sich her der Wind davontreibt.
-1:6 Nein, Frevler können doch zum Glück empor nicht kommen, * und Sünder werden nicht zusammen bleiben mit den Gottesdienern.
-1:7 Denn segnend anerkennt der Herr das Tun der Guten, * der Weg der Bösen aber endigt im Verderben.
+1:3 Und dem kein Blättchen abfällt; * und alles, was er unternimmt, hat guten Fortgang.
+1:4 Nicht also kann's den Frevlern gehen, nicht also, * sie sind im Gegenteil wie Spreu, die überm Boden vor sich her der Wind davontreibt.
+1:5 Nein, Frevler können doch zum Glück empor nicht kommen, * und Sünder werden nicht zusammen bleiben mit den Gottesdienern.
+1:6 Denn segnend anerkennt der Herr das Tun der Guten, * der Weg der Bösen aber endigt im Verderben.

--- a/web/www/horas/English/psalms1/Psalm1.txt
+++ b/web/www/horas/English/psalms1/Psalm1.txt
@@ -1,7 +1,7 @@
 1:1 Blessed is the man who hath not walked in the counsel of the ungodly, nor stood in the way of sinners, * nor sat in the chair of pestilence.
 1:2 But his will is in the law of the Lord, * and on his law he shall meditate day and night.
 1:3 And he shall be like a tree which is planted near the running waters, * which shall bring forth its fruit, in due season.
-1:4 And his leaf shall not fall off: * and all whatsoever he shall do shall prosper.
-1:5 Not so the wicked, not so: * but like the dust, which the wind driveth from the face of the earth.
-1:6 Therefore the wicked shall not rise again in judgment: * nor sinners in the council of the just.
-1:7 For the Lord knoweth the way of the just: * and the way of the wicked shall perish.
+1:3 And his leaf shall not fall off: * and all whatsoever he shall do shall prosper.
+1:4 Not so the wicked, not so: * but like the dust, which the wind driveth from the face of the earth.
+1:5 Therefore the wicked shall not rise again in judgment: * nor sinners in the council of the just.
+1:6 For the Lord knoweth the way of the just: * and the way of the wicked shall perish.

--- a/web/www/horas/Francais/psalms1/Psalm1.txt
+++ b/web/www/horas/Francais/psalms1/Psalm1.txt
@@ -1,7 +1,7 @@
 1:1 Heureux l'homme qui ne marche pas dans le conseil des impies, qui ne se tient pas dans la voie des pécheurs, * et qui ne s'assied pas dans la compagnie des moqueurs,
 1:2 Mais qui a son plaisir dans la loi de Yahweh, * et qui la médite jour et nuit !
 1:3 Il est comme un arbre planté près d'un cours d'eau, * qui donne son fruit en son temps :
-1:4 Et dont le feuillage ne se flétrit pas : * tout ce qu'il fait réussit.
-1:5 Il n'en est pas ainsi des impies : * ils sont comme la paille que chasse le vent.
-1:6 Aussi les impies ne resteront-ils pas debout au jour du jugement, * ni les pécheurs dans l'assemblée des justes.
-1:7 Car Yahweh connaît la voie du juste, * mais la voie des pécheurs mène à la ruine.
+1:3 Et dont le feuillage ne se flétrit pas : * tout ce qu'il fait réussit.
+1:4 Il n'en est pas ainsi des impies : * ils sont comme la paille que chasse le vent.
+1:5 Aussi les impies ne resteront-ils pas debout au jour du jugement, * ni les pécheurs dans l'assemblée des justes.
+1:6 Car Yahweh connaît la voie du juste, * mais la voie des pécheurs mène à la ruine.

--- a/web/www/horas/Italiano/psalms1/Psalm1.txt
+++ b/web/www/horas/Italiano/psalms1/Psalm1.txt
@@ -1,7 +1,7 @@
 1:1 Beato l'uomo che non permane nel consiglio degli empi, e non si ferma nella via dei peccatori, * né si pone a sedere sulla cattedra di pestilenza:
 1:2 Ma il suo diletto è nella legge del Signore, * e nella legge di lui medita giorno e notte.
 1:3 Egli sarà come un albero piantato lungo correnti d'acqua, * che darà il suo frutto a suo tempo;
-1:4 e la cui foglia non avvizzirà, * e tutto quello che egli farà prospererà.
-1:5 Non così gli empi, non cosi: * ma saranno come la pula che il vento disperde dalla superficie della terra.
-1:6 Perciò gli empi, non risorgeranno nel giudizio, * né i peccatori nel consesso dei giusti;
-1:7 Poiché il Signore conosce la via dei giusti; * e la via degli empi finirà nella perdizione.
+1:3 e la cui foglia non avvizzirà, * e tutto quello che egli farà prospererà.
+1:4 Non così gli empi, non cosi: * ma saranno come la pula che il vento disperde dalla superficie della terra.
+1:5 Perciò gli empi, non risorgeranno nel giudizio, * né i peccatori nel consesso dei giusti;
+1:6 Poiché il Signore conosce la via dei giusti; * e la via degli empi finirà nella perdizione.

--- a/web/www/horas/Latin/psalms1/Psalm1.txt
+++ b/web/www/horas/Latin/psalms1/Psalm1.txt
@@ -1,7 +1,7 @@
 1:1 Beátus vir, qui non ábiit in consílio impiórum, et in via peccatórum non stetit, * et in cáthedra pestiléntiæ non sedit:
 1:2 Sed in lege Dómini volúntas ejus, * et in lege ejus meditábitur die ac nocte.
 1:3 Et erit tamquam lignum, quod plantátum est secus decúrsus aquárum, * quod fructum suum dabit in témpore suo:
-1:4 Et fólium ejus non défluet: * et ómnia quæcúmque fáciet, prosperabúntur.
-1:5 Non sic ímpii, non sic: * sed tamquam pulvis, quem proícit ventus a fácie terræ.
-1:6 Ideo non resúrgent ímpii in judício: * neque peccatóres in concílio justórum.
-1:7 Quóniam novit Dóminus viam justórum: * et iter impiórum períbit.
+1:3 Et fólium ejus non défluet: * et ómnia quæcúmque fáciet, prosperabúntur.
+1:4 Non sic ímpii, non sic: * sed tamquam pulvis, quem proícit ventus a fácie terræ.
+1:5 Ideo non resúrgent ímpii in judício: * neque peccatóres in concílio justórum.
+1:6 Quóniam novit Dóminus viam justórum: * et iter impiórum períbit.

--- a/web/www/horas/Magyar/psalms1/Psalm1.txt
+++ b/web/www/horas/Magyar/psalms1/Psalm1.txt
@@ -1,7 +1,7 @@
 1:1 Boldog ember, ki az istentelenek tanácsán nem jár, és a bűnösök útján meg nem áll, * és a mirígy székében nem ül;
 1:2 hanem az Úr törvényében telik kedve, * és éjjel-nappal az ő törvényében elmélkedik.
 1:3 És leszen mint a fa, mely vízfolyások mellé ültettetett, * mely gyümölcsét megadja idejében,
-1:4 és levele el nem hull; * és amit cselekszik, mind sikerül.
-1:5 Nem így az istentelenek, nem így; * hanem mint a por, melyet a szél elhány a föld színéről.
-1:6 Azért az istentelenek meg nem állhatnak az ítéletben; * sem a bűnösök az igazak gyülekezetében.
-1:7 Mert az Úr ismeri az igazak útját; * és az istentelenek útja elvész.
+1:3 és levele el nem hull; * és amit cselekszik, mind sikerül.
+1:4 Nem így az istentelenek, nem így; * hanem mint a por, melyet a szél elhány a föld színéről.
+1:5 Azért az istentelenek meg nem állhatnak az ítéletben; * sem a bűnösök az igazak gyülekezetében.
+1:6 Mert az Úr ismeri az igazak útját; * és az istentelenek útja elvész.

--- a/web/www/horas/Polski/psalms1/Psalm1.txt
+++ b/web/www/horas/Polski/psalms1/Psalm1.txt
@@ -1,7 +1,7 @@
 1:1 Błogosławiony mąż, który nie chodził w radzie niezbożnych, i na drodze grzesznych nie stał, * i na stolicy zaraźliwości nie siedział:
 1:2 Ale w zakonie Pańskim wola jego, * a w zakonie jego będzie rozmyślał we dnie i w nocy.
 1:3 I będzie jako drzewo, które wsadzone jest nad ściekaniem wód, * które swój owoc da czasu swego:
-1:4 A liście jego nie opadnie: * i wszystko, cokolwiek czynić będzie, poszczęści się.
-1:5 Nie tak niezbożni, nie tak: * ale jako proch, który rozmiata wiatr z wierzchu ziemi.
-1:6 Przetóż nie powstaną niezbożnicy na sądzie: * ani grzesznicy w zebraniu sprawiedliwych.
-1:7 Albowiem zna Pan drogę sprawiedliwych: * a droga niezbożnych zginie.
+1:3 A liście jego nie opadnie: * i wszystko, cokolwiek czynić będzie, poszczęści się.
+1:4 Nie tak niezbożni, nie tak: * ale jako proch, który rozmiata wiatr z wierzchu ziemi.
+1:5 Przetóż nie powstaną niezbożnicy na sądzie: * ani grzesznicy w zebraniu sprawiedliwych.
+1:6 Albowiem zna Pan drogę sprawiedliwych: * a droga niezbożnych zginie.


### PR DESCRIPTION
This is the first patch updating numbering of verses in psalms. The proposal was presented in #838.

Psalm 1 is relatively simple, because there are no references to parts of it in `LANG/Psalterium/Psalmi minor.txt` or other files.

The changes are first manually applied to the Latin version, and then programmatically transferred to other languages with necessary validation. Encoding of files (including BOM) is preserved.