### PR TITLE
Remove Superfluous English from Magyar Texts

### DIFF
--- a/web/www/missa/Magyar/Tempora/093-3.txt
+++ b/web/www/missa/Magyar/Tempora/093-3.txt
@@ -7,61 +7,19 @@ Feria Quarta Quattuor Temporum Septembris;;Feria major;;4
 [Rule]
 LectioL1
 
-[Introitus]
-!Ps 80:2-5
-v. Sing joyfully to God our strength; acclaim the God of Jacob. Take up a pleasant psalm with the harp; blow the trumpet in the beginning of the month; for it is a statute in Israel, an ordinance of the God of Jacob.
-!Ps 80:6
-He made it a decree for Joseph, when he came forth from the land of Egypt: he heard an unfamiliar speech.
-&Gloria
-v. Sing joyfully to God our strength; acclaim the God of Jacob. Take up a pleasant psalm with the harp; blow the trumpet in the beginning of the month; for it is a statute in Israel, an ordinance of the God of Jacob.
-
-[Oratio]
-May our frailty, we beseech You, O Lord, find support in the help of Your mercy; so that what is marred by its own nature may be restored by Your grace.
-$Per Dominum
-
 [LectioL1]
 Olvasmány Ámos próféta könyvéből
 !Amos 9:13-15
 v. Igen, jönnek napok - mondja az Úr -, amikor együtt jár a szántóvető és az arató, a sajtoló és a magvető, újbor fakad a hegyekből, patakzik minden halomból.  Népemet, Izraelt helyreállítottam: fölépítik a romba dőlt városokat és bennük laknak, szőlőskerteket ültetnek, és isszák a borát, kerteket telepítenek, és eszik a gyümölcsét.  Letelepítem őket földjükre, soha többé nem tépik ki őket földjükből, amelyeket nekik adtam - mondja az Úr, a te Istened. 
 $Deo gratias
 
-[GradualeL1]
-!Ps 112:5-7
-Who is like the Lord, our God, Who is enthroned on high and looks upon the heavens and the earth below?
-V. He raises up the lowly from the dust; from the dunghill He lifts up the poor.
-
-[OratioL1]
-O Lord, we beseech You, grant to Your praying household that, as they fast from bodily food, they may also abstain mentally from sin.
-$Per Dominum
-
 [Lectio]
 Olvasmány Nehemiás könyvéből
 !Neh 8:1-10
 v. Akkor egy emberként összegyűlt az egész nép a Víz-kapu előtti térségen. Felszólították Ezdrás papot, hogy hozza elő Mózes törvénykönyvét, amelyet az Úr rendelt Izraelnek.  Akkor Ezdrás a férfiak, a nők és mindazok gyülekezete elé tárta a törvénykönyvet, akik meg tudták érteni. A hetedik hónap első napja volt.  A Víz-kapu előtti térségen reggeltől délig olvasott belőle a férfiaknak, a nőknek és mindazoknak, akik meg tudták érteni. Az egész nép figyelt a törvény könyvére.  Ezdrás írástudó felállt az erre a célra készült faállványra. Jobbja felől Mattitja, Sema, Anaja, Urija, Hilkija és Maaszeja állt, balján Pedaja, Misael, Malkija, Hasum, Hasbaddana, Zakariás és Mesullam.  Ezdrás kinyitotta a könyvet az egész nép szeme láttára - magasabban állt ugyanis, mint a nép -, s amikor kinyitotta, az egész nép felállt.  Akkor Ezdrás áldotta az Urat, a nagy Istent, s az egész nép kitárt kézzel ráfelelte: ámen, ámen, ámen, majd mélyen meghajoltak, s földre borulva imádták az Urat.  [Jesua, Bani, Serebja, Jamin, Akkub, Sabtai, Hodija, Maaszeja, Kelita, Azarja, Jozabad, Hanan, Pelaja, akik leviták voltak, kifejtették a törvényt a népnek. Közben a nép a helyén állt.]  Ezdrás felolvasott az Isten törvénykönyvéből, lefordította és megmagyarázta az értelmét, úgyhogy meg is értették, amit felolvasott.  Akkor [Nehemiás, a kormányzó], Ezdrás pap és írástudó, s a leviták, akik a népet tanították, így szóltak az egész néphez: "Ez a nap az Úrnak, a ti Isteneteknek van szentelve. Ne szomorkodjatok hát és ne sírjatok!" Mert amikor a törvény szavait meghallotta, az egész nép sírt.  Így szólt továbbá hozzájuk: "Menjetek és egyetek zsíros ételeket és igyatok édes italokat! Küldjetek belőle azoknak is, akik nem készítettek! Ez a nap ugyanis szent a mi Urunknak. Ne szomorkodjatok, hiszen az Úrban való öröm az erősségetek." 
 
