### PR TITLE
1960: Advent ferias are third-class.

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -1613,7 +1613,7 @@ sub setheadline {
         my @ranktable = (
           '',
           'IV. classis',
-          'IV. classis',
+          'III. classis',
           'III. classis',
           'II. classis',
           'II. classis',


### PR DESCRIPTION
Internally this is represented by a rank of 2.  This was handled correctly; only the reporting was wrong.

----

Testing: Advent ferias are shown correctly now.  Green ferias are still shown as IV. cl.