### PR TITLE
Remove Credo from Sancta Missa for Conversione S. Pauli Apostoli

### DIFF
--- a/web/www/missa/English/Sancti/01-25.txt
+++ b/web/www/missa/English/Sancti/01-25.txt
@@ -7,7 +7,6 @@ In Conversione S. Pauli Apostoli;;Duplex Fest;;5;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 
 [Introitus]

--- a/web/www/missa/English/Sancti/01-25r.txt
+++ b/web/www/missa/English/Sancti/01-25r.txt
@@ -4,7 +4,6 @@ In Conversione S. Pauli Apostoli;;Duplex majus;;4;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 Sub unica conclusione
 

--- a/web/www/missa/French/Sancti/01-25.txt
+++ b/web/www/missa/French/Sancti/01-25.txt
@@ -7,7 +7,6 @@ In Conversione S. Pauli Apostoli;;Duplex Fest;;5;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 
 [Introitus]

--- a/web/www/missa/French/Sancti/01-25r.txt
+++ b/web/www/missa/French/Sancti/01-25r.txt
@@ -4,7 +4,6 @@ In Conversione S. Pauli Apostoli;;Duplex majus;;4;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 Sub unica conclusione
 

--- a/web/www/missa/Italiano/Sancti/01-25.txt
+++ b/web/www/missa/Italiano/Sancti/01-25.txt
@@ -7,7 +7,6 @@ In Conversione S. Pauli Apostoli;;Duplex Fest;;5;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 
 [Introitus]

--- a/web/www/missa/Italiano/Sancti/01-25r.txt
+++ b/web/www/missa/Italiano/Sancti/01-25r.txt
@@ -4,7 +4,6 @@ In Conversione S. Pauli Apostoli;;Duplex majus;;4;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 Sub unica conclusione
 

--- a/web/www/missa/Latin/Sancti/01-25.txt
+++ b/web/www/missa/Latin/Sancti/01-25.txt
@@ -7,7 +7,6 @@ In Conversione S. Pauli Apostoli;;Duplex Fest;;5;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 
 [Introitus]

--- a/web/www/missa/Latin/Sancti/01-25r.txt
+++ b/web/www/missa/Latin/Sancti/01-25r.txt
@@ -4,7 +4,6 @@ In Conversione S. Pauli Apostoli;;Duplex majus;;4;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 Sub unica conclusione
 

--- a/web/www/missa/Magyar/Sancti/01-25.txt
+++ b/web/www/missa/Magyar/Sancti/01-25.txt
@@ -7,7 +7,6 @@ In Conversione S. Pauli Apostoli;;Duplex Fest;;5;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 
 [Lectio]

--- a/web/www/missa/Magyar/Sancti/01-25r.txt
+++ b/web/www/missa/Magyar/Sancti/01-25r.txt
@@ -4,7 +4,6 @@ In Conversione S. Pauli Apostoli;;Duplex majus;;4;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 Sub unica conclusione
 

--- a/web/www/missa/Polski/Sancti/01-25r.txt
+++ b/web/www/missa/Polski/Sancti/01-25r.txt
@@ -4,7 +4,6 @@ In Conversione S. Pauli Apostoli;;Duplex majus;;4;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 Sub unica conclusione
 

--- a/web/www/missa/Portugues/Sancti/01-25r.txt
+++ b/web/www/missa/Portugues/Sancti/01-25r.txt
@@ -4,7 +4,6 @@ In Conversione S. Pauli Apostoli;;Duplex majus;;4;;ex Sancti/06-30
 [Rule]
 ex Sancti/06-30;
 Gloria
-Credo
 Prefatio=Apostolis
 Sub unica conclusione
 


### PR DESCRIPTION
Other missals omit the Credo for this feast.