-[Graduale]
-!Ps 32:12, 6.
-Happy the nation whose God is the Lord, the people the Lord has chosen for His own inheritance.
-V. By the word of the Lord the heavens were made; by the breath of His mouth all their host.
-
 [Evangelium]
 Evangélium + szent Márk Evangélista kőnyvéből
 !Mark 9:16-28
 v. Megkérdezte tőlük: "Miről vitatkoztok velük?"  Valaki megszólalt a tömegből: "Mester, elhoztam hozzád a fiamat, akit néma lélek szállt meg.  Amikor hatalmába keríti, a földhöz vágja, habzik a szája, csikorgatja a fogait és megmerevedik. Már szóltam tanítványaidnak, hogy űzzék ki, de nem tudták."  "Ó, te hitetlen nemzedék - válaszolta -, meddig maradjak még körödben? Meddig tűrjelek benneteket? Hozzátok ide hozzám!"  Odavitték. Mihelyt a lélek meglátta, nyomban gyötörni kezdte a fiút, úgyhogy az a földre zuhant s habzó szájjal fetrengett.  "Mióta szenved a bajban?" - kérdezte apját. "Kicsi kora óta - válaszolta. -  Sokszor tűzbe meg vízbe kergette, csakhogy elpusztítsa. Ha valamit tehetsz, segíts rajtunk, és légy részvéttel irántunk."  Jézus így felelt: "Ha valamit tehetsz?... Minden lehetséges annak, aki hisz."  A fiú apja erre felkiáltott: "Hiszek! Segíts hitetlenségemen!"  Amikor Jézus látta, hogy egyre nagyobb tömeg gyűlik össze, ráparancsolt a tisztátalan lélekre: "Néma és süket lélek, parancsolom neked, menj ki belőle, és ne térj többé vissza belé!"  Az felordított, s heves rángatások közepette kiment belőle. A fiú olyan lett, mintha halott volna. Sokan úgy vélték, hogy meghalt.  Jézus azonban megfogta a kezét, felsegítette, s a gyermek talpra állt.  Amikor bement a házba, tanítványai külön megkérdezték: "Mi miért nem tudtuk kiűzni?" 
-
-[Offertorium]
-!Ps 118:47-48
-I will delight in Your commands, which I love exceedingly. And I will lift up my hands to Your commands, which I love.
-
-[Secreta]
-May this offering, O Lord, we beseech You, wipe away our transgressions, and make holy the minds and bodies of Your servants for celebrating this sacrifice.
-$Per Dominum
-
-[Communio]
-!2 Esd. 8:10
-Eat fat meats, and drink sweet wine, and send portions to those who have not prepared for themselves: because it is the holy day of the Lord, be not sad, for the joy of the Lord is our strength.
-
-[Postcommunio]
-In partaking of Your heavenly gifts, we humbly entreat You, O Lord, that by Your grace we may receive what, through Your bounty, we perform in diligent service.
-$Per Dominum
 

--- a/web/www/missa/Magyar/Tempora/093-5.txt
+++ b/web/www/missa/Magyar/Tempora/093-5.txt
@@ -6,46 +6,14 @@ Feria Sexta Quattuor Temporum Septembris;;Feria major;;4
 
 [Rule]
 
-[Introitus]
-!Ps 104:3-4
-v. Rejoice, O hearts that seek the Lord! Look to the Lord, and be strengthened; seek His face evermore.
-!Ps 104:1
-Give thanks to the Lord, invoke His name; make known among the nations His deeds.
-&Gloria
-v. Rejoice, O hearts that seek the Lord! Look to the Lord, and be strengthened; seek His face evermore.
-
-[Oratio]
-Grant, we beseech You, almighty God, that we who devoutly keep the sacred observances year by year may be pleasing unto You both in body and soul.
-$Per Dominum
 
 [Lectio]
 Olvasmány Ozeás próféta könyvéből
 !Hos 14:2-10
 v. Izrael, térj vissza az Úrhoz, a te Istenedhez, hisz bűnöd miatt buktál el!  Hozzatok szavakat magatokkal, és térjetek vissza az Úrhoz! Mondjátok neki: "Végy el minden gonoszságot, hogy elnyerjük a jót, és ajkunk gyümölcsét hozhassuk áldozatul.  Asszíria nem segít rajtunk, lóra sem szállunk többé. Nem mondjuk kezünk alkotásának ezután: Te vagy a mi Istenünk! Mert az árva csak nálad talál irgalmat."  Meggyógyítom hűtlenségüket, s szívemből szeretni fogom őket, elfordul tőlük haragom.  Izraelhez olyan leszek, mint a harmat; virul majd, mint a liliom, gyökeret ereszt, mint a nyárfa.  Hajtásai messze ágaznak, pompás lesz, mint az olajfa, s illatos, mint a Libanon.  Visszatérnek, hogy árnyékomban lakjanak, búzát termelnek, és gondozzák a szőlőt, amelynek olyan híre lesz, mint a helboni bornak.  Mi köze Efraimnak ezentúl a bálványokhoz? Én hallgatom meg, én viselek rá gondot. Olyan leszek, mint a zöldellő ciprus; tőlem származik gyümölcsöd.  Aki bölcs, értse meg ezeket! Aki értelmes, lássa be ezt mind! Mert egyenesek az Úr útjai, azokon járnak az igazak, de a gonoszok elbuknak rajtuk. 
 
