### PR TITLE
Corrections mostly to Latin

### DIFF
--- a/web/www/horas/English/Sancti/05-01r.txt
+++ b/web/www/horas/English/Sancti/05-01r.txt
@@ -32,7 +32,7 @@ Christ the Lord * deigned to be thought the son of a carpenter, alleluia.
 
 [Oratio]
 God, Creator of all things, who didst lay on the human race the law of labour: graciously grant; that by following the example of Saint Joseph and under his patronage, we may carry out the work thou dost command, and obtain the reward thou dost promise.
-$Qui vivis
+$Per Dominum
 
 [Invit]
 The Lord, King of kings, who deigned to be reckoned the son of a workman, * O come let us adore him, alleluia.

--- a/web/www/horas/Italiano/Sancti/05-01r.txt
+++ b/web/www/horas/Italiano/Sancti/05-01r.txt
@@ -35,7 +35,7 @@ Cristo Signore * si è degnato di farsi chiamare figlio dell'artigiano, alleluia
 
 [Oratio]
 O Dio, creatore del mondo, che hai dato al genere umano la legge del lavoro; concedici benigno, per l'esempio e il patrocinio di San Giuseppe, di compiere le opere che comandi e di ottenere la ricompensa che prometti.
-$Qui vivis
+$Per Dominum
 
 [Invit]
 Il Signore Re dei re, che degnò farsi figlio putativo di un falegname, * venite, adoriamo, alleluia.

--- a/web/www/horas/Latin/Sancti/02-09.txt
+++ b/web/www/horas/Latin/Sancti/02-09.txt
@@ -19,7 +19,7 @@ Deus, qui beátum Cyríllum Confessórem tuum atque Pontíficem divínæ materni
 $Per eumdem
 
 [Commemoratio]
-!Commemoratio S. Appolloniæ Virginis et Martyris
+!Commemoratio S. Apolloniæ Virginis et Martyris
 @Commune/C6:Oratio proper
 $Oremus
 Deus qui inter cétera poténtiæ tuæ mirácula étiam in sexu frágili victóriam martýrii contulísti: concéde propítius; ut, qui beátæ Apollóniæ Vírginis et Mártyris tuæ natalícia cólimus, per ejus ad te exémpla gradiámur.

--- a/web/www/horas/Latin/Sancti/03-25.txt
+++ b/web/www/horas/Latin/Sancti/03-25.txt
@@ -172,3 +172,6 @@ $Deo gratias
 
 [Ant 3]
 Gabriel Angelus * locútus est Maríæ dicens: Ave, grátia plena; Dóminus tecum: benedícta tu in muliéribus. (Allelúja.) 
+
+[Versum 3]
+@:Versum 1

--- a/web/www/horas/Latin/Sancti/04-28.txt
+++ b/web/www/horas/Latin/Sancti/04-28.txt
@@ -6,7 +6,7 @@ vide C5;mtv
 9 lectiones
 
 [Oratio]
-Dómine Jesu Christe, qui, ad mystérium Crucis prædicándum, sanctum Paulum singulári caritáte donásti, et per eum novam in Ecclésia famíliam floréscere voluísti: ipsíus nobis intercessióne concéde; ut, passiónem tuam júgiter recoléntes in terris, ejúsdem fructum cónsequi mereámur in cælis:
+Dómine Jesu Christe, qui, ad mystérium crucis prædicándum, sanctum Paulum singulári caritáte donásti, et per eum novam in Ecclésia famíliam floréscere voluísti: ipsíus nobis intercessióne concéde; ut, passiónem tuam júgiter recoléntes in terris, ejúsdem fructum cónsequi mereámur in cælis:
 $Qui vivis
 
 [Lectio4]

--- a/web/www/horas/Latin/Sancti/04-30.txt
+++ b/web/www/horas/Latin/Sancti/04-30.txt
@@ -9,7 +9,7 @@ vide C6;
 @Commune/C6:Hymnus Matutinum 1
 
 [Oratio]
-Da, quǽsumus, omnípotens Deus: ut, qui beátæ Catharínæ Vírginis tuæ natalícia cólimus; et ánnua solemnitáte lætámur, et tantæ virtútis proficiámus exémplo.
+Da, quǽsumus, omnípotens Deus: ut, qui beátæ Catharínæ Vírginis tuæ natalícia cólimus; et ánnua solemnitáte lætémur, et tantæ virtútis proficiámus exémplo.
 $Per Dominum
 
 [Lectio4]

