### PR TITLE
Psalterium Pianum: original verse divisions, strophes

### DIFF
--- a/web/www/horas/Latin/PiusXII/Psalm109.txt
+++ b/web/www/horas/Latin/PiusXII/Psalm109.txt
@@ -1,8 +1,7 @@
-109:1 Dixit Dóminus Dómino meo: * Sede a dextris meis,
-109:2 Donec ponam inimícos tuos * scabéllum pedum tuórum.
-109:3 Sceptrum poténtiæ tuæ proténdet Dóminus ex Sion: * domináre in médio inimicórum tuórum!
-109:4 Tecum principátus die ortus tui in splendóre sanctitátis: * ante lucíferum, tamquam rorem, génui te.
-109:5 Jurávit Dóminus et non pænitébit eum; * Tu es sacérdos in ætérnum secúndum órdinem Melchísedech.
-109:6 Dóminus a dextris tuis: * cónteret die iræ suæ reges.
-109:7 Judicábit natiónes, acervábit cadávera; * cónteret cápita late per terram.
-109:8 De torrénte in via bibet, * proptérea extóllet caput.
+109:1 Dixit Dóminus Dómino meo: « Sede a dextris meis, * donec ponam inimícos tuos scabéllum pedum tuórum ».
+109:2 Sceptrum poténtiæ tuæ proténdet Dóminus ex Sion: * « Domináre in médio inimicórum tuórum!
+109:3 Tecum principátus die ortus tui in splendóre sanctitátis: * ante lucíferum, tamquam rorem, génui te ». —
+109:4 Jurávit Dóminus et non pænitébit eum: * « Tu es sacérdos in ætérnum secúndum órdinem Melchísedech ». —
+109:5 Dóminus a dextris tuis: * cónteret die iræ suæ reges.
+109:6 Judicábit natiónes, acervábit cadávera; * cónteret cápita late per terram.
+109:7 De torrénte in via bibet, * proptérea extóllet caput.

--- a/web/www/horas/Latin/PiusXII/Psalm110.txt
+++ b/web/www/horas/Latin/PiusXII/Psalm110.txt
@@ -1,10 +1,10 @@
 110:1 Celebrábo Dóminum toto corde, * in cœtu justórum et congregatióne.
 110:2 Magna sunt ópera Dómini, * scrutánda ómnibus qui díligunt ea.
 110:3 Majéstas et magnificéntia opus ejus; * et justítia ejus manet in ætérnum.
-110:4 Memoránda fecit mirabília sua; miséricors et clemens est Dóminus. Escam dedit timéntibus se;
-110:5 Memor erit in ætérnum fœ́deris sui. * Poténtiam óperum suórum manifestávit pópulo suo,
-110:6 Ut daret eis possessiónem géntium. * Opera mánuum ejus sunt fidélia et justa;
-110:7 Firma sunt ómnia præcépta ejus, stabilíta in sǽcula, in ætérnum, * facta cum firmitáte et æquitáte.
-110:8 Redemptiónem misit pópulo suo, * státuit in ætérnum fœdus suum;
-110:9 (fit reverentia) Sanctum et venerábile est nomen ejus. * inítium sapiéntiæ timor Dómini:
-110:10 Prudénter agunt omnes, qui colunt eum; * laus ejus manet in ætérnum.
+110:4 Memoránda fecit mirabília sua; * miséricors et clemens est Dóminus.
+110:5 Escam dedit timéntibus se; * memor erit in ætérnum fœ́deris sui.
+110:6 Poténtiam óperum suórum manifestávit pópulo suo, * ut daret eis possessiónem géntium.
+110:7 Opera mánuum ejus sunt fidélia et justa; * firma sunt ómnia præcépta ejus,
+110:8 Stabilíta in sǽcula, in ætérnum, * facta cum firmitáte et æquitáte.
+110:9 Redemptiónem misit pópulo suo, státuit in ætérnum fœdus suum; * sanctum et venerábile est nomen ejus.
+110:10 Inítium sapiéntiæ timor Dómini: prudénter agunt omnes, qui colunt eum; * laus ejus manet in ætérnum.

--- a/web/www/horas/Latin/PiusXII/Psalm111.txt
+++ b/web/www/horas/Latin/PiusXII/Psalm111.txt
@@ -2,8 +2,9 @@
 111:2 Potens in terra erit semen ejus; * generatióni rectórum benedicétur.
 111:3 Opes et divítiæ erunt in domo ejus, * et munificéntia ejus manébit semper.
 111:4 Orítur in ténebris ut lumen rectis, * clemens et miséricors et justus.
-111:5 Bene est viro qui miserétur et cómmodat, * qui dispónit res suas cum justítia. In ætérnum non vacillábit;
-111:6 In memória ætérna erit justus. * A núntio tristi non timébit;
-111:7 Firmum est cor ejus, sperans in Dómino. constans est cor ejus, non timébit, * donec confúsos vídeat adversários suos.
-111:8 Distríbuit, donat paupéribus, munificéntia ejus manébit semper; * cornu ejus extollétur cum glória.
-111:9 Peccátor vidébit et indignábitur, déntibus suis frendet et tabéscet; * desidérium peccatórum períbit.
+111:5 Bene est viro qui miserétur et cómmodat, * qui dispónit res suas cum justítia.
+111:6 In ætérnum non vacillábit; * in memória ætérna erit justus.
+111:7 A núntio tristi non timébit; * firmum est cor ejus, sperans in Dómino.
+111:8 Constans est cor ejus, non timébit, * donec confúsos vídeat adversários suos.
+111:9 Distríbuit, donat paupéribus, munificéntia ejus manébit semper; * cornu ejus extollétur cum glória.
+111:10 Peccátor vidébit et indignábitur, déntibus suis frendet et tabéscet; * desidérium peccatórum períbit.