-
-[Graduale]
-!Ps 89:13, 1.
-Return, O Lord! How long? Have pity on Your servants.
-V. O Lord, You have been our refute through all generations.
-
 [Evangelium]
 Evangélium + szent Lukács Evangélista kőnyvéből
 !Luke 7:36-50
 v. Egy farizeus meghívta, hogy egyék nála. Betért hát a farizeus házába, és asztalhoz telepedett.  Élt a városban egy bűnös nő. Amikor megtudta, hogy a farizeus házában van vendégségben, alabástrom edényben illatos olajat hozott.  Megállt hátul a lábánál, és sírva fakadt. Könnyeit Jézus lábára hullatta, majd hajával megtörölte, elárasztotta csókjaival, és megkente illatos olajjal.  Mikor ezt a farizeus házigazda látta, így szólt magában: "Ha próféta volna, tudná, hogy ki és miféle az, aki érinti: hogy bűnös nő."  Jézus akkor hozzá fordult: "Simon, mondanék neked valamit." Az kérte: "Mester! Hát mondd el!"  "Egy hitelezőnek két adósa volt. Az egyik ötszáz dénárral tartozott neki, a másik ötvennel.  Nem volt miből fizetniük, hát elengedte mind a kettőnek. Melyikük szereti most jobban?"  "Úgy gondolom az, akinek többet elengedett" - felelte Simon. "Helyesen feleltél" - mondta neki.  Majd az asszony felé fordulva így szólt Simonhoz: "Látod ezt az asszonyt? Betértem házadba, s nem adtál vizet a lábamra. Ez a könnyeivel áztatta lábamat, és a hajával törölte meg.  Csókot sem adtál nekem, ez meg egyfolytában csókolgatja a lábam, amióta csak bejött.  Aztán a fejemet sem kented meg olajjal. Ez meg a lábamat keni illatos olajával.  Azt mondom hát neked, sok bűne bocsánatot nyer, mert nagyon szeretett. Akinek kevés bűnét bocsátják meg, az csak kevéssé szeret."  Aztán így szólt az asszonyhoz: "Bűneid bocsánatot nyernek."  A vendégek összesúgtak: "Ki ez, hogy még a bűnöket is megbocsátja?"  De ő ismét az asszonyhoz fordult: "A hited megmentett. Menj békével!" 
 
-[Offertorium]
-!Ps 102:2, 5.
-Bless the Lord, O my soul, and forget not all His benefits; and your youth shall be renewed like the eagles.
-
-[Secreta]
-May the gift of our fasting, we beseech You, O Lord, be acceptable to You, and by its purifying power make us worthy of Your grace and bring us to the eternal bliss You have promised us.
-$Per Dominum
-
-[Communio]
-!Ps 118:22, 24.
-Take away from me reproach and contempt, for I observe Your decrees, O Lord. Your decrees are my delight.
-
-[Postcommunio]
-We beseech You, O almighty God, that, showing gratitude for the gifts we have received, we may obtain yet greater benefits.
-$Per Dominum

--- a/web/www/missa/Magyar/Tempora/093-6.txt
+++ b/web/www/missa/Magyar/Tempora/093-6.txt
@@ -9,32 +9,11 @@ Sabbato Quattuor Temporum Septembris;;Feria major;;4
 (si missa brevior et rubrica 1960) LectioL1
 LectioL5
 
-[Introitus]
-!Ps 94:6-7
-v. Come, let us bow down in worship to God; let us kneel before the Lord. Let us weep before Him Who made us; for He is the Lord our God.
-!Ps 94:1
-Come, let us sing joyfully to the Lord; let us acclaim God our Saviour.
-&Gloria
-v. Come, let us bow down in worship to God; let us kneel before the Lord. Let us weep before Him Who made us; for He is the Lord our God.
-
-[Oratio]
-Almighty, everlasting God, You Who cure body and soul through healing self-denial, we humbly entreat Your majesty to hear favorably the devout prayer of those who fast, and to grant us help for the present and the future.
-$Per Dominum
-
 [LectioL1]
 Olvasmány Mózes harmadik könyvéből
 !Lev 23:26-32
 v. Az Úr ezt mondta Mózesnek:  "Ennek a hónapnak a tizedik napja az engesztelés napja. Tartsatok rajta szent összejövetelt. Böjtöljetek, és mutassatok be áldozatot az Úrnak.  Ezen a napon ne végezzetek semmiféle szolgai munkát, mert ez az engesztelés napja, amelyen elvégzik fölöttetek az engesztelés szertartását az Úr, a ti Istenetek előtt.  Aki nem böjtöl ezen a napon, azt ki kell irtani övéi közül,  aki pedig dolgozik, azt én pusztítom ki népéből.  Ne végezzetek semmiféle munkát, ez örök törvény utódaitok számára, bárhol laktok is.  Szombati nyugalom legyen ez számotokra. Tartsátok meg a böjtöt, s a hónap kilencedik napjának estéjétől a következő estig tartózkodjatok a munkától." 
 $Deo gratias
