### PR TITLE
1960 Newcalendar: Prefer feasts specified in 'Cum Sanctissima' to Lenten ferias.

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -574,17 +574,6 @@ sub getrank {
 #  $comrank = 0;
   if ($version =~ /Trid/i && $trank[2] < 5.1 && $trank[0] =~ /Dominica/i) { $trank[2] = 2.9; }
 
-  if (
-    $version =~ /1960|Newcal|Monastic/i
-    && ( floor($trank[2]) == 3
-      || $dayname[0] =~ /Quad[1-5]/i
-      || ($dayname[0] =~ /quadp3/i && $dayofweek >= 3))
-    && $srank[2] < 5
-    )
-  {
-    $trank[2] = 4.9;
-  }
-
   if ($version =~ /1960/ && $dayofweek == 0) {
     if (($trank[2] >= 6 && $srank[2] < 6) || ($trank[2] >= 5 && $srank[2] < 5)) { $srank = ''; @srank = undef; }
   }

--- a/web/www/horas/Latin/Sancti/02-11.txt
+++ b/web/www/horas/Latin/Sancti/02-11.txt
@@ -1,6 +1,9 @@
 [Rank]
 In Apparitione Beatæ Mariæ Virginis Immaculatæ;;Duplex majus;;4;;ex C11
 
+[Rank1960]
+In Apparitione Beatæ Mariæ Virginis Immaculatæ;;Duplex;;3;;ex C11
+
 [RankNewcal]
 In Apparitione Beatæ Mariæ Virginis Immaculatæ;;Duplex optional;;2;;ex C11
 

--- a/web/www/horas/Latin/Sancti/03-06.txt
+++ b/web/www/horas/Latin/Sancti/03-06.txt
@@ -1,7 +1,7 @@
 [Rank]
 Ss. Perpetuæ et Felicitatis Martyrum;;Duplex;;3.1;;vide C7
 
-[Rank](rubrica 1960)
+[Rank](rubrica Rubrics 1960)
 Ss. Perpetuæ et Felicitatis Martyrum;;Duplex;;3;;vide C7
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/03-07.txt
+++ b/web/www/horas/Latin/Sancti/03-07.txt
@@ -1,7 +1,7 @@
 [Rank]
 S. Thomæ de Aquino Confessoris et Ecclesiæ Doctoris;;Duplex;;3.1;;vide C5a
 
-[Rank](rubrica 1960)
+[Rank](rubrica Rubrics 1960)
 S. Thomæ de Aquino Confessoris et Ecclesiæ Doctoris;;Duplex;;3;;vide C5a
 
 [Name]

--- a/web/www/horas/Latin/Sancti/03-09.txt
+++ b/web/www/horas/Latin/Sancti/03-09.txt
@@ -1,7 +1,7 @@
 [Rank]
 S. Franciscæ Romanæ Viduæ;;Duplex;;3.1;;vide C7a
 
-[Rank1960]
+[Rank] (rubrica Rubrics 1960)
 S. Franciscæ Romanæ Viduæ;;Duplex;;3;;vide C7a
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/03-12.txt
+++ b/web/www/horas/Latin/Sancti/03-12.txt
@@ -1,7 +1,7 @@
 [Rank]
 S. Gregorii Papæ Confessoris et Ecclesiæ Doctoris;;Duplex;;3.1;;vide C4a
 
-[Rank](rubrica 1960)
+[Rank](rubrica Rubrics 1960)
 S. Gregorii Papæ Confessoris et Ecclesiæ Doctoris;;Duplex;;3;;vide C4a
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/03-21.txt
+++ b/web/www/horas/Latin/Sancti/03-21.txt
@@ -1,6 +1,9 @@
 [Rank]
 S. Benedicti Abbatis;;Duplex majus;;4;;vide C5
 
+[Rank] (rubrica Rubrics 1960)
+S. Benedicti Abbatis;;Duplex;;3;;vide C5
+
 [Rule]
 vide C4;
 9 lectiones;

--- a/web/www/horas/Latin/Sancti/03-24.txt
+++ b/web/www/horas/Latin/Sancti/03-24.txt
@@ -1,6 +1,9 @@
 [Rank]
 S. Gabrielis Archangeli;;Duplex majus;;4;;ex Sancti/05-08
 
+[Rank] (rubrica Rubrics 1960)
+S. Gabrielis Archangeli;;Duplex;;3;;ex Sancti/05-08
+
 [Rule]
 ex Sancti/05-08
 9 lectiones

--- a/web/www/horas/Latin/Sancti/04-11.txt
+++ b/web/www/horas/Latin/Sancti/04-11.txt
@@ -1,7 +1,7 @@
 [Rank]
 S. Leonis I Papæ Confessoris et Ecclesiæ Doctoris;;Duplex;;3.1;;vide C4a
 
-[Rank1960]
+[Rank] (rubrica Rubrics 1960)
 S. Leonis I Papæ Confessoris et Ecclesiæ Doctoris;;Duplex;;3;;vide C4a
 
 [Name]

--- a/web/www/horas/Latin/Sancti/04-14.txt
+++ b/web/www/horas/Latin/Sancti/04-14.txt
@@ -1,7 +1,7 @@
 [Rank]
 S. Justini Martyris;;Duplex;;3.1;;vide C2
 
-[Rank1960]
+[Rank] (rubrica Rubrics 1960)
 S. Justini Martyris;;Duplex;;3;;vide C2
 
 [Rule]


### PR DESCRIPTION
The logic to force the rank of Lenten/Passiontide ferias to 4.9 was redundant, predating the ability to set ranks conditionally according to rubrics in the datafiles.  Having removed this, the datafiles of the relevant feasts have been changed so that they maintain their pre-1960 rank that allows them to beat such ferias.

----

Testing: Manual checking of `kalendar.pl` for "Rubrics 1960" and "1960 Newcalendar" for March 2020.  The former is unchanged; the latter now prefers the feasts.