### PR TITLE
Standardise rubrica DSL

### DIFF
--- a/web/www/horas/Deutsch/Sancti/02-22.txt
+++ b/web/www/horas/Deutsch/Sancti/02-22.txt
@@ -53,7 +53,7 @@ V. Du bist ein auserwähltes Gefäß, o heiliger Apostel Paulus.
 R. Der Verkünder der Wahrheit auf der ganzen Erde.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 O Gott, der du alle Völker durch die Predigt des heiligen Apostels Paulus gelehrt hast, gewähre uns, wir bitten dich, die Gnade, dass wir von demjenigen, dessen Gedächtnis wir begehen, auch die Fürsprache bei dir fühlen.
 $Per Dominum
 

--- a/web/www/horas/Deutsch/Sancti/07-23.txt
+++ b/web/www/horas/Deutsch/Sancti/07-23.txt
@@ -57,7 +57,7 @@ Apollináris cum Príncipe Apostolórum Antiochía Romam venit; a quo, ordinátu
 Apollinaris kam mit dem Apostelfürsten von Antiochien nach Rom; von ihm zum Bischof geweiht, wurde er nach Ravenna zur Verkündigung des Evangeliums Christi, des Herrn, gesandt; als er dort viele zum Glauben an Christus bekehrte, wurde er von den Götzenpriestern ergriffen und grausam geschlagen. Als nun auf sein Gebet hin Bonifatius, ein vornehmer Mann, der lange Zeit stumm gewesen war, die Sprache erhielt, und seine Tochter vom unreinen Geist frei geworden war, erhob sich von neuem ein Aufstand gegen ihn. Daher ertrug er viele verschiedene Strafen. Als er später in Ämilia das Evangelium predigte, bekehrte er mehrere vom Götzendienst. Nach Ravenna zurückgekehrt, ermahnte er die Christen zur Standhaftigkeit im Glauben ermahnte, und schied mit dem Ruhm des Martyriums ausgezeichnet, aus dem Leben. Sein Leib wurde in der Nähe der Stadtmauer beigesetzt.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
 !Kommemoration der hl. Christina.
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/Deutsch/Sancti/07-23.txt
+++ b/web/www/horas/Deutsch/Sancti/07-23.txt
@@ -57,7 +57,7 @@ Apollináris cum Príncipe Apostolórum Antiochía Romam venit; a quo, ordinátu
 Apollinaris kam mit dem Apostelfürsten von Antiochien nach Rom; von ihm zum Bischof geweiht, wurde er nach Ravenna zur Verkündigung des Evangeliums Christi, des Herrn, gesandt; als er dort viele zum Glauben an Christus bekehrte, wurde er von den Götzenpriestern ergriffen und grausam geschlagen. Als nun auf sein Gebet hin Bonifatius, ein vornehmer Mann, der lange Zeit stumm gewesen war, die Sprache erhielt, und seine Tochter vom unreinen Geist frei geworden war, erhob sich von neuem ein Aufstand gegen ihn. Daher ertrug er viele verschiedene Strafen. Als er später in Ämilia das Evangelium predigte, bekehrte er mehrere vom Götzendienst. Nach Ravenna zurückgekehrt, ermahnte er die Christen zur Standhaftigkeit im Glauben ermahnte, und schied mit dem Ruhm des Martyriums ausgezeichnet, aus dem Leben. Sein Leib wurde in der Nähe der Stadtmauer beigesetzt.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina)
 !Kommemoration der hl. Christina.
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/Deutsch/Sancti/12-11.txt
+++ b/web/www/horas/Deutsch/Sancti/12-11.txt
@@ -44,6 +44,6 @@ Damasus stammte aus Spanien. Er war ein hervorragender Mann und wohlbewandert in
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Deutsch/Sancti/12-13.txt
+++ b/web/www/horas/Deutsch/Sancti/12-13.txt
@@ -21,7 +21,7 @@ Durch die Ausdauer im Leid * hast du dir deine Seele erhalten, o Braut Christi, 
 Erhöre uns, o Gott, du Urquell unseres Segens, damit wir, die wir am Feste deiner heiligen Jungfrau und Martyrin Luzia Freude haben, so auch in der Gesinnung veredelt und zur liebevollen Unterwürfigkeit angeleitet werden.
 $Per Dominum
 
-[Commemoratio 2] (rubrica 1910 aut rubrica Divino)
+[Commemoratio 2] (rubrica 1910 aut rubrica divino)
 !Kommemoration des Tags innerhalb der Oktav der unbefleckten Empfängnis Mariä
 @Sancti/12-08:Oratio
 

--- a/web/www/horas/Deutsch/Tempora/Nat1-0.txt
+++ b/web/www/horas/Deutsch/Tempora/Nat1-0.txt
@@ -72,7 +72,7 @@ R. Er liegt in der Krippe und ist König im Himmel.
 Es hat also Geheimnisvolles verkündet Simeon, Geheimnisvolles verkündet die Jungfrau (Maria), Geheimnisvolles verkündet die ans Eheband Geknüpfte (Elisabeth); es musste noch Geheimnisvolles verkünden die Witwe, damit kein Beruf und kein Geschlecht fehle. Und darum wird Anna in Bezug auf die Verwertung der Witwenschaft und in Bezug auf ihren Wandel derartig eingeführt, dass sie als würdig gilt, die Ankunft des Heilandes allen zu verkünden. Da ich deren Vorzüge anderswo geschildert habe, als ich die Mahnungen an die Witwen gerichtet habe, brauche ich es, glaube ich, an dieser Stelle, weil ich zu anderem eilen muss, nicht zu wiederholen.
 &teDeum
 
-[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Lectio Prima] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4,7
 v. So gibt es also keinen Knecht mehr, sondern nur Söhne; wenn aber Söhne, dann auch Anwärter auf den Reichtum, gemäß der Anordnung Gottes.
 

--- a/web/www/horas/Deutsch/Tempora/Nat1-0.txt
+++ b/web/www/horas/Deutsch/Tempora/Nat1-0.txt
@@ -72,7 +72,7 @@ R. Er liegt in der Krippe und ist König im Himmel.
 Es hat also Geheimnisvolles verkündet Simeon, Geheimnisvolles verkündet die Jungfrau (Maria), Geheimnisvolles verkündet die ans Eheband Geknüpfte (Elisabeth); es musste noch Geheimnisvolles verkünden die Witwe, damit kein Beruf und kein Geschlecht fehle. Und darum wird Anna in Bezug auf die Verwertung der Witwenschaft und in Bezug auf ihren Wandel derartig eingeführt, dass sie als würdig gilt, die Ankunft des Heilandes allen zu verkünden. Da ich deren Vorzüge anderswo geschildert habe, als ich die Mahnungen an die Witwen gerichtet habe, brauche ich es, glaube ich, an dieser Stelle, weil ich zu anderem eilen muss, nicht zu wiederholen.
 &teDeum
 
-[Lectio Prima] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4,7
 v. So gibt es also keinen Knecht mehr, sondern nur Söhne; wenn aber Söhne, dann auch Anwärter auf den Reichtum, gemäß der Anordnung Gottes.
 

--- a/web/www/horas/Deutsch/Tempora/Pasc5-4.txt
+++ b/web/www/horas/Deutsch/Tempora/Pasc5-4.txt
@@ -324,7 +324,7 @@ R. Hat seinen Sitz bereitet, alleluja.
 
 [Versum 3]
 @:Versum 1
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @:Versum 2
 
 [Ant 3]
@@ -335,7 +335,7 @@ Ant. O du König voll Herrlichkeit, * o Herr aller Mächte, der du als Triumphat
 _
 V. Gott steigt empor im Jubel, alleluja.
 R. Der Herr beim feierlichen Schalle der Trompeten, alleluja.
-(sed rubrica Tridentina loco haec versus dicitur)
+(sed rubrica tridentina loco haec versus dicitur)
 V. Der Herr im Himmel, alleluja.
 R. Hat seinen Sitz bereitet, alleluja.
 _

--- a/web/www/horas/Deutsch/Tempora/Quad6-4.txt
+++ b/web/www/horas/Deutsch/Tempora/Quad6-4.txt
@@ -165,7 +165,7 @@ $Pater noster
 !etwas höher
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 
 [Oratio Matutinum]
@@ -209,7 +209,7 @@ $Pater noster
 !etwas höher
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 (sed rubrica 1955 aut rubrica 1960 loco horum versuum dicuntur)
 v. Nimm, wir bitten dich, o Herr, Wohnung in diesem Gemach und alle Nachstellungen des Feindes scheuche weit von ihm weg; deine heiligen Engel mögen in ihm Wohnung nehmen, die uns im Frieden beschützen, und dein Segen walte stets über uns.

--- a/web/www/horas/Deutsch/Tempora/Quad6-6.txt
+++ b/web/www/horas/Deutsch/Tempora/Quad6-6.txt
@@ -154,7 +154,7 @@ R. Sepulto Domino, signatum est monumentum, volventes lapidem ad ostium monument
 [Ant Laudes]
 O Tod, * ich werde dein Tod sein, dein Zerbeißer werde ich sein, o Hölle.
 Sie werden über ihn trauern * wie über einen Erstgebornen, denn der Herr ist unschuldig getötet worden.
-(sed rubrica Tridentina) Sie werden über ihn trauern * wie über einen Erstgebornen, denn der Herr ist unschuldig getötet worden.;;42
+(sed rubrica tridentina) Sie werden über ihn trauern * wie über einen Erstgebornen, denn der Herr ist unschuldig getötet worden.;;42
 Gebet acht, * ihr Völker alle, und schauet meinen Schmerz.
 Von der Pforte der Hölle * rette, o Herr, meine Seele.;;222
 O ihr alle, die ihr auf dem Wege vorübergehet, gebet acht und schauet, ob ein Schmerz ist wie mein Schmerz.

--- a/web/www/horas/English/Commune/C9.txt
+++ b/web/www/horas/English/Commune/C9.txt
@@ -30,7 +30,7 @@ _
 &pater_noster
 _
 &psalm(145)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 _
 V. From the gates of hell.
 R. Deliver their souls, O Lord!

--- a/web/www/horas/English/Psalterium/Major Special.txt
+++ b/web/www/horas/English/Psalterium/Major Special.txt
@@ -500,7 +500,7 @@ R. And let there descend upon us thy mercy.
 [Day1 Ant 2]
 Blessed be the Lord * the God of Israel, because he has visited and redeemed his people.
 
-[Day1 Ant 2] (rubrica Trident aut rubrica Monastic)
+[Day1 Ant 2] (rubrica tridentina aut rubrica monastica)
 Blessed be the Lord * the God of Israel.
 
 [Day1 Ant 3]
@@ -536,7 +536,7 @@ O Lord, give light * to those who sit in darkness and in the shadow of death, an
 [Day6 Ant 3]
 God hath received * Israel his servant: as he spoke to our fathers, to Abraham and to his seed for ever. 
 
-[Day6 Ant 3] (rubrica Trident aut rubrica Monastic)
+[Day6 Ant 3] (rubrica tridentina aut rubrica monastica)
 God hath received * Israel his servant: as he spoke to our fathers, to Abraham and to his seed, and hath exalted the humble forever. 
 
 [Adv Laudes]

--- a/web/www/horas/English/Sancti/01-02.txt
+++ b/web/www/horas/English/Sancti/01-02.txt
@@ -117,7 +117,7 @@ Blessed is He That cometh in the name of the Lord; Hosanna in the highest,'~
 is all evidently written in honour of the coniing of our Lord.
 &teDeum
 
-[Oratio] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Oratio] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 O Almighty and everlasting God, Who hast dedicated the first-fruits of Thy~
 Martyrs with the blood of the Blessed Stephen; grant, we beseech Thee, that the~
 same may pray for us also, who prayed even for his murderers to our Lord Jesus Christ Thy Son:

--- a/web/www/horas/English/Sancti/01-02.txt
+++ b/web/www/horas/English/Sancti/01-02.txt
@@ -117,7 +117,7 @@ Blessed is He That cometh in the name of the Lord; Hosanna in the highest,'~
 is all evidently written in honour of the coniing of our Lord.
 &teDeum
 
-[Oratio] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Oratio] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 O Almighty and everlasting God, Who hast dedicated the first-fruits of Thy~
 Martyrs with the blood of the Blessed Stephen; grant, we beseech Thee, that the~
 same may pray for us also, who prayed even for his murderers to our Lord Jesus Christ Thy Son:

--- a/web/www/horas/English/Sancti/01-03.txt
+++ b/web/www/horas/English/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Sir 15:1-2
 v. He that feareth God, will do good: and he that possesseth justice, shall lay~
 hold on her,And she will meet him as an honourable mother

--- a/web/www/horas/English/Sancti/01-03.txt
+++ b/web/www/horas/English/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Capitulum Vespera] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Sir 15:1-2
 v. He that feareth God, will do good: and he that possesseth justice, shall lay~
 hold on her,And she will meet him as an honourable mother

--- a/web/www/horas/English/Sancti/01-10.txt
+++ b/web/www/horas/English/Sancti/01-10.txt
@@ -10,7 +10,7 @@ Lectio1 tempora
 Doxology=Epi
 9 lectiones
 Feria Te Deum
