### PR TITLE
Fix error in Español compline that caused infinite loop.

### DIFF
--- a/web/www/horas/Espanol/Ordinarium/Completorium.txt
+++ b/web/www/horas/Espanol/Ordinarium/Completorium.txt
@@ -44,7 +44,7 @@ Amén.
 V. Tú estás con nosotros, Señor; sobre nosotros se ha invocado tu nombre: no nos abandones, Señor Dios nuestro.
 R. Demos gracias a Dios.
 _
-Resp. br. A tus manos, Señor, * encomiendo mi espíritu.  
+R.br. A tus manos, Señor, * encomiendo mi espíritu.  
 R. A tus manos, Señor, * encomiendo mi espíritu.
 V. Tú, el Dios leal, nos librarás.
 R. Encomiendo mi espíritu.  

--- a/web/www/horas/Espanol/Ordinarium/Completorium1960.txt
+++ b/web/www/horas/Espanol/Ordinarium/Completorium1960.txt
@@ -47,7 +47,7 @@ Amén.
 V. Tú estás con nosotros, Señor; sobre nosotros se ha invocado tu nombre: no nos abandones, Señor Dios nuestro.
 R. Demos gracias a Dios.
 _
-Resp. br. A tus manos, Señor, * encomiendo mi espíritu.  
+R.br. A tus manos, Señor, * encomiendo mi espíritu.  
 R. A tus manos, Señor, * encomiendo mi espíritu.
 V. Tú, el Dios leal, nos librarás.
 R. Encomiendo mi espíritu.  


### PR DESCRIPTION
www/cgi-bin/horas/specials.pl line 233 searches for R.br., but does not consider that it might not exist:
```Perl
while ($t[$tind] !~ /^\s*R\.br\./) { push(@s, $t[$tind++]); }
```
The Spanish compline files had "R. brev." instead of "R.br", so `$tind` kept growing without limit, far past the end of the array. Eventually the server kills the Perl process, and the user gets an error (see #1620).

This PR fixes the compline files, but it would be good to fix the Perl as well. I don't do it myself because I don't have time to work out the logic. If the code is changed, what should it do if it does not find "R.br."?
