### PR TITLE
remove nasty unicode linebreaks

### DIFF
--- a/web/www/horas/Latin/Commune/C6.txt
+++ b/web/www/horas/Latin/Commune/C6.txt
@@ -118,7 +118,8 @@ Quo tibi puri resonémus almum
 Péctoris hymnum.
 _
 Glória Patri genitǽque Proli,
-Et tibi compar utriúsque semper Spíritus alme, Deus unus, omni
+Et tibi compar utriúsque semper
+Spíritus alme, Deus unus, omni
 Témpore sæcli.
 Amen.
 

--- a/web/www/horas/Latin/SanctiM/03-12.txt
+++ b/web/www/horas/Latin/SanctiM/03-12.txt
@@ -31,7 +31,8 @@ Tu munus jam post géminum,
 Prǽbes et vas argénteum.
 _
 Ex hoc te Christus témpore,
-Suæ præfert Ecclésiæ:  _
+Suæ præfert Ecclésiæ: 
+_
 Sic Petri gradum pércipis,
 Cujus et normam séqueris.
 _

--- a/web/www/horas/Latin/Tempora/Pasc5-4.txt
+++ b/web/www/horas/Latin/Tempora/Pasc5-4.txt
@@ -140,31 +140,42 @@ Amen.
 v. Ætérne Rex altíssime,
 Redémptor et fidélium,
 Quo mors solúta déperit,
-Datur triúmphum grátiæ. _
+Datur triúmphum grátiæ.
+_
 Scandens tribúnal déxteræ
-Patris, potéstas ómnium Colláta Iesu cǽlitus,
-Quæ non errat humánitus. _
+Patris, potéstas ómnium
+Colláta Iesu cǽlitus,
+Quæ non errat humánitus.
+_
 Ut trina rerum máchina,
 Cæléstium, terréstrium,
 Et inferórum cóndita
 Flectat genu iam súbdita.
-_ Tremunt vidéntes Angeli,
+_
+Tremunt vidéntes Angeli,
 Versam vicem mortálium:
 Culpat caro, purgat caro,
-Regnat Deus, Dei caro. _
+Regnat Deus, Dei caro.
+_
 Tu esto nostrum gáudium,
 Manens olýmpo prǽditum:
 Mundi regis qui fábricam,
-Mundána vincens gáudia. _
+Mundána vincens gáudia.
+_
 Hinc te precántes quǽsumus,
 Ignósce culpis ómnibus,
 Et corda sursum súbleva
-Ad te supérna grátia. _
-Ut, cum repénte cœ́peris Clarére nube Iúdicis,
+Ad te supérna grátia.
+_
+Ut, cum repénte cœ́peris
+Clarére nube Iúdicis,
 Pœnas repéllas débitas,
 Reddas corónas pérditas.
-_ Glória tibi Dómine,
-Qui scandis super sídera, Cum Patre, et Sancto Spíritu, In sempitérna sǽcula.
+_
+Glória tibi Dómine,
+Qui scandis super sídera,
+Cum Patre, et Sancto Spíritu,
+In sempitérna sǽcula.
 Amen.
 
 [Ant Matutinum]

--- a/web/www/horas/Latin/Tempora/Pasc7-0.txt
+++ b/web/www/horas/Latin/Tempora/Pasc7-0.txt
@@ -113,32 +113,47 @@ Allelúja, Spíritus Dómini replévit orbem terrárum: * Veníte, adorémus, al
 v. Iam Christus astra ascénderat,
 Revérsus unde vénerat,
 Promíssum Patris múnere,
-Sanctum datúrus Spíritum. _
-Solémnis urgébat dies, Quo mýstico septémplici
+Sanctum datúrus Spíritum.
+_
+Solémnis urgébat dies,
+Quo mýstico septémplici
 Orbis volútus sépties,
-Signat beáta témpora. _
+Signat beáta témpora.
+_
 Cum lucis hora tértia
 Repénte mundus íntonat,
 Orántibus Apóstolis
 Deum venísse núntiat.
-_ De Patris ergo lúmine
-Decórus ignis almus est, Qui fida Christi péctora
-Calóre Verbi cómpleat. _
+_
+De Patris ergo lúmine
+Decórus ignis almus est,
+Qui fida Christi péctora
+Calóre Verbi cómpleat.
+_
 Impléta gaudent víscera,
 Affláta Sancto Spíritu,
-Vocésque divérsas íntonant, Fantur Dei magnália. _
+Vocésque divérsas íntonant,
+Fantur Dei magnália.
+_
 Ex omni gente cógniti,
 Græcis, Latínis, Bárbaris,
-Cunctísque admirántibus, Linguis loquúntur ómnium.
-_ Iudǽa tunc incrédula,
+Cunctísque admirántibus,
+Linguis loquúntur ómnium.
+_
+Iudǽa tunc incrédula,
 Vesána torvo spíritu,
 Ructáre musti crápulam,
-Alúmnos Christi cóncrepat. _
-Sed signis et virtútibus Occúrrit, et docet Petrus,
-Falsa profári pérfidos, Ioéle teste cómprobans. _
+Alúmnos Christi cóncrepat.
+_
+Sed signis et virtútibus
+Occúrrit, et docet Petrus,
+Falsa profári pérfidos,
+Ioéle teste cómprobans.
+_
 Glória Patri Dómino,
 Natóque, qui a mórtuis
-Surréxit, ac Paráclito, In sæculórum sǽcula.
+Surréxit, ac Paráclito,
+In sæculórum sǽcula.
 Amen.
 
 [Hymnus Matutinum]

--- a/web/www/horas/Latin/Tempora/Pent01-0.txt
+++ b/web/www/horas/Latin/Tempora/Pent01-0.txt
@@ -63,9 +63,12 @@ Deum verum, unum in Trinitáte, et Trinitátem in Unitáte, * Veníte, adorémus
 v. Summæ Deus cleméntiæ,
 Mundíque Factor máchinæ,
 Unus potentiáliter,
-Trinúsque personáliter. _
-Da déxteram sugéntibus, Exsúrgat ut mens sóbria,
-Flagrans et in laudem Dei, Grates repéndet débitas.
+Trinúsque personáliter.
+_
+Da déxteram sugéntibus,
+Exsúrgat ut mens sóbria,
+Flagrans et in laudem Dei,
+Grates repéndet débitas.
 _
 Glória Patri Dómino,
 Glória Unigénito,


### PR DESCRIPTION
Removes nasty unicode linebreaks `\2028` and replaces them with nice real linebreaks `\n`.

Feel free to reject if these are actually needed for something.