### PR TITLE
Fix line break in Vespers Hymn

### DIFF
--- a/web/www/horas/English/Sancti/12-25.txt
+++ b/web/www/horas/English/Sancti/12-25.txt
@@ -54,8 +54,8 @@ From sin redeemed, are marked for God,
 On this the day that saw Thy birth,
 Sing the new song of ransomed earth.
 _
-O Lord, the Virgin-born, to 
-Thee Eternal praise and glory be, 
+O Lord, the Virgin-born, to Thee
+Eternal praise and glory be, 
 Whom with the Father we adore 
 And Holy Ghost forevermore.
 Amen.


### PR DESCRIPTION
The meter was off in the last stanza of the Vespers Hymn because it appears that the line break between the first and second lines was off by one word.