-(rubrica Divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hyginus;
+(rubrica divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hyginus;
 Infra octavam Epiphaniae Domini
 
 [Lectio1]
@@ -123,6 +123,6 @@ All nations shall come * from afar, bringing their gifts with them, alleluia.
 [Ant 3]
 All they from Saba shall come, * they shall bring gold and frankincense, alleluia, alleluia.
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !For St. Hyginus Pope and Martyr
 @Commune/C2:Oratio Gregem

--- a/web/www/horas/English/Sancti/01-10.txt
+++ b/web/www/horas/English/Sancti/01-10.txt
@@ -10,7 +10,7 @@ Lectio1 tempora
 Doxology=Epi
 9 lectiones
 Feria Te Deum
-(rubrica Divino aut rubrica Tridentina aut rubrica Monastica) CPapaM=Hyginus;
+(rubrica Divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hyginus;
 Infra octavam Epiphaniae Domini
 
 [Lectio1]
@@ -123,6 +123,6 @@ All nations shall come * from afar, bringing their gifts with them, alleluia.
 [Ant 3]
 All they from Saba shall come, * they shall bring gold and frankincense, alleluia, alleluia.
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !For St. Hyginus Pope and Martyr
 @Commune/C2:Oratio Gregem

--- a/web/www/horas/English/Sancti/01-25.txt
+++ b/web/www/horas/English/Sancti/01-25.txt
@@ -90,7 +90,7 @@ V. Thou art Peter.
 R. And upon this rock I will build My Church.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 O God, Who hast given unto thy Blessed Apostle Peter the keys of the kingdom of~
 heaven, and the power to bind and to loose, loose us, we beseech thee, at his~
 mighty intercession, from all the bands of our sins.

--- a/web/www/horas/English/Sancti/02-22.txt
+++ b/web/www/horas/English/Sancti/02-22.txt
@@ -61,7 +61,7 @@ V. O Holy Apostle Paul, thou art a chosen vessel unto God.
 R. To preach the Gospel throughout the whole world.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 v. O God, Who, through the preaching of the Blessed Apostle Paul, hast~
 caused the light of the Gospel to shine throughout the world, grant, we beseech~
 thee, that we, who do keep his memorial, may continually be helped by his~

--- a/web/www/horas/English/Sancti/04-28.txt
+++ b/web/www/horas/English/Sancti/04-28.txt
@@ -9,7 +9,7 @@ vide C5;mtv
 Lord Jesus Christ, Who didst gift thine holy servant Paul with great love that he might preach the mystery of thy cross, and hast been pleased that through him a new family should grow up in thy Church, grant unto us at his prayers that upon earth we may so call thy sufferings to mind as worthily to gain the fruit thereof in heaven.
 $Qui vivis
 
-[Commemoratio] (rubrica Divino aut rubrica tridentina aut rubrica Reduced)
+[Commemoratio] (rubrica divino aut rubrica tridentina aut rubrica Reduced)
 !Commemoratio S. Vitalis Mart.
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/English/Sancti/04-28.txt
+++ b/web/www/horas/English/Sancti/04-28.txt
@@ -9,7 +9,7 @@ vide C5;mtv
 Lord Jesus Christ, Who didst gift thine holy servant Paul with great love that he might preach the mystery of thy cross, and hast been pleased that through him a new family should grow up in thy Church, grant unto us at his prayers that upon earth we may so call thy sufferings to mind as worthily to gain the fruit thereof in heaven.
 $Qui vivis
 
-[Commemoratio] (rubrica Divino aut rubrica Tridentina aut rubrica Reduced)
+[Commemoratio] (rubrica Divino aut rubrica tridentina aut rubrica Reduced)
 !Commemoratio S. Vitalis Mart.
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/English/Sancti/06-13.txt
+++ b/web/www/horas/English/Sancti/06-13.txt
@@ -15,7 +15,7 @@ Anthony
 O God, make thy Church to be glad at the solemn memorial of thy blessed Confessor and Doctor Anthony, causing her ever to be strong through thy ghostly succour, and fitting her to relish blessedness at thy right hand for evermore.
 $Per Dominum.
 
-[Oratio] (rubrica Divino aut rubrica tridentina)
+[Oratio] (rubrica divino aut rubrica tridentina)
 @:OratioText:s/ and Doctor//
 
 [Lectio4]

--- a/web/www/horas/English/Sancti/07-23.txt
+++ b/web/www/horas/English/Sancti/07-23.txt
@@ -110,7 +110,7 @@ all, and have followed thee. (Matth. xix. 27.)
 Apollinaris came from Antioch to Rome with the Prince of the Apostles, who ordained him a bishop and sent him to Ravenna to preach the Gospel of the Lord Christ. Here, when Apollinaris had converted many pagans to faith in Christ, he was seized by the priests of the idols and beaten severely. When his prayers brought the gift of speech to a nobleman named Boniface who had been dumb for a long time and freed his daughter from an unclean spirit, a commotion was again raised against Apollinaris, and he suffered many kinds of torments. Afterwards, preaching the Gospel throughout Emilia, he turned many of the people away from the worship of idols. He came back to Ravenna, exhorted the Christians to constancy in the faith and died the glorious death of a martyr. His body was buried near the city wall.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina)
 !Commemoratio S. Christinae.
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/English/Sancti/07-23.txt
+++ b/web/www/horas/English/Sancti/07-23.txt
@@ -110,7 +110,7 @@ all, and have followed thee. (Matth. xix. 27.)
 Apollinaris came from Antioch to Rome with the Prince of the Apostles, who ordained him a bishop and sent him to Ravenna to preach the Gospel of the Lord Christ. Here, when Apollinaris had converted many pagans to faith in Christ, he was seized by the priests of the idols and beaten severely. When his prayers brought the gift of speech to a nobleman named Boniface who had been dumb for a long time and freed his daughter from an unclean spirit, a commotion was again raised against Apollinaris, and he suffered many kinds of torments. Afterwards, preaching the Gospel throughout Emilia, he turned many of the people away from the worship of idols. He came back to Ravenna, exhorted the Christians to constancy in the faith and died the glorious death of a martyr. His body was buried near the city wall.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
 !Commemoratio S. Christinae.
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/English/Sancti/08-24.txt
+++ b/web/www/horas/English/Sancti/08-24.txt
@@ -26,7 +26,7 @@ There he brought to the Christian faith Polymius the King, and his wife, and lik
 [Lectio6]
 His body was buried at the town of Albanopolis in the Greater Armenia, where he had suffered. It was afterwards taken to the Island of Lipari, and thence carried to Benevento. Lastly, the Emperor Otto III brought it to Rome, where it was laid in the Church dedicated to God in his name on the Island in the Tiber. 
 
-[Lectio6] (rubrica Tridentina)
+[Lectio6] (rubrica tridentina)
 His body was buried at the town of Albanopolis in the Greater Armenia, where he had suffered. It was afterwards taken to the Island of Lipari, and thence carried to Benevento. Lastly, the Emperor Otho III. brought it to Rome, where it was laid in the Church dedicated to God in his name on the Island in the Tiber. His Feast is kept at Rome upon the 25th day of August, and is celebrated by great crowds of people at the Church above mentioned, during the eight days following.
 
 [Lectio7]

--- a/web/www/horas/English/Sancti/11-01.txt
+++ b/web/www/horas/English/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica divino) Vesperae Defunctorum
 
 [Ant Vespera]
 I beheld, and, lo, great multitude, which no man could number, * of all nations, (and kindreds, and people, and tongues,) stood before the throne.

--- a/web/www/horas/English/Sancti/11-01.txt
+++ b/web/www/horas/English/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica Tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
 
 [Ant Vespera]
 I beheld, and, lo, great multitude, which no man could number, * of all nations, (and kindreds, and people, and tongues,) stood before the throne.

--- a/web/www/horas/English/Sancti/11-18.txt
+++ b/web/www/horas/English/Sancti/11-18.txt
@@ -3,7 +3,7 @@
 [Rule]
 ex C8;
 9 lectiones
-(rubrica Divino aut rubrica 1955) Festum Domini
+(rubrica divino aut rubrica 1955) Festum Domini
 
 [Lectio5]
 Whither came the Emperor Constantine the Great upon the eighth day after his~

--- a/web/www/horas/English/Tempora/105-1.txt
+++ b/web/www/horas/English/Tempora/105-1.txt
@@ -10,7 +10,7 @@ Lesson from the second book of Machabees
 
 [Lectio1]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio1Tridentina
 
 [Lectio2Tridentina]
@@ -25,7 +25,7 @@ Lesson from the second book of Machabees
 
 [Lectio2]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio2Tridentina
 
 [Lectio3Tridentina]
@@ -37,5 +37,5 @@ Lesson from the second book of Machabees
 
 [Lectio3]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio3Tridentina

--- a/web/www/horas/English/Tempora/105-2.txt
+++ b/web/www/horas/English/Tempora/105-2.txt
@@ -8,7 +8,7 @@ Lesson from the second book of Machabees
 
 [Lectio1]
 @Tempora/105-1:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio1Tridentina
 
 [Lectio2Tridentina]
@@ -22,7 +22,7 @@ Lesson from the second book of Machabees
 
 [Lectio2]
 @Tempora/105-1:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio2Tridentina
 
 [Lectio3Tridentina]
@@ -38,5 +38,5 @@ Lesson from the second book of Machabees
 
 [Lectio3]
 @Tempora/105-1:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio3Tridentina

--- a/web/www/horas/English/Tempora/105-3.txt
+++ b/web/www/horas/English/Tempora/105-3.txt
@@ -9,7 +9,7 @@ Lesson from the second book of Machabees
 
 [Lectio1]
 @Tempora/105-2:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio1Tridentina
 
 [Lectio2Tridentina]
@@ -21,7 +21,7 @@ Lesson from the second book of Machabees
 
 [Lectio2]
 @Tempora/105-2:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio2Tridentina
 
 [Lectio3Tridentina]
@@ -37,5 +37,5 @@ Lesson from the second book of Machabees
 
 [Lectio3]
 @Tempora/105-2:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio3Tridentina

--- a/web/www/horas/English/Tempora/Nat1-0.txt
+++ b/web/www/horas/English/Tempora/Nat1-0.txt
@@ -66,7 +66,7 @@ R. Lying in a manger, reigning in heaven.
 There had been a triple prophecy; the prophecy of Simeon had followed the prophecy of the virgin, and the prophecy of the wife; those, namely, of Mary and Elizabeth. And now ought the widow also to prophesy, that no sex nor state might be wanting. And Anna is brought before us with such a title from her widowhood and her life, that we may well believe that she received the grace to announce the Advent of the Redeemer. In our exhortation addressed to widows we have already treated of her gifts at length, and, as we have much matter before us, we will not now again enter on the subject.
 &teDeum
 
-[Lectio Prima] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4:7
 v. Therefore now he is not a servant, but a son. And if a son, an heir also through God.
 

--- a/web/www/horas/English/Tempora/Nat1-0.txt
+++ b/web/www/horas/English/Tempora/Nat1-0.txt
@@ -66,7 +66,7 @@ R. Lying in a manger, reigning in heaven.
 There had been a triple prophecy; the prophecy of Simeon had followed the prophecy of the virgin, and the prophecy of the wife; those, namely, of Mary and Elizabeth. And now ought the widow also to prophesy, that no sex nor state might be wanting. And Anna is brought before us with such a title from her widowhood and her life, that we may well believe that she received the grace to announce the Advent of the Redeemer. In our exhortation addressed to widows we have already treated of her gifts at length, and, as we have much matter before us, we will not now again enter on the subject.
 &teDeum
 
-[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Lectio Prima] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4:7
 v. Therefore now he is not a servant, but a son. And if a son, an heir also through God.
 

--- a/web/www/horas/English/Tempora/Pasc6-0.txt
+++ b/web/www/horas/English/Tempora/Pasc6-0.txt
@@ -29,7 +29,7 @@ _
 (deinde dicitur)
 V. God is gone up with a shout, alleluia.
 R. And the Lord with the sound of a trumpet, alleluia.
-(sed rubrica Tridentina loco huius versus dicitur)
+(sed rubrica tridentina loco huius versus dicitur)
 V. The Lord in heaven, alleluia.
 R. Hath prepared his throne, alleluia.
 (deinde dicitur)

--- a/web/www/horas/English/Tempora/Quad4-0.txt
+++ b/web/www/horas/English/Tempora/Quad4-0.txt
@@ -126,7 +126,7 @@ R. Incline your ears to the words of My mouth.
 Then shalt Thou be pleased * with the sacrifices of righteousness, when Thou hast hidden thy face from my sins.
 It is better to trust * in the Lord, than to trust in princes.
 Thy right hand hath * received me, O Lord.
-(sed rubrica Trident)
+(sed rubrica tridentina)
 Let God, even our own God, bless us; * let God bless us.
 O Lord, Thou art mighty * to save us; with a strong hand deliver us, O our God.
 Kings of the earth, * and all people, praise God.

--- a/web/www/horas/English/Tempora/Quad6-4.txt
+++ b/web/www/horas/English/Tempora/Quad6-4.txt
@@ -175,7 +175,7 @@ $Pater noster
 !lower voice
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 
 [Oratio Matutinum]
@@ -219,7 +219,7 @@ $Pater noster
 !lower voice
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 (sed rubrica 1955 aut rubrica 1960 loco horum versuum dicuntur)
 v. Visit, we beseech thee, O Lord, this dwelling, and drive far from it the snares of the enemy. Let thy holy angels dwell herein to preserve us in peace and let thy blessing be always upon us.

--- a/web/www/horas/English/Tempora/Quad6-6.txt
+++ b/web/www/horas/English/Tempora/Quad6-6.txt
@@ -163,7 +163,7 @@ R. After that the Lord was buried, they sealed the sepulchre, rolling a stone to
 [Ant Laudes]
 O death, I will be thy death; * O grave, I will be thy destruction.
 They shall mourn for Him * as one mourneth for his only son, for the innocent Lord hath been put to death.
-(sed rubrica Tridentina) They shall mourn for Him * as one mourneth for his only son, for the innocent Lord hath been put to death.;;42
+(sed rubrica tridentina) They shall mourn for Him * as one mourneth for his only son, for the innocent Lord hath been put to death.;;42
 O all ye nations, behold * and see my sorrow.
 O Lord, deliver my soul * from the gates of the grave.;;222
 O all ye that pass by * behold, and see if there be any sorrow like unto my sorrow.

--- a/web/www/horas/Espanol/Commune/C9.txt
+++ b/web/www/horas/Espanol/Commune/C9.txt
@@ -31,7 +31,7 @@ _
 &pater_noster
 _
 &psalm(145)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 _
 V. De las puertas del infierno.
 R. Libra, Señor, su alma (sus almas).

--- a/web/www/horas/Espanol/Sancti/01-02.txt
+++ b/web/www/horas/Espanol/Sancti/01-02.txt
@@ -76,7 +76,7 @@ Preguntamos quién sea este Zacarías hijo de Baraquías; ya que conocemos por l
 Otros quieren que este Zacarías sea el que mató Joás, rey de Judá, entre el templo y el altar, según la historia de los Reyes. Mas aquel Zacarías no es hijo de Baraquías, sino hijo del sacerdote Joíada. Por lo cual dice la Escritura: “No se acordó Joás de que su padre Joíada le había hecho muchos beneficios”. Teniendo, pues, por una parte, a Zacarías, y siendo, por otra, el lugar en que sufrió la muerte el antes indicado, preguntamos: ¿por qué se dice hijo de Baraquías y no de Joíada? Baraquías en nuestra lengua significa Bendito del Señor, y en hebreo Joíada significa justicia. En el Evangelio de que se sirven los Nazarenos en lugar de hijo de Baraquías, hallamos hijo de Joíada.
 &teDeum
 
-[Oratio] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Oratio] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 Oh Dios omnipotente y eterno, que consagraste las primicias de los Mártires con la sangre del bienaventurado levita Esteban; te rogamos nos concedas que sea nuestro intercesor, aquel que también rogó por sus perseguidores a nuestro Señor Jesucristo tu Hijo.
 $Qui tecum
 

--- a/web/www/horas/Espanol/Sancti/01-02.txt
+++ b/web/www/horas/Espanol/Sancti/01-02.txt
@@ -76,7 +76,7 @@ Preguntamos quién sea este Zacarías hijo de Baraquías; ya que conocemos por l
 Otros quieren que este Zacarías sea el que mató Joás, rey de Judá, entre el templo y el altar, según la historia de los Reyes. Mas aquel Zacarías no es hijo de Baraquías, sino hijo del sacerdote Joíada. Por lo cual dice la Escritura: “No se acordó Joás de que su padre Joíada le había hecho muchos beneficios”. Teniendo, pues, por una parte, a Zacarías, y siendo, por otra, el lugar en que sufrió la muerte el antes indicado, preguntamos: ¿por qué se dice hijo de Baraquías y no de Joíada? Baraquías en nuestra lengua significa Bendito del Señor, y en hebreo Joíada significa justicia. En el Evangelio de que se sirven los Nazarenos en lugar de hijo de Baraquías, hallamos hijo de Joíada.
 &teDeum
 
-[Oratio] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Oratio] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 Oh Dios omnipotente y eterno, que consagraste las primicias de los Mártires con la sangre del bienaventurado levita Esteban; te rogamos nos concedas que sea nuestro intercesor, aquel que también rogó por sus perseguidores a nuestro Señor Jesucristo tu Hijo.
 $Qui tecum
 

--- a/web/www/horas/Espanol/Sancti/01-03.txt
+++ b/web/www/horas/Espanol/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Sir 15:1-2
 v. El que teme al Señor, hace el bien; el que se agarra a la ley, la sigue. Ella le sale al encuentro como una madre.
 $Deo gratias

--- a/web/www/horas/Espanol/Sancti/01-03.txt
+++ b/web/www/horas/Espanol/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Capitulum Vespera] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Sir 15:1-2
 v. El que teme al Señor, hace el bien; el que se agarra a la ley, la sigue. Ella le sale al encuentro como una madre.
 $Deo gratias

--- a/web/www/horas/Espanol/Sancti/01-19.txt
+++ b/web/www/horas/Espanol/Sancti/01-19.txt
@@ -8,7 +8,7 @@ vide C3;
 Atiende, Señor, a tu pueblo que te suplica por la intercesión de tus santos, que nos regocijemos con tu paz en esta vida, y alcanzar los medios de conseguir la eterna.
 $Per Dominum
 
-[Commemoratio] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Commemoratio] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 !Conmemoración de S. Canuto, Mártir
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Espanol/Sancti/02-22.txt
+++ b/web/www/horas/Espanol/Sancti/02-22.txt
@@ -84,7 +84,7 @@ V. Tú eres el vaso de mi elección, San Pablo Apóstol.
 R. Predicador de la verdad por todo el mundo.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 v. ¡Oh Dios, que instruiste al mundo entero con la predicación del apóstol San Pablo!; concédenos, a cuantos celebramos hoy su recuerdo, caminar hacia ti siguiendo sus ejemplos.
 $Per Dominum
 

--- a/web/www/horas/Espanol/Sancti/04-28.txt
+++ b/web/www/horas/Espanol/Sancti/04-28.txt
@@ -36,7 +36,7 @@ Pablo de la Cruz nació en Uvada, Liguria; llegado al uso de la razón, se quem�
 [Lectio9]
 @Commune/C1a:Lectio9
 
-[Commemoratio] (rubrica Divino aut rubrica tridentina aut rubrica Reduced)
+[Commemoratio] (rubrica divino aut rubrica tridentina aut rubrica Reduced)
 !Conmemoración de S. Vidal, Märtir
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Espanol/Sancti/04-28.txt
+++ b/web/www/horas/Espanol/Sancti/04-28.txt
@@ -36,7 +36,7 @@ Pablo de la Cruz nació en Uvada, Liguria; llegado al uso de la razón, se quem�
 [Lectio9]
 @Commune/C1a:Lectio9
 
-[Commemoratio] (rubrica Divino aut rubrica Tridentina aut rubrica Reduced)
+[Commemoratio] (rubrica Divino aut rubrica tridentina aut rubrica Reduced)
 !Conmemoración de S. Vidal, Märtir
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Espanol/Sancti/05-05.txt
+++ b/web/www/horas/Espanol/Sancti/05-05.txt
@@ -31,6 +31,6 @@ El sultán de los turcos Selim, cuya audacia creció con sus victorias, reunió 
 Pío nació en Bosco, Lombardía, e ingresó a la Orden de Predicadores a la edad de 14 años. Ordenado al sacerdocio, predicó en muchas iglesias con mucho fruto espiritual. Durante mucho tiempo ejerció el cargo de Inquisidor de una manera vigorosa y digna de elogio. Fue promovido por Pablo IV al obispado de Nepi y Sutri, y dos años más tarde le elevó a la dignidad de Cardenal de la Iglesia. Pío IV lo trasladó a la sede de Mondóvi en Piamonte, donde visitó toda su diócesis y remedió muchos abusos. A partir de entonces, regresó a Roma, donde estuvo involucrado en muchos asuntos importantes. Cuando Pío IV murió, fue elegido Papa, contra todas las expectativas, no cambiando nada en su vida, excepto sus vestiduras. No tanto por las armas como por las oraciones, venció a Selim, sultán de los turcos, que había reunido una gran flota en Lepanto. En el año 1572, mientras preparaba una nueva expedición contra los turcos, murió pacíficamente en el Señor, a la edad de sesenta y ocho años. Su cuerpo es venerado por los fieles en la basílica de Santa María la Mayor. Clemente XI lo inscribió entre los Santos.
 &teDeum
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Espanol/Sancti/05-19.txt
+++ b/web/www/horas/Espanol/Sancti/05-19.txt
@@ -56,7 +56,7 @@ $Oremus
 v. Escúchanos, Dios Salvador nuestro, para que, en la alegría de la fiesta de Santa Pudenciana, virgen, aprendamos a servirte con amor.
 $Per Dominum
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 
 [Lectio94]

--- a/web/www/horas/Espanol/Sancti/05-25.txt
+++ b/web/www/horas/Espanol/Sancti/05-25.txt
@@ -39,6 +39,6 @@ El Papa Gregorio VII, llamado Hildebrando, nació cerca de Savona en Toscana. Se
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Espanol/Sancti/06-13.txt
+++ b/web/www/horas/Espanol/Sancti/06-13.txt
@@ -18,7 +18,7 @@ $Per Dominum
 [Oratio]
 @:OratioText
 
-[Oratio] (rubrica Divino aut rubrica tridentina)
+[Oratio] (rubrica divino aut rubrica tridentina)
 @:OratioText:s/ y Doctor//
 
 [Lectio1] (rubrica tridentina)

