### PR TITLE
Corrections to commemorations in Christmastide

### DIFF
--- a/web/cgi-bin/horas/specials.pl
+++ b/web/cgi-bin/horas/specials.pl
@@ -1573,7 +1573,7 @@ sub getcommemoratio {
   my %w = %{officestring($datafolder, $lang, $wday, ($ind == 1) ? 1 : 0)};
   my %c = undef;
 
-  if ($winner =~ /Nat1/ && $version !~ /1960/ && $wday =~ /12-30/) { return ''; }
+  if ($version =~ /Trident|Divino/i && $wday =~ /12-30/) { return ''; }
 
   if ($hora =~ /Vespera/i && $rank >= 5 && $w{Rank} =~ /;;1/ && $winner !~ /Tempora/i) {
     return '';

--- a/web/www/horas/Latin/Sancti/12-25.txt
+++ b/web/www/horas/Latin/Sancti/12-25.txt
@@ -415,3 +415,6 @@ _
 $Oremus
 v. Concéde, quǽsumus, omnípotens Deus: ut nos Unigéniti tui nova per carnem Natívitas líberet; quos sub peccáti jugo vetústa sérvitus tenet.
 $Per eumdem
+
+[Octava 1]
+@:Octava 3

--- a/web/www/horas/Latin/Sancti/12-26.txt
+++ b/web/www/horas/Latin/Sancti/12-26.txt
@@ -206,3 +206,6 @@ _
 $Oremus
 v. Da nobis, quǽsumus, Dómine, imitári quod cólimus: ut discámus et inimícos dilígere; quia ejus natalícia celebrámus, qui novit étiam pro persecutóribus exoráre Dóminum nostrum Jesum Christum Fílium tuum:
 $Qui tecum
+
+[Octava 1]
+@:Octava 3

--- a/web/www/horas/Latin/Sancti/12-27.txt
+++ b/web/www/horas/Latin/Sancti/12-27.txt
@@ -211,3 +211,6 @@ _
 $Oremus
 v. Ecclésiam tuam, Dómine, benígnus illústra: ut beáti Joánnis Apóstoli tui et Evangelístæ, illumináta doctrínis, ad dona pervéniat sempitérna.
 $Per Dominum
+
+[Octava 1]
+@:Octava 3

--- a/web/www/horas/Latin/Sancti/12-28.txt
+++ b/web/www/horas/Latin/Sancti/12-28.txt
@@ -272,3 +272,6 @@ _
 $Oremus
 v. Deus, cuius hodiérna die præcónium Innocéntes Mártyres non loquéndo, sed moriéndo conféssi sunt: ómnia in nobis vitiórum mala mortífica; ut fidem tuam, quam lingua nostra lóquitur, étiam móribus vita fateátur.
 $Per Dominum
+
+[Octava 1]
+@:Octava 3

--- a/web/www/horas/Latin/Sancti/12-29.txt
+++ b/web/www/horas/Latin/Sancti/12-29.txt
@@ -2,7 +2,7 @@
 S. Thomæ Episcopi et Martyris;;Duplex;;3;;vide C2
 
 [Rank1570]
-S. Thomæ Episcopi et Martyris;;Semiduplex;;2;;vide C2
+S. Thomæ Episcopi et Martyris;;Semiduplex;;2.1;;vide C2
 
 [Rank1960]
 Die quinta post Nativitatem;;Duplex II class;;5;;ex Sancti/12-25

--- a/web/www/horas/Latin/Tempora/Nat1-0.txt
+++ b/web/www/horas/Latin/Tempora/Nat1-0.txt
@@ -29,11 +29,14 @@ Dum médium siléntium * tenérent ómnia, et nox in suo cursu médium iter per�
 Omnípotens sempitérne Deus, dírige actus nostros in beneplácito tuo: ut in nómine dilécti Fílii tui mereámur bonis opéribus abundáre:
 $Qui tecum
 
-[Commemoratio 2] (rubrica Divino aut rubrica Tridentina)
+[Commemoratio] (rubrica Divino)
 @Sancti/12-25:Octava
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina)
+[Commemoratio] (rubrica Tridentina)
 @Sancti/12-25:Octava
+@Sancti/12-26:Octava
+@Sancti/12-27:Octava
+@Sancti/12-28:Octava
 
 [Responsory3](rubrica 1960)
 @Sancti/12-25:Responsory4


### PR DESCRIPTION
Fixes some issues with commemorations in Christmastide from #2176: 
- Vespers on 12-29 and 12-30 now has the vespers commemorations of the octaves including the nativity, 
- Commemoratio Die VI infra Octavam Nativitatis is omitted on 12-30

TODO: the commemoration of St. Thomas Becket is still last on 12-29 (it should be first)