### PR TITLE
Typos in First Vespers

### DIFF
--- a/web/www/horas/Magyar/Sancti/05-08.txt
+++ b/web/www/horas/Magyar/Sancti/05-08.txt
@@ -29,14 +29,14 @@ The Father's power and glory bright!
 thee with the Angels we extol;
 From thee they draw their life and light.
 _
-thy thousand thousand hosts are spread
+Thy thousand thousand hosts are spread
 Embattled o'er the azure sky;
 But Michael bears thy standard dread,
 And lifts the mighty Cross on high.
 _
 He in that Sign the rebel power.
 Did with their Dragon Prince expel;
-And hurled them from the heaven.' high towers,
+And hurled them from the heaven's high towers,
 Down like a thunderbolt to hell.
 _
 Grant us, with Michael, still, Lord,


### PR DESCRIPTION
Typos in hymn in First Vespers for Feast of St. Michael the Archangel