### PR TITLE
Change English to match Latin in Communion Antiphon (correction of #2…

### DIFF
--- a/web/www/missa/English/Commune/C6b.txt
+++ b/web/www/missa/English/Commune/C6b.txt
@@ -60,7 +60,7 @@ $Per Dominum
 
 [Communio]
 !Matt 25:4; 25:6
-v. The five wise virgins took oil in their vessels with the lamps. And at midnight there was a cry made: Behold the bridegroom cometh, go ye forth to meet him.
+v. The five wise virgins took oil in their vessels with the lamps. And at midnight there was a cry made: Behold the bridegroom cometh, go ye forth to meet Christ the Lord.
 
 [Postcommunio]
 Thou hast fed thy servants, O Lord, with the holy gifts; comfort us ever we pray, by her intercession whose festival we celebrate.

--- a/web/www/missa/English/Commune/C6bp.txt
+++ b/web/www/missa/English/Commune/C6bp.txt
@@ -43,7 +43,7 @@ $Per Dominum
 
 [Communio]
 !Matt 25:4; 25:6
-v.  The five wise virgins took oil in their vessels with the lamps. And at midnight there was a cry made: Behold the bridegroom cometh, go ye forth to meet him. Alleluia.
+v.  The five wise virgins took oil in their vessels with the lamps. And at midnight there was a cry made: Behold the bridegroom cometh, go ye forth to meet Christ the Lord. Alleluia.
 
 [Postcommunio]
 Thou hast fed thy servants, O Lord, with the holy gifts; comfort us ever we pray, by her intercession whose festival we celebrate.


### PR DESCRIPTION
…590)

This looks better now.  I think the problem was the cntl/linefeeds.

Sorry for the confusion.