--- a/web/www/horas/Latin/PiusXII/Psalm112.txt
+++ b/web/www/horas/Latin/PiusXII/Psalm112.txt
@@ -1,8 +1,8 @@
 112:1 Laudáte, servi Dómini, * laudáte nomen Dómini.
-112:2 (fit reverentia) Sit nomen Dómini benedíctum * et nunc et usque in ætérnum.
-112:3 A solis ortu usque ad occásum ejus * laudétur nomen Dómini.
+112:2 Sit nomen Dómini benedíctum * et nunc et usque in ætérnum.
+112:3 A solis ortu usque ad occásum ejus * laudétur nomen Dómini. —
 112:4 Excélsus super omnes gentes Dóminus, * super cælos glória ejus.
-112:5 Quis sicut Dóminus, Deus noster, qui sedet in alto * et óculos demíttit in cælum et in terram?
+112:5 Quis sicut Dóminus, Deus noster, qui sedet in alto * et óculos demíttit in cælum et in terram? —
 112:6 Súblevat e púlvere ínopem, * e stércore érigit páuperem,
 112:7 Ut cóllocet eum cum princípibus, * cum princípibus pópuli sui.
 112:8 Habitáre facit eam, quæ stérilis erat in domo, * matrem filiórum lætántem.

--- a/web/www/horas/Latin/PiusXII/Psalm113.txt
+++ b/web/www/horas/Latin/PiusXII/Psalm113.txt
@@ -1,19 +1,19 @@
 113:1 Cum exíret Israël de Ægýpto, * domus Jacob de pópulo bárbaro,
-113:2 Factus est Juda sanctuárium ejus, * Israël regnum ejus.
+113:2 Factus est Juda sanctuárium ejus, * Israël regnum ejus. —
 113:3 Mare vidit et fugit, * Jordánis vertit se retrórsum.
-113:4 Montes saltárunt ut aríetes, * colles ut agnélli.
+113:4 Montes saltárunt ut aríetes, * colles ut agnélli. —
 113:5 Quid est tibi, mare, quod fugis? * Jordánis, quod vertis te retrórsum?
-113:6 Montes, quod saltátis ut aríetes, * Colles, ut agnélli?
+113:6 Montes, quod saltátis ut aríetes, * Colles, ut agnélli? —
 113:7 A fácie Dómini contremísce, terra, * a fácie Dei Jacob,
-113:8 Qui convértit petram in stagnum aquárum, * rupem in fontes aquárum.
-113:9 Non nobis, Dómine, non nobis, * sed nómini tuo da glóriam,
-113:10 Propter misericórdiam tuam, propter fidelitátem tuam. * Quare dicant gentes: úbinam est Deus eórum?
-113:11 Deus noster in cælo est; * ómnia, quæ vóluit, fecit.
+113:8 Qui convértit petram in stagnum aquárum, * rupem in fontes aquárum. —
+113:9 Non nobis, Dómine, non nobis, sed nómini tuo da glóriam, * propter misericórdiam tuam, propter fidelitátem tuam.
+113:10 Quare dicant gentes: * « Ubinam est Deus eórum? »
+113:11 Deus noster in cælo est; * ómnia, quæ vóluit, fecit. —
 113:12 Idóla eórum sunt argéntum et aurum, * opus mánuum hóminum.
 113:13 Os habent, et non loquúntur; * óculos habent, et non vident.
 113:14 Aures habent, et non áudiunt; * nares habent, et non odorántur.
 113:15 Manus habent, et non palpant; pedes habent, et non ámbulant; * sonum non edunt gútture suo.
-113:16 Símiles illis erunt, qui fáciunt ea, * omnis qui confídit in eis.
+113:16 Símiles illis erunt, qui fáciunt ea, * omnis qui confídit in eis. —
 113:17 Domus Israël confídit in Dómino: * adjútor eórum et clípeus eórum est.
 113:18 Domus Aaron confídit in Dómino: * adjútor eórum et clípeus eórum est.
 113:19 Qui timent Dóminum, confídunt in Dómino: * adjútor eórum et clípeus eórum est.


### PR DESCRIPTION
Related to #817

Psalterium Pianum not only changed "words", but also made significant shifts in structure of the psalms, in order to adjust verses as prayed in the Divine Office to the inner structure of the Hebrew text. Boundaries of divisions of the longer psalms prayed in parts were occasionally shifted, too. Strophes was marked in some psalms.

Currently the psalms are arranged in the traditional way, all the distinctive structural features mentioned above are thus lost. I propose switching to the "proper Psalterium Pianum arrangement", as printed in the liturgical books between 1945 and 1960'. This PR rearranges Psalms of Sunday Vespers. I am willing to proceed in a slow pace with the rest of the Psalter if the idea gets a "go" from project maintainers.