### PR TITLE
Recent typos

### DIFF
--- a/web/www/horas/Latin/Commune/C1.txt
+++ b/web/www/horas/Latin/Commune/C1.txt
@@ -261,7 +261,7 @@ V. Annuntiavérunt ópera Dei.
 R. Et facta ejus intellexérunt.
 
 [Ant 2]
-Vos qui reliquístis * ómnia, et secúti estis me, centúplum accipiétis, et vitam ætérnam possidébitis.
+Vos qui reliquístis * ómnia, et secúti estis me, céntuplum accipiétis, et vitam ætérnam possidébitis.
 
 [Oratio]
 Quǽsumus, omnípotens Deus, ut beátus N. Apóstolus, cujus prævenímus festivitátem, tuum pro nobis implóret auxílium: ut a nostris reátibus absolúti a cunctis étiam perículis eruámur.

--- a/web/www/horas/Latin/Sancti/05-28.txt
+++ b/web/www/horas/Latin/Sancti/05-28.txt
@@ -1,8 +1,8 @@
 [Rank]
-S. Augustíni Episcopi et ConfessorisDuplex;;3;;vide C4
+S. Augustíni Episcopi et Confessoris;;Duplex;;3;;vide C4
 
 [RankNewcal]
-S. Augustíni Episcopi et ConfessorisDuplex optional;;2;;vide C4
+S. Augustíni Episcopi et Confessoris;;Duplex optional;;2;;vide C4
 
 [Rule]
 vide C4;mtv

--- a/web/www/horas/Latin/Sancti/10-18.txt
+++ b/web/www/horas/Latin/Sancti/10-18.txt
@@ -11,7 +11,7 @@ Psalmi Dominica
 Antiphonas horas
 
 [Oratio]
-Intervéniat pro nobis, quǽsumus, Dómine, sanctus tuus Lucas Evangélista: qui crucis mortificatiónem jugiter in suo córpore, pro tui nóminis honóre, portávit.
+Intervéniat pro nobis, quǽsumus, Dómine, sanctus tuus Lucas Evangelísta: qui crucis mortificatiónem júgiter in suo córpore, pro tui nóminis honóre, portávit.
 $Per Dominum
 
 [Lectio4]

--- a/web/www/horas/Latin/Sancti/11-02.txt
+++ b/web/www/horas/Latin/Sancti/11-02.txt
@@ -95,7 +95,7 @@ Quæ cum ita sint, non existimémus ad mórtuos, pro quibus curam gérimus, perv
 [Lectio7]
 De Epístola prima beáti Pauli Apóstoli ad Corínthios
 !1 Cor 15:12-22
-12 Si autem Christus prædicátur quod resurréxit a mórtuis, quómodo quidam dicunt in vobis, quóniam resurréctio mortuórum non est?
+12 Si Christus prædicátur quod resurréxit a mórtuis, quómodo quidam dicunt in vobis, quóniam resurréctio mortuórum non est?
 13 Si autem resurréctio mortuórum non est: neque Christus resurréxit.
 14 Si autem Christus non resurréxit, inánis est ergo prædicátio nostra, inánis est et fides vestra:
 15 invenímur autem et falsi testes Dei: quóniam testimónium díximus advérsus Deum quod suscitáverit Christum, quem non suscitávit, si mórtui non resúrgunt.
@@ -112,17 +112,17 @@ De Epístola prima beáti Pauli Apóstoli ad Corínthios
 35 Sed dicet áliquis: Quómodo resúrgunt mórtui? qualíve córpore vénient?
 36 Insípiens, tu quod séminas non vivificátur, nisi prius moriátur:
 37 et quod séminas, non corpus, quod futúrum est, séminas, sed nudum granum, ut puta trítici, aut alicújus ceterórum.
-38 Deus autem dat illi corpus sicut vult: ut unicuíque séminum próprium corpus.
+38 Deus autem dat illi corpus sicut vult, et unicuíque séminum próprium corpus.
 39 Non omnis caro, éadem caro: sed ália quidem hóminum, ália vero pécorum, ália volúcrum, ália autem píscium.
 40 Et córpora cæléstia, et córpora terréstria: sed ália quidem cæléstium glória, ália autem terréstrium.
-41 Alia cláritas solis, ália cláritas lunæ, et ália cláritas stellárum. Stella enim a stella differt in claritáte:
+41 Alia cláritas solis, ália cláritas lunæ, et ália cláritas stellárum; stella enim a stella differt in claritáte:
 42 sic et resurréctio mortuórum. Seminátur in corruptióne, surget in incorruptióne.
 43 Seminátur in ignobilitáte, surget in glória: seminátur in infirmitáte, surget in virtúte:
 44 seminátur corpus animále, surget corpus spiritále. 
 
 [Lectio9]
 !1 Cor 15:51-58
-51 Ecce mystérium vobis dico: omnes quidem resurgémus, sed non omnes immutábimur.
+51 Ecce mystérium vobis dico: Omnes quidem resurgémus, sed non omnes immutábimur.
 52 In moménto, in ictu óculi, in novíssima tuba: canet enim tuba, et mórtui resúrgent incorrúpti: et nos immutábimur.
 53 Opórtet enim corruptíbile hoc indúere incorruptiónem: et mortále hoc indúere immortalitátem.
 54 Cum autem mortále hoc indúerit immortalitátem, tunc fiet sermo, qui scriptus est: Absórpta est mors in victória.


### PR DESCRIPTION
* A typo in the `[Rank]` section of St. Augustine's office made it disappear from the calendar.
* The office of All Souls had a spurious *autem* and an *et* turned into *ut.*