--- a/web/www/horas/Espanol/Sancti/07-03.txt
+++ b/web/www/horas/Espanol/Sancti/07-03.txt
@@ -36,6 +36,6 @@ El papa León II, siciliano de origen, estaba muy versado en la ciencia de las s
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Espanol/Sancti/07-23.txt
+++ b/web/www/horas/Espanol/Sancti/07-23.txt
@@ -52,7 +52,7 @@ Convirtámonos, y procuremos que no haya entre nosotros, para perdición, disput
 Apolinar vino de Antioquía a Roma con San Pedro, quien lo ordenó como obispo y lo envió a Rávena a predicar el Evangelio de Jesucristo. Cuando Apolinar había convertido a muchos paganos a la fe en Cristo, fue capturado por los sacerdotes de los ídolos y golpeado severamente. Cuando sus oraciones devolvieron la palabra a un noble llamado Bonifacio que había estado mudo durante mucho tiempo, y liberó a su hija de un espíritu inmundo, se volvió a levantar una conmoción contra Apolinar, y sufrió muchos tipos de tormentos. Luego, predicando el Evangelio por toda Emilia, alejó a muchas personas de la idolatría. Volvió a Ravena, exhortó a los cristianos a la constancia en la fe y murió la gloriosa muerte de un mártir. Su cuerpo fue enterrado cerca de la muralla de la ciudad.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
 !Conmemoración de Sta. Cristina, Virgen y Mártir
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/Espanol/Sancti/07-23.txt
+++ b/web/www/horas/Espanol/Sancti/07-23.txt
@@ -52,7 +52,7 @@ Convirtámonos, y procuremos que no haya entre nosotros, para perdición, disput
 Apolinar vino de Antioquía a Roma con San Pedro, quien lo ordenó como obispo y lo envió a Rávena a predicar el Evangelio de Jesucristo. Cuando Apolinar había convertido a muchos paganos a la fe en Cristo, fue capturado por los sacerdotes de los ídolos y golpeado severamente. Cuando sus oraciones devolvieron la palabra a un noble llamado Bonifacio que había estado mudo durante mucho tiempo, y liberó a su hija de un espíritu inmundo, se volvió a levantar una conmoción contra Apolinar, y sufrió muchos tipos de tormentos. Luego, predicando el Evangelio por toda Emilia, alejó a muchas personas de la idolatría. Volvió a Ravena, exhortó a los cristianos a la constancia en la fe y murió la gloriosa muerte de un mártir. Su cuerpo fue enterrado cerca de la muralla de la ciudad.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina)
 !Conmemoración de Sta. Cristina, Virgen y Mártir
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/Espanol/Sancti/08-24.txt
+++ b/web/www/horas/Espanol/Sancti/08-24.txt
@@ -23,7 +23,7 @@ Convirtió allí a la fe cristiana al rey Polimio, a su esposa y doce ciudades, 
 [Lectio6]
 Su cuerpo, sepultado primeramente en Albanópolis, ciudad de la gran Armenia y lugar de su martirio, fue más tarde trasladado, en primer lugar a Lípari, y por último a Roma, por el emperador Otón III, donde fue colocado en una iglesia consagrada bajo su advocación en la isla Tiberina.
 
-[Lectio6] (rubrica Tridentina)
+[Lectio6] (rubrica tridentina)
 Su cuerpo, sepultado primeramente en Albanópolis, ciudad de la gran Armenia y lugar de su martirio, fue más tarde trasladado, en primer lugar a Lípari, y por último a Roma, por el emperador Otón III, donde fue colocado en una iglesia consagrada bajo su advocación en la isla Tiberina.
 
 [Lectio7]

--- a/web/www/horas/Espanol/Sancti/11-01.txt
+++ b/web/www/horas/Espanol/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica divino) Vesperae Defunctorum
 
 [Ant Vespera]
 Vi una gran muchedumbre * que nadie podía contar, de todos los pueblos, de pie ante el trono.

--- a/web/www/horas/Espanol/Sancti/11-01.txt
+++ b/web/www/horas/Espanol/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica Tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
 
 [Ant Vespera]
 Vi una gran muchedumbre * que nadie podía contar, de todos los pueblos, de pie ante el trono.

--- a/web/www/horas/Espanol/Sancti/11-18.txt
+++ b/web/www/horas/Espanol/Sancti/11-18.txt
@@ -3,7 +3,7 @@
 [Rule]
 ex C8;
 9 lectiones
-(rubrica Divino aut rubrica 1955) Festum Domini
+(rubrica divino aut rubrica 1955) Festum Domini
 
 [Lectio5]
 @Sancti/11-18o

--- a/web/www/horas/Espanol/Sancti/12-11.txt
+++ b/web/www/horas/Espanol/Sancti/12-11.txt
@@ -41,6 +41,6 @@ Dámaso, español eminente, aprendió en las Sagradas Escrituras. Convocó el pr
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Espanol/Sancti/12-13.txt
+++ b/web/www/horas/Espanol/Sancti/12-13.txt
@@ -25,7 +25,7 @@ Con tu paciencia * te hiciste dueña de tu alma, Lucía, esposa de Cristo: odias
 [Oratio]
 @Commune/C7::s/N\./Lucía, tu Virgen y Mártir/
 
-[Commemoratio 2] (rubrica 1910 aut rubrica Divino)
+[Commemoratio 2] (rubrica 1910 aut rubrica divino)
 !Conmemoración del Día de la Octava de la Inmaculada Concepción de la B.M.V.
 @Sancti/12-08:Oratio
 

--- a/web/www/horas/Espanol/Tempora/105-1.txt
+++ b/web/www/horas/Espanol/Tempora/105-1.txt
@@ -10,7 +10,7 @@ Del libro segundo de los Macabeos
 
 [Lectio1]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio1Tridentina
 
 [Responsory1]
@@ -28,7 +28,7 @@ Del libro segundo de los Macabeos
 
 [Lectio2]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio2Tridentina
 
 [Responsory2]
@@ -43,7 +43,7 @@ Del libro segundo de los Macabeos
 
 [Lectio3]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Espanol/Tempora/105-2.txt
+++ b/web/www/horas/Espanol/Tempora/105-2.txt
@@ -7,7 +7,7 @@ Del Libro segundo de los Macabeos.
 27 e inclinándose hacia el niño, burlándose del cruel tirano, en lengua patria le dijo así: “Hijo, ten compasión de mí, que por nueve meses te llevé en mi seno, que por tres años te amamanté, que te crié, te eduqué, te alimenté hasta ahora. 
 [Lectio1]
 @Tempora/105-1:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio1Tridentina
 
 [Responsory1]
@@ -24,7 +24,7 @@ Del Libro segundo de los Macabeos.
 
 [Lectio2]
 @Tempora/105-1:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio2Tridentina
 
 [Responsory2]
@@ -43,7 +43,7 @@ Del Libro segundo de los Macabeos.
 
 [Lectio3]
 @Tempora/105-1:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Espanol/Tempora/105-3.txt
+++ b/web/www/horas/Espanol/Tempora/105-3.txt
@@ -9,7 +9,7 @@ Del Libro segundo de los Macabeos
 
 [Lectio1]
 @Tempora/105-2:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio1Tridentina
 
 [Responsory1]
@@ -24,7 +24,7 @@ Del Libro segundo de los Macabeos
 
 [Lectio2]
 @Tempora/105-2:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio2Tridentina
 
 [Responsory2]
@@ -43,7 +43,7 @@ Del Libro segundo de los Macabeos
 
 [Lectio3]
 @Tempora/105-2:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Espanol/Tempora/Nat1-0.txt
+++ b/web/www/horas/Espanol/Tempora/Nat1-0.txt
@@ -97,7 +97,7 @@ Así que, profetizó Simeón, había profetizado la virgen, había también prof
 [Ant 2]
 @:Ant 1
 
-[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Lectio Prima] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Gál 4:7
 v. Así que ya no eres esclavo, sino hijo; y, si eres hijo, eres también heredero por voluntad de Dios.
 

--- a/web/www/horas/Espanol/Tempora/Nat1-0.txt
+++ b/web/www/horas/Espanol/Tempora/Nat1-0.txt
@@ -97,7 +97,7 @@ Así que, profetizó Simeón, había profetizado la virgen, había también prof
 [Ant 2]
 @:Ant 1
 
-[Lectio Prima] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Gál 4:7
 v. Así que ya no eres esclavo, sino hijo; y, si eres hijo, eres también heredero por voluntad de Dios.
 

--- a/web/www/horas/Espanol/Tempora/Pasc5-4.txt
+++ b/web/www/horas/Espanol/Tempora/Pasc5-4.txt
@@ -311,7 +311,7 @@ R. Estableció su trono. Aleluya.
 
 [Versum 3]
 @:Versum 1
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @:Versum 2
 
 [Ant 3]

--- a/web/www/horas/Espanol/Tempora/Quad6-4.txt
+++ b/web/www/horas/Espanol/Tempora/Quad6-4.txt
@@ -175,7 +175,7 @@ $Pater noster
 !en voz alta
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 
 [Oratio Matutinum]
@@ -219,7 +219,7 @@ $Pater noster
 !en voz alta
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 (sed rubrica 1955 aut rubrica 1960 loco horum versuum dicuntur)
 v. Visita, Señor, esta habitación: aleja de ella las insidias del enemigo; que tus ángeles santos habiten en ella y nos guarden en paz.

--- a/web/www/horas/Espanol/Tempora/Quad6-6.txt
+++ b/web/www/horas/Espanol/Tempora/Quad6-6.txt
@@ -164,7 +164,7 @@ R. Sepultado el Señor, fue sellado el sepulcro, haciendo correr la piedra en su
 [Ant Laudes]
 ¡Oh muerte!, * yo seré tu muerte; infierno, yo seré tu destrucción.
 Le llorarán * como se llora al primogénito, porque siendo inocente fue muerto el Señor.
-(sed rubrica Tridentina) Le llorarán * como se llora al primogénito, porque siendo inocente fue muerto el Señor.;;42
+(sed rubrica tridentina) Le llorarán * como se llora al primogénito, porque siendo inocente fue muerto el Señor.;;42
 Mirad, * pueblos todos, y ved si hay dolor como el mío.
 Libra, Señor, * mi alma de las puertas del infierno.;;222
 Vosotros, * los que pasáis por el camino, mirad y ved si hay dolor como el mío.

--- a/web/www/horas/Francais/Commune/C9.txt
+++ b/web/www/horas/Francais/Commune/C9.txt
@@ -30,7 +30,7 @@ _
 &pater_noster
 _
 &psalm(145)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 _
 V. De la puissance de l'enfer.
 R. Délivrez, Seigneur, leurs âmes !

--- a/web/www/horas/Francais/Sancti/01-10.txt
+++ b/web/www/horas/Francais/Sancti/01-10.txt
@@ -10,7 +10,7 @@ Lectio1 tempora
 Doxology=Epi
 9 lectiones
 Feria Te Deum
-(rubrica Divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hygínum ;
+(rubrica divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hygínum ;
 Infra octavam Epiphaniæ Domini
 
 [Lectio1]
@@ -79,6 +79,6 @@ Toutes les nations * viendront de loin, apportant leurs présents, alléluia.
 [Ant 3]
 Tous viendront de Saba, * apportant l’or et l’encens, alléluia, alléluia.
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Mémoire de S. Hygin, Pape et Martyr :
 @Commune/C2:Oratio Gregem

--- a/web/www/horas/Francais/Sancti/01-10.txt
+++ b/web/www/horas/Francais/Sancti/01-10.txt
@@ -10,7 +10,7 @@ Lectio1 tempora
 Doxology=Epi
 9 lectiones
 Feria Te Deum
-(rubrica Divino aut rubrica Tridentina aut rubrica Monastica) CPapaM=Hygínum ;
+(rubrica Divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hygínum ;
 Infra octavam Epiphaniæ Domini
 
 [Lectio1]
@@ -79,6 +79,6 @@ Toutes les nations * viendront de loin, apportant leurs présents, alléluia.
 [Ant 3]
 Tous viendront de Saba, * apportant l’or et l’encens, alléluia, alléluia.
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Mémoire de S. Hygin, Pape et Martyr :
 @Commune/C2:Oratio Gregem

--- a/web/www/horas/Francais/Sancti/01-19.txt
+++ b/web/www/horas/Francais/Sancti/01-19.txt
@@ -8,7 +8,7 @@ vide C3 ;
 Exaucez, Seigneur, les supplications de votre peuple, jointes au patronage de vos saints, afin que vous nous accordiez de jouir de la paix en la vie temporelle et d’obtenir le secours pour celle de l’éternité.
 $Per Dominum
 
-[Commemoratio] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Commemoratio] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 !Mémoire de S. Canut, Roi et Martyr :
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Francais/Sancti/01-25.txt
+++ b/web/www/horas/Francais/Sancti/01-25.txt
@@ -107,7 +107,7 @@ V. Tu es Pierre.
 R. Et sur cette pierre, je bâtirai mon Église.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 v. O Dieu qui, en confiant au bienheureux Pierre, votre Apôtre, les clefs du royaume des cieux, lui avez donné tout pouvoir pour lier et délier, accordez-nous que, grâce à son intercession, nous soyons délivrés des liens de nos péchés.
 $Qui vivis
 

--- a/web/www/horas/Francais/Sancti/02-22.txt
+++ b/web/www/horas/Francais/Sancti/02-22.txt
@@ -57,7 +57,7 @@ V. Vous êtes un vase d’élection, saint Apôtre Paul.
 R. Prédicateur de la vérité dans le monde entier.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 v. O Dieu, qui avez instruit la multitude des nations par la prédication du bienheureux Apôtre Paul, accordez à notre demande qu’en vénérant sa mémoire, nous sentions l’effet de son patronage auprès de vous.
 $Per Dominum
 

--- a/web/www/horas/Francais/Sancti/07-03.txt
+++ b/web/www/horas/Francais/Sancti/07-03.txt
@@ -36,6 +36,6 @@ Leo secúndus, Sículus, humánis et divínis lítteris Græce et Latíne doctus
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Francais/Sancti/07-23.txt
+++ b/web/www/horas/Francais/Sancti/07-23.txt
@@ -53,7 +53,7 @@ Convertámur ígitur, et caveámus, ne in perditiónem aliqua inter nos de præl
 Apollináris cum Príncipe Apostolórum Antiochía Romam venit; a quo, ordinátus epíscopus, Ravénnam ad Christi Dómini Evangélium prædicándum míttitur; ubi, cum ad Christi fidem plúrimos convérteret, captus ab idolórum sacerdótibus, gráviter cæsus est. Cumque ipso oránte Bonifátius nóbilis vir, qui diu mutus fúerat, loquerétur, ejúsque fília immúndo spíritu liberáta esset, íterum est in illum commóta sedítio. Quare divérsas et multíplices pœnas perpéssus est. Póstea per Æmíliam Evangélium prædicans, plúrimos ab idolórum cultu revocávit. Ravénnam revérsus, exhórtans Christiános ad fídei constántiam, gloriósum martýrium consummávit. Ejus corpus prope murum urbis sepúltum est.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina)
 !Commemoratio S. Christinæ Virg. et Mart.
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/Francais/Sancti/07-23.txt
+++ b/web/www/horas/Francais/Sancti/07-23.txt
@@ -53,7 +53,7 @@ Convertámur ígitur, et caveámus, ne in perditiónem aliqua inter nos de præl
 Apollináris cum Príncipe Apostolórum Antiochía Romam venit; a quo, ordinátus epíscopus, Ravénnam ad Christi Dómini Evangélium prædicándum míttitur; ubi, cum ad Christi fidem plúrimos convérteret, captus ab idolórum sacerdótibus, gráviter cæsus est. Cumque ipso oránte Bonifátius nóbilis vir, qui diu mutus fúerat, loquerétur, ejúsque fília immúndo spíritu liberáta esset, íterum est in illum commóta sedítio. Quare divérsas et multíplices pœnas perpéssus est. Póstea per Æmíliam Evangélium prædicans, plúrimos ab idolórum cultu revocávit. Ravénnam revérsus, exhórtans Christiános ad fídei constántiam, gloriósum martýrium consummávit. Ejus corpus prope murum urbis sepúltum est.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
 !Commemoratio S. Christinæ Virg. et Mart.
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/Francais/Sancti/08-24.txt
+++ b/web/www/horas/Francais/Sancti/08-24.txt
@@ -23,7 +23,7 @@ Là, il convertit à la foi chrétienne le roi Polymius, la reine son épouse, e
 [Lectio6]
 Son corps, enseveli à Albanopoli, ville de la grande Arménie et lieu de son martyre, fut, dans la suite, transporté d’abord à Lipari, puis à Bénévent, et enfin à Rome, par, l’Empereur Othon III. On le plaça dans une église consacrée sous son patronage, dans l’île du Tibre. Sa Fête se fait à Rome le huitième jour des calendes de septembre, et elle est célébrée pendant huit jours consécutifs dans cette basilique, par un grand concours de peuple.
 
-[Lectio6] (rubrica Tridentina)
+[Lectio6] (rubrica tridentina)
 Son corps, enseveli à Albanopoli, ville de la grande Arménie et lieu de son martyre, fut, dans la suite, transporté d’abord à Lipari, puis à Bénévent, et enfin à Rome, par, l’Empereur Othon III. On le plaça dans une église consacrée sous son patronage, dans l’île du Tibre. Sa Fête se fait à Rome le huitième jour des calendes de septembre, et elle est célébrée pendant huit jours consécutifs dans cette basilique, par un grand concours de peuple.
 
 [Lectio7]

--- a/web/www/horas/Francais/Sancti/11-01.txt
+++ b/web/www/horas/Francais/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica divino) Vesperae Defunctorum
 
 [Ant Vespera]
 Je vis une grande troupe * que personne ne pouvait compter, de toutes les nations, qui était debout devant le trône.

--- a/web/www/horas/Francais/Sancti/11-01.txt
+++ b/web/www/horas/Francais/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica Tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
 
 [Ant Vespera]
 Je vis une grande troupe * que personne ne pouvait compter, de toutes les nations, qui était debout devant le trône.

--- a/web/www/horas/Francais/Sancti/11-18.txt
+++ b/web/www/horas/Francais/Sancti/11-18.txt
@@ -3,7 +3,7 @@
 [Rule]
 ex C8 ;
 9 lectiones
