### PR TITLE
Begin Moving to Github Actions for Container Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: build
+
+# Test of CI build of docker image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  schedule:
+    # Build the image regularly (each Friday) to get new security fixes, even if pushes don't occur
+    - cron: '13 23 * * 5'
+
+jobs:
+  build:
+    name: Build, scan & push
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t divinumofficiumweb/divinumofficium:citest .
+      
+      # TODO : get push working
+      #- name: Docker login
+      #  run: >-
+      #    echo "${{ secrets.GHCR_TOKEN }}"
+      #    | docker login -u "${{ github.actor }}" --password-stdin ghcr.io
+          
+      #- name: Push image to GitHub
+      #  run: |
+      #    docker push ghcr.io/wonderfall/nextcloud
+      #    docker push ghcr.io/wonderfall/nextcloud:$(grep -oP '(?<=NEXTCLOUD_VERSION=).*' Dockerfile | head -c6)
+      #    docker push ghcr.io/wonderfall/nextcloud:$(grep -oP '(?<=NEXTCLOUD_VERSION=).*' Dockerfile | head -c2)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-# Test of CI build of docker image
+# Test of CI build of docker image - this isn't yet doing anything, but it's a start.
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
After dockerhub locked down auto builds, I had to move the build-and-push script to one of my personal servers in the short term.

This is the first step of the long term solution, which will build container images in github actions, which will eliminate the dependency on my personal infrastructure, but also provide improved visibility in github to things like failed builds, and providing nice feedback in Pull Requests if a code change is going to fail the build.

Currently this CI file builds the container image on pushes to `master`, but does not push that container image anywhere. A future CI PR will iterate further on this.