### PR TITLE
Fix horas.pl for epub generation

### DIFF
--- a/web/cgi-bin/horas/horas.pl
+++ b/web/cgi-bin/horas/horas.pl
@@ -16,6 +16,21 @@ my $precesferiales;
 
 $a = 1;
 
+# REPAIRS ERROR 
+# --> EofficiumXhtml.pl: Undefined subroutine &horas::ante_post
+# --> called at /Users/user/divinum-officium/standalone/tools/epubgen2/../../../web/cgi-bin/horas/horas.pl line 61.
+# this error occured when generating an epub for Divino Afflatu
+sub ante_post {
+  my $title = shift;
+
+  if ($Ck) {return;}
+  my $colspan = ($only) ? '' : 'COLSPAN=2';
+
+  print "<TR><TD $background VALIGN=TOP $colspan ALIGN=CENTER>\n";
+  print "<INPUT TYPE=RADIO NAME=link onclick='linkit(\"\$$title\", 0, \"Latin\");'>\n";
+  print "<FONT SIZE=1>$title Divinum officium</FONT></TD></TR>";
+}
+
 #*** horas($hora)
 # collects and prints the officium for the given $hora
 # first let specials to fill the chapters


### PR DESCRIPTION
Error would occur when trying to generate an epub with Divino Afflatu rubrics. The issue was that ante_post was an undefined subroutine at horas.pl. As Perl is not my go-to language, I am sure that there is a better fix than the one that I proposed.