### PR TITLE
Changes to the Tridentine office on saturdays

### DIFF
--- a/web/cgi-bin/horas/specmatins.pl
+++ b/web/cgi-bin/horas/specmatins.pl
@@ -363,8 +363,7 @@ sub psalmi_matutinum {
   my @psalm_indices = (
     $version =~ /Trident/i &&    # Tridentine rubrics, necessarily 3 lessons;
       $dayofweek == 6 &&         # on a Saturday;
-      $rule !~ /ex C10/i &&      # not of the BVM;
-      $rule !~ /1 nocturn/i
+      $rule =~ /ex C10/i
     )
     ?                            # not in the octaves of Easter or Pentecost:
     (0, 8, 2)
@@ -378,6 +377,12 @@ sub psalmi_matutinum {
     }
     $spec[0] = $psalmi[6];
     $spec[1] = $psalmi[7];
+    
+    if ($dayofweek == 6 && $rule =~ /ex C10/i) {
+      my @a = split("\n", $psalmi{"BMV Versum"});
+      $spec[0] = $a[0];
+      $spec[1] = $a[1];
+    }
 
     if ($dayname[0] =~ /(Adv|Quad|Pasc)([0-9])/i) {
       my $name = $1;

--- a/web/www/horas/English/Commune/C10t.txt
+++ b/web/www/horas/English/Commune/C10t.txt
@@ -9,3 +9,8 @@ ex C10
 Special Benedictio
 Special Lectio 3
 Doxology=Nat
+
+[Responsory2]
+@Commune/C11:Responsory7
+&Gloria
+R. Christ, our God.

--- a/web/www/horas/English/Psalterium/Psalmi matutinum.txt
+++ b/web/www/horas/English/Psalterium/Psalmi matutinum.txt
@@ -151,6 +151,10 @@ The King, * even the Most High, cometh therefore let the hearts of men be purifi
 V. The Lord cometh out of His holy place. 
 R. He will come and save His people. 
 
+[BMV Versum]
+V. Grace is poured into thy lips.
+R. Therefore God hath blessed thee for ever.
+
 [Adv 0 Versum]
 V. For behold, the Lord will come out of his place.
 R. He comes to save his people.
@@ -417,6 +421,7 @@ Visit us * with Thy salvation, O Lord.;;105;106
 I will greatly praise * the Lord with my mouth.;;107;108
 V. O Lord, hear my prayer.
 R. And let my cry come unto Thee. 
+It is good * to give praise to God.;;91;100
 
 [Adv0]
 Behold, there cometh the King * even the Most High, with great power, to save the nations, alleluia.;;1;2;3;6

--- a/web/www/horas/Latin/Commune/C10t.txt
+++ b/web/www/horas/Latin/Commune/C10t.txt
@@ -43,11 +43,22 @@ Doxology=Nat
 [Benedictio]
 @Commune/C10:Benedictio
 
+[Responsory1]
+@Commune/C11:Responsory1
+
+[Responsory2]
+@Commune/C11:Responsory7
+&Gloria
+R. Christus, Deus noster.
+
 [Capitulum Laudes]
 @Commune/C10:Capitulum Laudes
 
 [Hymnus Laudes]
 @Commune/C10:Hymnus Laudes
+
+[HymnusM Laudes]
+@Commune/C10:HymnusM Laudes
 
 [Versum 2]
 @Commune/C10:Versum 2
@@ -102,6 +113,9 @@ Doxology=Nat
 
 [Ant 23]
 @:Ant 13
+
+[Ant Laudes]
+@Commune/C11:Ant Laudes
 
 [Lectio Prima]
 @Commune/C10:Lectio Prima

--- a/web/www/horas/Latin/Psalterium/Psalmi matutinum.txt
+++ b/web/www/horas/Latin/Psalterium/Psalmi matutinum.txt
@@ -151,6 +151,10 @@ In advéntu * summi Régis mundéntur corda hóminum, ut digne ambulémus in occ
 V. Egrediétur Dóminus de loco sancto suo.
 R. Véniet ut salvet pópulum suum.
 
+[BMV Versum]
+V. Diffúsa est grátia in lábiis tuis.
+R. Proptérea benedíxit te Deus in ætérnum.
+
 [Adv 0 Versum]
 V. Egrediétur Dóminus de loco sancto suo.
 R. Véniet ut salvet pópulum suum.
@@ -417,6 +421,7 @@ Vísita nos * Dómine in salutári tuo;;105;106
 Confitébor Dómino * nimis in ore meo;;107;108
 V. Dómine, exáudi oratiónem meam.
 R. Et clamor meus ad te véniat.
+Bonum est * confitéri Dómino;;91;100
 
 [Adv0]
 Véniet ecce Rex, * excélsus cum potestáte magna, ad salvandas gentes. Allelúja.;;1;2;3;6


### PR DESCRIPTION
- ferial saturday matins has 12 psalms (99 and 100 were missing)
- BVM saturday matins has psalm 91 instead of 99
- BVM saturday lauds has antiphons and psalms as on feasts of the BVM
- BVM saturday matins has special V (Diffúsa est etc.)
- BVM saturday matins has special responsories
- BVM saturday lauds 1570 has old hymn