### PR TITLE
Use slim perl docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        perl:5.28
+FROM        perl:5.28-slim
 MAINTAINER  Ben Yanke <ben@benyanke.com>
 
 # Set envs
@@ -9,15 +9,16 @@ ENV APACHE_RUN_USER www-data \
     APACHE_PID_FILE /var/run/apache2/apache2.pid \
     APACHE_SERVER_NAME localhost
 
-# Get dumb-init to use a proper init system
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 && \
-    chmod +x /usr/local/bin/dumb-init
-
 # Install packages
 RUN apt-get update && apt-get install -y \
+    wget \
     apache2 \
     libcgi-session-perl \
     && rm -rf /var/lib/apt/lists/*
+
+# Get dumb-init to use a proper init system
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 && \
+    chmod +x /usr/local/bin/dumb-init
 
 # Load config files
 COPY docker/apache/ports.conf /etc/apache2/ports.conf


### PR DESCRIPTION
Fix #1126: 340 MB instead of 1.02 GB.