-(rubrica Divino aut rubrica 1955) Festum Domini
+(rubrica divino aut rubrica 1955) Festum Domini
 
 [Lectio5]
 @Sancti/11-18o

--- a/web/www/horas/Francais/Sancti/12-11.txt
+++ b/web/www/horas/Francais/Sancti/12-11.txt
@@ -44,6 +44,6 @@ L’Espagnol Damase, homme remarquable et versé dans les Écritures, ayant conv
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Francais/Sancti/12-13.txt
+++ b/web/www/horas/Francais/Sancti/12-13.txt
@@ -28,7 +28,7 @@ $Oremus
 v. Exaucez-nous, ô Dieu, notre Sauveur : en sorte que, tout en nous donnant la joie, la fête de la bienheureuse Lucie, votre Vierge et Martyre, nous instruise par le sentiment d’une pieuse dévotion.
 $Per Dominum
 
-[Commemoratio 2] (rubrica 1910 aut rubrica Divino)
+[Commemoratio 2] (rubrica 1910 aut rubrica divino)
 !Commémoraison dans l'Octave de L’immaculée Conception de la B.V.Marie
 @Sancti/12-08:Oratio
 

--- a/web/www/horas/Francais/Tempora/105-1.txt
+++ b/web/www/horas/Francais/Tempora/105-1.txt
@@ -10,7 +10,7 @@ Lesson from the second book of Machabees
 
 [Lectio1]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio1Tridentina
 
 [Lectio2Tridentina]
@@ -25,7 +25,7 @@ Lesson from the second book of Machabees
 
 [Lectio2]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio2Tridentina
 
 [Lectio3Tridentina]
@@ -37,5 +37,5 @@ Lesson from the second book of Machabees
 
 [Lectio3]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio3Tridentina

--- a/web/www/horas/Francais/Tempora/105-2.txt
+++ b/web/www/horas/Francais/Tempora/105-2.txt
@@ -8,7 +8,7 @@ Lesson from the second book of Machabees
 
 [Lectio1]
 @Tempora/105-1:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio1Tridentina
 
 [Lectio2Tridentina]
@@ -22,7 +22,7 @@ Lesson from the second book of Machabees
 
 [Lectio2]
 @Tempora/105-1:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio2Tridentina
 
 [Lectio3Tridentina]
@@ -38,5 +38,5 @@ Lesson from the second book of Machabees
 
 [Lectio3]
 @Tempora/105-1:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio3Tridentina

--- a/web/www/horas/Francais/Tempora/105-3.txt
+++ b/web/www/horas/Francais/Tempora/105-3.txt
@@ -9,7 +9,7 @@ Lesson from the second book of Machabees
 
 [Lectio1]
 @Tempora/105-2:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio1Tridentina
 
 [Lectio2Tridentina]
@@ -21,7 +21,7 @@ Lesson from the second book of Machabees
 
 [Lectio2]
 @Tempora/105-2:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio2Tridentina
 
 [Lectio3Tridentina]
@@ -37,5 +37,5 @@ Lesson from the second book of Machabees
 
 [Lectio3]
 @Tempora/105-2:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio3Tridentina

--- a/web/www/horas/Francais/Tempora/Nat1-0.txt
+++ b/web/www/horas/Francais/Tempora/Nat1-0.txt
@@ -30,10 +30,10 @@ Tandis qu’un paisible silence * enveloppait toutes choses et que la nuit étai
 Dieu tout-puissant et éternel, dirigez nos actions selon votre bon plaisir pour que nous méritions d’abonder en bonnes œuvres au nom de votre Fils bien-aimé ;
 $Qui tecum
 
-[Commemoratio 2] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 2] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
 [Responsory3](rubrica 1960)
@@ -97,7 +97,7 @@ Siméon a donc prophétisé ; la Vierge avait prophétisé ; une femme mariée (
 [Ant 2]
 @:Ant 1
 
-[Lectio Prima] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4:7
 v. C'est pourquoi nul n’est plus serviteur, mais fils ; mais s’il est fils, il est, grâce à Dieu, héritier.
 

--- a/web/www/horas/Francais/Tempora/Nat1-0.txt
+++ b/web/www/horas/Francais/Tempora/Nat1-0.txt
@@ -30,10 +30,10 @@ Tandis qu’un paisible silence * enveloppait toutes choses et que la nuit étai
 Dieu tout-puissant et éternel, dirigez nos actions selon votre bon plaisir pour que nous méritions d’abonder en bonnes œuvres au nom de votre Fils bien-aimé ;
 $Qui tecum
 
-[Commemoratio 2] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 2] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
 [Responsory3](rubrica 1960)
@@ -97,7 +97,7 @@ Siméon a donc prophétisé ; la Vierge avait prophétisé ; une femme mariée (
 [Ant 2]
 @:Ant 1
 
-[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Lectio Prima] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4:7
 v. C'est pourquoi nul n’est plus serviteur, mais fils ; mais s’il est fils, il est, grâce à Dieu, héritier.
 

--- a/web/www/horas/Francais/Tempora/Pasc5-4.txt
+++ b/web/www/horas/Francais/Tempora/Pasc5-4.txt
@@ -353,7 +353,7 @@ R. Parávit sedem suam, allelúja.
 
 [Versum 3]
 @:Versum 1
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @:Versum 2
 
 [Ant 3]
@@ -364,7 +364,7 @@ Ant. Ô Roi de gloire, Seigneur des armées, qui êtes monté aujourd’hui en t
 _
 V. Dieu S'est élevé au milieu des acclamations, alléluia.
 R. Et le Seigneur au son de la trompette, alléluia.
-(sed rubrica Tridentina loco hæc versus dicitur)
+(sed rubrica tridentina loco hæc versus dicitur)
 V. Le Seigneur dans le ciel, alléluia.
 R. A dressé Son trône, alléluia.
 _

--- a/web/www/horas/Francais/Tempora/Pasc6-0.txt
+++ b/web/www/horas/Francais/Tempora/Pasc6-0.txt
@@ -35,7 +35,7 @@ _
 (deinde dicitur)
 V. Ascéndit Deus in jubilatióne, allelúja.
 R. Et Dóminus in voce tubæ, allelúja.
-(sed rubrica Tridentina loco huius versus dicitur)
+(sed rubrica tridentina loco huius versus dicitur)
 V. Dominus in cælo, allelúja.
 R. Paravit sedem suam, allelúja.
 (deinde dicitur)
@@ -128,7 +128,7 @@ $Deo gratias
 
 [Versum 2]
 @Tempora/Pasc5-4:Versum 1
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @:Versum 1
 
 [Commemoratio 2]

--- a/web/www/horas/Francais/Tempora/Quad6-4.txt
+++ b/web/www/horas/Francais/Tempora/Quad6-4.txt
@@ -175,7 +175,7 @@ $Pater noster
 !aliquantulum altius
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 
 [Oratio Matutinum]
@@ -219,7 +219,7 @@ $Pater noster
 !aliquantulum altius
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 (sed rubrica 1955 aut rubrica 1960 loco horum versuum dicuntur)
 v. Vísita, quǽsumus, Dómine, habitatiónem istam, et omnes insídias inimíci ab ea lónge repélle : Ángeli tui sancti hábitent in ea, qui nos in pace custódiant ; et benedíctio tua sit super nos semper.

--- a/web/www/horas/Francais/Tempora/Quad6-6.txt
+++ b/web/www/horas/Francais/Tempora/Quad6-6.txt
@@ -165,7 +165,7 @@ R. Le Seigneur ayant été enseveli, ils scellèrent le sépulcre, roulant la pi
 [Ant Laudes]
 O mort, * je serai ta mort ; je serai ta morsure ô enfer. 
 Ils le pleureront comme un fils unique parce que, bien qu'innocent, le Seigneur a été mis à mort.
-(sed rubrica Tridentina) Ils le pleureront comme un fils unique parce que, bien qu'innocent, le Seigneur a été mis à mort.;;42
+(sed rubrica tridentina) Ils le pleureront comme un fils unique parce que, bien qu'innocent, le Seigneur a été mis à mort.;;42
 Regardez, peuples de l'univers, et voyez ma douleur.
 Arrachez mon âme, Seigneur, à la puissance de l'enfer.;;222
 O vous tous qui passez par le chemin, regardez et voyez s'il est douleur semblable à ma douleur.

--- a/web/www/horas/Italiano/Commune/C9.txt
+++ b/web/www/horas/Italiano/Commune/C9.txt
@@ -30,7 +30,7 @@ _
 &pater_noster
 _
 &psalm(145)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 _
 V. Dalla porta dell'inferno.
 R. Libera, o Signore, le loro anime.

--- a/web/www/horas/Italiano/Sancti/01-02.txt
+++ b/web/www/horas/Italiano/Sancti/01-02.txt
@@ -76,7 +76,7 @@ Ecco la vostra casa vi sarà lasciata deserta. Proprio lo stesso aveva già dett
 Vi dico infatti: non mi vedrete più, fino a che diciate: Benedetto colui che viene nel nome del Signore. Parla a Gerusalemme, ed al popolo dei Giudei. Questo versetto, del quale anche i fanciulli ed i lattanti hanno usato all'ingresso a Gerusalemme del Signore e Salvatore, quando dissero: Benedetto colui che viene nel nome del Signore, osanna nell'alto dei cieli, prende dal Salmo 117, che è stato chiaramente scritto riguardo la venuta del Signore.
 &teDeum
 
-[Oratio] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Oratio] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 Dio onnipotente ed eterno, che inaugurasti le primizie dei Martiri nel sangue del beato Diacono Stefano: concedici, che si faccia nostro intercessore chi perfino per i suoi persecutori supplicò nostro Signore Gesù Cristo tuo Figlio: 
 $Per Dominum
 

--- a/web/www/horas/Italiano/Sancti/01-02.txt
+++ b/web/www/horas/Italiano/Sancti/01-02.txt
@@ -76,7 +76,7 @@ Ecco la vostra casa vi sarà lasciata deserta. Proprio lo stesso aveva già dett
 Vi dico infatti: non mi vedrete più, fino a che diciate: Benedetto colui che viene nel nome del Signore. Parla a Gerusalemme, ed al popolo dei Giudei. Questo versetto, del quale anche i fanciulli ed i lattanti hanno usato all'ingresso a Gerusalemme del Signore e Salvatore, quando dissero: Benedetto colui che viene nel nome del Signore, osanna nell'alto dei cieli, prende dal Salmo 117, che è stato chiaramente scritto riguardo la venuta del Signore.
 &teDeum
 
-[Oratio] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Oratio] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 Dio onnipotente ed eterno, che inaugurasti le primizie dei Martiri nel sangue del beato Diacono Stefano: concedici, che si faccia nostro intercessore chi perfino per i suoi persecutori supplicò nostro Signore Gesù Cristo tuo Figlio: 
 $Per Dominum
 

--- a/web/www/horas/Italiano/Sancti/01-03.txt
+++ b/web/www/horas/Italiano/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Sir 15:1-2
 v. Chi teme Dio, farà il bene: e chi osserva la giustizia con esattezza, possederà la sapienza, ed essa gli andrà incontro qual madre veneranda.
 $Deo gratias

--- a/web/www/horas/Italiano/Sancti/01-03.txt
+++ b/web/www/horas/Italiano/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Capitulum Vespera] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Sir 15:1-2
 v. Chi teme Dio, farà il bene: e chi osserva la giustizia con esattezza, possederà la sapienza, ed essa gli andrà incontro qual madre veneranda.
 $Deo gratias

--- a/web/www/horas/Italiano/Sancti/01-10.txt
+++ b/web/www/horas/Italiano/Sancti/01-10.txt
@@ -10,7 +10,7 @@ Lectio1 tempora
 Doxology=Epi
 9 lectiones
 Feria Te Deum
-(rubrica Divino aut rubrica tridentina aut rubrica monastica) CPapaM=Igino;
+(rubrica divino aut rubrica tridentina aut rubrica monastica) CPapaM=Igino;
 Infra octavam Epiphaniae Domini
 
 [Lectio1]
@@ -79,7 +79,7 @@ Tutte le nazioni verranno da lungi portando i loro doni, alleluia.
 Verranno tutti quelli di Saba * portando oro ed incenso, alleluia, alleluia.
 
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Commemorazione di S. Igino Papa e Martire
 @Commune/C2:Oratio proper Gregem
 _

--- a/web/www/horas/Italiano/Sancti/01-10.txt
+++ b/web/www/horas/Italiano/Sancti/01-10.txt
@@ -10,7 +10,7 @@ Lectio1 tempora
 Doxology=Epi
 9 lectiones
 Feria Te Deum
-(rubrica Divino aut rubrica Tridentina aut rubrica Monastica) CPapaM=Igino;
+(rubrica Divino aut rubrica tridentina aut rubrica monastica) CPapaM=Igino;
 Infra octavam Epiphaniae Domini
 
 [Lectio1]
@@ -79,7 +79,7 @@ Tutte le nazioni verranno da lungi portando i loro doni, alleluia.
 Verranno tutti quelli di Saba * portando oro ed incenso, alleluia, alleluia.
 
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Commemorazione di S. Igino Papa e Martire
 @Commune/C2:Oratio proper Gregem
 _

--- a/web/www/horas/Italiano/Sancti/01-19.txt
+++ b/web/www/horas/Italiano/Sancti/01-19.txt
@@ -8,7 +8,7 @@ vide C3;
 Esaudisci, Signore, il tuo popolo che ti supplica sotto il patrocinio dei tuoi Santi affinché ci conceda di godere la pace nella vita presente e di trovare soccorso per l'eterna.
 $Per Dominum
 
-[Commemoratio] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Commemoratio] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 !Commemorazione di S. Canuto Mart.
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Italiano/Sancti/01-25.txt
+++ b/web/www/horas/Italiano/Sancti/01-25.txt
@@ -110,7 +110,7 @@ V. Tu sei Pietro.
 R. E su questa pietra io edificherò la mia Chiesa.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 O Dio, che consegnando al  tuo beato Apostolo Pietro le chiavi del regno celeste, gli affidasti il supremo potere di legare e sciogliere: concedi, che, coll'aiuto della sua intercessione, veniamo sciolti dai lacci dei nostri peccati: 
 $Qui vivis
 

--- a/web/www/horas/Italiano/Sancti/02-22.txt
+++ b/web/www/horas/Italiano/Sancti/02-22.txt
@@ -59,7 +59,7 @@ V. Tu sei uno strumento eletto, o san Paolo Apostolo.
 R. Il predicatore della verità per tutto il mondo.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 v. O Dio, che istruisti una moltitudine di Gentili colla predicazione del beato Paolo Apostolo: concedici, che come ne veneriamo la memoria, ne sperimentiamo il patrocinio presso di te. 
 $Per Dominum
 

--- a/web/www/horas/Italiano/Sancti/04-28.txt
+++ b/web/www/horas/Italiano/Sancti/04-28.txt
@@ -9,7 +9,7 @@ vide C5;mtv
 Signore Gesù Cristo, che hai dotato san Paolo di un'unzione particolare per predicare il mistero della croce, e per suo mezzo hai voluto far fiorire nella Chiesa una nuova famiglia: concedici, per sua intercessione, che meditando continuamente la tua passione in terra, meritiamo di conseguirne il frutto nei cieli:
 $Qui vivis
 
-[Commemoratio] (rubrica Divino aut rubrica Tridentina aut rubrica Reduced)
+[Commemoratio] (rubrica Divino aut rubrica tridentina aut rubrica Reduced)
 !Commemoratio S. Vitalis Mart.
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Italiano/Sancti/04-28.txt
+++ b/web/www/horas/Italiano/Sancti/04-28.txt
@@ -9,7 +9,7 @@ vide C5;mtv
 Signore Gesù Cristo, che hai dotato san Paolo di un'unzione particolare per predicare il mistero della croce, e per suo mezzo hai voluto far fiorire nella Chiesa una nuova famiglia: concedici, per sua intercessione, che meditando continuamente la tua passione in terra, meritiamo di conseguirne il frutto nei cieli:
 $Qui vivis
 
-[Commemoratio] (rubrica Divino aut rubrica tridentina aut rubrica Reduced)
+[Commemoratio] (rubrica divino aut rubrica tridentina aut rubrica Reduced)
 !Commemoratio S. Vitalis Mart.
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Italiano/Sancti/05-05.txt
+++ b/web/www/horas/Italiano/Sancti/05-05.txt
@@ -34,6 +34,6 @@ Egli sconfisse, non tanto colle armi quanto colle preghiere innalzate a Dio, pre
 Pio, nato a Bosco presso Alessandria, a 14 anni entrò nell'ordine dei Predicatori. Divenuto sacerdote, tenne sacre predicazioni in diversi luoghi con grandissimo frutto per le anime.  Dopo aver esercitato in modo energico e lodevole per lungo tempo l'ufficio di inquisitore. Paolo IV lo promosse vescovo di Nepi e Sutri e dopo due anni lo nominò cardinale. Pio IV lo trasferì alla diocesi di Mondovì, in Piemonte, ch'egli visitò e nella quale represse gli abusi. Ritornato a Roma, gli fu affidato il disbrigo dei più gravi affari. Dopo la morte di Pio IV, contro l'aspettativa di tutti fu eletto pontefice, ma egli, salvo la veste esterna, nulla cambiò nel suo sistema di vita. Con le sue assidue preghiere, più che con le armi, sconfisse presso le isole Curzolari, il sultano dei Turchi Solimano, che ivi si trovava con una grande flotta. Morì serenamente nell'anno 1572 a 68 anni, mentre attendeva ad apprestare una nuova spedizione contro i Turchi. Il suo corpo, sepolto nella basilica di santa Maria Maggiore, è venerato dai fedeli con grandissima devozione. Clemente XI Io annoverò fra i santi.
 &teDeum
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Italiano/Sancti/05-19.txt
+++ b/web/www/horas/Italiano/Sancti/05-19.txt
@@ -56,7 +56,7 @@ $Oremus.
 Esaudiscici, Dio nostra salvezza: affinché, come esultiamo per la festa della tua beata Vergine Pudenziana, cosi ne apprendiamo il sentimento d'una tenera devozione. 
 $Per Dominum
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 
 [Lectio94]

