### PR TITLE
Fix BMV Sabbato on Friday before Vigils

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -426,7 +426,7 @@ sub getrank {
   if ($transfer{$cday} !~ /tempora/i && transfered($cday)) { $cday = 'none'; }
   if (exists($transfer{$cday}) && $transfer{$cday} !~ /Tempora/i) { $cday = $transfer{$cday}; }
   if ($tname =~ /Nat/ && $cday =~ /Nat/) { $cday = 'none'; }
-
+  $BMVSabbato = ($cday =~ /v/) ? 0 : 1;
   if ($hora =~ /(vespera|completorium)/i) {
     if ($cday !~ /(tempora|DU)/i) { $cday = "$kalendar{$cday}"; }
     my $cdayd = $cday;
@@ -438,7 +438,6 @@ sub getrank {
     $dirge = 1 if (($dirgeline && $cdayd && $dirgeline =~ /$cdayd/) || $saint{Rule} =~ /Vesperae Defunctorum/);
     if ($cday && $cday !~ /tempora/i) { $cday = "$sanctiname/$cday"; }
     if ($testmode =~ /^Season$/i) { $cday = 'none'; }
-
     if (-e "$datafolder/Latin/$cday.txt") {
       $cname = "$cday.txt";
       %csaint = updaterank(setupstring($datafolder, 'Latin', "$cname"));
@@ -601,6 +600,8 @@ sub getrank {
       && $crank !~ /;;[2-7]/
       && $srank !~ /;;[5-7]/
       && $crank !~ /Vigil/i
+      && $csaint{Rank} !~ /vigilia/i
+      && $BMVSabbato == 1
       && $version !~ /(1960|Newcal)/
       && $saint{Rule} !~ /BMV/i
       && $trank !~ /;;[2-7]/
@@ -767,6 +768,7 @@ sub getrank {
           && $dayofweek == 5
           && $trank[2] < 2
           && $srank[0] !~ /Vigil/i
+	  && $BMVSabbato == 1
           && $csaint{Rank} !~ /Vigil/i
           && $version !~ /(1960|Newcal)/)
       )

--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -438,6 +438,7 @@ sub getrank {
     $dirge = 1 if (($dirgeline && $cdayd && $dirgeline =~ /$cdayd/) || $saint{Rule} =~ /Vesperae Defunctorum/);
     if ($cday && $cday !~ /tempora/i) { $cday = "$sanctiname/$cday"; }
     if ($testmode =~ /^Season$/i) { $cday = 'none'; }
+    
     if (-e "$datafolder/Latin/$cday.txt") {
       $cname = "$cday.txt";
       %csaint = updaterank(setupstring($datafolder, 'Latin', "$cname"));
@@ -599,8 +600,6 @@ sub getrank {
       && $dayofweek == 5
       && $crank !~ /;;[2-7]/
       && $srank !~ /;;[5-7]/
-      && $crank !~ /Vigil/i
-      && $csaint{Rank} !~ /vigilia/i
       && $BMVSabbato == 1
       && $version !~ /(1960|Newcal)/
       && $saint{Rule} !~ /BMV/i
@@ -769,7 +768,6 @@ sub getrank {
           && $trank[2] < 2
           && $srank[0] !~ /Vigil/i
 	  && $BMVSabbato == 1
-          && $csaint{Rank} !~ /Vigil/i
           && $version !~ /(1960|Newcal)/)
       )
       )


### PR DESCRIPTION
(#2653)

The previous version did use the variable $csaint{Rank} to test whether concurring day was a vigil. It did not work, because the variable was redefined somewhere in between. I used the already defined $BMVSabbato variable which seems have had no purpose before.