-
-[GradualeL1]
-!Ps 78:9-10
-Pardon our sins, O Lord; why should the nations say, Where is their God?
-V. Help us, O God our Saviour; because of the glory of Your name, O Lord, deliver us.
-
-[OratioL1]
-Grant us, we beseech You, almighty God, that by fasting we may be filled with Your grace, and by abstinence we may be made stronger than all our enemies.
-$Per Dominum
 
 [LectioL2]
 Olvasmány Mózes harmadik könyvéből
@@ -42,44 +21,17 @@ Olvasmány Mózes harmadik könyvéből
 v. A hetedik hónap tizenötödik napján, amikor már betakarítottátok a föld termését, üljetek hétnapos ünnepet az Úrnak. Az első és a nyolcadik napon legyen teljes nyugalom.  Az első napon vigyetek magatokkal szép gyümölcsöket, pálmaágakat, patak menti fűzfaágakat, és vigadjatok hét napig az Úr, a ti Istenetek színe előtt.  Így üljétek meg évenként az Úr ünnepét hét napon át. Örök törvény ez utódaitok számára. A hetedik hónapban tartsátok ezt az ünnepet.  Hét napig lakjatok sátorban. Izrael népének minden tagja lakjék sátor alatt;  így utódaitok megtudják, hogy sátorban lakattam Izrael fiait, amikor kihoztam őket Egyiptom földjéről. Én vagyok az Úr, a ti Istenetek." 
 $Deo gratias
 
-[GradualeL2]
-!Ps 83:10, 9.
-Behold, O God, our Protector, and look upon Your servants.
-V. O Lord God of Hosts, hear the prayers of Your servants.
-
-[OratioL2]
-Protect Your people, we beseech You, O Lord, so that we may by Your gift, obtain those means of eternal salvation which we seek through Your inspiration.
-$Per Dominum
-
 [LectioL3]
 Olvasmány Mikeás próféta könyvéből
 !Mic 7:14; 7:16; 7:18-20
 v. Legeltesd botoddal népedet, örökséged nyáját, amely egyedül él az erdőben, egy gyümölcsöskertnek a közepén. Bárcsak legelhetne a Básánon és Gileádban, mint hajdanában!  Látni fogják a népek, és megszégyenülnek minden hatalmuk ellenére; a kezüket a szájukra teszik, a fülük pedig megsüketül.  Melyik isten olyan, mint te, aki elveszed a gonoszságot, és megbocsátod a vétkeket? Aki nem haragszol mindörökre, hanem kedved leled az irgalomban?  Irgalmazz nekünk még ez egyszer, tipord össze vétkeinket, vesd a tenger mélyére minden bűnünket!  Tanúsíts hűséget Jákob iránt, irgalmat Ábrahám iránt, amint megesküdtél atyáinknak ősidőktől fogva. 
 $Deo gratias
 
-[GradualeL3]
-!Ps 89:13, 1.
-Return, O Lord! How long? Have pity on Your servants.
-V. O Lord, You have been our refuge through all generations.
-
-[OratioL3]
-Grant, we beseech You, almighty God, that we may so fast from bodily food as to abstain also from the sins that beset us.
-$Per Dominum
-
 [LectioL4]
 Olvasmány Zakariás próféta könyvéből
 !Zech 8:14-19
 v. Ezt mondja a Seregek Ura: Amint elhatároztam, hogy rosszul bánok veletek, amikor atyáitok megharagítottak - mondja a Seregek Ura, és nem is irgalmaztam,  úgy most, ezekben a napokban elhatároztam, hogy jót teszek Jeruzsálemmel és Júda házával. Ne féljetek!  Csak ezeket a dolgokat tegyétek meg: Mondjatok egymásnak igazat, kapuitokban úgy szolgáltassatok igazságot, hogy békét szerezzetek.  Szívetekben ne forraljatok gonoszságot egymás ellen, hogy ne szeressétek a hamis esküt, mert ezek a dolgok, amelyeket gyűlölök - mondja az Úr.  A Seregek Ura a következő szózatot intézte hozzám:  Ezt mondja a Seregek Ura: A negyedik hónap böjtje, az ötödik hónap böjtje, a hetedik hónap böjtje és a tizedik hónap böjtje Júda háza számára vidámságot, örömet és kellemes ünnepet fog jelenteni. De szeressétek az igazságot és a békét! 
 $Deo gratias
-
-[GradualeL4]
-!Ps 140:2
-Let my prayer come like incense before You, O Lord.
-V. The lifting up of my hands, like the evening sacrifice.
-
-[OratioL4]
-As You give us the grace, O Lord, to offer You our solemn fast, grant us, we beseech You, the support of Your forgiveness.
-$Per Dominum
 
 [LectioL5]
 Olvasmány Dániel próféta könyvéből
@@ -99,37 +51,3 @@ _
 Glória Patri, et Fílio, et Spirítui Sancto. Et laudábili et glorióso in saecula. Sicut erat in princípio, et nunc, et semper: et in saecula sćculórum. Et laudábili et glorióso in saecula. 
 Benedíctus es, Dómine, Deus patrum nostrórum. Et laudábilis et gloriósus in saecula.
 
