### PR TITLE
Introit: adducántur → adducéntur

### DIFF
--- a/web/www/missa/Latin/Commune/C10b.txt
+++ b/web/www/missa/Latin/Commune/C10b.txt
@@ -13,7 +13,7 @@ eam: próximæ ejus adducéntur tibi in lætítia et exsultatióne.
 !Ps 44:2
 Eructávit cor meum verbum bonum: dico ego ópera mea Regi.
 &Gloria
-v. Vultum tuum deprecabúntur omnes dívites plebis: adducántur Regi Vírgines post~
+v. Vultum tuum deprecabúntur omnes dívites plebis: adducéntur Regi Vírgines post~
 eam: próximæ ejus adducéntur tibi in lætítia et exsultatióne.
 
 [Oratio]


### PR DESCRIPTION
Was _adducéntur_ initially, but in repetition of verse in introit, it changed to _adducántur_; it should be _adducéntur_.