### PR TITLE
Update Docker Badge links to public ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ examples.
 
 ## Docker
 
-[![](https://images.microbadger.com/badges/version/divinumofficiumweb/divinumofficium.svg)](https://cloud.docker.com/u/divinumofficiumweb/repository/docker/divinumofficiumweb/divinumofficium "DockerHub Container")
+[![](https://images.microbadger.com/badges/version/divinumofficiumweb/divinumofficium.svg)](https://hub.docker.com/r/divinumofficiumweb/divinumofficium "DockerHub Container")
 
-[![](https://images.microbadger.com/badges/image/divinumofficiumweb/divinumofficium.svg)](https://cloud.docker.com/u/divinumofficiumweb/repository/docker/divinumofficiumweb/divinumofficium "DockerHub Container")
+[![](https://images.microbadger.com/badges/image/divinumofficiumweb/divinumofficium.svg)](https://hub.docker.com/r/divinumofficiumweb/divinumofficium "DockerHub Container")
 
 ### Production
 


### PR DESCRIPTION
The old links were only accessible to the docker-hub repo admin.

These new ones are proper public links to the image.