--- a/web/www/horas/Italiano/Sancti/05-25.txt
+++ b/web/www/horas/Italiano/Sancti/05-25.txt
@@ -52,6 +52,6 @@ Papa Gregorio VII, di nome Ildebrando, nacque a Soana in Toscana. Grande innanzi
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Italiano/Sancti/07-03.txt
+++ b/web/www/horas/Italiano/Sancti/07-03.txt
@@ -39,5 +39,5 @@ Leone II, sommo Pontefice, Siciliano, dotto nelle scienze sacre e profane, posse
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Italiano/Sancti/07-23.txt
+++ b/web/www/horas/Italiano/Sancti/07-23.txt
@@ -55,7 +55,7 @@ Convertiamoci dunque, e badiamo che non sorga fra noi, per nostra rovina, contes
 Apollinare venne da Antiochia a Roma col Principe degli apostoli, il quale lo ordinò vescovo e lo inviò a Ravenna a predicare il Vangelo di Cristo. Ivi, avendo convertito moltissime persone alla fede di Cristo, fu preso dai sacerdoti pagani e crudelmente battuto. Per le sue preghiere il nobile Bonifacio, muto da molto tempo, ricuperò la parola ed una sua figlia fu liberata dallo spirito maligno. In seguito a ciò, fu suscitata una nuova sedizione contro di lui, per cui dovette soffrire molte e varie pene. Dopo questi avvenimenti, si recò a predicare il Vangelo nell'Emilia e convertì molti. Tornato a Ravenna, esortando i cristiani alla costanza nella fede, coronò la vita con il martirio. Il suo corpo venne sepolto presso le mura della città.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
 !Commemorazione di S. Cristina.
 @Commune/C6:Oratio proper
 v. Preghiamo.

--- a/web/www/horas/Italiano/Sancti/07-23.txt
+++ b/web/www/horas/Italiano/Sancti/07-23.txt
@@ -55,7 +55,7 @@ Convertiamoci dunque, e badiamo che non sorga fra noi, per nostra rovina, contes
 Apollinare venne da Antiochia a Roma col Principe degli apostoli, il quale lo ordinò vescovo e lo inviò a Ravenna a predicare il Vangelo di Cristo. Ivi, avendo convertito moltissime persone alla fede di Cristo, fu preso dai sacerdoti pagani e crudelmente battuto. Per le sue preghiere il nobile Bonifacio, muto da molto tempo, ricuperò la parola ed una sua figlia fu liberata dallo spirito maligno. In seguito a ciò, fu suscitata una nuova sedizione contro di lui, per cui dovette soffrire molte e varie pene. Dopo questi avvenimenti, si recò a predicare il Vangelo nell'Emilia e convertì molti. Tornato a Ravenna, esortando i cristiani alla costanza nella fede, coronò la vita con il martirio. Il suo corpo venne sepolto presso le mura della città.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina)
 !Commemorazione di S. Cristina.
 @Commune/C6:Oratio proper
 v. Preghiamo.

--- a/web/www/horas/Italiano/Sancti/08-24.txt
+++ b/web/www/horas/Italiano/Sancti/08-24.txt
@@ -24,7 +24,7 @@ Là egli convertì alla fede cristiana il re Polimio, la regina sua sposa e dodi
 Il suo corpo venne sepolto in Albanopoli, città della grande Armenia e luogo del suo martirio. In seguito fu trasportato nell'isola di Lipari, e di là a Benevento. Infine fu portato a Roma dall'imperatore Ottone III, e riposto nella chiesa consacrata a Dio sotto il suo nome nell'isola Tiberina.
 
 
-[Lectio6] (rubrica Tridentina)
+[Lectio6] (rubrica tridentina)
 Il suo corpo venne sepolto in Albanopoli, città della grande Armenia e luogo del suo martirio. In seguito fu trasportato nell'isola di Lipari, e di là a Benevento. Infine fu portato a Roma dall'imperatore Ottone III, e riposto nella chiesa consacrata a Dio sotto il suo nome nell'isola Tiberina. A Roma si celebra la festa il 25 settembre, e per gli otti giorni seguenti quella grande basilica viene frequentata da una grande folla.
 
 [Lectio7]

--- a/web/www/horas/Italiano/Sancti/11-01.txt
+++ b/web/www/horas/Italiano/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica divino) Vesperae Defunctorum
 
 [Ant Vespera]
 Vidi una gran turba, * che nessuno poteva contare, di tutte le genti, che stavano davanti al trono.

--- a/web/www/horas/Italiano/Sancti/11-01.txt
+++ b/web/www/horas/Italiano/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica Tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
 
 [Ant Vespera]
 Vidi una gran turba, * che nessuno poteva contare, di tutte le genti, che stavano davanti al trono.

--- a/web/www/horas/Italiano/Sancti/11-18.txt
+++ b/web/www/horas/Italiano/Sancti/11-18.txt
@@ -10,7 +10,7 @@ In Dedicatione Basilicarum Ss. Apostolorum Petri et Pauli;;Duplex optional;;2;;v
 [Rule]
 ex C8;
 9 lectiones
-(rubrica Divino aut rubrica 1955) Festum Domini
+(rubrica divino aut rubrica 1955) Festum Domini
 
 [Oratio]
 O Dio, tu ogni anno rinnovi per noi la festa della dedicazione di questo tuo sacro tempio, e ci dai la grazia di partecipare ancora ai santi misteri: ascolta le preghiere del tuo popolo, e chiunque entra in questo tempio a pregarti abbia la gioia di ottenere i tuoi benefici.

--- a/web/www/horas/Italiano/Sancti/12-11.txt
+++ b/web/www/horas/Italiano/Sancti/12-11.txt
@@ -44,6 +44,6 @@ Damaso, oriundo dalla Spagna, uomo distinto ed erudito nelle sacre Scritture, in
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Italiano/Sancti/12-13.txt
+++ b/web/www/horas/Italiano/Sancti/12-13.txt
@@ -21,7 +21,7 @@ Colla tua pazienza * hai posseduto la tua anima, o Lucia, sposa di Cristo: hai o
 Esaudiscici, Dio nostro salvatore: e come esultiamo per la festa della tua beata Vergine e Martire Lucia, così ne impariamo il sentimento d'una tenera devozione. 
 $Per Dominum
 
-[Commemoratio 2] (rubrica 1910 aut rubrica Divino)
+[Commemoratio 2] (rubrica 1910 aut rubrica divino)
 !Commemorazione del giorno entro l'Ottava dell'Immacolata Concezione della B.M.V.
 @Sancti/12-08:Oratio
 

--- a/web/www/horas/Italiano/Tempora/105-1.txt
+++ b/web/www/horas/Italiano/Tempora/105-1.txt
@@ -10,7 +10,7 @@ Dal secondo libro dei Maccabei
 
 [Lectio1]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio1Tridentina
 
 [Responsory1]
@@ -28,7 +28,7 @@ Dal secondo libro dei Maccabei
 
 [Lectio2]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio2Tridentina
 
 [Responsory2]
@@ -43,7 +43,7 @@ Dal secondo libro dei Maccabei
 
 [Lectio3]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Italiano/Tempora/105-2.txt
+++ b/web/www/horas/Italiano/Tempora/105-2.txt
@@ -8,7 +8,7 @@ Dal secondo libro dei Maccabei
 
 [Lectio1]
 @Tempora/105-1:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio1Tridentina
 
 [Responsory1]
@@ -25,7 +25,7 @@ Dal secondo libro dei Maccabei
 
 [Lectio2]
 @Tempora/105-1:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio2Tridentina
 
 [Responsory2]
@@ -44,7 +44,7 @@ Dal secondo libro dei Maccabei
 
 [Lectio3]
 @Tempora/105-1:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Italiano/Tempora/105-3.txt
+++ b/web/www/horas/Italiano/Tempora/105-3.txt
@@ -9,7 +9,7 @@ Dal secondo libro dei Maccabei
 
 [Lectio1]
 @Tempora/105-2:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio1Tridentina
 
 [Responsory1]
@@ -24,7 +24,7 @@ Dal secondo libro dei Maccabei
 
 [Lectio2]
 @Tempora/105-2:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio2Tridentina
 
 [Responsory2]
@@ -43,7 +43,7 @@ Dal secondo libro dei Maccabei
 
 [Lectio3]
 @Tempora/105-2:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Italiano/Tempora/Nat1-0.txt
+++ b/web/www/horas/Italiano/Tempora/Nat1-0.txt
@@ -29,10 +29,10 @@ Mentre un tranquillo silenzio * avvolgeva ogni cosa e la notte nel suo corso era
 Dio onnipotente ed eterno, dirigi le nostre azioni secondo il tuo volere: affinché nel nome del diletto tuo Figlio, meritiamo arricchirci di opere buone:
 $Qui tecum
 
-[Commemoratio 2] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 2] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
 [Lectio4]
@@ -102,7 +102,7 @@ R. E abitò tra noi, alleluia.
 [Ant 2]
 Mentre un tranquillo silenzio * avvolgeva ogni cosa e la notte nel suo corso era a metà del cammino, il tuo Verbo onnipotente, o Signore, discese dal cielo, dal trono reale, alleluia.
 
-[Lectio Prima] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4:7
 v. Dunque non sei più servo, ma figlio: e se figlio, anche erede per grazia di Dio.
 

--- a/web/www/horas/Italiano/Tempora/Nat1-0.txt
+++ b/web/www/horas/Italiano/Tempora/Nat1-0.txt
@@ -29,10 +29,10 @@ Mentre un tranquillo silenzio * avvolgeva ogni cosa e la notte nel suo corso era
 Dio onnipotente ed eterno, dirigi le nostre azioni secondo il tuo volere: affinché nel nome del diletto tuo Figlio, meritiamo arricchirci di opere buone:
 $Qui tecum
 
-[Commemoratio 2] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 2] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
 [Lectio4]
@@ -102,7 +102,7 @@ R. E abitò tra noi, alleluia.
 [Ant 2]
 Mentre un tranquillo silenzio * avvolgeva ogni cosa e la notte nel suo corso era a metà del cammino, il tuo Verbo onnipotente, o Signore, discese dal cielo, dal trono reale, alleluia.
 
-[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Lectio Prima] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4:7
 v. Dunque non sei più servo, ma figlio: e se figlio, anche erede per grazia di Dio.
 

--- a/web/www/horas/Italiano/Tempora/Pasc6-0.txt
+++ b/web/www/horas/Italiano/Tempora/Pasc6-0.txt
@@ -32,7 +32,7 @@ _
 (deinde dicitur)
 V. È asceso Iddio tra voci di giubilo, alleluia.
 R. E il Signore al suono della tromba, alleluia.
-(sed rubrica Tridentina loco huius versus dicitur)
+(sed rubrica tridentina loco huius versus dicitur)
 V. Il Signore nel cielo, alleluia.
 R. Ha stabilito il suo trono, alleluia
 (deinde dicitur)
@@ -111,7 +111,7 @@ Quindi aggiunse, come conseguenza, queste parole che abbiamo cominciato a spiega
 
 [Versum 2]
 @Tempora/Pasc5-4:Versum 1
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @:Versum 1
 
 [Commemoratio 2]

--- a/web/www/horas/Italiano/Tempora/Quad6-4.txt
+++ b/web/www/horas/Italiano/Tempora/Quad6-4.txt
@@ -175,7 +175,7 @@ $Pater noster
 !un poco più forte 
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 
 [Oratio Matutinum]
@@ -219,7 +219,7 @@ $Pater noster
 !un poco più forte
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 (sed rubrica 1955 aut rubrica 1960 loco horum versuum dicuntur)
 v. Visita, o Signore, te ne preghiamo, quest'abitazione e respingi lungi da essa tutte le insidie del nemico: i tuoi Santi Angeli abitino in essa, ci custodiscano in pace; e la tua benedizione sia sempre sopra di noi.

--- a/web/www/horas/Italiano/Tempora/Quad6-6.txt
+++ b/web/www/horas/Italiano/Tempora/Quad6-6.txt
@@ -164,7 +164,7 @@ R. Sepolto il Signore, fu sigillato il sepolcro e messa una pietra all'ingresso 
 [Ant Laudes]
 O morte, * io sarò la tua morte, sarò il tuo strazio, o inferno.
 Lo piangeranno * come un figlio unico, perché il Signore innocente è stato ucciso.
-(sed rubrica Tridentina) Lo piangeranno * come un figlio unico, perché il Signore innocente è stato ucciso.;;42
+(sed rubrica tridentina) Lo piangeranno * come un figlio unico, perché il Signore innocente è stato ucciso.;;42
 Guardate, * popoli tutti, e vedete il mio dolore.
 Dalla porta del sepolcro, * libera, o Signore, l'anima mia.;;222
 O voi tutti, * che passate per la via, guardate e vedete se c'è dolore simile al mio dolore.

--- a/web/www/horas/Latin/Commune/C10.txt
+++ b/web/www/horas/Latin/Commune/C10.txt
@@ -81,16 +81,16 @@ Nos cum prole pia benedícat Virgo María. Amen.
 Ipsa Virgo Vírginum intercédat pro nobis ad Dóminum. Amen.
 Per Vírginem matrem concédat nobis Dóminus salútem et pacem. Amen.
 
-[Responsory1](rubrica Trident)
+[Responsory1](rubrica tridentina)
 @Commune/C11
 
-[Responsory2](rubrica Trident)
+[Responsory2](rubrica tridentina)
 @Commune/C11:Responsory7:1-3
 R. Quia ex te ortus est sol justítiæ
 &Gloria
 R. Christus, Deus noster.
 
-[Ant Laudes](rubrica Trident)
+[Ant Laudes](rubrica tridentina)
 @Commune/C11:Ant Vespera:s/;;.*//g
 
 [Capitulum Laudes]

--- a/web/www/horas/Latin/Commune/C10n.txt
+++ b/web/www/horas/Latin/Commune/C10n.txt
@@ -9,5 +9,5 @@
 [Oratio]
 @Sancti/01-01
 
-[Ant Laudes](rubrica Trident)
+[Ant Laudes](rubrica tridentina)
 @Sancti/01-01:Ant Vespera:s/;;.*//g

--- a/web/www/horas/Latin/Commune/C9.txt
+++ b/web/www/horas/Latin/Commune/C9.txt
@@ -31,7 +31,7 @@ _
 &pater_noster
 _
 &psalm(145)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 _
 V. A porta ínferi.
 R. Erue, Dómine, ánimas eórum.

--- a/web/www/horas/Latin/Psalterium/Major Special.txt
+++ b/web/www/horas/Latin/Psalterium/Major Special.txt
@@ -687,7 +687,7 @@ missing from próprium
 [Day1 Ant 2]
 Benedíctus * Dóminus Deus Israël, quia visitávit et liberávit nos.
 
-[Day1 Ant 2] (rubrica Trident aut rubrica Monastic)
+[Day1 Ant 2] (rubrica tridentina aut rubrica monastica)
 Benedíctus * Dóminus Deus Israël.
 
 [Day1 Ant 3]
@@ -699,13 +699,13 @@ Eréxit nobis * Dóminus cornu salútis in domo David púeri sui.
 [Day2 Ant 3]
 Exsultávit * spíritus meus in Deo salutári meo.
 
-[Day2 Ant 3] (rubrica Trident aut rubrica Monastic)
+[Day2 Ant 3] (rubrica tridentina aut rubrica monastica)
 Exsúltet * spíritus meus in Deo salutári meo.
 
 [Day3 Ant 2]
 De manu ómnium * qui odérunt nos, liberávit nos Dóminus.
 
-[Day3 Ant 2] (rubrica Trident aut rubrica Monastic)
+[Day3 Ant 2] (rubrica tridentina aut rubrica monastica)
 De manu ómnium * qui odérunt nos, líbera nos Dómine.
 
 [Day3 Ant 3]
@@ -717,7 +717,7 @@ In sanctitáte * serviámus Dómino, et liberábit nos ab inimícis nostris.
 [Day4 Ant 3]
 Fecit Deus * poténtiam in brácchio suo: dispérsit supérbos mente cordis sui.
 
-[Day4 Ant 3] (rubrica Trident aut rubrica Monastic)
+[Day4 Ant 3] (rubrica tridentina aut rubrica monastica)
 Fac Deus, * poténtiam in brácchio tuo: dispérde supérbos, et exálta húmiles.
 
 [Day5 Ant 2]
@@ -726,19 +726,19 @@ Per víscera misericórdiæ * Dei nostri visitávit nos Óriens ex alto.
 [Day5 Ant 3]
 Depósuit Dóminus * poténtes de sede, et exaltávit húmiles.
 
-[Day5 Ant 3] (rubrica Trident aut rubrica Monastic)
+[Day5 Ant 3] (rubrica tridentina aut rubrica monastica)
 Depósuit poténtes, * Sanctos persequéntes: et exaltávit húmiles, Christum confiténtes.
 
 [Day6 Ant 2]
 Illúmina, Dómine, * sedéntes in ténebris et umbra mortis, et dírige pedes nostros in viam pacis.
 
-[Day6 Ant 2] (rubrica Trident aut rubrica Monastic)
+[Day6 Ant 2] (rubrica tridentina aut rubrica monastica)
 Illumináre, Dómine, * his qui in ténebris sedent: et dírige pedes nostros in viam pacis, Deus Israël.
 
 [Day6 Ant 3]
 Suscépit Deus * Israël, púerum suum: sicut locútus est ad Ábraham, et semen ejus usque in sǽculum.
 
-[Day6 Ant 3] (rubrica Trident aut rubrica Monastic)
+[Day6 Ant 3] (rubrica tridentina aut rubrica monastica)
 Suscépit Deus * Israël, púerum suum: sicut locútus est ad Ábraham, et semen ejus: exaltáre húmiles usque in sǽculum.
 
 [Adv Laudes]

