### PR TITLE
Update 10-07.txt

### DIFF
--- a/web/www/horas/Francais/Sancti/10-07.txt
+++ b/web/www/horas/Francais/Sancti/10-07.txt
@@ -30,10 +30,10 @@ $Deo gratias
 [Hymnus Vespera]
 v. Un messager de la cour céleste,
 Révélant les mystères de la Divinité,
-Salue pleine de grâce
+Salue, pleine de grâce,
 La Vierge qui doit infanter Dieu.
 _
-La Vierge fait visité
+La Vierge fait visite
 A la mère de Jean, sa parente ;
 Jean, captif encore au sein maternel,
 Annonce par ses tressaillements la présence du Christ.
@@ -53,7 +53,7 @@ Retrouve son Fils pleine d'allégresse :
 Il expliquait aux docteurs
 Ce qu'ils ignoraient.
 _
-@Psalterium/Doxologies :Nat
+@Psalterium/Doxologies:Nat
 
 [Versum 1]
 V. Reine du Très saint Rosaire, priez pour nous.
@@ -63,7 +63,7 @@ R. Afin que nous devenions dignes des promesses de Jésus-Christ.
 Bienheureuse êtes-vous, * Vierge Marie, Mère de Dieu, qui avez cru au Seigneur ; en vous s’est accompli ce qui vous a été dit ; intercédez pour nous, près du Seigneur, notre Dieu.
 
 [Oratio]
-O Dieu, dont le Fils unique nous a obtenu le prix du salut éternel par sa vie, sa mort et sa résurrection ; faites, nous vous en prions, qu’honorant ces mystères au moyen du très saint Rosaire de la bienheureuse Vierge Marie, nous imitions ce qu’ils contiennent, et obtenions ce qu’ils promettent.
+O Dieu, dont le Fils unique nous a obtenu le prix du salut éternel par sa vie, sa mort et sa résurrection ; faites, nous vous en prions, qu’honorant ces mystères au moyen du très saint Rosaire de la bienheureuse Vierge Marie, nous imitions ce qu’ils contiennent et obtenions ce qu’ils promettent.
 $Per eumdem
 
 [Commemoratio 2]
@@ -223,7 +223,7 @@ R. Et mes fleurs sont des fruits d’honneur et de richesse
 
 [Lectio8]
 !Sermo de Aquæductu
-« Le Verbe s’est fait chair, » et déjà il habite en nous. Il habite dans notre mémoire, il habite dans notre pensée, car il descend jusque dans notre imagination elle-même. Comment cela, dites-vous ? En gisant sur la paille de la crèche, en reposant sur un sein virginal, en prêchant sur la montagne, en passant la nuit en prières, en se laissant suspendre à la croix et défigurer par le trépas, en se montrant « libre entre les morts » et en commandant à l’enfer ; en ressuscitant le troisième jour, en montrant à ses Apôtres, dans les traces des clous, les signes de sa victoire, enfin en s’élevant devant eux au plus haut du ciel.
+« Le Verbe s’est fait chair » et déjà il habite en nous. Il habite dans notre mémoire, il habite dans notre pensée car il descend jusque dans notre imagination elle-même. Comment cela, dites-vous ? En gisant sur la paille de la crèche, en reposant sur un sein virginal, en prêchant sur la montagne, en passant la nuit en prières, en se laissant suspendre à la croix et défigurer par le trépas, en se montrant « libre entre les morts » et en commandant à l’enfer ; en ressuscitant le troisième jour, en montrant à ses Apôtres, dans les traces des clous, les signes de sa victoire, enfin en s’élevant devant eux au plus haut du ciel.
 
 [Responsory8]
 R. Lève-toi, hâte-toi, mon amie, car déjà l’hiver est passé, la pluie est partie, et elle s’est retirée :
@@ -237,10 +237,10 @@ R. Les fleurs ont paru sur notre terre.
 @Sancti/10-07t :Lectio93
 
 [Ant Laudes]
