### PR TITLE
correct search str for Lectio 12 Nat2M

### DIFF
--- a/web/www/horas/Latin/TemporaM/Nat2-0.txt
+++ b/web/www/horas/Latin/TemporaM/Nat2-0.txt
@@ -67,13 +67,13 @@ Psalmi Dominica
 @Sancti/01-01:Responsory8
 
 [Lectio11]
-@Sancti/01-05:Lectio9:s/Nazaræus sanctus .*//s
+@Sancti/01-05:Lectio9:s/Nazarǽus sanctus .*//s
 
 [Responsory11]
 @SanctiM/01-01
 
 [Lectio12]
-@Sancti/01-05:Lectio9:s/.* Nazaræus sanctus /Nazaræus sanctus /s s/$/~/
+@Sancti/01-05:Lectio9:s/.* Nazarǽus sanctus /Nazarǽus sanctus /s s/$/~/
 Póssumus et áliter dícere; quod étiam eísdem verbis, juxta hebráicam veritátem, in Isáia scriptum sit: Exiet virga de radíce Iesse, et Nazarǽus de radíce ejus conscéndet.
 
 [Responsory12]


### PR DESCRIPTION
There appears to be a typo in this replace str, which doesn't have an accent an an æ ligature.  Probably the accent was added at a later date in the target.

As a consequence Lectio12 at mattins for the second sunday of the Nativity is incorrect in the Latin, as can be seen by comparing it at divinumofficium.com with the English.

In broader thinking, it would be good to add a test for failing regexs in the Perl.  But Perl is to me a closed book so I'll leave that to someone else.

Either that or the English is wrong!