--- a/web/www/horas/Latin/Sancti/01-02.txt
+++ b/web/www/horas/Latin/Sancti/01-02.txt
@@ -76,7 +76,7 @@ Ecce relinquétur vobis domus vestra desérta. Hoc ipsum ex persóna Jeremíæ j
 Dico enim vobis: Non me vidébitis ámodo, donec dicátis: Benedíctus qui venit in nómine Dómini. Ad Jerúsalem lóquitur, et ad pópulum Judæórum. Versículum autem istum, quo et párvuli atque lacténtes in ingréssu Jerúsalem Dómini Salvatóris usi sunt, quando dixérunt: Benedíctus qui venit in nómine Dómini, hosánna in excélsis, sumpsit de centésimo décimo séptimo Psalmo, qui maniféste de advéntu Dómini scriptus est.
 &teDeum
 
-[Oratio] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Oratio] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 Omnípotens sempitérne Deus, qui primítias Mártyrum in beáti Levítæ Stéphani sánguine dedicásti: tríbue quǽsumus; ut pro nobis intercéssor exsístat, qui pro suis étiam persecutóribus exorávit Dóminum nostrum Jesum Christum Fílium tuum: 
 $Qui tecum
 

--- a/web/www/horas/Latin/Sancti/01-02.txt
+++ b/web/www/horas/Latin/Sancti/01-02.txt
@@ -76,7 +76,7 @@ Ecce relinquétur vobis domus vestra desérta. Hoc ipsum ex persóna Jeremíæ j
 Dico enim vobis: Non me vidébitis ámodo, donec dicátis: Benedíctus qui venit in nómine Dómini. Ad Jerúsalem lóquitur, et ad pópulum Judæórum. Versículum autem istum, quo et párvuli atque lacténtes in ingréssu Jerúsalem Dómini Salvatóris usi sunt, quando dixérunt: Benedíctus qui venit in nómine Dómini, hosánna in excélsis, sumpsit de centésimo décimo séptimo Psalmo, qui maniféste de advéntu Dómini scriptus est.
 &teDeum
 
-[Oratio] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Oratio] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 Omnípotens sempitérne Deus, qui primítias Mártyrum in beáti Levítæ Stéphani sánguine dedicásti: tríbue quǽsumus; ut pro nobis intercéssor exsístat, qui pro suis étiam persecutóribus exorávit Dóminum nostrum Jesum Christum Fílium tuum: 
 $Qui tecum
 

--- a/web/www/horas/Latin/Sancti/01-03.txt
+++ b/web/www/horas/Latin/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Sir 15:1-2
 v. Qui timet Deum, fáciet bona: et qui cóntinens est justítiæ, apprehéndet~
 illam, et obviábit illi quasi mater honorificáta.

--- a/web/www/horas/Latin/Sancti/01-03.txt
+++ b/web/www/horas/Latin/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Capitulum Vespera] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Sir 15:1-2
 v. Qui timet Deum, fáciet bona: et qui cóntinens est justítiæ, apprehéndet~
 illam, et obviábit illi quasi mater honorificáta.

--- a/web/www/horas/Latin/Sancti/01-10.txt
+++ b/web/www/horas/Latin/Sancti/01-10.txt
@@ -10,7 +10,7 @@ Lectio1 tempora
 Doxology=Epi
 9 lectiones
 Feria Te Deum
-(rubrica Divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hygínum;
+(rubrica divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hygínum;
 Infra octavam Epiphaniæ Domini
 
 [Lectio1]
@@ -78,6 +78,6 @@ Omnes natiónes * vénient a longe, portántes múnera sua, allelúja.
 [Ant 3]
 Omnes de Saba * vénient, aurum et thus deferéntes, allelúja, allelúja.
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Commemoratio S. Hygini Papæ et Martyris
 @Commune/C2:Oratio Gregem

--- a/web/www/horas/Latin/Sancti/01-10.txt
+++ b/web/www/horas/Latin/Sancti/01-10.txt
@@ -10,7 +10,7 @@ Lectio1 tempora
 Doxology=Epi
 9 lectiones
 Feria Te Deum
-(rubrica Divino aut rubrica Tridentina aut rubrica Monastica) CPapaM=Hygínum;
+(rubrica Divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hygínum;
 Infra octavam Epiphaniæ Domini
 
 [Lectio1]
@@ -78,6 +78,6 @@ Omnes natiónes * vénient a longe, portántes múnera sua, allelúja.
 [Ant 3]
 Omnes de Saba * vénient, aurum et thus deferéntes, allelúja, allelúja.
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Commemoratio S. Hygini Papæ et Martyris
 @Commune/C2:Oratio Gregem

--- a/web/www/horas/Latin/Sancti/01-19.txt
+++ b/web/www/horas/Latin/Sancti/01-19.txt
@@ -9,7 +9,7 @@ Exáudi, Dómine, pópulum tuum cum Sanctórum tuórum patrocínio supplicántem
 temporális vitæ nos tríbuas pace gaudére; et ætérnæ reperíre subsídium.
 $Per Dominum
 
-[Commemoratio] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Commemoratio] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 !Commemoratio S. Canuti Martyris
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Latin/Sancti/01-25.txt
+++ b/web/www/horas/Latin/Sancti/01-25.txt
@@ -104,7 +104,7 @@ V. Tu es Petrus.
 R. Et super hanc petram ædificábo Ecclésiam meam.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 v. Deus, qui beáto Petro Apóstolo tuo, collátis clávibus regni cæléstis, ligándi atque solvéndi pontifícium tradidísti: concéde; ut, intercessiónis eius auxílio, a peccatórum nostrórum néxibus liberémur:
 $Qui vivis
 

--- a/web/www/horas/Latin/Sancti/02-22.txt
+++ b/web/www/horas/Latin/Sancti/02-22.txt
@@ -76,7 +76,7 @@ V. Tu es vas electiónis, sancte Paule Apostóle.
 R. Prædicátor veritátis in univérso mundo.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 v. Deus, qui multitúdinem géntium beáti Pauli Apóstoli prædicatióne docuísti: da nobis, quǽsumus; ut, cuius commemoratiónem cólimus, eius apud te patrocínia sentiámus.
 $Per Dominum
 

--- a/web/www/horas/Latin/Sancti/04-28.txt
+++ b/web/www/horas/Latin/Sancti/04-28.txt
@@ -36,7 +36,7 @@ Paulus a Cruce, Uvádæ in Ligúria natus, a primo ratiónis usu, Jesu Christi c
 [Lectio9]
 @Commune/C1a:Lectio9
 
-[Commemoratio] (rubrica Divino aut rubrica tridentina aut rubrica Reduced)
+[Commemoratio] (rubrica divino aut rubrica tridentina aut rubrica Reduced)
 !Commemoratio S. Vitalis Mart.
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Latin/Sancti/04-28.txt
+++ b/web/www/horas/Latin/Sancti/04-28.txt
@@ -36,7 +36,7 @@ Paulus a Cruce, Uvádæ in Ligúria natus, a primo ratiónis usu, Jesu Christi c
 [Lectio9]
 @Commune/C1a:Lectio9
 
-[Commemoratio] (rubrica Divino aut rubrica Tridentina aut rubrica Reduced)
+[Commemoratio] (rubrica Divino aut rubrica tridentina aut rubrica Reduced)
 !Commemoratio S. Vitalis Mart.
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Latin/Sancti/05-05.txt
+++ b/web/www/horas/Latin/Sancti/05-05.txt
@@ -34,6 +34,6 @@ Selímum Turcárum tyrannum multis elátum victoriis, ingénti comparáta classe
 Pius, Boschi in Insúbria natus, cum quatuórdecim esset annórum, órdinem Prædicatórum ingréssus est. Sacerdótio auctus, sacras conciónes plúribus in locis cum ingénti animárum fructu hábuit. Inquisitóris offícium diu fórtiter ac laudabíliter sustínuit, et a Paulo quarto ad Nepesínum et Sutrínum episcopátum promótus, post biénnium inter patres cardináles adscríptus est. A Pio quarto translátus ad ecclésiam Montis Regális in Subalpínis, diœcésim vísitans, abúsus représsit; et Romam revérsus, in gravíssimis negótiis expediéndis fuit occupátus. Mórtuo autem Pio, præter ómnium exspectatiónem eléctus Póntifex, nihil in vitæ ratióne, excépto exterióri hábitu, immutávit. Selímum Turcárum tyránnum, ingénti comparáta classe, ad Echínadas ínsulas non tam armis quam fusis précibus devícit. Dum vero novam in ipsos Turcas expeditiónem paráret, piíssime óbiit in Dómino, anno millésimo quingentésimo septuagésimo secúndo, ætátis suæ sexagésimo octávo. Corpus ejus in basílica sanctæ Maríæ majóris summa fidélium veneratióne cólitur. Eum Clemens Papa undécimus catálogo Sanctórum adscrípsit.
 &teDeum
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Latin/Sancti/05-19.txt
+++ b/web/www/horas/Latin/Sancti/05-19.txt
@@ -56,7 +56,7 @@ $Oremus
 v. Exáudi nos, Deus, salutáris noster: ut, sicut de beátæ Pudentiánæ Vírginis tuæ festivitáte gaudémus; ita piæ devotiónis erudiámur afféctu.
 $Per Dominum
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 
 [Lectio94]

--- a/web/www/horas/Latin/Sancti/05-25.txt
+++ b/web/www/horas/Latin/Sancti/05-25.txt
@@ -41,6 +41,6 @@ Gregórius Papa séptimus, ántea Hildebrándus, Suánæ in Etrúria natus, doct
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Latin/Sancti/06-13.txt
+++ b/web/www/horas/Latin/Sancti/06-13.txt
@@ -20,7 +20,7 @@ $Per Dominum
 [Oratio]
 @:OratioText
 
-[Oratio] (rubrica Divino aut rubrica tridentina)
+[Oratio] (rubrica divino aut rubrica tridentina)
 @:OratioText:s/ atque Doctóris//
 
 [Lectio1] (rubrica tridentina)

--- a/web/www/horas/Latin/Sancti/07-03.txt
+++ b/web/www/horas/Latin/Sancti/07-03.txt
@@ -36,6 +36,6 @@ Leo secúndus, Sículus, humánis et divínis lítteris Græce et Latíne doctus
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Latin/Sancti/07-23.txt
+++ b/web/www/horas/Latin/Sancti/07-23.txt
@@ -53,7 +53,7 @@ Convertámur ígitur, et caveámus, ne in perditiónem aliqua inter nos de præl
 Apollináris cum Príncipe Apostolórum Antiochía Romam venit; a quo, ordinátus epíscopus, Ravénnam ad Christi Dómini Evangélium prædicándum míttitur; ubi, cum ad Christi fidem plúrimos convérteret, captus ab idolórum sacerdótibus, gráviter cæsus est. Cumque ipso oránte Bonifátius nóbilis vir, qui diu mutus fúerat, loquerétur, ejúsque fília immúndo spíritu liberáta esset, íterum est in illum commóta sedítio. Quare divérsas et multíplices pœnas perpéssus est. Póstea per Æmíliam Evangélium prǽdicans, plúrimos ab idolórum cultu revocávit. Ravénnam revérsus, exhórtans Christiános ad fídei constántiam, gloriósum martýrium consummávit. Ejus corpus prope murum urbis sepúltum est.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina)
 !Commemoratio S. Christinæ Virg. et Mart.
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/Latin/Sancti/07-23.txt
+++ b/web/www/horas/Latin/Sancti/07-23.txt
@@ -53,7 +53,7 @@ Convertámur ígitur, et caveámus, ne in perditiónem aliqua inter nos de præl
 Apollináris cum Príncipe Apostolórum Antiochía Romam venit; a quo, ordinátus epíscopus, Ravénnam ad Christi Dómini Evangélium prædicándum míttitur; ubi, cum ad Christi fidem plúrimos convérteret, captus ab idolórum sacerdótibus, gráviter cæsus est. Cumque ipso oránte Bonifátius nóbilis vir, qui diu mutus fúerat, loquerétur, ejúsque fília immúndo spíritu liberáta esset, íterum est in illum commóta sedítio. Quare divérsas et multíplices pœnas perpéssus est. Póstea per Æmíliam Evangélium prǽdicans, plúrimos ab idolórum cultu revocávit. Ravénnam revérsus, exhórtans Christiános ad fídei constántiam, gloriósum martýrium consummávit. Ejus corpus prope murum urbis sepúltum est.
 &teDeum
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
 !Commemoratio S. Christinæ Virg. et Mart.
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/Latin/Sancti/08-06.txt
+++ b/web/www/horas/Latin/Sancti/08-06.txt
@@ -59,7 +59,7 @@ Cum Patre, et almo Spíritu,
 In sempitérna sǽcula.
 Amen.
 
-[Doxology](rubrica Monastic aut rubrica 1570)
+[Doxology](rubrica monastica aut rubrica 1570)
 Glória tibi, Dómine,
 Qui apparuísti hódie,
 Cum Patre, et almo Spíritu,

--- a/web/www/horas/Latin/Sancti/08-24.txt
+++ b/web/www/horas/Latin/Sancti/08-24.txt
@@ -23,7 +23,7 @@ Ibi Polýmium regem et cónjugem ejus ac prætérea duódecim civitátes ad chri
 [Lectio6]
 Ejus corpus Albáni, quæ est urbs majoris Arméniæ, ubi is passus fúerat, sepúltus est. Quod póstea ad Líparam ínsulam delátum, inde Benevéntum translátum est. Postrémo Romam ab Ottóne tértio imperatóre portátum, in Tíberis ínsula, in ecclésia ejus nómine Deo dicáta, collocátum fuit.
 
-[Lectio6] (rubrica Tridentina)
+[Lectio6] (rubrica tridentina)
 Ejus corpus Albáni, quæ est urbs majoris Arméniæ, ubi is passus fúerat, sepúltus est. Quod póstea ad Líparam insulam delátum, inde Benevéntum translátum est. Postrémo Romam ab Ottóne tértio imperatóre portátum, in Tíberis ínsula, in ecclésia ejus nómine Deo dicáta, collocátum fuit. Agitur autem Romæ dies festus octavo Kalendas Septembris, et per octo consequentes dies illa basilica magna populi frequentia celebratur.
 
 [Lectio7]

--- a/web/www/horas/Latin/Sancti/11-01.txt
+++ b/web/www/horas/Latin/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica divino) Vesperae Defunctorum
 
 [Ant Vespera]
 Vidi turbam magnam, * quam dinumeráre nemo póterat, ex ómnibus géntibus, stantes ante thronum.

--- a/web/www/horas/Latin/Sancti/11-01.txt
+++ b/web/www/horas/Latin/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica Tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
 
 [Ant Vespera]
 Vidi turbam magnam, * quam dinumeráre nemo póterat, ex ómnibus géntibus, stantes ante thronum.

--- a/web/www/horas/Latin/Sancti/11-18.txt
+++ b/web/www/horas/Latin/Sancti/11-18.txt
@@ -3,7 +3,7 @@
 [Rule]
 ex C8;
 9 lectiones
-(rubrica Divino aut rubrica 1955) Festum Domini
+(rubrica divino aut rubrica 1955) Festum Domini
 
 [Lectio5]
 @Sancti/11-18o

--- a/web/www/horas/Latin/Sancti/12-11.txt
+++ b/web/www/horas/Latin/Sancti/12-11.txt
@@ -44,6 +44,6 @@ Dámasus Hispánus, vir egrégius et erudítus in Scriptúris sacris, indícto p
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis
 

--- a/web/www/horas/Latin/Sancti/12-13.txt
+++ b/web/www/horas/Latin/Sancti/12-13.txt
@@ -25,7 +25,7 @@ In tua patiéntia * possedísti ánimam tuam, Lúcia, sponsa Christi: odísti qu
 [Oratio]
 @Commune/C7::s/N\./Lúciæ Vírginis et Mártyris tuæ/
 
-[Commemoratio 2] (rubrica 1910 aut rubrica Divino)
+[Commemoratio 2] (rubrica 1910 aut rubrica divino)
 !Commemoratio Diei infra Octavam Immaculatæ Conceptionis B.M.V.
 @Sancti/12-08:Oratio
 

--- a/web/www/horas/Latin/Tempora/105-1.txt
+++ b/web/www/horas/Latin/Tempora/105-1.txt
@@ -10,7 +10,7 @@ De libro secúndo Machabæórum
 
 [Lectio1]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio1Tridentina
 
 [Responsory1]
@@ -28,7 +28,7 @@ De libro secúndo Machabæórum
 
 [Lectio2]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio2Tridentina
 
 [Responsory2]
@@ -43,7 +43,7 @@ De libro secúndo Machabæórum
 
 [Lectio3]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Latin/Tempora/105-2.txt
+++ b/web/www/horas/Latin/Tempora/105-2.txt
@@ -8,7 +8,7 @@ De libro secúndo Machabæórum
 
 [Lectio1]
 @Tempora/105-1:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio1Tridentina
 
 [Responsory1]
@@ -25,7 +25,7 @@ De libro secúndo Machabæórum
 
 [Lectio2]
 @Tempora/105-1:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio2Tridentina
 
 [Responsory2]
@@ -44,7 +44,7 @@ De libro secúndo Machabæórum
 
 [Lectio3]
 @Tempora/105-1:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Latin/Tempora/105-3.txt
+++ b/web/www/horas/Latin/Tempora/105-3.txt
@@ -9,7 +9,7 @@ De libro secúndo Machabæórum
 
 [Lectio1]
 @Tempora/105-2:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio1Tridentina
 
 [Responsory1]
@@ -24,7 +24,7 @@ De libro secúndo Machabæórum
 
 [Lectio2]
 @Tempora/105-2:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio2Tridentina
 
 [Responsory2]
@@ -43,7 +43,7 @@ De libro secúndo Machabæórum
 
 [Lectio3]
 @Tempora/105-2:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Latin/Tempora/Nat1-0.txt
+++ b/web/www/horas/Latin/Tempora/Nat1-0.txt
@@ -32,7 +32,7 @@ $Qui tecum
 [Commemoratio] (rubrica Divino)
 @Sancti/12-25:Octava
 
-[Commemoratio] (rubrica Tridentina)
+[Commemoratio] (rubrica tridentina)
 @Sancti/12-25:Octava
 @Sancti/12-26:Octava
 @Sancti/12-27:Octava
