### PR TITLE
Fix #2209

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -184,7 +184,7 @@ sub getrank {
   my @trank = ();
   my @srank = ();
   our $transfervigil = '';
-  our %transfer = {};
+  my %transfer;
   our $hymncontract = 0;
   my $kalendarname =
       ($version =~ /Monastic/i) ? 'M'
@@ -236,8 +236,6 @@ sub getrank {
     $tr =~ s/\=/\;\;/g;
     %transfer = split(';;', $tr);
     if (exists($transfer{dirge})) { $dirgeline = $transfer{dirge}; }    #&& !$caller
-  } else {
-    %transfer = {};
   }
   $transfer = $transfer{$sday};
 


### PR DESCRIPTION
Also changes (fixes, hope) many Vespera precedences in Trident & Divino when there is no transfer file.
I'm not sure if removing old transfer files was good move but at least it allowed to spot this bug.
+AMDG+