### PR TITLE
Fix Rubrics style of French Credo

### DIFF
--- a/web/www/missa/French/Ordo/Ordo.txt
+++ b/web/www/missa/French/Ordo/Ordo.txt
@@ -164,8 +164,7 @@ R. Et avec votre esprit.
 
 # Profession de Foi
 !*&Credo
-!Le prêtre revient au centre de l’autel et entonne le Credo. Si la
-messe est lue, les fidèles peuvent le réciter avec le célébrant. Quand il dit Deum, il incline la tête, ce qu’il fait pareillement lorsqu’il dit Iesum Christum, et simul adoratur. Mais à ces mots Et incarnátus est, il met le genou en terre jusqu’à ce qu’il soit dit Et homo factus est. À la fin, à Et vitam ventúri sǽculi, il se signe du signe de la croix, du front à la poitrine.
+!Le prêtre revient au centre de l’autel et entonne le Credo. Si la messe est lue, les fidèles peuvent le réciter avec le célébrant. Quand il dit Deum, il incline la tête, ce qu’il fait pareillement lorsqu’il dit Iesum Christum, et simul adoratur. Mais à ces mots Et incarnátus est, il met le genou en terre jusqu’à ce qu’il soit dit Et homo factus est. À la fin, à Et vitam ventúri sǽculi, il se signe du signe de la croix, du front à la poitrine.
 v. Je crois en un seul Dieu. Le Père tout-puissant, Créateur du ciel et de la terre, de l’univers visible et invisible.
 Et en un seul Seigneur Jésus-Christ, le Fils unique de Dieu, né du Père avant tous les siècles. Dieu de Dieu, Lumière de Lumière, vrai Dieu de vrai Dieu. Engendré, non pas créé, consubstantiel au Père, et par qui tout a été fait.
 Pour nous, les hommes, et pour notre salut, il est descendu des cieux.


### PR DESCRIPTION
The rubrics style was broken after "Si la" as a newline was inserted probably by mistake.