@@ -99,7 +99,7 @@ Prophetávit itaque Simeon, prophetáverat virgo, prophetáverat copuláta conju
 [Ant 2]
 @:Ant 1
 
-[Lectio Prima] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4:7
 v. Itaque jam non est servus, sed fílius: quod si fílius, et hæres per Deum.
 

--- a/web/www/horas/Latin/Tempora/Nat1-0.txt
+++ b/web/www/horas/Latin/Tempora/Nat1-0.txt
@@ -29,7 +29,7 @@ Dum médium siléntium * tenérent ómnia, et nox in suo cursu médium iter per�
 Omnípotens sempitérne Deus, dírige actus nostros in beneplácito tuo: ut in nómine dilécti Fílii tui mereámur bonis opéribus abundáre:
 $Qui tecum
 
-[Commemoratio] (rubrica Divino)
+[Commemoratio] (rubrica divino)
 @Sancti/12-25:Octava
 
 [Commemoratio] (rubrica tridentina)
@@ -99,7 +99,7 @@ Prophetávit itaque Simeon, prophetáverat virgo, prophetáverat copuláta conju
 [Ant 2]
 @:Ant 1
 
-[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Lectio Prima] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4:7
 v. Itaque jam non est servus, sed fílius: quod si fílius, et hæres per Deum.
 

--- a/web/www/horas/Latin/Tempora/Pasc5-4.txt
+++ b/web/www/horas/Latin/Tempora/Pasc5-4.txt
@@ -395,7 +395,7 @@ R. Parávit sedem suam, allelúja.
 
 [Versum 3]
 @:Versum 1
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @:Versum 2
 
 [Ant 3]
@@ -406,7 +406,7 @@ Ant. O Rex glóriæ, * Dómine virtútum, qui triumphátor hódie super omnes c�
 _
 V. Ascéndit Deus in jubilatióne, allelúja.
 R. Et Dóminus in voce tubæ, allelúja.
-(sed rubrica Tridentina loco hæc versus dicitur)
+(sed rubrica tridentina loco hæc versus dicitur)
 V. Dóminus in cælo, allelúja.
 R. Parávit sedem suam, allelúja.
 _

--- a/web/www/horas/Latin/Tempora/Pasc6-0.txt
+++ b/web/www/horas/Latin/Tempora/Pasc6-0.txt
@@ -35,7 +35,7 @@ _
 (deinde dicitur)
 V. Ascéndit Deus in jubilatióne, allelúja.
 R. Et Dóminus in voce tubæ, allelúja.
-(sed rubrica Tridentina loco huius versus dicitur)
+(sed rubrica tridentina loco huius versus dicitur)
 V. Dóminus in cælo, allelúja.
 R. Parávit sedem suam, allelúja.
 (deinde dicitur)
@@ -128,7 +128,7 @@ $Deo gratias
 
 [Versum 2]
 @Tempora/Pasc5-4:Versum 1
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @:Versum 1
 
 [Commemoratio 2]

--- a/web/www/horas/Latin/Tempora/Quad4-0.txt
+++ b/web/www/horas/Latin/Tempora/Quad4-0.txt
@@ -127,7 +127,7 @@ R. Inclináte aurem vestram in verba oris mei.
 Tunc acceptábis * sacrifícium justítiæ, si avérteris fáciem tuam a peccátis meis.
 Bonum est * speráre in Dómino, quam speráre in princípibus.
 Me suscépit * déxtera tua, Dómine.
-(sed rubrica Trident)
+(sed rubrica tridentina)
 Benedicat nos Deus, * Deus noster, benedicat nos Deus.
 Potens es, Dómine, * erípere nos de manu forti: líbera nos, Deus noster.
 Reges terræ * et omnes pópuli, laudáte Deum.

--- a/web/www/horas/Latin/Tempora/Quad6-4.txt
+++ b/web/www/horas/Latin/Tempora/Quad6-4.txt
@@ -175,7 +175,7 @@ $Pater noster
 !aliquantulum altius
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 
 [Oratio Matutinum]
@@ -219,7 +219,7 @@ $Pater noster
 !aliquantulum altius
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 (sed rubrica 1955 aut rubrica 1960 loco horum versuum dicuntur)
 v. Vísita, quǽsumus, Dómine, habitatiónem istam, et omnes insídias inimíci ab ea lónge repélle: Ángeli tui sancti hábitent in ea, qui nos in pace custódiant; et benedíctio tua sit super nos semper.

--- a/web/www/horas/Latin/Tempora/Quad6-6.txt
+++ b/web/www/horas/Latin/Tempora/Quad6-6.txt
@@ -164,7 +164,7 @@ R. Sepúlto Dómino, signátum est monuméntum, volvéntes lápidem ad óstium m
 [Ant Laudes]
 O mors, * ero mors tua, morsus tuus ero, inférne.
 Plangent eum * quasi unigénitum, quia ínnocens Dóminus occísus est.
-(sed rubrica Tridentina) Plangent eum * quasi unigénitum, quia ínnocens Dominus occísus est.;;42
+(sed rubrica tridentina) Plangent eum * quasi unigénitum, quia ínnocens Dominus occísus est.;;42
 Atténdite * univérsi pópuli, et vidéte dolórem meum.
 A porta ínferi * érue, Dómine, ánimam meam.;;222
 O vos omnes, * qui transítis per viam, atténdite et vidéte, si est dolor sicut dolor meus.

--- a/web/www/horas/Latin/TemporaM/Pasc6-0.txt
+++ b/web/www/horas/Latin/TemporaM/Pasc6-0.txt
@@ -44,7 +44,7 @@ _
 (deinde dicitur)
 V. Ascéndit Deus in jubilatióne, allelúja.
 R. Et Dóminus in voce tubæ, allelúja.
-(sed rubrica Tridentina loco huius versus dicitur)
+(sed rubrica tridentina loco huius versus dicitur)
 V. Dominus in cælo, allelúja.
 R. Paravit sedem suam, allelúja.
 (deinde dicitur)
@@ -132,7 +132,7 @@ $Deo gratias
 
 [Versum 2]
 @Tempora/Pasc5-4:Versum 1
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @:Versum 1
 
 [Commemoratio 2]

--- a/web/www/horas/Magyar/Commune/C9.txt
+++ b/web/www/horas/Magyar/Commune/C9.txt
@@ -24,7 +24,7 @@ $Qui vivis
 &pater_noster
 _
 &psalm(145)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 _
 [Oratio 2]
 &pater_noster

--- a/web/www/horas/Magyar/Sancti/01-03.txt
+++ b/web/www/horas/Magyar/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Capitulum Vespera] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Sir 15:1-2
 v. A ki Istent féli, jót cselekszik; és ki az igazságnak megtartója, eljut~
 hozzá. És eléje megyen, mint egy tisztes anya, és mint szöz menyasszony fogadja~

--- a/web/www/horas/Magyar/Sancti/01-03.txt
+++ b/web/www/horas/Magyar/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Sir 15:1-2
 v. A ki Istent féli, jót cselekszik; és ki az igazságnak megtartója, eljut~
 hozzá. És eléje megyen, mint egy tisztes anya, és mint szöz menyasszony fogadja~

--- a/web/www/horas/Magyar/Sancti/01-10.txt
+++ b/web/www/horas/Magyar/Sancti/01-10.txt
@@ -10,7 +10,7 @@ Lectio1 tempora
 Doxology=Epi
 9 lectiones
 Feria Te Deum
-(rubrica Divino aut rubrica Tridentina aut rubrica Monastica) CPapaM=Hyginus;
+(rubrica Divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hyginus;
 Infra octavam Epiphaniae Domini
 
 [Lectio1]

--- a/web/www/horas/Magyar/Sancti/01-10.txt
+++ b/web/www/horas/Magyar/Sancti/01-10.txt
@@ -10,7 +10,7 @@ Lectio1 tempora
 Doxology=Epi
 9 lectiones
 Feria Te Deum
-(rubrica Divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hyginus;
+(rubrica divino aut rubrica tridentina aut rubrica monastica) CPapaM=Hyginus;
 Infra octavam Epiphaniae Domini
 
 [Lectio1]

--- a/web/www/horas/Magyar/Sancti/11-01.txt
+++ b/web/www/horas/Magyar/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphones horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica Tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
 
 [Hymnus Vespera]
 {:H-PlacareChriste:}v. Kis szolgáidnak megbocsáss,

--- a/web/www/horas/Magyar/Sancti/11-01.txt
+++ b/web/www/horas/Magyar/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphones horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica divino) Vesperae Defunctorum
 
 [Hymnus Vespera]
 {:H-PlacareChriste:}v. Kis szolgáidnak megbocsáss,

--- a/web/www/horas/Magyar/Sancti/11-18.txt
+++ b/web/www/horas/Magyar/Sancti/11-18.txt
@@ -10,7 +10,7 @@ In Dedicatione Basilicarum Ss. Apostolorum Petri et Pauli.;;Duplex optional;;2;;
 [Rule]
 ex C8;
 9 lectiones
-(rubrica Divino aut rubrica 1955) Festum Domini
+(rubrica divino aut rubrica 1955) Festum Domini
 
 [Lectio1]
 Olvasmány a Jelenések könyvéből

--- a/web/www/horas/Magyar/Tempora/105-1.txt
+++ b/web/www/horas/Magyar/Tempora/105-1.txt
@@ -10,7 +10,7 @@ A Makkabeusok második könyvéből
 
 [Lectio1]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio1Tridentina
 
 [Responsory1]
@@ -28,7 +28,7 @@ A Makkabeusok második könyvéből
 
 [Lectio2]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio2Tridentina
 
 [Responsory2]
@@ -43,7 +43,7 @@ A Makkabeusok második könyvéből
 
 [Lectio3]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Magyar/Tempora/105-2.txt
+++ b/web/www/horas/Magyar/Tempora/105-2.txt
@@ -8,7 +8,7 @@ A Makkabeusok második könyvéből
 
 [Lectio1]
 @Tempora/105-1:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio1Tridentina
 
 [Responsory1]
@@ -25,7 +25,7 @@ A Makkabeusok második könyvéből
 
 [Lectio2]
 @Tempora/105-1:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio2Tridentina
 
 [Responsory2]
@@ -44,7 +44,7 @@ A Makkabeusok második könyvéből
 
 [Lectio3]
 @Tempora/105-1:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Magyar/Tempora/105-3.txt
+++ b/web/www/horas/Magyar/Tempora/105-3.txt
@@ -15,7 +15,7 @@ szabadítsa meg őket, hisz az istentelen Nikanor máris eladta őket,
 
 [Lectio1]
 @Tempora/105-2:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio1Tridentina
 
 [Responsory1]
@@ -38,7 +38,7 @@ Szancherib száznyolcvanötezer embere,
 
 [Lectio2]
 @Tempora/105-2:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio2Tridentina
 
 [Responsory2]
@@ -67,7 +67,7 @@ között.
 
 [Lectio3]
 @Tempora/105-2:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio3Tridentina
 
 [Responsory3]

--- a/web/www/horas/Magyar/Tempora/Nat1-0.txt
+++ b/web/www/horas/Magyar/Tempora/Nat1-0.txt
@@ -20,10 +20,10 @@ jóllehet mindennek ura. Gyámok és gondviselők felügyelete alatt áll, apjá
 meghatározott ideig.
 $Deo gratias
 
-[Commemoratio 2] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 2] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
 [Responsory6]
@@ -55,7 +55,7 @@ jóllehet mindennek ura. Gyámok és gondviselők felügyelete alatt áll, apjá
 meghatározott ideig.
 $Deo gratias
 
-[Lectio Prima] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4:7
 v. Tehát nem vagy többé szolga, hanem fiú, s ha fiú, akkor Isten kegyelméből~
 örökös is.

--- a/web/www/horas/Magyar/Tempora/Nat1-0.txt
+++ b/web/www/horas/Magyar/Tempora/Nat1-0.txt
@@ -20,10 +20,10 @@ jóllehet mindennek ura. Gyámok és gondviselők felügyelete alatt áll, apjá
 meghatározott ideig.
 $Deo gratias
 
-[Commemoratio 2] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 2] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 @Sancti/12-25:Octava
 
 [Responsory6]
@@ -55,7 +55,7 @@ jóllehet mindennek ura. Gyámok és gondviselők felügyelete alatt áll, apjá
 meghatározott ideig.
 $Deo gratias
 
-[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Lectio Prima] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Gal 4:7
 v. Tehát nem vagy többé szolga, hanem fiú, s ha fiú, akkor Isten kegyelméből~
 örökös is.

--- a/web/www/horas/Magyar/Tempora/Quad6-4.txt
+++ b/web/www/horas/Magyar/Tempora/Quad6-4.txt
@@ -73,7 +73,7 @@ $Pater noster
 !lower voice
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 
 [Oratio Matutinum]
@@ -104,7 +104,7 @@ $Pater noster
 !lower voice
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 (sed rubrica 1955 aut rubrica 1960 loco horum versuum dicuntur)
 v. Látogasd meg Urunk hajlékunkat, és az ellenség minden cselvetését tartsd távol tőlünk; angyalaid lakjanak velünk akik békében védelmeznek minket; és áldásod legyen velünk mindig.

--- a/web/www/horas/Polski/Commune/C9.txt
+++ b/web/www/horas/Polski/Commune/C9.txt
@@ -30,7 +30,7 @@ _
 &pater_noster
 _
 &psalm(145)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 _
 V. Od wrót piekielnych.
 R. Wybaw dusze ich, Panie.

--- a/web/www/horas/Polski/Psalterium/Major Special.txt
+++ b/web/www/horas/Polski/Psalterium/Major Special.txt
@@ -476,7 +476,7 @@ R. I niech zstąpi na nas miłosierdzie Twoje.
 [Day1 Ant 2]
 Błogosławiony * Pan, Bóg Izraelski: iż nawiedził i wybawił nas.
 
-[Day1 Ant 2] (rubrica Trident aut rubrica Monastic)
+[Day1 Ant 2] (rubrica tridentina aut rubrica monastica)
 Błogosławiony * Pan, Bóg Izraelski.
 
 [Day1 Ant 3]
@@ -500,7 +500,7 @@ W świętobliwości * służmy Panu, a wybawi nas od nieprzyjaciół naszych.
 [Day4 Ant 3]
 Uczynił Bóg * moc ramieniem swojem: rozproszył pyszne myśli serca ich.
 
-[Day4 Ant 3] (rubrica Trident aut rubrica Monastic)
+[Day4 Ant 3] (rubrica tridentina aut rubrica monastica)
 Uczyń Boże, * mocą ramienia Twego: rozprosz pyszne, a podwyższ niskie.
 
 [Day5 Ant 2]
@@ -512,13 +512,13 @@ Złożył Pan * mocarze z stolice: a podwyższył niskie.
 [Day6 Ant 2]
 Oświeć Panie, * siedzących w ciemności i w cieniu śmierci, ku wyprostowaniu nóg naszych na drogę pokoju.
 
-[Day6 Ant 2] (rubrica Trident aut rubrica Monastic)
+[Day6 Ant 2] (rubrica tridentina aut rubrica monastica)
 Oświeć Panie, * tych którzy siedzą w ciemności, ku wyprostowaniu nóg naszych na drogę pokoju.
 
 [Day6 Ant 3]
 Przyjął Bóg * Izraela, sługę swego: jako mówił do ojców naszych: Abrahamowi i nasieniu jego na wieki.
 
-[Day6 Ant 3] (rubrica Trident aut rubrica Monastic)
+[Day6 Ant 3] (rubrica tridentina aut rubrica monastica)
 Przyjął Bóg * Izraela, sługę swego: jako mówił do ojców naszych: Abrahamowi i nasieniu jego, podwyższając niskie na wieki.
 
 [Adv Laudes]

--- a/web/www/horas/Polski/Sancti/01-02.txt
+++ b/web/www/horas/Polski/Sancti/01-02.txt
@@ -34,7 +34,7 @@ Z Listu św. Pawła Apostoła do Rzymian
 11 A nie tylko; ale się téż i chlubimy w Bogu przez Pana naszego, Jezusa Chrystusa, przez któregośmy teraz pojednanie otrzymali.
 12 Dlatego, jako przez jednego człowieka grzech na ten świat wszedł, a przez grzech śmierć, i tak na wszystkie ludzie śmierć przeszła, w którym wszyscy zgrzeszyli.
 
-[Oratio] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Oratio] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 Wszechmogący, wieczny Boże, który poświęciłeś pierwociny Męczenników we krwi błogosławionego diakona Szczepana; pozwól, prosimy, aby on, który się nawet za swoich prześladowców modlił, wstawiał się i za nami do Pana naszego, Jezusa Chrystusa, Syna Twojego:
 $Qui tecum
 

--- a/web/www/horas/Polski/Sancti/01-02.txt
+++ b/web/www/horas/Polski/Sancti/01-02.txt
@@ -34,7 +34,7 @@ Z Listu św. Pawła Apostoła do Rzymian
 11 A nie tylko; ale się téż i chlubimy w Bogu przez Pana naszego, Jezusa Chrystusa, przez któregośmy teraz pojednanie otrzymali.
 12 Dlatego, jako przez jednego człowieka grzech na ten świat wszedł, a przez grzech śmierć, i tak na wszystkie ludzie śmierć przeszła, w którym wszyscy zgrzeszyli.
 
-[Oratio] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Oratio] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 Wszechmogący, wieczny Boże, który poświęciłeś pierwociny Męczenników we krwi błogosławionego diakona Szczepana; pozwól, prosimy, aby on, który się nawet za swoich prześladowców modlił, wstawiał się i za nami do Pana naszego, Jezusa Chrystusa, Syna Twojego:
 $Qui tecum
 

--- a/web/www/horas/Polski/Sancti/01-03.txt
+++ b/web/www/horas/Polski/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Syr 15:1-2
 v. Kto się Boga boi, będzie czynił dobrze, a kto się trzyma sprawiedliwości, dostanie jej; i zabieży mu jako uczciwa matka.
 $Deo gratias

--- a/web/www/horas/Polski/Sancti/01-03.txt
+++ b/web/www/horas/Polski/Sancti/01-03.txt
@@ -13,7 +13,7 @@ Feria Te Deum
 Comkey=70
 9 lectiones
 
