### PR TITLE
Multi fallback implementation (#938) - discussion needed

### DIFF
--- a/web/cgi-bin/horas/dialogcommon.pl
+++ b/web/cgi-bin/horas/dialogcommon.pl
@@ -304,6 +304,13 @@ sub setupstring($$$%)
       # English layers on top of Latin.
       $base_sections = setupstring($basedir, 'Latin', $fname, 'resolve@' => RESOLVE_NONE);
     }
+    elsif ($lang =~ /_/)
+    {
+      # If $lang contains underscore, the part before the last underscore is taken as a new fallback
+      my $temp = $lang;
+      $temp =~ s/_[^_]+$//;
+      $base_sections = setupstring($basedir, $temp, $fname, 'resolve@' => RESOLVE_NONE);
+    }
     elsif ($lang && $lang ne 'Latin')
     {
       # Other non-Latin languages layer on top of English.

--- a/web/cgi-bin/horas/dialogcommon.pl
+++ b/web/cgi-bin/horas/dialogcommon.pl
@@ -304,11 +304,11 @@ sub setupstring($$$%)
       # English layers on top of Latin.
       $base_sections = setupstring($basedir, 'Latin', $fname, 'resolve@' => RESOLVE_NONE);
     }
-    elsif ($lang =~ /_/)
+    elsif ($lang =~ /-/)
     {
-      # If $lang contains underscore, the part before the last underscore is taken as a new fallback
+      # If $lang contains dash, the part before the last dash is taken as a new fallback
       my $temp = $lang;
-      $temp =~ s/_[^_]+$//;
+      $temp =~ s/-[^-]+$//;
       $base_sections = setupstring($basedir, $temp, $fname, 'resolve@' => RESOLVE_NONE);
     }
     elsif ($lang && $lang ne 'Latin')

--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -149,15 +149,15 @@ sub geteaster {
 
 #*** checkfile($lang, $filename) 
 # substitutes English if no $lang item, Latin if no English
-# if $lang contains underscore, the part before the last underscore is taken as a fallback recursively (till something exists)
+# if $lang contains dash, the part before the last dash is taken as a fallback recursively (till something exists)
 sub checkfile {
   my $lang = shift;
   my $file = shift;  
                              
   if (-e "$datafolder/$lang/$file") {return "$datafolder/$lang/$file";}
-  elsif ($lang =~ /_/) {
+  elsif ($lang =~ /-/) {
     my $temp = $lang;
-    $temp =~ s/_[^_]+$//;
+    $temp =~ s/-[^-]+$//;
     return checkfile($temp, $file);
   }
   elsif ($lang =~ /english/i) {return "$datafolder/Latin/$file";}

--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -149,12 +149,18 @@ sub geteaster {
 
 #*** checkfile($lang, $filename) 
 # substitutes English if no $lang item, Latin if no English
+# if $lang contains underscore, the part before the last underscore is taken as a fallback recursively (till something exists)
 sub checkfile {
   my $lang = shift;
   my $file = shift;  
                              
   if (-e "$datafolder/$lang/$file") {return "$datafolder/$lang/$file";}
   elsif ($lang =~ /english/i) {return "$datafolder/Latin/$file";}
+  elsif ($lang =~ /_/) {
+    my $temp = $lang;
+    $temp =~ s/_[^_]+$//;
+    return checkfile($temp, $file);
+  }
   elsif (-e "$datafolder/English/$file") {return "$datafolder/English/$file";}
   else {return "$datafolder/Latin/$file";}
 }

--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -155,12 +155,12 @@ sub checkfile {
   my $file = shift;  
                              
   if (-e "$datafolder/$lang/$file") {return "$datafolder/$lang/$file";}
-  elsif ($lang =~ /english/i) {return "$datafolder/Latin/$file";}
   elsif ($lang =~ /_/) {
     my $temp = $lang;
     $temp =~ s/_[^_]+$//;
     return checkfile($temp, $file);
   }
+  elsif ($lang =~ /english/i) {return "$datafolder/Latin/$file";}
   elsif (-e "$datafolder/English/$file") {return "$datafolder/English/$file";}
   else {return "$datafolder/Latin/$file";}
 }


### PR DESCRIPTION
I've implemented a fallback mechanism for #938 according to @fiapps suggestion ([link](https://github.com/DivinumOfficium/divinum-officium/issues/938#issuecomment-434046885)).

There is a bug, though. In some places the parameter `$lang` has `_` replaced with ` ` (a space), notably `mpopup.pl`. Owing to this fact, if I click the link to the `Communio` popup (while reading `Sancta Missa`), using the `Polski_New` language (without the proper translation of the communio among the files), I get English instead of Polish.

I see two ways of fixing this:
1. Change the separator to `-` (easy, but not elegant).
2. Remember to replace a space with and underscore where needed in `$lang` (at the moment I know only about `mpopup.pl`).
3. (best) Find a reason why `_` is encoded as space and fix it.