--- a/web/www/horas/Latin/Sancti/05-01r.txt
+++ b/web/www/horas/Latin/Sancti/05-01r.txt
@@ -35,7 +35,7 @@ Christus Dóminus * fabri fílius putári dignátus est, allelúja.
 
 [Oratio]
 Rerum cónditor Deus, qui legem labóris humáno géneri statuísti: concéde propítius; ut, sancti Ioseph exémplo et patrocínio, ópera perficiámus quae prǽcipis, et prǽmia consequámur quae promíttis.
-$Qui vivis
+$Per Dominum
 
 [Invit]
 Regem regum Dóminum, qui putári dignátus est fabri fílius, * Veníte, adorémus, allelúja.

--- a/web/www/horas/Latin/Tempora/Pasc0-5.txt
+++ b/web/www/horas/Latin/Tempora/Pasc0-5.txt
@@ -39,7 +39,7 @@ R. Itaque epulémur in Dómino, allelúja.
 R. Itaque epulémur in Dómino, allelúja.
 
 [Lectio3]
-Docéntes eos serváre ómnia, quæcúmque mandávi vobis. Ordo præcípuus: jussit Apóstolis, ut primum docérent univérsas Gentes, deínde fidei intíngerent sacraménto, et post fidem ac baptísma, quæ essent observánda præcíperent. Ac ne putémus levia esse, quæ jussa sunt, et pauca, áddidit: Omnia quæcúmque mandávi vobis: ut quicúmque credíderint, qui in Trinitáte fúerint baptizáti, ómnia fáciant, quæ præcépta sunt. Et ecce ego vobíscum sum usque ad consummatiónem sǽculi. Qui usque ad consummatiónem sǽculi cum discípulis se futúrum esse promíttit, et illos osténdit semper esse victúros, et se nunquam a credéntibus recessúrum.
+Docéntes eos serváre ómnia, quæcúmque mandávi vobis. Ordo præcípuus: jussit Apóstolis, ut primum docérent univérsas Gentes, deínde fidei intíngerent sacraménto, et post fidem ac baptísma, quæ essent observánda præcíperent. Ac ne putémus levia esse, quæ jussa sunt, et pauca, áddidit: Omnia quæcúmque mandávi vobis: ut quicúmque credíderint, qui in Trinitáte fúerint baptizáti, ómnia fáciant, quæ præcépta sunt. Et ecce ego vobíscum sum usque ad consummatiónem sǽculi. Qui usque ad consummatiónem sǽculi cum discípulis se futúrum esse promíttit, et illos osténdit semper esse victúros, et se numquam a credéntibus recessúrum.
 &teDeum
 
 [Ant 2]

--- a/web/www/horas/Latin/Tempora/Quad6-5.txt
+++ b/web/www/horas/Latin/Tempora/Quad6-5.txt
@@ -46,7 +46,7 @@ v. Jerúsalem, Jerúsalem, convértere ad Dóminum Deum tuum.
 R. Omnes amíci mei dereliquérunt me, et prævaluérunt insidiántes mihi: trádidit me quem diligébam: 
 * Et terríbílibus óculis plaga crudéli percutiéntes, acéto potábant me.
 V. Inter iníquos projecérunt me, et non pepercérunt ánimæ meæ.
-R. Et terríbílibus óculis plaga cruéeli percutiéntes, acéto potábant me.
+R. Et terríbílibus óculis plaga crudéli percutiéntes, acéto potábant me.
 
 [Lectio2]
 !Lam 2:12-15

--- a/web/www/horas/Polski/Sancti/05-01r.txt
+++ b/web/www/horas/Polski/Sancti/05-01r.txt
@@ -25,7 +25,7 @@ Chrystus Pan * raczył stać się synem cieśli, alleluja.
 
 [Oratio]
 Boże, Stwórco wszechrzeczy, który nałożyłeś na rodzaj ludzki obowiązek pracy, spraw łaskawie, abyśmy za przykładem i pod opieką św. Józefa wykonywali prace, które nam nakazujesz, i otrzymali nagrodę, którą nam przyrzekasz.
-$Qui vivis
+$Per Dominum
 
 [Lectio1]
 Z Księgi Rodzaju


### PR DESCRIPTION
* Most of these commits correct typos.
* The Annunciation had lost the versicle at vespers. I've restored it with a reference.
* The new oratio for St. Joseph (1962 rubrics) had the wrong conclusion. I've corrected it for all languages.

As a rule, I check my corrections with the *editio typica.*