### PR TITLE
Corrections to Spanish translation of Sext

### DIFF
--- a/web/www/horas/Espanol/Ordinarium/Sexta.txt
+++ b/web/www/horas/Espanol/Ordinarium/Sexta.txt
@@ -6,7 +6,7 @@ $Deus in adjutorium
 &Alleluia
 
 #Hymnus {:H-Sexta:}
-V. Oh Rector poderoso y Dios verídico,
+v. Oh Rector poderoso y Dios verídico,
 Que diriges las cosas y los tiempos,
 Por quien son luminosas las mañanas,
 Por quien los mediodías son esplendidos:

--- a/web/www/horas/Espanol/Ordinarium/Sexta1960.txt
+++ b/web/www/horas/Espanol/Ordinarium/Sexta1960.txt
@@ -4,7 +4,7 @@ $Deus in adjutorium
 &Alleluia
 
 #Hymnus {:H-Sexta:}
-V. Oh Rector poderoso y Dios verídico,
+v. Oh Rector poderoso y Dios verídico,
 Que diriges las cosas y los tiempos,
 Por quien son luminosas las mañanas,
 Por quien los mediodías son esplendidos:

--- a/web/www/horas/Espanol/Ordinarium/Sexta1960.txt
+++ b/web/www/horas/Espanol/Ordinarium/Sexta1960.txt
@@ -1,0 +1,32 @@
+﻿#Incipit
+$Deus in adjutorium
+&Gloria
+&Alleluia
+
+#Hymnus {:H-Sexta:}
+V. Oh Rector poderoso y Dios verídico,
+Que diriges las cosas y los tiempos,
+Por quien son luminosas las mañanas,
+Por quien los mediodías son esplendidos:
+_
+Libranos del ardor de las discordias
+Y del calor del pernicioso fuego;
+Dales salud a nuestros cuerpos frágiles
+Y verdadera paz a nuestros pechos.
+_
+* Escúchanos, oh Padre piadosísimo,
+Que siendo un solo Dios con tu Unigénito
+Y con el Santo Espíritu Paráclito
+Reinas en todo sitio y todo tiempo.
+Amén.
+
+#Psalmi
+
+#Capitulum Responsorium Versus
+
+#Oratio
+
+#Conclusio
+&Dominus_vobiscum
+&Benedicamus_Domino
+$Fidelium animae

--- a/web/www/horas/Espanol/Ordinarium/SextaM.txt
+++ b/web/www/horas/Espanol/Ordinarium/SextaM.txt
@@ -4,7 +4,7 @@ $Deus in adjutorium
 &Alleluia
 
 #Hymnus {:H-Sexta:}
-V. Oh Rector poderoso y Dios verídico,
+v. Oh Rector poderoso y Dios verídico,
 Que diriges las cosas y los tiempos,
 Por quien son luminosas las mañanas,
 Por quien los mediodías son espléndidos:


### PR DESCRIPTION
The Spanish translation of Sext produced an error with the 1960 rubrics because `Sext.txt` existed in the `Ordinarium` directory, but `Sext1960.txt` did not. The missing file has been created by copying `Sext.txt` and deleting the prayers that are no longer said with the 1960 rubrics.

The other commit fixes the code for a large capital at the beginning of the hymn for Sext.