-[OratioL5]
-O God, You Who tempered the flames of fire for the three young men, mercifully grant that the flames of sin may not burn us, Your servants.
-$Per Dominum
-
-[Lectio]
-Lesson
-!Heb 9:2-12
-Brethren: There was set up a tabernacle in the outer part of which were the lampstand and the table and the showbread, and this is called the Holy Place; but beyond the second veil was the tabernacle which is called the Holy of Holies, having a golden censer and the ark of the covenant, overlaid on every side with gold. In the ark was a golden pot containing the manna and the rod of Aaron which had budded, and the tablets of the covenant; and above it were the Cherubim of glory overshadowing the mercy-seat. But of all these we cannot now speak in detail. Such then being the arrangements, the priests always used to enter into the first tabernacle to perform the sacred rites; but into the second tabernacle the high priest alone entered once a year, not without blood, which he offered for his own and the peoples sins of ignorance. The Holy Spirit signified by this that the way into the Holies was not yet thrown open while the first tabernacle was still standing. This first tabernacle is a figure of the present time, inasmuch as gifts and sacrifices are offered that cannot perfect the worshipper in conscience, since they refer only to food and drink and various ablutions and bodily regulations imposed until a time of reformation. But when Christ appeared once for all through the greater and more perfect tabernacle, not made by hands that is, not of this creation, nor again by virtue of blood of goats and calves, but by virtue of His own Blood, into the Holies, having obtained eternal redemption.
-
-[Graduale]
-!Ps 116:1-2
-Praise the Lord, all you nations; glorify Him, all you peoples!
-V. For steadfast is His kindness toward us, and the fidelity of the Lord endures forever.
-
-[Evangelium]
-Continuation of the Holy Gospel according to
-!Luke 13:6-17
- At that time, Jesus spoke to the multitudes this parable: A certain man had a fig tree planted in his vineyard; and he came seeking fruit thereon, and found none. And he said to the vine-dresser, Behold, for three years now I have come seeking fruit on this fig tree, and I find none. Cut it down, therefore; why does it still encumber the ground? But he answered him and said, Sir, let it alone this year too, till I dig around it and manure it. Perhaps it may bear fruit; but if not, then afterwards you shall cut it down. Now He was teaching in one of their synagogues on the Sabbath. And behold, there was a woman who for eighteen years had had a sickness caused by a spirit; and she was bent over and utterly unable to look upwards. When Jesus saw her, He called her to Him and said to her, Woman, you are delivered from your infirmity. And He laid His hands upon her, and instantly she was made straight, and glorified God. But the ruler of the synagogue, indignant that Jesus had cured on the Sabbath, addressed the crowd, saying, There are six days in which one ought to work; on these therefore come and be cured, and not on the Sabbath. But the Lord answered him and said, Hypocrites! does not each one of you on the Sabbath loose his ox or ass from the manger, and lead it forth to water? And this woman, daughter of Abraham as she is, whom Satan has bound, lo, for eighteen years, ought not she to be loosed form this bond on the Sabbath? And as He said these things, all His adversaries were put to shame; and the entire crowd rejoiced at all the glorious things that were done by Him.
-
-[Offertorium]
-!Ps 87:2-3
-O Lord, the God of my salvation, by day I cry out, at night I clamor in Your presence. Let my prayer come before You, O Lord.
-
-[Secreta]
-Grant, we beseech You, almighty God, that the gift in the sight of Your majesty may obtain for us the grace of reverent devotion and secure eternal happiness.
-$Per Dominum
-
-[Communio]
-!Lev 21:41, 43.
-In the seventh month you shall keep this feast, as I made the Israelites dwell in booths, when I led them out of the land of Egypt. I, the Lord, am your God.
-
-[Postcommunio]
-May Your sacrament, we beseech You, O Lord, produce in us what it contains, and may we share in reality what we now perform as a sacramental rite.
-$Per Dominum

--- a/web/www/missa/Magyar/Votive/Coronatio.txt
+++ b/web/www/missa/Magyar/Votive/Coronatio.txt
@@ -5,77 +5,15 @@ Missa Votiva in Creatione et Coronatione Papae et in die anniversarii
 Gloria
 Credo
 
