### PR TITLE
Typos Good Friday

### DIFF
--- a/web/www/missa/English/Tempora/Quad6-5r.txt
+++ b/web/www/missa/English/Tempora/Quad6-5r.txt
@@ -206,7 +206,7 @@ v.  Let us pray, dearly beloved, for the holy Church of God: that our Lord and G
 P. Let us pray.
 D. Let us kneel.
 S. Arise.
-v.  Almighty and everlasting God, Who in Christ hast revealed Thy glory too all nations: guard the works of Thy mercy; that Thy Church, spread over the whole world, may with steadfast faith persevere in the confession of Thy Name.  Through the same Jesus Christ, Thy Son, our Lord, who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.  
+v.  Almighty and everlasting God, Who in Christ hast revealed Thy glory to all nations: guard the works of Thy mercy; that Thy Church, spread over the whole world, may with steadfast faith persevere in the confession of Thy Name.  Through the same Jesus Christ, Thy Son, our Lord, who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.  
 R. Amen.
 _
 _
@@ -401,7 +401,7 @@ Earth, and stars, and sky, and ocean,
 By that flood from stain are freed.
 _ `
 Ant. Faithful Cross! above all other, One and only noble Tree! None in foliage, none in blossom, None in fruit thy peer may be.
-b. Bend thy boughs, O Tree of glory!
+Bend thy boughs, O Tree of glory!
 Thy relaxing sinews bend;
 For awhile the ancient rigor,
 That thy birth bestowed, suspend:
@@ -463,7 +463,7 @@ Almighty and merciful God, who hast restored us by the Passion and Death of Thy 
 R. Amen.
 _ `
 v. Let us pray. 
-Be mindful of Thy mercies, O Lord, and hallow us with eternal protection us Thy servants, from whom Christ Thy Son established through His Blood this mystery of the Pasch.  Through the same Christ our Lord.  Amen.
+Be mindful of Thy mercies, O Lord, and hallow with eternal protection us Thy servants, from whom Christ Thy Son established through His Blood this mystery of the Pasch.  Through the same Christ our Lord.  Amen.
 R.  Amen.
 ! The Ministers genuflect before retiring to the Sacristy.
 


### PR DESCRIPTION
Change "too" to "to"
Remove b. from "Bend thy boughs
Remove incorrect "us"