### PR TITLE
references non existent file

### DIFF
--- a/web/www/horas/Latin/Sancti/08-18o.txt
+++ b/web/www/horas/Latin/Sancti/08-18o.txt
@@ -1,4 +1,4 @@
-@Sancti/08-18t
+@Sancti/08-18
 
 [Lectio4]
 Sermo sancti Joannis Damasceni


### PR DESCRIPTION
Reference is to non-existent file. I presume `-t` suffix files = tridentine, in which case `08-18` seems the best bet as it's clearly actually used for the 1570 and 1910 versions.

The web version seems to work anyhow. Probably something clever is going on in the Perl.  Give me latin over Perl any day.