- Réjouissez-vous, * Vierge Marie, le Christ est ressuscité du tombeau.
-Dieu est monté, * dans la jubilation, et le Seigneur, au son de la trompette.
+Réjouissez-vous, * Vierge Marie, le Christ est ressuscité du tombeau.
+Dieu est monté * dans la jubilation et le Seigneur, au son de la trompette.
 L’Esprit du Seigneur * a rempli l’orbe des terres.
-Elle a été élevée * au ciel, Marie ; les Anges se réjouissent, et dans leurs louanges, bénissent le Seigneur, alléluia.
+Elle a été élevée * au ciel, Marie ; les Anges se réjouissent et dans leurs louanges, bénissent le Seigneur, alléluia.
 Elle a été exaltée, * la Vierge Marie, au-dessus des chœurs des Anges et sur sa tête est une couronne de douze étoiles.
 
 [Capitulum Laudes]
@@ -263,7 +263,7 @@ C'est sur les siens en deuil une pluie de langues de feu
 Qui les embrase d'amour.
 _
 Délivrée du poids de la mortalité,
-La Vierge est enlevée par delà les nués ;
+La Vierge est enlevée par delà les nuées ;
 Elle est accueillie par le ciel en fête,
 Au milieu des cantiques des anges.
 _
@@ -272,7 +272,7 @@ La tête de la divine Mère :
 Son trône est près de celui de son Fils :
 Elle commande à toutes créatures.
 _
-@Psalterium/Doxologies :Nat
+@Psalterium/Doxologies:Nat
 
 [Versum 2]
 V. Le Seigneur l’a choisie et l’a préférée.
@@ -283,7 +283,7 @@ La solennité d’aujourd’hui, * du Très Saint Rosaire de Marie, Mère de Die
 
 [Lectio Prima]
 !Sir 24:17-18
-v. Comme le cèdre au Liban, j’ai été élevée, et comme le cyprès sur le mont Sion ; comme le palmier à Cadès, j’ai été élevée, et comme la plantation de rose, à Jéricho.
+v. Comme le cèdre au Liban, j’ai été élevée et comme le cyprès sur le mont Sion ; comme le palmier à Cadès, j’ai été élevée et comme la plantation de roses, à Jéricho.
 
 [Capitulum Tertia]
 @:Capitulum Vespera
@@ -312,7 +312,7 @@ R. Inviolée vous êtes demeurée.
 &Gloria
 R. Après l’enfantement, ô Vierge, * Inviolée vous êtes demeurée.
 _
-V. Belle vous avez été faite, et suave.
+V. Belle vous avez été faite et suave.
 R. En vos délices, sainte Mère de Dieu.
 
 [Capitulum Nona]
@@ -320,14 +320,14 @@ R. En vos délices, sainte Mère de Dieu.
 $Deo gratias
 
 [Responsory Nona]
-R.br. Belle vous avez été faite, * Et suave.
-R. Belle vous avez été faite, * Et suave.
+R.br. Belle vous avez été faite * Et suave.
+R. Belle vous avez été faite * Et suave.
 V. En vos délices, sainte Mère de Dieu.
 R. Et suave.
 &Gloria
-R. Belle vous avez été faite, * Et suave.
+R. Belle vous avez été faite * Et suave.
 _
-V. Dieu l’a choisie et l’â préférée.
+V. Dieu l’a choisie et l’a préférée.
 R. Et il l’a fait habiter dans son tabernacle.
 
 [Hymnus Vespera 3]
@@ -338,7 +338,7 @@ Dans les splendeurs de votre gloire.
 _
 Salut, dans l'allégresse
 De votre Conception, de votre Visite,
-De votre Enfantement, de l'Offlrande et du Recouvrement
+De votre Enfantement, de l'Offrande et du Recouvrement
 De votre Fils, Mère bienheureuse.
 _
 Salut, Mère douloureuse, endurant dans votre cœur


### PR DESCRIPTION
Quelques corrections.
ATTENTION : 
Dans le texte, sous l'hymne, à laudes comme à vêpres, apparaît la mention : PSALTERIUM/DOXOLOGOIES :NAT is missing!
J'ai supprimé l'espace entre doxologies et :Nat... mais je ne suis pas du tout sûr que cela corrigera le problème si la référence n'existe effectivement pas.