-[Introitus]
-!Eccli 45:30.
-v. The Lord made a covenant of friendship with him, and made him a prince; that~
-he should possess the dignity of priesthood forever. (Alleluia, alleluia.)
-!Ps 131:1
-Remember, O Lord, David and all his meekness.
-&Gloria
-v. The Lord made a covenant of friendship with him, and made him a prince; that~
-he should possess the dignity of priesthood forever. (Alleluia, alleluia.)
-
-[Oratio]
-O God, shepherd and ruler of all the faithful, look with favor upon Your servant~
-N.p, whom You willed to designate shepherd of Your Church; grant him, we beseech~
-You, that by word and example he may so benefit those in his charge, that~
-together with the flock committed to his care, he may attain life everlasting.
-$Per Dominum
-
 [Lectio]
 Olvasmány szent Péter apostol első leveléből
 !1 Pet 1:1 - 7.
 v. Péter, Jézus Krisztus apostola a zarándokoknak, akik Pontusz, Galácia, Kappadócia, Ázsia és Bitinia területén szórványokban élnek, s akiket az  Atyaisten előretudása birtokában kiválasztott, a Lélek megszentelő erejéből az engedelmességre és a Jézus Krisztus vérével való meghintésre. Kegyelemben és békében bőven legyen részetek!  Legyen áldott az Isten és Urunk, Jézus Krisztus Atyja, aki minket nagy irgalmában Jézusnak a halálból való feltámadása által új életre hívott, az élő reményre,  hogy a mennyekben elpusztíthatatlan, tiszta és soha el nem hervadó örökség várjon rátok.  Az Isten hatalma megőrzött titeket a hitben az örök üdvösségre, amely készen áll, hogy az utolsó időben majd megnyilvánuljon.  Abban örülni fogtok, noha most egy kicsit szomorkodnotok kell, mert különféle kísértések érnek benneteket,  hogy a próbát kiállva hitetek, amely értékesebb a tűz próbálta veszendő aranynál, Jézus Krisztus megjelenésekor méltó legyen a dicséretre, a dicsőségre és a tiszteletre. 
-
-[Graduale]
-!Ps. 106:32, 31.
-Let them extol him in the assembly of the people and praise him in the council~
-of the elders.
-V. Let them give thanks to the Lord for His kindness and His wondrous deeds to~
-the children of men. Alleluia, alleluia.
-V. Matt. 16:18. You are Peter, and upon this rock I will build My Church.~
-Alleluia.
-
-[Tractus]
-!Matt. 16:18 - 19.
-You are Peter, and upon this rock I will build My Church.
-V. And the gates of hell shall not prevail against it; and I will give you the keys of the kingdom of heaven.
-V. Whatever you shall bind on earth shall be bound in heaven.
-V. And whatever you shall loose on earth shall be loosed in heaven.
-
-[GradualeP]
-Alleluia, alleluia.
-!Ps. 106:8
-V. Let them give thanks to the Lord for His kindness and His wondrous deeds to~
-the children of men. Alleluia.
-!Matt. 16:18
-V. You are Peter, and upon this rock I will build My Church. Alleluia.
 
 [Evangelium]
 Evangélium szent Máté Apostol kőnyvéből
 !Matt 16:13-19
 v. Amikor Jézus Fülöp Cezáreájának vidékére ért, megkérdezte tanítványaitól: "Kinek tartják az emberek az Emberfiát?"  Így válaszoltak: "Van, aki Keresztelő Jánosnak, van, aki Illésnek, Jeremiásnak vagy valamelyik másik prófétának."  Jézus most hozzájuk fordult: "Hát ti mit mondtok, ki vagyok?"  Simon Péter válaszolt: "Te vagy Krisztus, az élő Isten Fia."  Erre Jézus azt mondta neki: "Boldog vagy, Simon, Jónás fia, mert nem a test és vér nyilatkoztatta ki ezt neked, hanem az én mennyei Atyám.  Én is mondom neked: Péter vagy, erre a sziklára építem egyházamat, s az alvilág kapui sem vesznek rajta erőt.  Neked adom a mennyek országa kulcsait. Amit megkötsz a földön, a mennyben is meg lesz kötve, s amit feloldasz a földön, a mennyben is fel lesz oldva." 
 
-[Offertorium]
-!Matt. 16:18 - 19.
-You are Peter, and upon this rock I will build My Church, and the gates of hell~
-shall not prevail against it; and I will give you the keys of the kingdom of~
-heaven (Alleluia.)
 
-[Secreta]
-Be appeased, O Lord, we beseech You, by the gifts we offer, and by Your~
-continual protection direct Your servant N.p, whom You willed to be shepherd of~
-Your Church.
-$Per Dominum
-
-[Communio]
-!Matt. 16:18.
-You are Peter, and upon this rock I will build My Church. (Alleluia.)
-
-[Postcommunio]
-May this reception of the divine sacrament, we beseech You, O Lord, be our~
-protection, and may it safeguard and shield at all times Your servant N.p, whom~
-You willed to rule over Your Church as shepherd, and with him, the flock~
-entrusted to his care.
-$Per Dominum
 

--- a/web/www/missa/Magyar/Votive/Dedicatio.txt
+++ b/web/www/missa/Magyar/Votive/Dedicatio.txt
@@ -7,102 +7,14 @@ Credo
 Prefatio=Communis
 
 [Introitus]