-[Capitulum Vespera] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Capitulum Vespera] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Syr 15:1-2
 v. Kto się Boga boi, będzie czynił dobrze, a kto się trzyma sprawiedliwości, dostanie jej; i zabieży mu jako uczciwa matka.
 $Deo gratias

--- a/web/www/horas/Polski/Sancti/01-10.txt
+++ b/web/www/horas/Polski/Sancti/01-10.txt
@@ -33,6 +33,6 @@ Wszystkie narody * przyjdą z daleka, niosąc dary swoje, alleluja.
 [Ant 3]
 Wszyscy z Saby * przyjdą, złoto i kadzidło przynosząc, alleluja, alleluja.
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Wspomnienie Św. Hygina Papieża i Męczennika
 @Commune/C2:Oratio Gregem

--- a/web/www/horas/Polski/Sancti/01-10.txt
+++ b/web/www/horas/Polski/Sancti/01-10.txt
@@ -33,6 +33,6 @@ Wszystkie narody * przyjdą z daleka, niosąc dary swoje, alleluja.
 [Ant 3]
 Wszyscy z Saby * przyjdą, złoto i kadzidło przynosząc, alleluja, alleluja.
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Wspomnienie Św. Hygina Papieża i Męczennika
 @Commune/C2:Oratio Gregem

--- a/web/www/horas/Polski/Sancti/01-19.txt
+++ b/web/www/horas/Polski/Sancti/01-19.txt
@@ -5,7 +5,7 @@
 Wysłuchaj, Panie, modlitw ludu Twego, który Cię błaga za przyczyną Świętych Twoich, abyśmy już mogli w tem doczesnem życiu cieszyć się pokojem i do osiągnięcia wiecznego pomoc Twoją otrzymać.
 $Per Dominum
 
-[Commemoratio] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Commemoratio] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 !Wspomnienie Św. Kanuta Męczennika
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Polski/Sancti/01-25.txt
+++ b/web/www/horas/Polski/Sancti/01-25.txt
@@ -56,7 +56,7 @@ V. Tyś jest opoka.
 R. A na tej opoce zbuduję Kościół mój.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 Boże, który św. Piotrowi, Apostołowi swemu, powierzyłeś klucze Królestwa niebieskiego i udzieliłeś mu najwyższej władzy wiązania i rozwiązywania, spraw, abyśmy wstawiennictwem jego od grzechów naszych uwolnieni zostali.
 $Qui vivis
 

--- a/web/www/horas/Polski/Sancti/02-22.txt
+++ b/web/www/horas/Polski/Sancti/02-22.txt
@@ -56,7 +56,7 @@ V. Tyś jest naczyniem wybranem, św. Pawle Apostole.
 R. Głosicielem prawdy po całym świecie.
 _
 $Oremus
-(sed rubrica 1960 aut rubrica Monastic hæc versus omittuntur)
+(sed rubrica 1960 aut rubrica monastica hæc versus omittuntur)
 v. Boże, któryś liczne narody wymową św. Pawła Apostoła oświecił, daj nam, prosimy Cię, abyśmy doznali u Ciebie wstawiennictwa tego, którego dziś pamiątkę obchodzimy.
 $Per Dominum
 

--- a/web/www/horas/Polski/Sancti/04-28.txt
+++ b/web/www/horas/Polski/Sancti/04-28.txt
@@ -9,7 +9,7 @@ vide C5;mtv
 Panie Jezu Chryste, któryś dla głoszenia tajemnicy Krzyża, św. Pawła szczególną obdarzył miłością i sprawił, że przez niego nowa rodzina powstała w Kościele, daj nam za jego przyczyną, abyśmy Mękę Twoją ustawicznie rozmyślając na ziemi, zasłużyli dostąpić jej skutków w niebie.
 $Qui vivis
 
-[Commemoratio] (rubrica Divino aut rubrica tridentina aut rubrica Reduced)
+[Commemoratio] (rubrica divino aut rubrica tridentina aut rubrica Reduced)
 !Wspominamy Św. Witalisa Męczennika
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Polski/Sancti/04-28.txt
+++ b/web/www/horas/Polski/Sancti/04-28.txt
@@ -9,7 +9,7 @@ vide C5;mtv
 Panie Jezu Chryste, któryś dla głoszenia tajemnicy Krzyża, św. Pawła szczególną obdarzył miłością i sprawił, że przez niego nowa rodzina powstała w Kościele, daj nam za jego przyczyną, abyśmy Mękę Twoją ustawicznie rozmyślając na ziemi, zasłużyli dostąpić jej skutków w niebie.
 $Qui vivis
 
-[Commemoratio] (rubrica Divino aut rubrica Tridentina aut rubrica Reduced)
+[Commemoratio] (rubrica Divino aut rubrica tridentina aut rubrica Reduced)
 !Wspominamy Św. Witalisa Męczennika
 @Commune/C2:Oratio proper
 $Oremus

--- a/web/www/horas/Polski/Sancti/06-13.txt
+++ b/web/www/horas/Polski/Sancti/06-13.txt
@@ -11,5 +11,5 @@ Antoni
 Niechaj się weseli Kościół Twój, Panie, z dorocznej uroczystości błogosławionego Antoniego, Wyznawcy Twego i Doktora, a Ty spraw, by mu nie zbywało na pomocy nadprzyrodzonej oraz by mógł zasłużyć na zakosztowanie radości wiecznych.
 $Per Dominum
 
-[Oratio] (rubrica Divino aut rubrica tridentina)
+[Oratio] (rubrica divino aut rubrica tridentina)
 @:OratioText:s/ i Doktora//

--- a/web/www/horas/Polski/Sancti/07-23.txt
+++ b/web/www/horas/Polski/Sancti/07-23.txt
@@ -41,7 +41,7 @@ Bo nie pokarm i napój daje się nam w nagrodę i jako wyraz uznania, lecz łąc
 [Lectio9]
 Nawracajmy się zatem i strzeżmy, by dla kogoś z nas wywyższenie nie stało się zgubne. Jeśli bowiem Apostołowie rywalizują, to nie zasługują na usprawiedliwienie, ale na ostrzeżenie. Jeśli i Piotr musiał się nawracać, choć pierwszy za Panem podążył, to kto może powiedzieć, że nie potrzebuje nawrócenia? Strzeż się zatem zaszczytów, strzeż się świata. Temu bowiem nakazano umacniać swych braci, który rzekł: wszystko pozostawiliśmy i poszliśmy za Tobą.
 
-[Commemoratio 3] (rubrica Divino aut rubrica Tridentina)
+[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
 !Wspominamy Św. Krystynę
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/Polski/Sancti/07-23.txt
+++ b/web/www/horas/Polski/Sancti/07-23.txt
@@ -41,7 +41,7 @@ Bo nie pokarm i napój daje się nam w nagrodę i jako wyraz uznania, lecz łąc
 [Lectio9]
 Nawracajmy się zatem i strzeżmy, by dla kogoś z nas wywyższenie nie stało się zgubne. Jeśli bowiem Apostołowie rywalizują, to nie zasługują na usprawiedliwienie, ale na ostrzeżenie. Jeśli i Piotr musiał się nawracać, choć pierwszy za Panem podążył, to kto może powiedzieć, że nie potrzebuje nawrócenia? Strzeż się zatem zaszczytów, strzeż się świata. Temu bowiem nakazano umacniać swych braci, który rzekł: wszystko pozostawiliśmy i poszliśmy za Tobą.
 
-[Commemoratio 3] (rubrica Divino aut rubrica tridentina)
+[Commemoratio 3] (rubrica divino aut rubrica tridentina)
 !Wspominamy Św. Krystynę
 @Commune/C6:Oratio proper
 $Oremus

--- a/web/www/horas/Polski/Sancti/11-01.txt
+++ b/web/www/horas/Polski/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica Tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
 
 [Ant Vespera]
 Potem widziałem rzeszę wielką. * której nie mógł nikt przeliczyć, ze wszech narodów i pokoleń, stojących przed stolicą.

--- a/web/www/horas/Polski/Sancti/11-01.txt
+++ b/web/www/horas/Polski/Sancti/11-01.txt
@@ -7,7 +7,7 @@ Psalmi Dominica
 Antiphonas horas
 Psalm5 Vespera=116
 Psalm5 Vespera3=115
-(rubrica tridentina aut rubrica Divino) Vesperae Defunctorum
+(rubrica tridentina aut rubrica divino) Vesperae Defunctorum
 
 [Ant Vespera]
 Potem widziałem rzeszę wielką. * której nie mógł nikt przeliczyć, ze wszech narodów i pokoleń, stojących przed stolicą.

--- a/web/www/horas/Polski/Sancti/12-11.txt
+++ b/web/www/horas/Polski/Sancti/12-11.txt
@@ -32,5 +32,5 @@ $Per Dominum
 [Lectio9]
 @Commune/C4:Lectio91
 
-[Ant 3] (rubrica Divino aut rubrica 1955 aut rubrica 1960)
+[Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Polski/Tempora/105-1.txt
+++ b/web/www/horas/Polski/Tempora/105-1.txt
@@ -10,7 +10,7 @@ Z Drugiej Księgi Machabejskiej
 
 [Lectio1]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio1Tridentina
 
 [Lectio2Tridentina]
@@ -25,7 +25,7 @@ Z Drugiej Księgi Machabejskiej
 
 [Lectio2]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio2Tridentina
 
 [Lectio3Tridentina]
@@ -37,5 +37,5 @@ Z Drugiej Księgi Machabejskiej
 
 [Lectio3]
 @Tempora/105-0
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-1:Lectio3Tridentina

--- a/web/www/horas/Polski/Tempora/105-2.txt
+++ b/web/www/horas/Polski/Tempora/105-2.txt
@@ -8,7 +8,7 @@ Z Drugiej Księgi Machabejskiej
 
 [Lectio1]
 @Tempora/105-1:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio1Tridentina
 
 [Lectio2Tridentina]
@@ -22,7 +22,7 @@ Z Drugiej Księgi Machabejskiej
 
 [Lectio2]
 @Tempora/105-1:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio2Tridentina
 
 [Lectio3Tridentina]
@@ -38,5 +38,5 @@ Z Drugiej Księgi Machabejskiej
 
 [Lectio3]
 @Tempora/105-1:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-2:Lectio3Tridentina

--- a/web/www/horas/Polski/Tempora/105-3.txt
+++ b/web/www/horas/Polski/Tempora/105-3.txt
@@ -9,7 +9,7 @@ Z Drugiej Księgi Machabejskiej
 
 [Lectio1]
 @Tempora/105-2:Lectio1Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio1Tridentina
 
 [Lectio2Tridentina]
@@ -21,7 +21,7 @@ Z Drugiej Księgi Machabejskiej
 
 [Lectio2]
 @Tempora/105-2:Lectio2Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio2Tridentina
 
 [Lectio3Tridentina]
@@ -37,5 +37,5 @@ Z Drugiej Księgi Machabejskiej
 
 [Lectio3]
 @Tempora/105-2:Lectio3Tridentina
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @Tempora/105-3:Lectio3Tridentina

--- a/web/www/horas/Polski/Tempora/Nat1-0.txt
+++ b/web/www/horas/Polski/Tempora/Nat1-0.txt
@@ -35,7 +35,7 @@ Homilia świętego Ambrożego, Biskupa
 !Księga 2. na rozdz. 2. Ewangelii wg św. Łukasza, pod koniec
 Jak widzisz, z urodzenia Pana obfity zdrój łask spłynął na wszystkich, a dar proroctwa był odmówiony niewierzącym, a nie sprawiedliwym. Oto i Symeon prorokuje, iż Pan Jezus Chrystus przybył na upadek i powstanie wielu, aby rozróżnił, na co zasłużyli niegodziwi, a na co sprawiedliwi, i że odpowiednio do naszych czynów Sędzia prawdziwy i sprawiedliwy wyznacza kary lub nagrody.
 
-[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
+[Lectio Prima] (rubrica divino aut rubrica tridentina aut rubrica monastica)
 !Ga 4:7
 v. A tak już nie jesteś niewolnikiem, ale synem: a jeźli synem, tedyć i dziedzicem przez Boga.
 

--- a/web/www/horas/Polski/Tempora/Nat1-0.txt
+++ b/web/www/horas/Polski/Tempora/Nat1-0.txt
@@ -35,7 +35,7 @@ Homilia świętego Ambrożego, Biskupa
 !Księga 2. na rozdz. 2. Ewangelii wg św. Łukasza, pod koniec
 Jak widzisz, z urodzenia Pana obfity zdrój łask spłynął na wszystkich, a dar proroctwa był odmówiony niewierzącym, a nie sprawiedliwym. Oto i Symeon prorokuje, iż Pan Jezus Chrystus przybył na upadek i powstanie wielu, aby rozróżnił, na co zasłużyli niegodziwi, a na co sprawiedliwi, i że odpowiednio do naszych czynów Sędzia prawdziwy i sprawiedliwy wyznacza kary lub nagrody.
 
-[Lectio Prima] (rubrica Divino aut rubrica Tridentina aut rubrica Monastica)
+[Lectio Prima] (rubrica Divino aut rubrica tridentina aut rubrica monastica)
 !Ga 4:7
 v. A tak już nie jesteś niewolnikiem, ale synem: a jeźli synem, tedyć i dziedzicem przez Boga.
 

--- a/web/www/horas/Polski/Tempora/Pasc5-4.txt
+++ b/web/www/horas/Polski/Tempora/Pasc5-4.txt
@@ -278,7 +278,7 @@ R. Przygotował stolicę swoję, alleluja.
 
 [Versum 3]
 @:Versum 1
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @:Versum 2
 
 [Ant 3]
@@ -289,7 +289,7 @@ Ant. O	Królu chwały, * Panie zastępów, który dziś jako Zwycięzca na najwy
 _
 V. Wstąpił Bóg przy okrzykach radosnych, alleluja.
 R. I Pan przy odgłosie trąb, alleluja.
-(sed rubrica Tridentina loco haec versus dicitur)
+(sed rubrica tridentina loco haec versus dicitur)
 V. Pan na niebie, alleluja.
 R. Przygotował stolicę swoję, alleluja.
 _

--- a/web/www/horas/Polski/Tempora/Pasc6-0.txt
+++ b/web/www/horas/Polski/Tempora/Pasc6-0.txt
@@ -67,7 +67,7 @@ R. Lecz gdy przyjdzie, nauczy was wszelkiéj prawdy, alleluja.
 
 [Versum 2]
 @Tempora/Pasc5-4:Versum 1
-(sed rubrica Tridentina)
+(sed rubrica tridentina)
 @:Versum 1
 
 [Commemoratio 2]

--- a/web/www/horas/Polski/Tempora/Quad4-0.txt
+++ b/web/www/horas/Polski/Tempora/Quad4-0.txt
@@ -109,7 +109,7 @@ R. Nakłońcie wasze uszy na słowa ust moich.
 Tedy przyjmiesz * ofiarę sprawiedliwości, jeśli odwrócisz oblicze twoje od grzechów moich.
 Lepiéj jest * mieć nadzieję w Panu, niźli mieć nadzieję w książętach.
 Broniła mię * prawica twoja, Panie.
-(sed rubrica Trident)
+(sed rubrica tridentina)
 Niech nas błogosławi Bóg, * Bóg nasz, niech nas błogosławi Bóg.
 Możnyś jest, Panie, * ratuj nas z ręki mocniejszych: wyzwól nas Boże nasz.
 Królowie ziemscy, * i wszyscy narodowie, chwalcie Pana.

--- a/web/www/horas/Polski/Tempora/Quad6-4.txt
+++ b/web/www/horas/Polski/Tempora/Quad6-4.txt
@@ -175,7 +175,7 @@ $Pater noster
 !nieco głośniej
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 
 [Oratio Matutinum]
@@ -219,7 +219,7 @@ $Pater noster
 !nieco głośniej
 _
 &psalm(50)
-(sed rubrica 1955 aut rubrica 1960 aut rubrica Monastic omittitur)
+(sed rubrica 1955 aut rubrica 1960 aut rubrica monastica omittitur)
 @:Oratio Matutinum
 (sed rubrica 1955 aut rubrica 1960 loco horum versuum dicuntur)
 v. Nawiedź, prosimy Cię, Panie, ten dom, i oddal od niego wszelkie wrogie zasadzki: niech mieszkają w nim Twoi święci Aniołowie i strzegą nas w pokoju; a błogosławieństwo Twoje niech zawsze będzie z nami.

--- a/web/www/horas/Polski/Tempora/Quad6-6.txt
+++ b/web/www/horas/Polski/Tempora/Quad6-6.txt
@@ -164,7 +164,7 @@ R. Gdy Pan był już pogrzebion, zapieczętowano grób, przywaliwszy kamień do 
 [Ant Laudes]
 O śmierci, * śmiercią twą będę, o piekło, śmiertelnym ciosem twym będę.
 Będą go opłakiwali * jako jednorodzonego: albowiem Pan niewinny jest zabity.
-(sed rubrica Tridentina) Będą go opłakiwali * jako jednorodzonego: albowiem Pan niewinny jest zabity.;;42
+(sed rubrica tridentina) Będą go opłakiwali * jako jednorodzonego: albowiem Pan niewinny jest zabity.;;42
 Uważajcie * wszystkie narody i patrzcie na boleść moją.
 Od wrót piekielnych * wybaw Panie duszę moją.;;222
 O wy wszyscy * którzy idziecie przez drogę, obaczcie a przypatrzcie się, jeśli jest boleść jako boleść moja.


### PR DESCRIPTION
This commit enforces the following rules for (rubrica xxx) declarations:

- version is always lowercase
- version is always latin (so `monastica` not `monastic`).

Per my testing (not tried to run regressions, just browsing) this seems to have no effect on the output, it's just about enforcing consistency.  However, regression should be run against this PR.

It would be handy if regression testing where possible locally.  I've had a glance at `regress/scripts/travis.sh` and it would likely not be very hard. But I haven't the time to dig into it now.  If anyone who knows how it works wants to add a `local_regress.sh` that would be great!