-!Gen. 28:17.
-v. How awesome is this place! This is none other than the house of God; this is~
-the gate of heaven; and it shall be called the court of God. (Alleluia,~
-alleluia.)
-!Ps 83:2-3
-How lovely is Your dwelling place, O Lord of Hosts! My soul yearns and pines for~
-the courts of the Lord.
-&Gloria
-v. How awesome is this place! This is none other than the house of God; this is~
-the gate of heaven; and it shall be called the court of God. (Alleluia,~
-alleluia.)
-
-[Oratio] Prayer on the anniversary of the dedication:
-O God, Who for us bring each year the recurrence of the consecration day of this~
-Your holy temple, and always bring us back safely to the sacred rites, hear the~
-prayers of Your people and grant that whoever enters this temple to pray for~
-blessings, may rejoice in having obtained whatever he sought.
-$Per Dominum
-
-[Oratio1] Prayer on the day of dedication:
-O God, Who invisibly sustain all thing, and yet, for the salvation of mankind,~
-show visibly the signs of Your power, enlighten this temple by the power of Your~
-indwelling presence, and grant that all who gather here to pray, may obtain the~
-blessings of Your support in whatever trials they may call upon You.
-$Per Dominum
 
 [Lectio]
 Olvasmány a Jelenések könyvéből
 !Rev 21:2-5
 v. Akkor láttam, hogy a szent város, az új Jeruzsálem alászállt az égből, az Istentől. Olyan volt, mint a vőlegényének fölékesített menyasszony.  Akkor hallottam, hogy a trón felől megszólal egy hangos szózat, ezt mondva: "Íme, Isten hajléka az emberek között! Velük fog lakni és ők az ő népe lesznek, és maga az Isten lesz velük.  Letöröl szemükről minden könnyet. Nem lesz többé halál, sem gyász, sem jajgatás, sem fáradság, mert az elsők elmúltak."  Akkor a trónon ülő megszólalt: "Íme, újjáteremtek mindent!" Majd hozzám fordult: "Írd fel: ezek a szavak hitelesek és igazak." 
 
-[Graduale]
-!
-This place was made by God, a priceless mystery; it is without reproof.
-V. O God, before Whom stands the choir of angels, give ear to the prayers of~
-Your servants. Alleluia, alleluia.
-!Ps 137:2
-I will worship at Your holy temple and give thanks to Your name. Alleluia.
-
-[Tractus]
-!Ps. 124:1 - 2.
-They who trust in the Lord are like Mount Sinai, which is immovable; which forever stands.
-V. Mountains are round about Jerusalem; so the Lord is round about His people, both now and forever.
-
-[GradualeP]
-Alleluia, alleluia. Ps 137:2
-V. I will worship at Your holy temple and give thanks to Your name. Alleluia.
-V. The house of the Lord is well founded upon a firm rock. Alleluia.
-
 [Evangelium]
 Evangélium szent Lukács Evangélista kőnyvéből
 !Luke 19:1-10
 v. Aztán odaért Jerikóba és végigment rajta.  Élt ott egy Zakeus nevű tehetős ember, a vámosok feje.  Szerette volna látni Jézust szemtől szemben, de a tömeg miatt nem tudta, mert alacsony termetű volt.  Így hát előrefutott, felmászott egy vadfügefára, hogy láthassa, mert arra kellett elhaladnia.  Amikor Jézus odaért, felnézett és megszólította: "Zakeus, gyere le hamar! Ma a te házadban kell megszállnom."  Erre az gyorsan lemászott, és boldogan fogadta.  Akik ezt látták, méltatlankodva megjegyezték, hogy bűnös emberhez tér be megpihenni.  Zakeus azonban odaállt az Úr elé, és így szólt: "Íme, Uram, vagyonom felét a szegényeknek adom, és ha valakit valamiben megcsaltam, négyannyit adok helyette."  Jézus ezt felelte neki: "Ma üdvösség köszöntött erre a házra, hiszen ő is Ábrahám fia.  Az Emberfia azért jött, hogy megkeresse és megmentse azt, ami elveszett." 
 
-[Offertorium]
-!1 Par 29:17-18
-O Lord God, in the simplicity of my heart I have joyfully offered all these~
-things; and I have seen with great joy Your people which are here present: O God~
-of Israel, keep this will. (Alleluia.)
-
-[Secreta] Secret on the anniversary of the dedication in the church dedicated:
-Look with favor upon our prayers, we beseech You, O Lord, that we who are~
-gathered together within the confines of this temple to keep the anniversary day~
-of its dedication, may please You with full and perfect devotion, may please You~
-with full and perfect devotion of body and soul, that as we now offer these~
-prayers, we may, by Your assistance, be found worthy to attain everlasting~
-rewards.
-$Per Dominum
-
-[Secreta2] Outside the dedicated church:
-Look with favor upon our prayers, we beseech You, O Lord, that as we offer our~
-prayers before You, we may, with Your help attain eternal rewards.
-$Per Dominum
-
-[Secreta1] On the day of dedication:
-O God, the creator of things fitting for sacrifice unto You, pour forth Your~
-blessing upon this house of prayer, so that all who herein call upon Your name~
-may enjoy the support of Your protection.
-$Per Dominum
-
-[Communio]
-!Matt. 21:13
-My house shall be called a house of prayer, says the Lord; in it everyone who~
-asks receives: and he who seeks finds, and to him who knocks it shall be opened.
-
-[Postcommunio] On the anniversary of the dedication:
-O God, Who from living and chosen stones prepare an eternal dwelling place for~
-Your Majesty, help Your people who call upon You, so that whatever benefits come~
-to Your Church materially may be even greater through its spiritual extension.
-$Per Dominum
-
-[Postcommunio] On the day of dedication:
-We beseech You, almighty God, that in this place which we, all unworthy, have~
-dedicated to Your name, You will give a favorable hearing to all who petition~
-You.
-$Per Dominum
-
-[ ]
-!In the Mass of Dedication in the act of the Consecration of the Church there is added, under a single conclusion, the prayer of the Mystery or Saint in whose honor the Church or the Oratory is consecrated, and no other commemoration is added, not even a privileged one. After the Solemn Blessing of a Church or Oratory, and after the consecration of the altar, there is said, as a Votive Mass of the Second Class, a Mass of the Mystery or Saint in whose honor the Church or Oratory is blessed or the altar consecrated.

--- a/web/www/missa/Magyar/Votive/Defunctorum.txt
+++ b/web/www/missa/Magyar/Votive/Defunctorum.txt
@@ -8,37 +8,10 @@ Prefatio=Defunctorum
 Sequentia
 Requiem gloria
 
-[Introitus]
-!4 Esd. 2:34-35.
-v. Eternal rest give to them, O Lord; and let perpetual light shine upon them.
-!Ps 64:2-3
-To You we owe our hymn of praise, O God, in Sion; to You must vows be fulfilled~
-in Jerusalem. Hear my prayer; to You all flesh must come.
-v. Eternal rest give to them, O Lord; and let perpetual light shine upon them.
-
-[Oratio]
-O God, Creator and Redeemer of all the faithful, grant to the souls of Your~
-servants and handmaids the remission of all their sins, that by loving prayers~
-they may obtain the forgiveness they have ever desired.
-$Qui vivis
-
 [Lectio]
 Olvasmány a Jelenések könyvéből
 !Rev 14:13.
 v. Erre szózatot hallottam az égből: "Jegyezd fel: Mostantól fogva boldogok a halottak, akik az Úrban haltak meg. Igen, mondja a Lélek, hadd pihenjék ki fáradalmaikat, mert tetteik elkísérik őket." 
-
-[Graduale]
-!4 Esd. 2:34 - 35.
-Eternal rest give to them, O Lord; and let perpetual light shine upon them.
-!Ps 111:7
-The just man shall be in everlasting remembrance; an evil report he shall not~
-fear.
-_
-!Tractus
-O Lord, absolve the souls of all the faithful departed from every bond of sin.
-V. And by the help of Your grace may they be worthy to escape the sentence of~
-vengeance.
-V. And to enjoy all the beatitude of the light eternal.
 
 [Sequentia]
 !elmaradhat
@@ -124,32 +97,4 @@ Evangélium + szent János Apostol kőnyvéből
 !John 6:51-55.
 v. Én vagyok a mennyből alászállott élő kenyér. Aki e kenyérből eszik, örökké él. A kenyér, amelyet adok, a testem a világ életéért."  Erre vita támadt a zsidók közt: "Hogy adhatja ez a testét eledelül?"  Jézus ezt mondta rá: "Bizony, bizony, mondom nektek: Ha nem eszitek az Emberfia testét és nem isszátok a vérét, nem lesz élet bennetek.  De aki eszi az én testemet, és issza az én véremet, annak örök élete van, s feltámasztom az utolsó napon.  A testem ugyanis valóságos étel, s a vérem valóságos ital. 
 
-[Offertorium]
-O Lord, Jesus Christ, King of glory, deliver the souls of all the~
-faithful departed from the pains of hell and the deep pit; deliver them from the~
-lions mouth, that hell engulf them not, nor they fall into darkness, but that~
-Michael, the holy standard-bearer, bring them into the holy light * which You~
-once promised to Abraham and his seed.
-V. We offer You, O Lord, sacrifices and prayers of praise; accept them for those~
-souls whom we this day commemorate; grant them, O Lord, to pass from death to~
-the life * which You once promised to Abraham and his seed.
-
-[Secreta]
-Look mercifully, we beseech You, O Lord, upon the sacrificial gifts we offer You~
-for the souls of Your servants and handmaids; and since You have given them the~
-merit of Christian faith, also grant them its reward.
-$Per Dominum
-
-[Communio]
-!4 Esdr 2:35; 2:34
-May light eternal shine upon them, O Lord, with Your Saints forever, for You are~
-kind.
-V. Grant them eternal rest, O Lord; and let perpetual light shine upon them:~
-with Your Saints forever, for You are kind.
-
-[Postcommunio]
-May the prayers of Your suppliants be helpful to the souls of Your servants and~
-handmaids, we beseech You, O Lord, that You may free them from all sin and make~
-them sharers in Your redemption.
-$Qui vivis
 


### PR DESCRIPTION
Removed superfluous English and Latin.  Left Latin at end of hymn from Daniel in 093-6.txt. Please advise if needs to be removed.