### PR TITLE
Resolving naming conflicts in Commune (#2752)

### DIFF
--- a/web/cgi-bin/horas/specials.pl
+++ b/web/cgi-bin/horas/specials.pl
@@ -1775,11 +1775,13 @@ sub tryoldhymn {
   }
 }
 
+#*** checkmtv(version, winner)
+# after "Cum Nostra Hac Aetate", the verse has always changed
 sub checkmtv {
   my $version = shift;
   my $winner = shift;
   my %winner = %$winner;
-  ($version =~ /1955|1960/ || $winner{Rule} =~ /\;mtv/i) && $winner{Rule} =~ /C[45]/ ? '1' : '';
+  ($version =~ /1955|1960|Monastic/ || $winner{Rule} =~ /\;mtv/i) && $winner{Rule} =~ /C[45]/ ? '1' : '';
 }
 
 sub hymnusmajor {

--- a/web/www/horas/Deutsch/Commune/C2.txt
+++ b/web/www/horas/Deutsch/Commune/C2.txt
@@ -185,7 +185,7 @@ R. Der die Drohungen der Richter nicht gefürchtet und den Glanz irdischer Würd
 &Gloria
 R. Der die Drohungen der Richter nicht gefürchtet und den Glanz irdischer Würde nicht gesucht hat, sondern zum himmlischen Reiche gelangt ist.
 
-[Responsory8NonEffusorum]
+[Responsory8 non Effusorum]
 R. O Herr, du hast ihn begnadet mit köstlichstem Segen,
 * Hast aufs Haupt ihm gesetzt eine Krone von edelsten Steinen.
 V. Er hatte gefleht um Erhaltung seines Lebens; du aber gewährst ihm ein dauerndes Dasein auf immer und ewig.
@@ -304,104 +304,104 @@ R. Entwickelt sich wie auf dem Libanon die Zeder.
 [Ant 3]
 Wer mein Jünger sein will, * muss sich selbst verleugnen und sein Kreuz auf sich nehmen, und dann mag er mir folgen.
 
-[Lectio41]
-De Epístola sancti Cypriáni Epíscopi et Mártyris ad Mártyres et Confessóres.
+[Lectio4 in 2 loco]
+De Epístola sancti Cypriáni Epíscopi et Mártyris ad Mártyres et Confessóres
 !Lib. 2. Epist. 6.
 Quibus ego vos láudibus prǽdicem, fortíssimi Mártyres? robur péctoris vestri, et perseverántiam fídei, quo præcónio vocis exórnem? Tolerástis usque ad consummatiónem glóriæ duríssimam quæstiónem: nec cessístis supplíciis, sed vobis pótius supplícia cessérunt. Finem dolóribus, quem torménta non dabant, corónæ dedérunt. Laniéna grávior ad hoc diu perseverávit, non ut stantem fidem deíceret, sed ut hómines Dei ad Deum velócius mítteret.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 R. Lux perpétua lucébit Sanctis tuis, Dómine,
-* Et ætérnitas témporum, allelúia, allelúia.
+* Et ætérnitas témporum, allelúja, allelúja.
 V. Lætítia sempitérna erit super cápita eórum: gáudium et exsultatiónem obtinébunt.
-R. Et ætérnitas témporum, allelúia, allelúia.
+R. Et ætérnitas témporum, allelúja, allelúja.
 
-[Lectio51]
+[Lectio5 in 2 loco]
 Vidit admírans præséntium multitúdo cæléste certamen, certámen Dei, certámen spiritále, prǽlium Christi: stetísse servos ejus voce líbera, mente incorrúpta, virtúte divína, telis quidem sæculáribus nudos, sed armis fídei ardéntis armátos. Stetérunt torti torquéntibus fortióres: et pulsántes ac laniántes úngulas, pulsáta ac laniáta membra vicérunt. Inexpugnábilem fidem superáre non pótuit sǽviens diu plaga repetíta, quamvis rupta compáge víscerum torqueréntur in servis Dei jam non membra, sed vúlnera. Fluébat sanguis, qui incéndium persecutiónis exstíngueret, qui flammas et ignes gehénnæ glorióso cruóre sopíret.
 
-[Responsory51]
-R. In servis suis, allelúia,
-* Consolábitur Deus, allelúia.
+[Responsory5 in 2 loco]
+R. In servis suis, allelúja,
+* Consolábitur Deus, allelúja.
 V. Judicábit Dóminus pópulum suum, et in servis suis.
-R. Consolábitur Deus, allelúia.
+R. Consolábitur Deus, allelúja.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 O quale illud fuit spectáculum Dómino, quam sublíme, quam magnum, quam Dei óculis sacraménto ac devotióne mílitis ejus accéptum: sicut scriptum est in Psalmis, Spíritu Sancto loquénte ad nos páriter et monénte: Pretiésa est in conspéctu Dómini mors justórum ejus. Pretiósa mors hæc est, quæ emit immortalitátem prétio sui sánguinis; quæ accépit corónam de consummatióne virtútis. Quam lætus illic Christus fuit, quam libens in tálibus servis suis et pugnávit, et vicit protéctor fídei, dans credéntibus tantum, quantum se credit cápere qui sumit! Certámini suo ádfuit, præliatóres atque assertóres sui nóminis eréxit, corroborávit, animávit. Et qui pro nobis mortem semel vicit, semper vincit in nobis.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Fíliæ Jerúsalem, veníte et vidéte Mártyres cum corónis, quibus coronávit eos Dóminus
-* In die solemnitátis et lætítiæ, allelúia.
+* In die solemnitátis et lætítiæ, allelúja.
 V. Quóniam confortávit seras portárum tuárum, benedíxit fílios tuos in te.
-R. In die solemnitátis et lætítiæ, allelúia.
+R. In die solemnitátis et lætítiæ, allelúja.
 &Gloria
-R. In die solemnitátis et lætítiæ, allelúia.
+R. In die solemnitátis et lætítiæ, allelúja.
 
-[Lectio71]
-Léctio sancti Evangélii secúndum Joánnem.
+[Lectio7 in 2 loco]
+Léctio sancti Evangélii secúndum Joánnem
 !Joannes 15:5-10
 In illo témpore: Dixit Jesus discípulis suis: Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum: quia sine me nihil potéstis fácere. Et réliqua.
 _
-Homilía sancti Augustíni Epíscopi.
-!Tract. 81. in Joan., sub med.
+Homilía sancti Augustíni Epíscopi
+!Tract. 81 in Joan., sub med.
 Ne quisquam putáret saltem parvum áliquem fructum posse a semetípso pálmitem ferre: cum dixísset, Hic fert fructum multum; non ait, Quia sine me parum potéstis fácere; sed, Nihil potéstis fácere. Sive ergo parum, sive multum, sine illo fíeri non potest, sine quo nihil fíeri potest: quia etsi parum attúlerit palmes, eum purgat agrícola, ut plus áfferat; tamen nisi in vite mánserit, et víxerit de rádice, quantúmlibet fructum a semetípso non potest ferre. Quamvis autem Christus vitis non esset, nisi homo esset: tamen istam grátiam palmítibus non præbéret, nisi étiam Deus esset.
 
-[Responsory71]
+[Responsory7 in 2 loco]
 R. Ego sum vitis vera, et vos pálmites:
-* Qui manet in me, et ego in eo, hic fert fructum multum, allelúia, allelúia.
+* Qui manet in me, et ego in eo, hic fert fructum multum, allelúja, allelúja.
 V. Sicut diléxit me Pater, et ego diléxi vos.
-R. Qui manet in me, et ego in eo, hic fert fructum multum, allelúia, allelúia.
+R. Qui manet in me, et ego in eo, hic fert fructum multum, allelúja, allelúja.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Verum quia ita sine ista grátia non potest vivi, ut et mors in potestáte sit líberi arbítrii: Si quis in me, inquit, non mánserit; mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet. Ligna ítaque vitis tanto sunt contemptibilióra si in vite non mánserint, quanto gloriosióra si mánserint. Dénique sicut de his étiam per Ezechiélem prophétam Dóminus dicit, præcísa nullis agricolárum úsibus prosunt, nullis fabrílibus opéribus deputántur. Unum de duóbus pálmiti congruit, aut vitis, aut ignis: si in vite non est, in igne erit: ut ergo in igne non sit, in vite sit.
 
-[Responsory81]
-R. Cándidi facti sunt Nazarǽi ejus, allelúia: splendórem Deo dedérunt, allelúia: 
-* Et sicut lac coaguláti sunt, allelúia, allelúia.
+[Responsory8 in 2 loco]
+R. Cándidi facti sunt Nazarǽi ejus, allelúja: splendórem Deo dedérunt, allelúja: 
+* Et sicut lac coaguláti sunt, allelúja, allelúja.
 V. Candidióres nive, nitidióres lacte, rubicundióres ébore antíquo, sapphíro pulchrióres.
-R. Et sicut lac coaguláti sunt, allelúia, allelúia.
+R. Et sicut lac coaguláti sunt, allelúja, allelúja.
 &Gloria
-R. Et sicut lac coaguláti sunt, allelúia, allelúia.
+R. Et sicut lac coaguláti sunt, allelúja, allelúja.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Si manséritis in me, inquit, et verba mea in vobis mánserint: quodcúmque voluéritis petétis, et fiet vobis. Manéndo quippe in Christo, quid velle possunt, nisi quod cónvenit Christo? Quid velle possunt manéndo in Salvatóre, nisi quod non est aliénum a salúte? Áliud quippe vólumus quia sumus in Christo: et áliud vólumus quia sumus adhuc in hoc sǽculo. De mansióne namque hujus sǽculi nobis aliquándo subrépit, ut hoc petámus, quod nobis non expedíre nescímus. Sed absit ut fiat nobis, si manémus in Christo, qui non facit quando pétimus, nisi quod éxpedit nobis.
 &teDeum
 
-[Lectio72]
-Léctio sancti Evangélii secúndum Matthǽum.
+[Lectio7 in 3 loco]
+Léctio sancti Evangélii secúndum Matthǽum
 !Matt 10:26-32
 In illo témpore: Dixit Jesus discípulis suis: Nihil est opértum, quod non revelábitur; et occúltum, quod non sciétur. Et réliqua.
 _
-Homilía sancti Hilárii Epíscopi.
-!Comment. in Matthaeum, can. 10. post medium.
+Homilía sancti Hilárii Epíscopi
+!Comment. in Matthaeum, can. 10 post medium
 Dóminus diem judícii osténdit, quæ abstrúsam voluntátis nostræ consciéntiam prodet: et ea quæ nunc occúlta existimántur, luce cognitiónis públicæ déteget. Ígitur non minas, non consília, non potestátes insectántium monet esse metuéndas: quia dies judícii nulla hæc fuísse, atque inánia revelábit. Et quod dico vobis in ténebris, dícite in lúmine: et quod in aure audítis, prædicáte super tecta. Non légimus Dóminum sólitum fuísse nóctibus sermocinári, et doctrínam in ténebris tradidísse: sed quia omnis sermo ejus carnálibus ténebræ sunt, et verbum ejus infidélibus nox est.
 
-[Responsory72]
+[Responsory7 in 3 loco]
 R. Coróna áurea super caput ejus:
 * Expréssa signo sanctitátis, glória honóris, et opus fortitúdinis.
 V. Quóniam prævenísti eum in benedictiónibus dulcédinis, posuísti in cápite ejus corónam de lápide pretióso.
 R. Expréssa signo sanctitátis, glória honóris, et opus fortitúdinis.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Ítaque id quod a se dictum est, cum libertáte fídei et confessiónis vult esse loquéndum. Idcírco quæ in ténebris dicta sunt prædicári jussit in lúmine: ut quæ secréto áurium commíssa sunt, super tecta, id est, excélso loquéntium præcónio audiántur. Constánter enim Dei ingerénda cognítio est, et profúndum doctrínæ evangélicæ secrétum in lúmine prædicatiónis apostólicæ revelándum: non timéntes eos, quibus cum sit licéntia in córpora, tamen in ánimam jus nullum est: sed timéntes pótius Deum, cui perdéndæ in gehénna et ánimæ et córporis sit potéstas.
 
-[Responsory82]
+[Responsory8 in 3 loco]
 @Commune/C2:Responsory8
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Nolíte timére eos qui occídunt corpus. Nullus ígitur córporum nostrórum casus est pertimescéndus, neque ullus interiméndæ carnis admitténdus est dolor: quando pro natúræ suæ atque oríginis conditióne resolúta, in substántiam spirituális ánimæ refundátur. Et quia doctrínis tálibus confirmátos opórtet líberam confiténdi Dei habére constántiam, étiam conditiónem, qua tenerémur, adjécit: negatúrum se eum Patri in cælis, qui se homínibus in terra negásset: eum porro qui conféssus coram homínibus se fuísset, a se in cælis confiténdum: qualésque nos nóminis sui testes homínibus fuissémus, tali nos apud Deum Patrem testimónio ejus usúros.
 &teDeum
 
-[Lectio73]
-Léctio sancti Evangélii secúndum Matthǽum.
+[Lectio7 in 4 loco]
+Léctio sancti Evangélii secúndum Matthǽum
 !Matt 16:24-27
 In illo témpore: Dixit Jesus discípulis suis: Si quis vult post me veníre, ábneget semetípsum, et tollat crucem suam, et sequátur me. Et réliqua.
 _
-Homilía sancti Gregórii Papæ.
-!Homilia 32. in Evang.
+Homilía sancti Gregórii Papæ
+!Homilia 32 in Evang.
 Quia Dóminus ac Redémptor noster novus homo venit in mundum, nova præcépta dedit mundo. Vitæ étenim nostræ véteri in vítiis enutrítæ contrarietátem oppósuit novitátis suæ. Quid enim vetus, quid carnális homo nóverat, nisi sua retinére, aliéna rápere, si posset; concupíscere, si non posset? Sed cæléstis médicus síngulis quibúsque vítiis obviántia ádhibet medicaménta. Nam sicut arte medicínæ cálida frígidis, frígida cálidis curántur: ita Dóminus noster contrária oppósuit medicaménta peccátis, ut lúbricis continéntiam, tenácibus largitátem, iracúndis mansuetúdinem, elátis præcíperet humilitátem.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Certe cum se sequéntibus nova mandáta propóneret, dixit: Nisi quis renuntiáverit ómnibus quæ póssidet, non potest meus esse discípulus. Ac si apérte dicat: Qui per vitam véterem aliéna concupíscitis, per novæ conversatiónis stúdium et vestra largímini. Quid vero in hac lectióne dicat, audiámus: Qui vult post me veníre, ábneget semetípsum. Ibi dícitur, ut abnegémus nostra: hic dícitur, ut abnegémus nos. Et fortásse laboriósum non est hómini relínquere sua; sed valde laboriósum est relínquere semetípsum. Minus quippe est abnegáre quod habet; valde autem multum est abnegáre quod est.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Ad se autem nobis veniéntibus Dóminus præcépit, ut renuntiémus nostris: quia quicúmque ad fídei agónem vénimus, luctámen contra malígnos spíritus súmimus. Nihil autem malígni spíritus in hoc mundo próprium póssident: nudi ergo cum nudis luctári debémus. Nam si vestítus quisque cum nudo luctátur, cítius ad terram dejícitur, quia habet unde teneátur. Quid enim sunt terréna ómnia, nisi quædam córporis induménta? Qui ergo contra diábolum ad certámen próperat, vestiménta abjíciat, ne succúmbat.
 &teDeum

--- a/web/www/horas/Deutsch/Commune/C2p.txt
+++ b/web/www/horas/Deutsch/Commune/C2p.txt
@@ -65,13 +65,13 @@ Dignum et cóngruum est, fratres, ut post lætítiam Paschæ, quam in Ecclésia 
 Annuntiémus inquam sanctis Martýribus Domínicæ Paschæ grátiam: ut dum sepultúræ illíus prædicámus reseráta claustra, et horum sepúlcra reseréntur: dum corpus illíus mortuum dícimus tepéntibus venis súbito viguísse, horum quoque membra jam frígida immortalitátis calóre foveántur. Éadem enim rátio Mártyres súscitat, quæ et Dóminum suscitávit. Nam sicut viam passiónis ejus expérti sunt, ita experiéntur et vitæ; scriptum est enim in Psalmo: Notas mihi fecísti vias vitæ. Hoc útique in resurrectióne ex persóna dícitur Salvatóris: ut qui, dum post mortem ab ínferis redit ad súperos, incípiat notam habére viam vitæ, quæ ante habebátur ignóta.
 
 [Responsory5]
-@Commune/C2:Responsory51
+@Commune/C2:Responsory5 in 2 loco
 
 [Lectio6]
 Ignóta enim erat ante Christi advéntum via vitæ, quæ nullíus adhuc resurgéntis fúerat temeráta vestígio. At ubi Dóminus resurréxit, nota facta, solo attríta est plurimórum: de quibus sanctus Evangelísta ait: Multórum córpora Sanctórum surrexérunt cum eo, et introiérunt in sanctam civitátem. Unde cum Dóminus in resurrectióne sua díxerit, Notas mihi fecísti vias vitæ: póssumus et nos jam dícere Dómino: Notas fecísti nobis vias vitæ. Ipse enim nobis notas fecit vias vitæ, qui nobis sémitam manifestávit ad vitam. Notas enim mihi fecit vias vitæ, cum me dócuit fidem, misericórdiam, justítiam, castitátem: his enim pervenítur itinéribus ad salútem.
 
 [Responsory6]
-@Commune/C2:Responsory61
+@Commune/C2:Responsory6 in 2 loco
 
 [Lectio7]
 Léctio sancti Evangélii secúndum Joánnem.
@@ -134,16 +134,16 @@ Ego sum, inquit, vitis vera: et Pater meus agrícola est. Numquid unum sunt agr�
 [Ant 3]
 @Commune/C1p
 
-[Lectio41]
+[Lectio4 in 2 loco]
 De Epístola sancti Cypriáni Epíscopi et Mártyris ad Mártyres et Confessóres.
 !Lib. 2. Epist. 6.
 Quibus ego vos láudibus pr?dicem, fortíssimi Mártyres? robur péctoris vestri, et perseverántiam fídei, quo præcónio vocis exórnem? Tolerástis usque ad consummatiónem glóriæ duríssimam quæstiónem: nec cessístis supplíciis, sed vobis pótius supplícia cessérunt. Finem dolóribus, quem torménta non dabant, corónæ dedérunt. Laniéna grávior ad hoc diu perseverávit, non ut stantem fidem dejíceret, sed ut hómines Dei ad Deum velócius mítteret.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 @Commune/C1p:Responsory4
 
-[Lectio51]
+[Lectio5 in 2 loco]
 Vidit admírans præséntium multitúdo cæléste certámen, certámen Dei, certámen spiritále, pr?lium Christi: stetísse servos ejus voce líbera, mente incorrúpta, virtúte divína, telis quidem sæculáribus nudos, sed armis fídei ardéntis armátos. Stetérunt torti torquéntibus fortióres: et pulsántes ac laniántes úngulas, pulsáta ac laniáta membra vicérunt. Inexpugnábilem fidem superáre non pótuit s?viens diu plaga repetíta, quamvis rupta compáge víscerum torqueréntur in servis Dei jam non membra, sed vúlnera. Fluébat sanguis, qui incéndium persecutiónis exstíngueret, qui flammas et ignes gehénnæ glorióso cruóre sopíret.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 O quale illud fuit spectáculum Dómino, quam sublíme, quam magnum, quam Dei óculis sacraménto ac devotióne mílitis ejus accéptum: sicut scriptum est in Psalmis, Spíritu Sancto loquénte ad nos páriter et monénte: Pretiósa est in conspéctu Dómini mors justórum ejus. Pretiósa mors hæc est, quæ emit immortalitátem prétio sui sánguinis; quæ accépit corónam de consummatióne virtútis. Quam lætus illic Christus fuit, quam libens in tálibus servis suis et pugnávit, et vicit protéctor fídei, dans credéntibus tantum, quantum se credit cápere qui sumit! Certámini suo ádfuit, præliatóres atque assertóres sui nóminis eréxit, corroborávit, animávit. Et qui pro nobis mortem semel vicit, semper vincit in nobis.

--- a/web/www/horas/Deutsch/Commune/C3.txt
+++ b/web/www/horas/Deutsch/Commune/C3.txt
@@ -335,7 +335,7 @@ R. Es jauchzet laut in seinen Zelten.
 [Ant 3]
 Voll Freude sind im Himmel * die Seelen der Heiligen, die den Spuren Christi gefolgt sind; und da sie für ihn ihr Blut vergossen, deshalb jubeln sie mit Christus ohne Ende.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Léctio sancti Evangélii secúndum Lucam.
 !Luc 6:17-23
 In illo témpore: Descéndens Jesus de monte, stetit in loco campéstri, et turba discipulórum ejus, et multitúdo copiósa plebis ab omni Judǽa, et Jerúsalem, et marítima, et Tyri, et Sidónis. Et réliqua.
@@ -344,10 +344,10 @@ Homilía sancti Ambrósii Epíscopi
 !Lib. 5. in Lucam. Cap. 6., post init.
 Advérte ómnia diligénter, quómodo et cum Apóstolis ascéndat et descéndat ad turbas. Quómodo enim turba nisi in húmili Christum vidéret? Non séquitur ad excélsa, non ascéndit ad sublímia. Dénique ubi descéndit, invénit infírmos: in excélsis enim infírmi esse non possunt. Hinc étiam Matthǽus docet in inferióribus débiles esse sanátos. Prius enim unusquísque sanándus est, ut paulátim virtútibus procedéntibus ascéndere possit ad montem; et ídeo quemque in inferióribus sanat, hoc est, a libídine révocat, injúriam cæcitátis avértit. Ad vúlnera nostra descéndit: ut usu quodam et cópia suæ natúræ, compartícipes nos fáciat esse regni cæléstis.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Beáti páuperes, quia vestrum est regnum Dei. Quátuor tantum beatitúdines sanctus Lucas Domínicas posuit, octo vero sanctus Matthǽus: sed in illis octo istæ quátuor sunt, et in quátuor istis illæ octo. Hic enim quátuor velut virtútes ampléxus est cardináles: ille in illis octo mýsticum númerum reserávit. Pro octáva enim multi inscribúntur Psalmi: et mandátum áccipis octo illis partem dare fortásse benedictiónibus. Sicut enim spei nostræ octáva perféctio est, ita octáva summa virtútum est.
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. Hæc est vera fratérnitas, quæ numquam pótuit violári certámine: qui effúso sánguine secúti sunt Dóminum:
 * Contemnéntes aulam régiam, pervenérunt ad regna cæléstia.
 V. Ecce quam bonum et quam jucúndum habitáre fratres in unum.
@@ -355,6 +355,7 @@ R. Contemnéntes aulam régiam, pervenérunt ad regna cæléstia.
 &Gloria
 R. Contemnéntes aulam régiam, pervenérunt ad regna cæléstia.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Sed prius quæ sunt amplióra videámus. Beáti, inquit, páuperes, quóniam vestrum est regnum Dei. Primam benedictiónem hanc utérque Evangelísta pósuit. Órdine enim prima est, et parens quædam generatióque virtútum: quia qui contempsérit sæculária, ipse merébitur sempitérna: nec potest quisquam méritum regni cæléstis adipísci, qui mundi cupiditáte pressus, emergéndi non habet facultátem.
 &teDeum
+

--- a/web/www/horas/Deutsch/Commune/C4.txt
+++ b/web/www/horas/Deutsch/Commune/C4.txt
@@ -346,33 +346,33 @@ Während er höchster Bischof war, * fürchtete er nichts auf Erden, sondern sch
 V. Seinen Diener führte der Herr auf rechten Wegen.
 R. Und ließ das Gottesreich ihn sehen.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 De libro Ecclesiastici
 !Sir 44:1-5
-1 Laudemus viros gloriosos, et parentes nostros in generatione sua.
-2 Multam gloriam fecit Dominus: magnificentia sua a saeculo.
-3 Dominantes in potestatibus suis, homines magni virtute et prudentia sua praediti, nuntiantes in prophetis dignitatem prophetarum:
-4 et imperantes in praesenti populo, et virtute prudentiae populis sanctissima verba.
-5 In peritia sua requirentes modos musicos, et narrantes carmina scripturarum:
+1 Laudémus viros gloriósos, et paréntes nostros in generatióne sua.
+2 Multam glóriam fecit Dóminus: magnificéntia sua a sǽculo.
+3 Dominántes in potestátibus suis, hómines magni virtúte et prudéntia sua prǽditi, nuntiántes in prophétis dignitátem prophetárum:
+4 et imperántes in præsénti pópulo, et virtúte prudéntiæ pópulis sanctíssima verba:
+5 in perítia sua requiréntes modos músicos, et narrántes cármina Scripturárum:
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 44:6-9
-6 Homines divites in virtute, pulchritudinis studium habentes, pacificantes in domibus suis.
-7 Omnes isti in generationibus gentis suae gloriam adepti sunt, et in diebus suis habentur in laudibus.
-8 Qui de illis nati sunt reliquerunt nomen narrandi laudes eorum.
-9 Et sunt quorum non est memoria: perierunt quasi qui non fuerint: et nati sunt quasi non nati, et filii ipsorum cum ipsis.
+6 Hómines dívites in virtúte, pulchritúdinis stúdium habéntes, pacificántes in dómibus suis.
+7 Omnes isti in generatiónibus gentis suæ glóriam adépti sunt, et in diébus suis habéntur in láudibus.
+8 Qui de illis nati sunt reliquérunt nomen narrándi laudes eórum.
+9 Et sunt quorum non est memória: periérunt quasi qui non fúerint: et nati sunt quasi non nati, et fílii ipsórum cum ipsis.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 44:10-15
-10 Sed illi viri misericordiae sunt, quorum pietates non defuerunt.
-11 Cum semine eorum permanent bona:
-12 hereditas sancta nepotes eorum, et in testamentis stetit semen eorum:
-13 et filii eorum propter illos usque in aeternum manent: semen eorum et gloria eorum non derelinquetur.
-14 Corpora ipsorum in pace sepulta sunt, et nomen eorum vivit in generationem et generationem.
-15 Sapientiam ipsorum narrent populi, et laudem eorum nuntiet Ecclesia.
+10 Sed illi viri misericórdiæ sunt, quorum pietátes non defuérunt.
+11 Cum sémine eórum pérmanent bona:
+12 hæréditas sancta nepótes eórum, et in testaméntis stetit semen eórum:
+13 et fílii eórum propter illos usque in ætérnum manent: semen eórum et glória eórum non derelinquétur.
+14 Córpora ipsórum in pace sepúlta sunt, et nomen eórum vivit in generatiónem et generatiónem.
+15 Sapiéntiam ipsórum narrent pópuli, et laudem eórum núntiet ecclésia.
 
-[Lectio71]
-Léctio sancti Evangélii secúndum Matthæum
+[Lectio7 in 2 loco]
+Léctio sancti Evangélii secúndum Matthǽum
 !Matt 16:13-19
 In illo témpore: Venit Jesus in partes Cæsaréæ Philíppi, et interrogábat discípulos suos, dicens: Quem dicunt hómines esse Fílium hóminis? Et réliqua.
 _
@@ -380,37 +380,34 @@ Homilía sancti Leónis Papæ
 !Sermo 2 in anniversario assumpt. suæ ante medium
 Cum, sicut evangélica lectióne reserátum est, interrogásset Dóminus discípulos, quem ipsum (multis divérsa opinántibus) créderent; respondissétque beátus Petrus, dicens: Tu es Christus Fílius Dei vivi; Dóminus ait: Beátus es, Simon Bar-Jona, quia caro et sanguis non revelávit tibi, sed Pater meus, qui in cælis est: et ego dico tibi, quia tu es Petrus, et super hanc petram ædificábo Ecclésiam meam, et portæ ínferi non prævalébunt advérsus eam. Et tibi dabo claves regni cælórum: et quodcúmque ligáveris super terram, erit ligátum et in cælis: et quodcúmque sólveris super terram, erit solútum et in cælis. Manet ergo disposítio veritátis, et beátus Petrus, in accépta fortitúdine petræ persevérans, suscépta Ecclésiæ gubernácula non relíquit.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 In univérsa namque Ecclésia, Tu es Christus Fílius Dei vivi, quotídie Petrus dicit; et omnis lingua, quæ confitétur Dóminum, magistério hujus vocis imbúitur. Hæc fides diábolum vincit et captivórum ejus víncula dissólvit. Hæc érutos mundo, ínserit cælo, et portæ ínferi advérsus eam prævalére non possunt. Tanta enim divínitus soliditáte muníta est, ut eam neque hærética umquam corrúmpere právitas, nec pagána potúerit superáre perfídia. His ítaque modis, dilectíssimi, rationábile obséquio celebrétur hodiérna festívitas: ut in persóna humilitátis meæ ille intelligátur, ille honorétur, in quo et ómnium pastórum sollicitúdo, cum commendatárum sibi óvium custódia persevérat, et cujus étiam dígnitas in indígno heréde non déficit.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Cum ergo cohortatiónes nostras áuribus vestræ sanctitátis adhibémus, ipsum vobis, cujus vice fúngimur, loqui crédite: quia et illíus vos afféctu monémus, et non áliud vobis, quam quod dócuit, prædicámus; obsecrántes, ut succíncti lumbos mentis vestræ, castam et sóbriam vitam in Dei timóre ducátis. Coróna mea, sicut Apóstolus ait, et gáudium vos estis, si fides vestra, quæ ab inítio Evangélii in univérso mundo prædicáta est, in dilectióne et sanctitáte permánserit. Nam licet omnem Ecclésiam, quæ in toto est orbe terrárum, cunctis opórteat florére virtútibus; vos tamen præcípue inter céteros pópulos decet méritis pietátis excéllere, quos in ipsa apostólicæ petræ arce fundátos, et Dóminus noster Jesus Christus cum ómnibus redémit, et beátus Apóstolus Petrus præ ómnibus erudívit.
 &teDeum
 
-[Lectio73]
-Lectio sancti Evangelii secundum Matthaeum.
+[Lectio7 in 4 loco]
+Léctio sancti Evangélii secúndum Matthǽum
 !Matt 19:27-29
-In illo tempore: Dixit Petrus ad Jesum: Ecce nos reliquimus omnia, et secuti sumus te: quid ergo erit nobis? Et reliqua. De Homilia venerabilis Bedae Presbyteri.
-!In Natali S. Benedicti.
+In illo tempore: Dixit Petrus ad Jesum: Ecce nos reliquimus omnia, et secuti sumus te: quid ergo erit nobis? Et reliqua. 
+_
+De Homilía venerábilis Bedæ Presbýteri
+!In Natali S. Benedicti
 Duo sunt ordines electorum in judicio futuri: unus judicantium cum Domino, de quibus hoc loco memorat, qui reliquerunt omnia, et secuti sunt illum: alius judicandorum a Domino, qui non quidem omnia sua pariter reliquerunt, sed de his tamen quae habebant, quotidianas dare eleemosynas Christi pauperibus curabant: unde et audituri sunt in judicio: Venite benedicti Patris mei, possidete praeparatum vobis regnum a constitutione mundi. Esurivi enim, et dedistis mihi manducare: sitivi, et dedistis mihi bibere.
 
-[Responsory73]
+[Responsory7 in 4 loco]
 R. Iste est qui ante Deum magnas virtutes operatus est, et de omni corde suo laudavit Dominum:
 * Ipse intercedat pro peccatis omnium populorum.
 V. Ecce homo sine querela, verus Dei cultor, abstinens se ab omni opere malo, et permanens in innocentia sua.
 R. Ipse intercedat pro peccatis omnium populorum.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Sed et reproborum duos ibi futuros ordines Domino narrante comperimus: unum eorum, qui fidei christianae mysteriis initiati, opera fidei exercere contemnunt, quibus in judicio testatur: Discedite a me maledicti in ignem aeternum, qui praeparatus est diabolo, et angelis ejus: esurivi enim, et non dedistis mihi manducare. Alterum eorum, qui fidem et mysteria Christi vel numquam suscepere, vel susceptam per apostasiam deseruere: de quibus dicit: Qui autem non credit, jam judicatus est: quia non credit in nomine unigeniti Filii Dei.
 
-[Responsory83]
-R. Sint lumbi vestri praecincti, et lucernae ardentes in manibus vestris:
-* Et vos similes hominibus exspectantibus dominum suum, quando revertatur a nuptiis.
-V. Vigilate ergo, quia nescitis qua hora Dominus vester venturus sit.
-R. Et vos similes hominibus exspectantibus dominum suum, quando revertatur a nuptiis.
-&Gloria
-R. Et vos similes hominibus exspectantibus dominum suum, quando revertatur a nuptiis.
+[Responsory8 in 4 loco]
+@:Responsory8
 
-[Lectio93]
-Verum his cum timore et pavore debito paulisper commemoratis, ad laetissima potius Domini et Salvatoris nostri promissa convertamus auditum. Videamus quae tantae gratia pietatis: non aeternae tantummodo vitae praemia suis sequacibus, sed et praesentis munera pollicetur eximia. Et omnis, inquit, qui reliquerit domum, vel fratres, aut sorores, aut patrem, aut matrem, aut uxorem, aut filios, aut agros, propter nomen meum, centuplum accipiet, et vitam aeternam possidebit. Qui enim terrenis affectibus sive possessionibus pro Christi discipulatu renuntiaverit, quo plus in ejus amorem profecerit, eo plures inveniet, qui se interno suscipere affectu, et suis gaudeant sustentare substantiis.
+[Lectio9 in 4 loco]
+Verum his cum timore et pavore debito paulisper commemoratis, ad laetissima potius Domini et Salvatoris nostri promissa convertamus auditum. Videamus quae tantae gratia pietatis: non aeternae tantummodo vitae praemia suis sequacibus, sed et praesentis munera pollicetur eximia. Et omnis, inquit, qui reliquerit domum, vel fratres, aut sorores, aut patrem, aut matrem, aut uxorem, aut filios, aut agros, propter nomen meum, centuplum accipiet, et vitam aeternam possidebit. Qui enim terrenis affectibus sive possessionibus pro Christi discipulatu renuntiaverit, quo plus in ejus amórem profecerit, eo plures inveniet, qui se interno suscipere affectu, et suis gaudeant sustentare substantiis.
 &teDeum

--- a/web/www/horas/Deutsch/Commune/C4a.txt
+++ b/web/www/horas/Deutsch/Commune/C4a.txt
@@ -260,7 +260,7 @@ R. Und ließ das Gottesreich ihn sehen.
 [Ant 3]
 O du allseits guter Lehrer, * du Leuchte in der heiligen Kirche, heiliger N., Liebhaber des Gesetzes Gottes, flehe für uns bei dem göttlichen Sohne.
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Lesung aus dem heiligen Evangelium nach Matthäus.
 !Mt 5,13-19
 In jener Zeit sagte Jesus zu seinen Jüngern: Ihr seid das Salz der Erde. Wenn nun das Salz schal geworden ist, womit soll es gesalzen werden? Und so weiter.
@@ -269,9 +269,9 @@ Auslegung vom heiligen Johannes Chrysostomus.
 !Hom. 15 zu Mt.
 Attendite quid dixerit, Vos estis sal terrae: per quod ostendit quam necessario ista praecipiat. Non enim de vestra, inquit, tantummodo vita, sed de universo orbe vobis ratio reddenda est. Non ad duas quippe urbes, aut decem, aut viginti, neque ad unam gentem vos mitto, sicut mittebam prophetas: sed ad omnem terram prorsus ac mare, totumque mundum, et hunc variis criminibus oppressum.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Dicendo enim, Vos estis sal terrae, ostendit universam hominum infatuatam esse naturam, et peccatorum vi corruptam: et idcirco illas ab eis virtutes requirit, quae maxime ad multorum salutem procurandam necessariae sunt atque utiles. Nam qui mansuetus est ac modestus, et misericors et justus, non intra se tantummodo haec recte facta concludit, verum in aliorum quoque utilitatem praeclaros hos faciet effluere fontes. Igitur qui corde mundo est atque pacificus, et persecutionem pro veritate patitur, nihilominus in commune commodum vitam instituit.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Ne igitur putetis, inquit, ad levia vos ducendos esse certamina, neque exiguarum rerum vobis ineundam esse rationem. Vos estis sal terrae. Quid igitur? Ipsine putrefacta medicati sunt? Nequaquam: neque enim fieri potest, ut ea quae jam corrupta sunt, salis perfricatione reparentur. Non ergo hoc fecerunt, sed ante renovata, sibique tradita, atque ab illa jam putredine liberata, aspergebant sale, et in ea novitate conservabant, quam a Domino susceperant. Liberare quippe a putredine peccatorum, Christi virtutis est: ut autem ad illa iterum non revertantur, Apostolorum curae est ac laboris.
 &teDeum

--- a/web/www/horas/Deutsch/Commune/C5.txt
+++ b/web/www/horas/Deutsch/Commune/C5.txt
@@ -286,7 +286,7 @@ R. Und ließ das Gottesreich ihn sehen.
 [Ant 3]
 Dieser Mann hat verachtet die Welt * und irdische Freuden, hat triumphiert über sie und Reichtümer im Himmel niedergelegt in Worten und Taten.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 De libro Sapiéntiæ
 !Sap 4:7-14
 7 Justus si morte præoccupatus fúerit, in refrigerio erit;
@@ -298,7 +298,7 @@ De libro Sapiéntiæ
 13 Consummátus in brevi, explévit témpora multa;
 14 placita enim erat Deo ánima illíus: propter hoc properavit edúcere illum de médio iniquitátum. 
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sap 4:14-19
 14 Pópuli autem vidéntes, et non intelligentes, nec ponentes in præcordiis tália,
 15 quóniam grátia Dei et misericórdia est in sanctos ejus, et respéctus in eléctos illíus.
@@ -307,7 +307,7 @@ De libro Sapiéntiæ
 18 Vidébunt, et contemnent eum; illos autem Dóminus irridébit.
 19 Et erunt post hæc decidentes sine honóre, et in contumélia inter mórtuos in perpétuum: quóniam disrumpet illos inflatos sine voce, et commovébit illos a fundaméntis, et usque ad suprémum desolabuntur.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sap 4:19-20; 5:1-5
 19 Et erunt geméntes, et memória illórum períbit.
 20 Vénient in cogitatióne peccatórum suórum timidi, et traducent illos ex adverso iniquitátes ipsórum.
@@ -317,7 +317,7 @@ De libro Sapiéntiæ
 4 Nos insensati, vitam illórum æstimabamus insaniam, et finem illórum sine honóre;
 5 ecce quómodo computati sunt inter fílios Dei, et inter sanctos sors illórum est.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Léctio sancti Evangélii secúndum Lucam.
 !Luc 12:32-34
 In illo témpore: Dixit Jesus discípulis suis: Nolíte timére pusíllus grex, quia complácuit Patri vestro dare vobis regnum. Et réliqua.
@@ -326,14 +326,14 @@ Homilía sancti Bedæ Venerábilis Presbyteri.
 !Lib. 4. Cap. 4. in Luc. 12.
 Pusíllum gregem electórum, vel ob comparationem majóris numeri reproborum, vel pótius ob humilitátis devotiónem nóminat: quia vidélicet Ecclésiam suam quantalibet numerositate jam dilatatam, tamen usque ad finem mundi humilitáte vult crescere, et ad promíssum regnum humilitáte perveníre. Ideóque ejus labóres blande consolátus, quam regnum Dei tantum quærere præcipit, eídem regnum a Pátre dandum complacita benignitate promittit.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Vendite quæ possidetis, et date eleemosynam. Nolíte, inquit, timére, ne propter regnum Dei militantibus, hujus vitæ necessaria desint: quin étiam possessa propter eleemosynam vendite. Quod tunc digne fit, quando quis semel pro Dómino suis ómnibus spretis, nihilóminus post hæc labóre mánuum, unde et victum transigere, et eleemosynam dare queat, operátur. Unde gloriatur Apóstolus, dicens: Argéntum, et aurum, aut vestem nullius concupívi: ipsi scitis, quóniam ad ea quæ mihi opus erant, et his qui mecum sunt, ministraverunt manus istæ. Ómnia osténdi vobis, quóniam sic laborántes opórtet suscípere infirmos.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Fácite vobis sacculos qui non veterascunt: eleemósynas vidélicet operando quarum merces in ætérnum maneat. Ubi non hoc præcéptum esse putandum est, ut nil pecúniæ reservetur a sanctis, vel suis scílicet, vel páuperum usibus suggerendæ: cum et ipse Dóminus, cui ministrabant Ángeli, tamen ad informandam Ecclésiam suam loculos habuísse legatur, et a fidélibus oblata conservans, et suórum necessitátibus aliísque indigéntibus tribuens; sed ne Deo propter ista serviatur, et ob inópiæ timórem justítia deseratur.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Léctio sancti Evangélii secúndum Lucam.
 !Luc 19:12-26
 In illo témpore: Dixit Jesus discípulis suis parábolam hanc: Homo quidam nóbilis ábiit in regiónem longinquam, accípere sibi regnum, et revérti. Et réliqua.
@@ -342,9 +342,9 @@ Homilía sancti Ambrósii Epíscopi.
 !Lib. 8. in Lucam.
 Bonus ordo, ut vocaturus Gentes, et Judæos jussurus interfici, qui noluérunt regnáre supra se Christum, hanc præmitteret comparationem, ne dicerétur: Nihil déderat pópulo Judæórum, unde póterat mélior fíeri? ut quid ab eo qui nihil recépit, exigitur? Non mediocris ista est mna, quam supra múlier evangélica quia non invénit, lucérnam accéndit, lúmine quærit admoto, gratulatur inventam.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Dénique ex una decem mnas álius fecit, álius quinque. Fortásse iste moralia habet, quia quinque sunt córporis sensus: ille duplicia, id est, mystica legis, et moralia probitatis. Unde et Matthæus quinque talenta, et duo talenta pósuit: in quinque talentis ut sint moralia, in duóbus utrúmque, mysticum atque morale. Ita quod número inferius, re ubérius.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Et hic póssumus decem mnas decem verba intellígere, id est, legis doctrínam; quinque autem mnas, magisteria disciplínæ. Sed legisperitum in ómnibus volo esse perféctum; non enim in sermóne, sed in virtúte est regnum Dei. Bene autem, quia de Judæis dicit, duo soli multiplicatam pecúniam deferunt, non útique æris, sed dispensatiónis usúris. Ália est enim pecúniæ fnebris, ália doctrínæ cæléstis usúra.
 &teDeum

--- a/web/www/horas/Deutsch/Commune/C6.txt
+++ b/web/www/horas/Deutsch/Commune/C6.txt
@@ -307,7 +307,7 @@ R. So hat Gott dich gesegnet auf ewig.
 [Ant 3]
 @:Ant 1
 
-[Lectio11]
+[Lectio1 in 2 loco]
 De libro Ecclesiastici
 !Sir 51:1-7
 1 Confitebor tibi, Domine Rex, et collaudabo te Deum Salvatorem meum.
@@ -318,7 +318,7 @@ De libro Ecclesiastici
 6 a pressura flammae quae circumdedit me, et in medio ignis non sum aestuata;
 7 de altitudine ventris inferi, et a lingua coinquinata, et a verbo mendacii, a rege iniquo, et a lingua injusta.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 51:8-12
 8 Laudabit usque ad mortem anima mea Dominum,
 9 et vita mea appropinquans erat in inferno deorsum.
@@ -326,7 +326,7 @@ De libro Ecclesiastici
 11 Memorata sum misericordiae tuae Domine, et operationis tuae, quae a saeculo sunt:
 12 quoniam eruis sustinentes te, Domine, et liberas eos de manibus gentium.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 13 Exaltasti super terram habitationem meam, et pro morte defluente deprecata sum.
 14 Invocavi Dominum Patrem Domini mei, ut non derelinquat me in die tribulationis meae, et in tempore superborum, sine adjutorio.

--- a/web/www/horas/Deutsch/Sancti/02-27.txt
+++ b/web/www/horas/Deutsch/Sancti/02-27.txt
@@ -11,13 +11,13 @@ Deus, qui beatum Gabrielem dulcissimae Matris tuae dolores assidue recolere docu
 $Qui vivis
 
 [Lectio1](sed non rubrica 1960)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2](sed non rubrica 1960)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3](sed non rubrica 1960)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Gabrielis, Assisi in Umbria, honesto genere natus, et Franciscus ob seraphici~

--- a/web/www/horas/Deutsch/Sancti/03-04.txt
+++ b/web/www/horas/Deutsch/Sancti/03-04.txt
@@ -32,13 +32,13 @@ ihm gewährten Schutz freuen können.
 $Per Dominum.
 
 [Lectio1](sed non rubrica 1960)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2](sed non rubrica 1960)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3](sed non rubrica 1960)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Kasimir, dessen Vater Kasimir, König von Polen, dessen Mutter die Königin von ~

--- a/web/www/horas/Deutsch/Sancti/03-06.txt
+++ b/web/www/horas/Deutsch/Sancti/03-06.txt
@@ -24,13 +24,13 @@ $Per Dominum
 Wir wollen loben unsern Gott * Am Festtag der heiligen Perpetua und Felizitas.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Lectio4]
 Perpetua und Felizitas wurden in der Verfolgung unter dem Kaiser Severus ~

--- a/web/www/horas/Deutsch/Sancti/12-11.txt
+++ b/web/www/horas/Deutsch/Sancti/12-11.txt
@@ -36,13 +36,13 @@ Eine Wiedererstattungsstrafe ordnete er an für diejenigen, die einen anderen in
 Damasus stammte aus Spanien. Er war ein hervorragender Mann und wohlbewandert in der Heiligen Schrift. Er berief das erste Konzil von Konstantinopel und vernichtete dadurch die Irrlehren des Eunomius und Macedonius. Wie schon vor ihm Papst Liberius verurteilte er die Kirchenversammlung von Rimini, wo nach dem Zeugnis des heiligen Hieronymus die Verwerfung des nizänischen Glaubensbekenntnisses verkündet worden war, vor allem durch die Umtriebe des Valens und Ursacius. Er baute auch zwei Kirchen: jene des heiligen Laurentius beim Theater des Pompejus und eine andere an der Straße nach Ardea bei den Katakomben. Auch führte er für alle Kirchen den wechselweisen Psalmengesang bei Tag und bei Nacht ein, wie es schon an den meisten Orten üblich war, und ließ am Schluß jedes Psalmes das „Ehre sei dem Vater und dem Sohne und dem Heiligen Geiste“ beten. In seinem Auftrag schuf der heilige Hieronymus einen verbesserten Text des Neuen Testamentes nach dem griechischen Urtext. Er entdeckte auch zahlreiche Martyrergräber und versah ihre Gedenkstätten mit Inschriften. Nach einem Leben reich an Tugend, Gelehrsamkeit und Klugheit entschlief er im Herrn im Alter von fast achtzig Jahren unter der Regierung Theodosius' des Älteren.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Deutsch/Sancti/12-16.txt
+++ b/web/www/horas/Deutsch/Sancti/12-16.txt
@@ -18,16 +18,16 @@ Es wurde nun im folgenden Jahre nach Mailand eine Versammlung einberufen; und do
 Wie groß damals die Grausamkeit der Arianer und die freche Verletzung des Anstandes gegen ihn war, zeigen die ernsten von Kraft und Frömmigkeit und Ergebung gegen Gott vollen Briefe, die er aus Szythopolis an die Geistlichkeit von Vercellä und an das Volk und an andere in der Nachbarschaft schrieb; aus diesen geht auch klar hervor, dass er weder durch deren Drohungen und unmenschliche Grausamkeit jemals vom Rechten abgebracht, noch durch die schlangenartige schmeichelhafte Schlauheit zur Gemeinschaft mit ihnen hinüber gezogen werden konnte. Von dort nach Kappadozien, und zuletzt wegen seiner Standhaftigkeit nach der Thebais im oberen Ägypten überführt, ertrug er die Härten der Verbannung bis zum Tode des Konstantius; nach diesem wollte er trotz der Erlaubnis zur Rückkehr zu seiner Herde nicht früher zurückkehren, bevor er sich zur Gutmachung der dem Glauben zugefügten Schäden nach Alexandrien zur Versammlung begab, und nachher nach Art eines tüchtigen Arztes die Gegenden im Osten durchwanderte, die Glaubensschwachen durch Unterricht in der kirchlichen Lehre zur vollständigen Kraft zurückbrachte. Nachdem er von da zu gleich heilsamer Arbeit nach Illyrien abgelenkt und schließlich in Italien gelandet war, da tauschte Italien bei seiner Rückkehr die Trauerkleider um. Und nachdem er hier die von Fehlern gereinigten Erklärungen zu allen Psalmen von Origenes und auch die von Eusebius von Cäsarea herausgegeben, die er aus dem Griechischen ins Lateinische übersetzte, ging er schließlich, durch so viele hervorragende Leistungen berühmt, unter Valentinian und Valens in Vercellä, zu der durch so viel Leiden verdienten Krone der unverwelklichen Herrlichkeit ein.
 
 [Lectio7]
-@Commune/C2:Lectio73
+@Commune/C2:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C2:Lectio83
+@Commune/C2:Lectio8 in 4 loco
 
 [Responsory8]
-@Commune/C2:Responsory8NonEffusorum
+@Commune/C2:Responsory8 non Effusorum
 
 [Lectio9]
-@Commune/C2:Lectio93
+@Commune/C2:Lectio9 in 4 loco
 
 [Lectio94]
 Eusebius stammte aus Sardinien. Er übte in Rom das Lektorenamt aus, später wurde er Bischof von Vercelli. Mannhaft kämpfte er gegen den Arianismus, und sein unbesiegbarer Glaube war für Papst Liberius Trost und Stütze. Wegen seines Bekennermutes für den katholischen Glauben wurde er von Kaiser Konstantin nach Skythopolis verbannt, wo er Hunger, Durst und Misshandlungen zu erleiden hatte. Dann wurde er nach Kappadozien gebracht und duldete dort die Leiden des Exils bis zum Tode Konstantins. Als er darauf in seine Kirche zurückkehren durfte, legte ganz Italien die Trauerkleider ab. Daheim gab er dann die verbesserten Psalmenerklärungen des Origenes und die Werke des Eusebius von Cäsarea heraus, die er aus dem Griechischen ins Lateinische übersetzt hatte. Unter Valentinian und Valens kehrte er heim zum Herrn, um die unverwelkliche Krone der Herrlichkeit zu empfangen, die er durch so viele Leiden verdient hatte.

--- a/web/www/horas/Deutsch/Sancti/12-31.txt
+++ b/web/www/horas/Deutsch/Sancti/12-31.txt
@@ -58,13 +58,13 @@ Darum hat auf Veranlassung Silvesters der fromme Kaiser, bevor er den Christen d
 Derselbe hat nach der Überlieferung allen, die die Weihen erhalten hatten, die Zeit vorgeschrieben, in der sie die einzelnen Weihen in der Kirche ausüben sollten, ehe sie zu einer höheren Stufe hinaufstiegen; hat verordnet, dass kein Weltlicher einem Geistlichen Gewalt antun, dass kein Geistlicher vor einem weltlichen Gericht Anwalt sein dürfe. Unter Beibehaltung der Namen Sabbat und Tag des Herrn, hat er die übrigen Tage der Woche als Ferien unterschieden und ihnen, wie man schon vorher angefangen hatte, sie zu nennen, diesen Namen beigelegt. Dadurch sollte angedeutet werden, dass die Geistlichen täglich die Sorge um irdische Dinge ablegen und allein sich vollständig Gott widmen sollten. Dieser himmlischen Klugheit in der Verwaltung der Kirche entsprach ständig eine hervorragende Heiligkeit des Lebens und Mildtätigkeit gegen die Armen. Auf diesem Gebiete hat er dafür gesorgt, dass mit den reicheren Geistlichen die ärmeren vereinigt würden, dass den Gott geweihten Jungfrauen der notwendige Bedarf zum Leben verschafft wurde. Er lebte als Papst 21 Jahre, 10 Monate und einen Tag. Er ist bestattet im Zömeterium der Priscilla auf der Via Salaria. Er vollzog sieben Weihen im Monat Dezember, bei denen er 42 Priester weihte, 25 Diakone und für die verschiedenen Orte 65 Bischöfe.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Commemoratio 2]
 @Sancti/12-25:Octava

--- a/web/www/horas/English/Commune/C2.txt
+++ b/web/www/horas/English/Commune/C2.txt
@@ -185,7 +185,7 @@ R. Who feared not for the threats of judges, nor sought to be great with the glo
 &Gloria
 R. Who feared not for the threats of judges, nor sought to be great with the glory of this world, but pressed on unto the kingdom of heaven.
 
-[Responsory8NonEffusorum]
+[Responsory8 non Effusorum]
 R. O Lord, thou hast prevented him with blessings of sweetness:
 * Thou hast set on his head a crown of precious stones.
 V. He asked life of thee: and thou hast given him length of days for ever and ever.
@@ -301,30 +301,30 @@ R. He shall grow like a cedar in Lebanon.
 [Ant 3]
 If any man will come after me, * let him deny himself and take up his cross daily and follow me.
 
-[Lectio41]
+[Lectio4 in 2 loco]
 From the Epistle of St Cyprian, Bishop (of Carthage,) and himself Martyr, to the Martyrs and Confessors.
 !Bh. ii. ep. 6
 How shall I praise you, Martyrs so brilliantly victorious ? Can the voice of man's praise add anything to the glory of your manful heart and unshaken faithfulness ? Ye have borne all the hardness of the torment, and have attained unto the excellent height of glory : the tormentors have not worn you out, nay, ye rather have worn out the tormentors. When they that kill the body would give you no rest from suffering, ye suffered until ye gained the crown. And the torment waxing still more dread, waxed not to the casting down of your strong faith, but to the sooner sending God's men home to God.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 R. Eternal light will shine over your saints, O Lord.
 * And the eternity of the times, alleluia, alleluia.
 V. Everlasting joy shall be upon their heads, they shall obtain joy and gladness.
 R. And the eternity of the times, alleluia, alleluia.
 
-[Lectio51]
+[Lectio5 in 2 loco]
 They that stood by looked in wonder at your heavenly conflict, that battle of God, that wrestling of spirit, that combat of Christ. There they saw His servants standing with voice unshaken, with spirit unbroken, strong in God's strength, naked indeed, as to the arms of this world, but clothed on with the armour of God, and equipped with the fiery weapons of faith. There they that were tormented stood braver than they that tormented them. Their bruised and mangled bodies overcame the instruments of cruelty that bruised and mangled them. The bloody stripes, so often laid on, could not beat down the impregnable castle of their faith, even when the covering of their bowels was broken, and that which was tormented in God's servants was no longer limbs but wounds. The blood that ran down, ran down to quench the rage of persecution, noble blood, that can put out the flames and fire of hell.
 
-[Responsory51]
-R. God will comfort, alleluia
-* His servants, alleluia, alleluia.
-V. The Lord will judge His people, and will comfort.
-R. His servants, alleluia, alleluia.
+[Responsory5 in 2 loco]
+R. His servants, alleluia
+* God will comfort, alleluia, alleluia.
+V. The Lord will judge His people and, His servants,
+R. God will comfort, alleluia, alleluia.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 O what a spectacle was that in the eyes of the Lord! O how noble! O how mighty! O how precious in the sight of God were His soldiers' loyalty and faithfulness! Even as it is written in the Psalms, the Holy Ghost therein at once speaking to us and warning us :Precious in the sight of the Lord is the death of His Saints. O what a precious death is his, who maketh purchase of life that can never die, at the price of his own blood, and seizeth on the crown, when courage hath no more left to meet! O how joyful was Christ! How gladly fought He in such servants as these,in these how gladly did He triumph, the Keeper of their faith, and, in the end, to them how gladly did He give that reward which no man knoweth saving he that receiveth it! (Apoc. ii. 17.) He it was, Who was there when they fought, He it was, Who raised them up to be the champions and defenders of His holy Name, He, who gave them the strength, He, Who nerved them. He, That by death hath once conquered for us, liveth now for ever to conquer in us.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Come forth, O ye daughters of Jerusalem, and behold the Martyrs with the crowns wherewith the Lord crowned them;
 * In the day of His feasting, and of His gladness. Alleluia.
 V. For He hath strengthened the bars of thy gates He hath blessed thy children within thee.
@@ -332,7 +332,7 @@ R. In the day of His feasting, and of His gladness. Alleluia.
 &Gloria
 R. In the day of His feasting, and of His gladness. Alleluia.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 From the Holy Gospel according to John
 !John 15:5-10
 At that time, Jesus said unto His disciples: I am the vine, ye are the branches: He that abideth in Me and I in him, the same bringeth forth much fruit: for without Me ye can do nothing. And so on.
@@ -341,16 +341,16 @@ Homily by St Augustine, Bishop (of Hippo.)
 !Tract 81 on John.
 Lest any man should so take these words, "the same bringeth forth much fruit," as to think that the branch can of itself bring forth any fruit whatsoever, the Lord saith further, "without Me ye can do," not only "small things," but "nothing." Whether, then, it be little or much, there can be nothing done, save through Him, without Whom we can do nothing: for if the branch bring forth fruit, albeit but little, it is through Him That purgeth it, that it may bring forth more fruit. And if the branch abide not in the vine, and draw not his sap from the vine's root, it can bring forth no fruit whatsoever of itself. And as Christ would not have been the vine, if He had not been man, He could not have given grace to His branches, if He had not been God.
 
-[Responsory71]
+[Responsory7 in 2 loco]
 R. I am the vine: you the branches.
 * He that abideth in me, and I in him, the same beareth much fruit, alleluia, alleluia.
 V. As the Father hath loved me, I also have loved you.
 R. He that abideth in me, and I in him, the same beareth much fruit, alleluia, alleluia.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Whithout the sap of grace the branch cannot live, and it is within the power of his own free will to choose death rather than life. "If a man abide not in Me," saith the Lord, "he is cast forth as a branch, and is withered, and men gather them, and cast them into the fire, and they are burned." So much the more worthy as is the branch of the vine, if it abide in the vine, so much the baser is it, if it abide not in the vine. Then is it as the vine-branches whereof the Prophet Ezekiel saith (xv. 3, 4) that wood shall not be taken thereof to do any work, and it is meet for no work. The branch hath choice of two things, the vine, or the fire: if it abide not in the vine, it shall be cast into the fire; if, then, it would not be cast into the fire, let it abide in the vine.
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. Her Nazarites are become pure, Alleluia; they reflect the glory of God, Alleluia.
 * They are whiter than milk. Alleluia, Alleluia.
 V. They are purer than snow, they are whiter than milk, they are more ruddy in body than coral, their polishing is of sapphire.
@@ -358,11 +358,11 @@ R. They are whiter than milk. Alleluia, Alleluia.
 &Gloria
 R. They are whiter than milk. Alleluia, Alleluia.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 If ye abide in Me," saith the Lord, "and My words abide in you, ye shall ask what ye will and it shall be done unto you." And what can they will that abide in Christ, save the things of Christ? What can they will that abide in the Saviour save such things as tend to salvation? Since we are in Christ we will one thing, and since we are as yet in this world, we will another. Since we are yet in this world, it befalleth us to seek some things, whereof we know not that they be inexpedient for us. But far be it from us to think that we shall obtain them, if we abide in Christ, for, when we seek from Him, He giveth not, save that which is expedient for us.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 The Lesson is taken from the Holy Gospel according to Matthew
 !Matt 10:26-32
 At that time, Jesus said unto His disciples: There is nothing covered, that shall not be revealed, and hid, that shall not be known. And so on.
@@ -371,13 +371,13 @@ Homily by St Hilary, Bishop (of Poitiers.)
 !Comm. on Matt Chap. 10
 The Lord pointeth to the day of judgment, that day wherein the hidden counsels of the hearts shall be made manifest, and those things which are dark now shall be the subject of all men's knowledge. Therefore He warneth us not to fear threats, nor persuasions, nor the power of such as fight against us since in the day of judgment it will be manifest that all these things are null and void. "And what I tell you in darkness, that speak ye in light; and what ye hear in the ear, that preach ye upon the house-tops." We read not that the Lord's use was to speak by night, or to tell His doctrine in darkness, but that to the carnal all His words were darkness, and to the unbelieving all His discourse night.
 
-[Responsory72]
+[Responsory7 in 3 loco]
 @Commune/C2:Responsory7
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Therefore willeth He that that which He hath spoken, should be freely proclaimed in faith and in confession. Therefore commandeth He that that which He hath told in darkness shall be spoken in light, and that that which He hath made to be heard in the ear should be preached upon the house-tops, that is, with loud and high words. For it behoveth us ever to make God known, and to speak in the light of Apostolic preaching the dark things of the Gospel message, having no fear of them which have power over bodies, but none over our souls, but rather fearing God, Which is able to destroy both body and soul in hell.
 
-[ResponsoryNonEffusorum]
+[Responsory non Effusorum]
 R. O Lord, thou hast prevented him with blessings of sweetness:
 * Thou hast set on his head a crown of precious stones.
 V. He asked life of thee: and thou hast given him length of days for ever and ever.
@@ -385,11 +385,11 @@ R. Thou hast set on his head a crown of precious stones.
 &Gloria
 R. Thou hast set on his head a crown of precious stones.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Fear not them which kill the body. Therefore we need fear nothing which may chance to our bodies, nor sorrow because of the destruction of the flesh, when, according to the laws of our nature and that from whence we are taken, we are unclothed upon, and become a pure spirit. And, since it behoveth us who are rooted in such a doctrine, freely and constantly to confess God, even were it only because of the alternative whereby we are bound, He saith further: "Whosoever shall confess Me before men, him will I confess also before My Father, Which is in heaven. But whosoever shall deny Me before men, him will I also deny before My Father, Which is in heaven." Such witnesses as He hath seen us to have been here to His name before men, such a Witness shall we find Him to be hereafter to our names before His Father Which is in heaven.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 From the Holy Gospel according to Matthew
 !Matt 16:24-27
 At that time, Jesus said unto His disciples: If any man will come after Me, let him deny himself, and take up his cross, and follow Me. And so on.
@@ -398,9 +398,9 @@ Homily by Pope St Gregory (the Great.)
 !32nd on the Gospels
 Our Lord and Redeemer came into the world a new Man, and gave the world new commandments. For against the ways of our old life, brought and bred up in sin, He set the contrast of His new life. It was the old way, according to the knowledge of the carnal man, for every man to keep his own goods, and, if he were able to do it, to take his neighbour's goods also, and, if he were not able to take them, at least to lust after them. But the Heavenly Physician hath medicines wherewith to meet all the diseases of sin. For, even, as by the art of the physician, things hot are healed by things cold, and things cold by things hot, so doth our Lord set against sin holiness, ordaining for the lecherous purity, for the miserly munificence, for the hot-tempered meekness, and for the proud lowliness.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 So the Lord, when He would give a new commandment unto them that came to Him, said Whosoever he be of you that forsaketh not all that he hath, he cannot be My disciple, (Luke xiv. 33,) as though He had said openly: All ye that according to the old man lust after your neighbour's goods, must, according to the zeal of the new man, give away even that which is your own. But let us hear again what He saith in this place If any man will come after Me, let him deny himself. First He saith that we must deny to ourselves that which is our own, and now that we must even deny ourselves to ourselves. Perchance it is not hard for a man to give up that which is his own, but it is exceeding hard to give up himself. To deny himself his possessions is little but to deny himself himself is a denial exceeding great.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Let when we come unto Him the Lord will have us deny to ourselves even ourselves, since as many of us as are entered into the battle of faith, are entered into a contention against evil spirits. But the evil spirits have nothing of their own in this world, and therefore must we wrestle with them, naked with naked. For if he that is clothed, wrestle with him that is naked, he faileth swiftly, because he hath whereon he that is naked taketh hold. And what are all things earthly but things wherewith the soul is clothed upon? whosoever therefore will wrestle with Satan, let him cast away his clothes, lest he be thereby endangered.
 &teDeum

--- a/web/www/horas/English/Commune/C2p.txt
+++ b/web/www/horas/English/Commune/C2p.txt
@@ -37,8 +37,15 @@ Dearly beloved brethren, it is very meet and right that after the gladness of Ea
 [Lectio5]
 I say again, let us tell to the holy Martyrs what the grace of the Lord's Passover is let us tell them that, even as He hath opened the bars of His own grave, even so shall their graves also be opened let us tell them that, even as in His dead Body the Veins grew warm and quick again, even so shall their limbs, that now are cold, flush with the heat of an eternal vigor. That power which brought again our Lord from the dead will bring His Martyrs too. For as they have followed Him in His sufferings, so shall they follow Him also in His newness of life. It is written in the Psalms: "Thou hast shown Me the path of life" (xv. 12.) This is said of the Resurrection in the Person of the Saviour, as of Him Who, after that He died, came up again from hell, and began to have that path of life which was not known before.
 
+[Responsory5]
+@Commune/C2:Responsory5 in 2 loco
+
 [Lectio6]
 Before that Christ came, that path of life was not known, which none had risen from the dead to tread. But, since the Lord hath risen, it is known, and many have trodden it after the Lord. Touching them, the holy Evangelist saying: "Many bodies of the saints which slept arose with Him, and went into the holy city." (Matth. xxvii. 52, 53.) 4 Wherefore, when the Lord riseth again and saith: "Thou hast shown Me the path of life," we also can now say to Him "Thou hast shown us the path of life." For He hath shown us the path of life, Who hath shown us the way that leadeth unto life. He hath shown me the path of life, Who hath taught me faith, mercy, righteousness, and chastity for these are the ways that lead unto life eternal.
+
+[Responsory6]
+@Commune/C2:Responsory6 in 2 loco
+
 
 [Lectio7]
 @Sancti/10-27:Lectio1
@@ -50,18 +57,18 @@ Before that Christ came, that path of life was not known, which none had risen f
 @Sancti/10-27:Lectio3
 &teDeum
 
-[Lectio41]
+[Lectio4 in 2 loco]
 From the Epistle of St Cyprian, Bishop [of Carthage,] and himself Martyr, to the Martyrs and Confessors
 !Bk. ii, ep. 6
 How shall I praise you, Martyrs so brilliantly victorious? Can the voice of man's praise add anything to the glory of your manful heart and unshaken faithfulness? Ye have borne all the hardness of the torment, and have attained unto the excellent height of glory: the tormentors have not worn you out, nay, ye rather have worn out the tormentors. When they that kill the body would give you no rest from suffering, ye suffered until ye gained the crown. And the torment waxing still more dread, waxed not to the casting down of your strong faith, but to the sooner sending God's men home to God.
 
-[Lectio51]
+[Lectio5 in 2 loco]
 They that stood by looked in wonder at your heavenly conflict, that battle of God, that wrestling of spirit, that combat of Christ. There they saw His servants standing with voice unshaken, with spirit unbroken, strong in God's strength, naked indeed, as to the arms of this world, but clothed on with the armor of God, and equipped with the fiery weapons of faith. There they that were tormented stood braver than they that tormented them. Their bruised and mangled bodies overcame the instruments of cruelty that bruised and mangled them. The bloody stripes, so often laid on, could not beat down the impregnable castle of their faith, even when the covering of their bowels was broken, and that which was tormented in God's servants was no longer limbs but wounds. The blood that ran down, ran down to quench the rage of persecution, noble blood, that can put out the flames and fire of hell.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 O what a spectacle was that in the eyes of the Lord! O how noble! O how mighty! O how precious in the sight of God were His soldiers' loyalty and faithfulness! Even as it is written in the Psalms, the Holy Ghost therein at once speaking to us and warning us, "Precious in the sight of the Lord is the death of His Saints." O what a precious death is his, who maketh purchase of life that can never die, at the price of his own blood, and seizeth on the crown, when courage hath no more left to meet! O how joyful was Christ! How gladly fought He in such servants as these,in these how gladly did He triumph, the Keeper of their faith, and, in the end, to them how gladly did He give that reward which no man knoweth saving he that receiveth it! (Apoc. ii. 17.) He it was, Who was there when they fought, He it was, Who raised them up to be the champions and defenders of His holy Name, He, who gave them the strength, He, Who nerved them. He, That by death hath once conquered for us, liveth now for ever to conquer in us.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Come forth, O ye daughters of Jerusalem, and behold the Martyrs with the crowns wherewith the Lord crowned them;
 * In the day of His feasting, and of His gladness, alleluia.
 V. For He hath strengthtened the bars of thy gates He hath blessed thy children within thee.

--- a/web/www/horas/English/Commune/C3.txt
+++ b/web/www/horas/English/Commune/C3.txt
@@ -328,7 +328,7 @@ In the heavenly kingdoms, * there is the dwelling of the Saints there shall be t
 [Ant 3]
 In heaven do rejoice the souls of the Saints * who have followed the steps of Christ; and because they shed their blood for the love of Christ, therefore shall they be made glad for ever with Christ.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 From the Holy Gospel according to Luke
 !Luke 6:17-23
 At that time, Jesus came down from the mountain, and stood in the plain, and the company of His disciples, and a great multitude of people out of all Judea, and Jerusalem, and from the sea coast of Tyre and Sidon. And so on.
@@ -337,10 +337,10 @@ Homily by St Ambrose, Bishop (of Milan.)
 !Bk. v. on Luke vi.
 Mark well how Jesus goeth upward with His disciples, and downward to the multitude. How should the multitude behold Christ, save in a lower place? Such go not up to the things which are above; such attain not to the things which are high. And when Jesus cometh down, He findeth such as are diseased for such like go not up to the heights. Hence also Matthew saith that there were there all sick people, (iv. 23.) Of these every man had need of healing, that, when he had received strength, by and by, he might go up into the mountain. And therefore, being Himself come down, He healeth them in the plain, that is to say, He calleth them away from their lust, and freeth them of their blindness. He cometh down to our wounds, to the end that by a certain use of His nature, and by the abundance thereof, He might make us joint-heirs of the kingdom of heaven.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Blessed be ye poor, for your's is the kingdom of God. Saint Luke giveth us but four of the Lord's Beatitudes, and Saint Matthew eight but in those eight are contained these four, and in these four those eight. For in these four are embraced the cardinal virtues and in those eight they are set forth in a number full of mystery. It is written at the head of more than one of the Psalms that they are for the octave, and thou hast received the commandment Give a portion to seven, and also to eight to seven or eight what? Perchance degrees of blessedness. For as this eighth Beatitude doth name the most glorious realization of our hope the kingdom of Heaven so doth it also name the most royal exertion of our strength blessed are they which are persecuted.
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. Theirs is a brotherhood indeed, whose tie no storms availed to sever together they followed the Lord in the shedding of their blood.
 * Together they set at nought the Royal Palace; together they attained unto the kingdom of heaven.
 V. Behold how good and how pleasant it is for brethren to dwell together in unity.
@@ -348,6 +348,6 @@ R. Together they set at nought the Royal Palace; together they attained unto the
 &Gloria
 R. Together they set at nought the Royal Palace; together they attained unto the kingdom of heaven.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 But let us first consider the fuller of the forms of these Beatitudes. Blessed be ye poor, for your's is the kingdom of God. Both of the Evangelists give to this Beatitude the first place. Yea, surely, for poorness, at least in spirit, is the first in order, the mother, and procreatrix of virtues; since he that setteth no store by temporal things, winneth toward eternal things; neither is any man able to gain the kingdom of heaven, on whom the love of this present world doth so press, that he cannot rid himself thereof.
 &teDeum

--- a/web/www/horas/English/Commune/C4.txt
+++ b/web/www/horas/English/Commune/C4.txt
@@ -322,7 +322,7 @@ The Lord loved him * and beautified him. He clothed him with a robe of glory, an
 [Ant 3 summi Pontificis]
 While he was supreme Pontiff, * he feared not earthly powers, but gloriously went his way to the heavenly kingdom.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Lesson from the book of Ecclesiasticus
 !Sir 44:1-5
 1 Let us now praise men of renown, and our fathers in their generation.
@@ -331,14 +331,14 @@ Lesson from the book of Ecclesiasticus
 4 And ruling over the present people, and by the strength of wisdom instructing the people in most holy words.
 5 Such as by their skill sought out musical tunes, and published canticles of the scriptures.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 44:6-9
 6 Rich men in virtue, studying beautifulness: living at peace in their houses.
 7 All these have gained glory in their generations, and were praised in their days.
 8 They that were born of them have left a name behind them, that their praises might be related:
 9 And there are some, of whom there is no memorial: who are perished, as if they had never been: and are become as if they had never been born, and their children with them.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 44:10-15
 10 But these were men of mercy, whose godly deeds have not failed:
 11 Good things continue with their seed,
@@ -347,7 +347,7 @@ Lesson from the book of Ecclesiasticus
 14 Their bodies are buried in peace, and their name liveth unto generation and generation.
 15 Let the people shew forth their wisdom, and the church declare their praise.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 From the Holy Gospel according to Matthew
 !Matt 16:13-19
 At that time: When Jesus came into the coasts of Caesarea Philippi, he asked his disciples, saying, Whom do men say that I the Son of man am? And so on.
@@ -356,14 +356,14 @@ A Homily by St. Leo the Pope
 !Sermo 2 in anniversario assumpt. suæ ante medium
 When the Lord, as we read in the Gospel, asked his disciples who did men, amid their diverse speculations, believe him the Son of Man to be, blessed Peter answered and said: Thou art the Christ, the Son of the living God. And the Lord answered and said unto him: Blessed art thou, Simon Bar-Jona: for flesh and blood hath not revealed it unto thee, but my Father, which is in heaven: and I say also unto thee: That thou art Peter, and upon this rock I will build my Church, and the gates of hell shall not prevail against it; and I will give unto thee the keys of the kingdom of heaven; and whatsoever thou shalt bind on earth shall be bound in heaven; and whatsoever thou shalt loose on earth shall be loosed in heaven. But the dispensation of truth perdures, and blessed Peter, persevering in the strength of the rock which he hath received, hath not relinquished the position he assumed at the helm of the Church.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 In the universal Church it is as if Peter were still saying every day: Thou art the Christ, the Son of the living God. For every tongue which confesseth the Lord is taught that confession by the teaching of Peter. This is the Faith that overcometh the devil and looseth the bonds of his prisoners. This is the Faith which maketh men free of the world and bringeth them to heaven, and the gates of hell are impotent to prevail against it. This is the rock which God hath fortified with such ramparts of salvation, that the contagion of heresy will never be able to infect it, nor idolatry and unbelief to overcome it. And therefore, dearly beloved, we celebrate today’s festival with reasonable obedience, that in my humble person he may be acknowledged and honoured who doth continue to care for all the shepherds as well as sheep entrusted unto him, and who doth lose none of his dignity even in an unworthy successor.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 When, therefore, we address our exhortations to your godly ears, believe ye that ye are hearing him speak whose office we are discharging. Yea, it is with his love for you that we warn you. And we preach unto you no other thing than that which he taught, entreating you as did he: Gird up the loins of your mind; be sober; be ye holy in all manner of living; pass the time of your sojourning here in the fear of God. My disciples, dearly beloved, ye are to me as the disciples of the Apostle Paul were to him, namely: My crown and joy; if so be that your faith, abide, still in all lowliness and holiness, like unto the first times of the Gospel. For although the whole Church, which is in all the world, should indeed abound in all the virtues, it becometh especially you among all others to excel in acts of piety, founded as ye be on the very citadel of the Apostolic Rock ye who have not only been redeemed with the rest of men by our Lord Jesus Christ, but who have been instructed by the blessed Apostle Peter far beyond all others.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 The Lesson is taken from the Holy Gospel according to Matthew
 !Matt 19:27-29
 At that time: Peter said unto Jesus: Behold, we have forsaken all, and followed Thee: what shall we have therefore? And so on.
@@ -372,12 +372,12 @@ Homily by the Venerable Bede, Priest (at Jarrow and Doctor of the Church).
 !For St Benedict’s Birthday.
 In the judgment to come, the elect will be in two classes. One class are they who have forsaken all, and followed the Lord: and these shall judge along with Him. The other class are they who have not equally forsaken all that they had, but who have been careful daily to give alms of their goods to the poor of Christ: these shall be the subjects of judgment, and these are they who shall then hear these words: “Come, ye blessed of My Father, inherit the kingdom prepared for you from the foundation of the world: for I was an hungered, and ye gave Me meat: I was thirsty, and ye gave Me drink.” (Matth. xxv. 34, 35.)
 
-[Responsory73]
+[Responsory7 in 4 loco]
 @Commune/C5:Responsory7
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Of the reprobate also we gather, from the words of the Lord, that there will be two classes. One class are they who, being made partakers in the mystery of Christian faith, have neglected to show their faith by their works: these are they to whom it will be said at the judgment: “Depart from Me, ye cursed, into everlasting fire, prepared for the devil and his angels: for I was an-hungered, and ye gave Me no meat.” The other class are they who either have never received the faith and mysteries of Christ, or who, having received, have apostatised, and abandoned it: and touching these it is said: “But he that believeth not is condemned already, because he hath not believed in the name of the only-begotten Son of God.” (John iii. 18.)
 
-[Lectio93]
+[Lectio9 in 4 loco]
 And now that we have touched for a moment, with fear and just dread, upon these things, let us rather turn our hearing to the right joyful promises of our Lord and Saviour. Let us look what His so great, beautiful, and fatherly love will give to such as follow Him; not the reward of life everlasting only, but gifts exceeding precious in this life also. “Every one,” saith He, that hath forsaken houses, or brethren, or sisters, or father, or mother, or wife, or children, or lands, for My Name’s sake, shall receive an hundredfold, and shall inherit everlasting life.” For every one that shall forsake earthly affections and goods, to go and be Christ’s disciple, the further he goeth on in Christ’s love, the more shall he find who will rejoice to give him a place in their hearts, and to minister to him of their substance.
 &teDeum

--- a/web/www/horas/English/Commune/C4a.txt
+++ b/web/www/horas/English/Commune/C4a.txt
@@ -67,7 +67,7 @@ $Per Dominum
 Hear, O Lord, we beseech thee, the prayers which we offer thee on this the solemn feast-day of thy blessed Confessor and bishop N., and, for the sake of him who so nobly served thee, forgive us our trespasses.
 $Per Dominum.
 
-[Lectio72]
+[Lectio7 in 3 loco]
 From the Holy Gospel according to Matthew
 !Matt 5:13-19
 At that time: Jesus said unto His disciples: Ye are the salt of the earth. But if the salt have lost his savour, wherewith shall it be salted? And so on.
@@ -76,9 +76,9 @@ Homily by St John Chrysostom, Patriarch (of Constantinople.)
 !15/A on Matth.
 Consider how that the Lord saith: "Ye are the salt of the earth," by the which figure He showeth what a necessary of life is the Gospel. By this figure, He hath us to know that they unto whom He spake have an account to render, not of their own life only, but for the whole world. Not unto two cities, saith the Lord, nor unto ten, nor unto twenty, nor unto one people, as I sent the Prophets, send I you. But I send you unto every land and sea, even unto the whole world, lying groaning, as it is, under the burden of diverse sins.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 These words, "Ye are the salt of the earth," show unto us the whole nature of man as savourless and stinking with the strong corruption of sin. And therefore demandeth He of His Apostles such qualities as are most needful and useful to the furthering the salvation of many. He that is gentle and lowly, tender and just, shutteth not up all these good things in his own heart, but openeth these bright fountains that they may gush forth for the use of his neighbour. He whose heart is pure, and who seeketh peace, suffering persecution for the truth's sake, doth still lead a life for the good of the commonwealth.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Think not, saith the Lord, that the struggle is easy whereunto ye shall be led, neither shall your reckoning be of light matters. Ye are the salt of the earth. Have ye then salted that which is corrupted? Nay, for it is impossible that that which is once corrupted can be made sound again by the rubbing it with salt. This it is not asked of them to do. But their work is to sprinkle with salt, and to keep fresh thereafter, such things as the Lord hath given over into their charge, and which He Himself hath made new, and freed from all taint, before giving them. To make sound after the corruption of sin, is the work of Christ's power alone; to preserve from falling away again, is the duty and the toil commanded to the Apostles.
 &teDeum

--- a/web/www/horas/English/Commune/C5.txt
+++ b/web/www/horas/English/Commune/C5.txt
@@ -237,7 +237,7 @@ R. And showed him the kingdom of God.
 [Ant 3]
 Lo, a servant of God * who esteemed but little things earthly. And by word and work laid him up treasure in heaven.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Lesson from the book of Wisdom
 !Wis 4:7-14
 7 But the just man, if he be prevented with death, shall be in rest. 
@@ -249,7 +249,7 @@ Lesson from the book of Wisdom
 13 Being made perfect in a short space, he fulfilled a long time: 
 14 For his soul pleased God: therefore he hastened to bring him out of the midst of iniquities: 
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Wis 4:14-19
 14 but the people see this, and understand not, nor lay up such things in their hearts:
 15 That the grace of God, and his mercy is with his saints, and that he hath respect to his chosen.
@@ -258,7 +258,7 @@ Lesson from the book of Wisdom
 18 They shall see him, and shall despise him: but the Lord shall laugh them to scorn. 
 19 And they shall fall after this without honour, and be a reproach among the dead for ever: for he shall burst them puffed up and speechless, and shall shake them from the foundations, and they shall be utterly laid waste: 
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Wis 4:19-20; 5:1-5
 19 they shall be in sorrow, and their memory shall perish. 
 20 They shall come with fear at the thought of their sins, and their iniquities shall stand against them to convict them. 
@@ -268,7 +268,7 @@ Lesson from the book of Wisdom
 4 We fools esteemed their life madness, and their end without honour. 
 5 Behold how they are numbered among the children of God, and their lot is among the saints. 
 
-[Lectio71]
+[Lectio7 in 2 loco]
 From the Holy Gospel according to Luke
 !Luke 12:32-35
 At that time, Jesus said unto His disciples: Fear not, little flock, for it is your Father's good pleasure to give you the kingdom. And so on.
@@ -277,16 +277,16 @@ Homily by the Venerable Bede, Priest at Jarrow, and Doctor of the Church.
 !Bk. iv. Ch. 54 on Luke xii.
 The elect are called a little flock, perchance because the reprobate are far more in number than they, but, more probably, because they love to be lowly, since it is God's will that however much His Church should grow in numbers, she should grow with lowliness even unto the end of the world, and should enter lowly into that kingdom which is hers by His promise. That kingdom He promiseth to her here, when He biddeth her to seek only the kingdom of God, and, to comfort her in her travail, He doth so sweetly and so graciously say that her Father will give it to her.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Sell that ye have and give alms. Fear not, He saith, lest, while ye fight for the kingdom of God, ye should lack such things as are needful for this life, nay rather, sell even that which ye have, and give alms. This doth, whosoever for the Lord's sake leaveth all that he hath, and then worketh with his hands, that so he may have to eat, and withal to give alms. In this doth the Apostle boast himself, saying I have coveted no man's silver, or gold, or apparel, as ye yourselves know for these hands have ministered unto my necessities, and to them that were with me. I have showed you all things, how that so labouring ye ought to support the weak. (Acts xx. 33, 34, 35.)
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Provide yourselves bags which wax not old that is to say, by almsgiving, the~
 reward thereof remaineth for ever. Nevertheless, we must not think here that this commandment forbiddeth the Saints to keep money for their own use, and for~
 helping of the poor. The Lord Himself, to Whom Angels ministered, had a bag, and kept therein that which the faithful people gave unto Him (John xii. 6,) to relieve therewith the need of His disciples, and other poor folk. But we are commanded not to serve God for gain, nor to work unrighteousness for fear of poverty.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 From the Holy Gospel according to Luke
 !Luke 19:12-25
 At that time, Jesus spoke this parable unto His disciples: A certain nobleman went into a far country to receive for himself a kingdom and to return. And so on.
@@ -295,9 +295,9 @@ Homily by St. Ambrose, Bishop (of Milan.)
 !Book viii. on Luke.
 It is well ordered that, being about to call the Gentiles, and to command the destruction of those Jews, who would not have Christ to reign over them, He should put forth first this parable; lest it should be said He had given the Jews no means of becoming better. How can they be asked to repay who have received nothing? That is not a piece of silver of little worth, which, when the woman before mentioned in this Gospel (xv. 8) hath lost, she lighteth a candle, and sweepeth the house, and searcheth diligently until she findeth it.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 A single pound one gained ten and another five pounds. Perchance by him which had the five pounds is signified he which practiseth well, since the body hath five senses, and by him which had the ten, that is, double the other, he which is learned and orthodox in the deep things of doctrine, as well as upright in his practical life. Hence also in Matthew we have five talents and two talents the five talents signifying good practice, and the two talents precept and practice together. So that that which counteth as the greater number is but a fraction of the lesser number.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 And here we may also understand by the ten pounds the ten words, that is, the Commandments, and by the five pounds, the enforcement of their teaching. But I would that a lawyer should be in all things perfect. For the kingdom of God is not in word but in power. (1 Cor. iv. 20.) Meet also is it, that, in speaking of Jews, Christ should represent only two as bringing in increased capital, for these talents are talents not of money but of grace, and to increase money by usury is a very different thing from improving heavenly revelation by the like means.
 &teDeum

--- a/web/www/horas/English/Commune/C5a.txt
+++ b/web/www/horas/English/Commune/C5a.txt
@@ -22,7 +22,7 @@ He shall receive * a blessing from the Lord, and mercy from the God of his salva
 V. The law of his God is in his heart.
 R. None of his steps shall slide.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 And here we may also understand by the ten pounds the ten words, that is, the~
 Commandments, and by the five pounds, the enforcement of their teaching. But I~
 would that a lawyer should be in all things perfect. For the kingdom of God is~
@@ -33,7 +33,7 @@ usury is a very different thing from improving heavenly revelation by the like~
 means.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 From the Holy Gospel according to Matthew
 !Matt 16:24-27
 At that time, Jesus said unto His disciples: If any man will come after Me, let him deny himself, and take up his cross, and follow Me. And so on.
@@ -52,7 +52,7 @@ hot, so doth our Lord set against sin holiness, ordaining for the lecherous~
 purity, for the miserly munificence, for the hot-tempered meekness, and for the~
 proud lowliness.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 So the Lord, when He would give a new commandment unto them that came to Him,~
 said Whosoever he be of you that forsaketh not all that he hath, he cannot be~
 My disciple, (Luke xiv. 33,) as though He had said openly: All ye that according~
@@ -65,7 +65,7 @@ man to give up that which is his own, but it is exceeding hard to give up~
 himself. To deny himself his possessions is little but to deny himself himself~
 is a denial exceeding great.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Let when we come unto Him the Lord will have us deny to ourselves even ourselves,~
 since as many of us as are entered into the battle of faith, are entered into a~
 contention against evil spirits. But the evil spirits have nothing of their own~

--- a/web/www/horas/English/Commune/C6.txt
+++ b/web/www/horas/English/Commune/C6.txt
@@ -294,7 +294,7 @@ _
 V. Grace is poured into thy lips.
 R. Therefore God hath blessed thee for ever.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Lesson from the book of Ecclesiasticus
 !Sir 51:1-7
 1 A prayer of Jesus the son of Sirach. I will give glory to thee, O Lord, O King, and I will praise thee, O God my Saviour. 
@@ -305,7 +305,7 @@ Lesson from the book of Ecclesiasticus
 6 From the oppression of the flame which surrounded me, and in the midst of the fire I was not burnt. 
 7 From the depth of the belly of hell, and from an unclean tongue, and from lying words, from an unjust king, and from a slanderous tongue: 
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 51:8-12
 8 My soul shall praise the Lord even to death. 
 9 And my life was drawing near to hell beneath. 
@@ -313,7 +313,7 @@ Lesson from the book of Ecclesiasticus
 11 I remembered thy mercy, O Lord, and thy works, which are from the beginning of the world. 
 12 How thou deliverest them that wait for thee, O Lord, and savest them out of the hands of the nations. 
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 13 Thou hast exalted my dwelling place upon the earth and I have prayed for death to pass away. 
 14 I called upon the Lord, the father of my Lord, that he would not leave me in the day of my trouble, and in the time of the proud without help. 

--- a/web/www/horas/English/CommuneM/C6.txt
+++ b/web/www/horas/English/CommuneM/C6.txt
@@ -46,7 +46,7 @@ that he would not leave me in the day of my trouble, and in the time of the~
 proud without help.
 $Deo gratias
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 13 Thou hast exalted my dwelling place upon the earth and I have prayed for death to pass away. 
 14 I called upon the Lord, the father of my Lord, that he would not leave me in the day of my trouble, and in the time of the proud without help. 

--- a/web/www/horas/English/Sancti/01-16.txt
+++ b/web/www/horas/English/Sancti/01-16.txt
@@ -48,13 +48,13 @@ Rome in the month of December twenty - five Priests, two Deacons, and twenty -~
 one Bishops for diverse Sees.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Responsory8]
 R. O Lord, thou hast prevented him with blessings of sweetness: 

--- a/web/www/horas/English/Sancti/04-22.txt
+++ b/web/www/horas/English/Sancti/04-22.txt
@@ -47,10 +47,10 @@ Soter, a countryman of Fondi in Campania, succeeded the holy martyr Anicetus. It
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/English/Sancti/07-13o.txt
+++ b/web/www/horas/English/Sancti/07-13o.txt
@@ -27,10 +27,10 @@ Anacletus was an Athenian who governed the Church in the time of the Emperor Tra
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/English/Sancti/10-14.txt
+++ b/web/www/horas/English/Sancti/10-14.txt
@@ -44,13 +44,13 @@ which had been built by himself. There it lieth beneath the High Altar, and is~
 held in great reverence of all men.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Lectio7](rubrica tridentina)
 @Sancti/02-22:Lectio7

--- a/web/www/horas/English/Sancti/10-31v.txt
+++ b/web/www/horas/English/Sancti/10-31v.txt
@@ -10,13 +10,13 @@ Laudes 2
 No Suffragium 
 
 [Lectio1]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio2]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio3]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco
 
 [Oratio]
 Pour forth abundantly upon us of thy mercy, O Lord our God, and grant us grace~

--- a/web/www/horas/Espanol/Commune/C2.txt
+++ b/web/www/horas/Espanol/Commune/C2.txt
@@ -185,7 +185,7 @@ R. No tuvo temor a las amenazas de los jueces, no buscó la gloria de la terrena
 &Gloria
 R. No tuvo temor a las amenazas de los jueces, no buscó la gloria de la terrena dignidad, y por esto llegó al reino celestial. 
 
-[Responsory8NonEffusorum]
+[Responsory8 non Effusorum]
 R. Señor, Tú le preveniste con amorosas bendiciones. 
 * Pusiste sobre su frente una corona de piedras preciosas, 
 V. Te pidió la vida, y le concediste longura de días por los siglos de los siglos. 
@@ -304,30 +304,30 @@ R. Y se alzará como un cedro del Líbano.
 [Ant 3]
 El que quiera seguirme, * que se niegue a sí mismo, cargue con su cruz y se venga conmigo.
 
-[Lectio41]
+[Lectio4 in 2 loco]
 Epístola de San Cipriano, Obispo y Mártir.
 !Lib. 2. Epist. 6.
 ¿Con qué alabanzas podré ensalzaros, oh mártires valerosísimos? El valor de vuestro ánimo y la perseverancia en la fe ¿con qué encomios podré ponderarlos? Sufristeis hasta la consecución de la gloria, pruebas durísimas; no cedisteis a los suplicios, sino que más bien ellos cedieron a vosotros. No fueron los tormentos los que dieron fin a vuestros dolores; fueron vuestras coronas. Si la cruel carnicería de los verdugos duró largo tiempo, no pudo rendir una fe siempre firme; no hizo más que enviar a Dios los hombres de Dios.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 R. Una luz perpetua iluminará, Señor, a tus santos, 
 * Y vivirán por toda la eternidad, aleluya, aleluya, 
 V. Sobre ellos brillará una alegría eterna; conseguirán el gozo y la exultación.
 R. Y vivirán por toda la eternidad, aleluya, aleluya, 
 
-[Lectio51]
+[Lectio5 in 2 loco]
 La multitud contempló admirada este combate celestial, divino y espiritual, lucha por Jesucristo; vio a los siervos de Cristo firmes, con palabra libre y mente pura, llenos de fuerza divina, sin armas terrenas, pero armados con las de una fe ardiente. Los atormentados eran más fuertes que sus atormentadores, y los garfios de hierro que azotaban y desgarraban sus miembros, fueron vencidos por los miembros azotados y desgarrados. No pudieron doblegar su fe inexpugnable los golpes redoblados, ni aun cuando, por estar tan desgarradas las carnes de los siervos de Dios, atormentasen en ellos, más las heridas que los miembros. La gloriosa sangre que manaba de sus heridas, debía extinguir el fuego de la persecución y mitigar los ardores del infierno.
 
-[Responsory51]
+[Responsory5 in 2 loco]
 R. En sus siervos, aleluya, 
 * Se consolará el Señor, aleluya, 
 V. Juzgará el Señor a su pueblo, y en sus siervos. 
 R. Se consolará el Señor, aleluya.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 ¡Oh, cuán grande espectáculo a los ojos del Señor! ¡Cuán sublime, cuán agradable a Dios, por la constancia de los soldados alistados en su milicia y consagrados a su servicio! Como nos dice el Espíritu Santo y nos enseña Él mismo en sus salmos: “Es preciosa en la presencia de Dios la muerte de los justos”. Verdaderamente es preciosa esta muerte que compra la inmortalidad con el precio de la sangre derramada, que adquiere la corona con la perfección de la virtud. ¡Cuán gozoso estuvo allí Cristo, cuán de buena gana peleó y venció en tales siervos suyos, Él, protector de la fe; Él, que retribuye a los que creen en Él, a proporción de su confianza. Estuvo presente en su combate; sostuvo a los que peleaban y defendían su nombre; los esforzó y dio ánimo. Y el que por nosotros venció una vez la muerte, vence siempre en nosotros.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Hijas de Jerusalén, venid y ved a los mártires con coronas, con las cuales les ha honrado el Señor. 
 * En el día de su triunfo y alegría, aleluya, 
 V. Porque ha reforzado los cerrojos de tus puertas, y bendecido en ti a tus hijos. 
@@ -335,7 +335,7 @@ R. En el día de su triunfo y alegría, aleluya.
 &Gloria
 R. En el día de su triunfo y alegría, aleluya. 
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Lectura del santo Evangelio según San Juan
 !Jn 15:5-10
 En aquel tiempo: Dijo Jesús a sus discípulos: Yo soy la verdadera vid, y vosotros los sarmientos; el que permanece en mí y Yo en él, este lleva mucho fruto, ya que sin mí, nada podéis hacer. Y lo que sigue.
@@ -344,16 +344,16 @@ Homilía de S. Agustín, Obispo.
 !Tratado 81 sobre S. Juan, después del medio.
 A fin de que nadie pensara que el sarmiento pudiese producir de sí mismo, al menos un poco de fruto, después de haber dicho el Salvador: “Este produce mucho fruto”; no añadió: “Porque sin mí, poco podéis hacer”, sino “Nada podéis hacer”. No podemos producir poco ni mucho, separados de aquél sin el cual no se puede hacer nada. Si el sarmiento produce poco fruto, el labrador lo poda, a fin de que produzca más. Con todo, si no permanece en la vid y no vive unido a su ráíz, ningún fruto puede producir. Jesucristo no habría sido vid si no hubiera sido hombre; con todo, no podría comunicar una virtud tan grande a las ramas, si no fuese también Dios.
 
-[Responsory71]
+[Responsory7 in 2 loco]
 R. Yo soy la verdadera vid y vosotros los sarmientos. 
 * El que permanece en mí, y Yo en él, éste dará mucho fruto, aleluya, aleluya, 
 V. Así como me ha amado mi Padre, Yo también os he amado. 
 R. El que permanece en mí, y Yo en él, éste dará mucho fruto, aleluya, aleluya.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Sin esta gracia no se puede vivir, mas la muerte depende del libre albedrío. Por esto Jesús nos dice: “Si alguno no permaneciere en mí, será arrojado fuera como el sarmiento, y se secará, y lo recogerán, y lo arrojarán al fuego, y arderá”. Las ramas de la vid son tanto más despreciables si no están unidas a ella, cuanto son de más valor si permanecen con ella unidas. Como hace notar el Señor hablando por el Profeta Ezequiel, una vez son cortadas, no sirven ni para la agricultura ni para industria alguna. Al sarmiento no le queda otra  que permanecer unido a la vid o ser arrojado al fuego. Para que no sea arrojado al fuego, permanezca unido a la vid.
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. Sus Nazarenos han sido iluminados, aleluya; resplandecieron delante de Dios, aleluya: 
 * Y como la leche se cuajaron, aleluya, aleluya. 
 V. Más blancos que la nieve, más nítidos que la leche, más rojos que el marfil antiguo, más bellos que el zafiro, 
@@ -361,11 +361,11 @@ R. Y como la leche se cuajaron, aleluya, aleluya.
 &Gloria
 R. Y como la leche se cuajaron, aleluya, aleluya.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 “Si permaneciereis en mí, dice, y mis palabras permanecieren en vosotros, todo lo que pidiereis  se os dará”. Los que permanecen en Cristo, ¿qué quieren sino lo que conviene a Cristo? ¿Qué pueden querer, estando en el Salvador, sino lo que es conforme a la salvación? Las cosas que queremos cuando estamos unidos a Cristo, son diferentes de las que queremos cuando estamos aficionados al mundo. Por lo mismo que aún estamos en este mundo, puede suceder que alguna vez pidamos lo que ignoramos que nos sea nocivo. Lejos de nosotros  pensar obtener estas cosas si estamos en Cristo, el cual no nos concede cuando pedimos sino lo que nos conviene.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Lectura del santo Evangelio según San Mateo
 !Mt 10:26-32
 En aquel tiempo: Dijo Jesús a sus discípulos: Nada está encubierto que no se haya de descubrir, ni oculto que no se haya de saber. Y lo que sigue.
@@ -374,23 +374,23 @@ Homilía de San Hilario, Obispo.
 !Comentario sobre San Mateo, can. 10
 El Señor nos propone el día del juicio, en el cual manifestará los secretos de nuestra conciencia, y hará patentes aquellas cosas  desconocidas. Y por esto enseña que no deben ser temidas las amenazas, ni los designios, ni la potestad de los perseguidores, porque en el día del juicio nos revelará que todas estas cosas serán de ningún valor y precio. “Y lo que os digo de noche, decidlo a la luz del día; y lo que os digo al oído, predicadlo desde los tejados”. No leemos que el Señor acostumbrara predicar durante las noches, ni que enseñara su doctrina en la oscuridad. Pero esto se entiende, en cuanto todas sus palabras son tinieblas para las personas carnales, y como  noche para los infieles.
 
-[Responsory72]
+[Responsory7 in 3 loco]
 R. Una corona de oro puesta sobre su frente, 
 * Es la expresión de su santidad, gloria, honor y fortaleza, 
 V. Porque le preveniste con amorosas bendiciones, pusiste sobre su frente una corona de piedras preciosas. 
 R. Es la expresión de su santidad, gloria, honor y fortaleza.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Quiere que lo dicho por Él se publique con la libertad que reclaman nuestras creencias y nuestra profesión de fe. Por lo mismo, lo que ha predicado en la oscuridad, manda que sea enseñado a la luz del día, a fin de que lo dicho en secreto, sea oído sobre los tejados, es decir, publicado en voz alta por los predicadores. El conocimiento de Dios ha de ser inculcado, y el profundo secreto de la doctrina evangélica ha de ser manifestado por la luz de la predicación apostólica, sin temor a aquellos que,  teniendo poder para atormentar los cuerpos, no tienen ninguno sobre las almas, sino temiendo más bien a Dios, el cual tiene potestad para arrojar al infierno el cuerpo y el alma.
 
-[Responsory82]
+[Responsory8 in 3 loco]
 @Commune/C2:Responsory8
 
-[Lectio92]
+[Lectio9 in 3 loco]
 “No temáis a los que matan el cuerpo”. No hay que temer ningún peligro para nuestro cuerpo, y no debemos dar importancia al dolor de una carne destinada a perecer, ya que el hombre, una vez libre de la condición de su naturaleza y de su origen, debe resucitar conforme la sustancia de su alma espiritual. Y porque los confirmados en esta fe es necesario que tengan el valor de confesar a Dios, añadió Jesucristo que seríamos negados por Él en el cielo delante del Padre, si le negásemos delante de los hombres; pero que al que le reconociere delante de los hombres, Él le reconocería en el cielo. Según el testimonio que hayamos dado de Él delante de los hombres, Él lo dará de nosotros delante de Dios Padre.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Lectura del santo Evangelio según San Mateo
 !Mt 16:24-27
 En aquel tiempo: Dijo Jesús a sus discípulos: Si alguno quiere venir en pos de mí, niéguese a sí mismo, cargue con su cruz, y sígame. Y lo que sigue.
@@ -399,9 +399,9 @@ Homilía de San Gregorio, Papa.
 !Homilía 32 sobre el Evangelio.
 Porque nuestro Señor y Redentor vino al mundo como nuevo hombre, dio al mundo nuevos preceptos, pues  a nuestra antigua vida, alimentada por los vicios, impuso el deber de transformarse en una vida nueva. ¿qué pretendía el hombre viejo y carnal, sino retener lo suyo, arrebatando lo ajeno cuando le era posible, y deseándolo, si no podía? Mas el médico celeste  dio remedios adecuados a cada uno de los vicios. Pues así como en el arte de la medicina, lo caliente se cura con lo frío y lo frío con lo caliente, así nuestro Señor opuso medicinas contrarias a los pecados, enseñando a los deshonestos continencia, generosidad a los avaros,  mansedumbre a los iracundos, y  humildad a los soberbios.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Es verdad que al proponer nuevos mandamientos a los que le seguían, dijo: Si alguno no renuncia a todo lo que posee, no puede ser mi discípulo. Como si dijera: Los que siguiendo la vida antigua deseabais lo ajeno, si deseáis una vida nueva, dad de lo vuestro. Oigamos ahora lo que enseña: “El que quiera venir en pos de mí, niéguese a sí mismo”. Antes se nos ha dicho que renunciemos a nuestras cosas, ahora nos amonesta a que renunciemos a nosotros mismos. Algunas veces no es muy difícil que el hombre renuncie a lo que tiene, pero ciertamente lo es mucho dejarse a sí mismo. Es cosa pequeña sacrificar lo que tenemos, pero es cosa muy grande sacrificar lo que somos.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 El Señor ordenó a los que le seguían que renunciasen a todas las cosas, y esto porque cuantos nos preparamos para el combate de la fe, emprendemos una lucha contra los espíritus malignos. Ahora bien, éstos nada poseen de propio en este mundo; es preciso, pues, que luchemos desnudos con los que están desnudos. Pues si uno que está vestido pelea con otro que nada viste, será echado por tierra, ya que tiene de qué poderle asir. Y a la verdad, ¿qué son todas las cosas terrenas, sino como una especie de vestidos? De consiguiente, el que va a emprender una lucha contra el diablo, arroje de sí los vestidos para que no sucumba.
 &teDeum

--- a/web/www/horas/Espanol/Commune/C2p.txt
+++ b/web/www/horas/Espanol/Commune/C2p.txt
@@ -65,13 +65,13 @@ Es muy digno y conveniente que después de la alegría de Pascua, que hemos cele
 Anunciemos, os digo yo, a los santos mártires la gloriosa Pascua del Señor, para que al anuncio de la apertura de su sepulcro, se abran también sus sepulcros. Cuando reconocemos que el cuerpo del Señor, que realmente murió, sintió de repente circular por sus venas un nuevo vigor, también se reaniman los miembros helados de los mártires, con el calor vivificante de la inmortalidad. La misma virtud que resucitó al Señor, resucita también a los mártires. Pues así como le siguieron en la pasión, así le acompañarán en su vida gloriosa. Por esto dice el Salmo: Me manifestaste los caminos de la vida. Esto se dice de la persona del Salvador resucitado, quien, de los infiernos, a donde descenció tras su muerte, se elevó a los cielos, siendo el primero en conocer el camino de la vida que hasta entonces había sido desconocido.
 
 [Responsory5]
-@Commune/C2:Responsory51
+@Commune/C2:Responsory5 in 2 loco
 
 [Lectio6]
 Antes de venir Cristo era desconocido el camino de la vida, el cual aún no había sido allanado por alguno que hubiese resucitado. Mas luego que Cristo resucitó, el camino fue ya franqueable; muchos han podido caminar por él. A ellos se refiere el santo Evangelio: Muchos cuerpos de santos resucitaron con Él y entraron en la ciudad santa. Así, al decir el Señor, a propósito de su resurrección: Me hiciste manifiestos los caminos de la vida, podemos decirle: “A nosotros nos manifestasteis los caminos de la vida”. El mismo que nos abrió el camino de la vida, fue quien nos mostró las sendas de la vida. Me manifestó estas sendas cuando me enseñó la fe, la misericordia, la justicia, la castidad, por las cuales se llega a la salvación.
 
 [Responsory6]
-@Commune/C2:Responsory61
+@Commune/C2:Responsory6 in 2 loco
 
 [Lectio7]
 Lectura del santo Evangelio según San Juan
@@ -137,24 +137,24 @@ En este lugar del Evangelio, en donde el Señor se da el nombre de vid, y a sus 
 [Ant 3]
 @Commune/C1p
 
-[Lectio41]
+[Lectio4 in 2 loco]
 Epístola de San Cipriano, Obispo y Mártir.
 !Lib. 2. Epist. 6.
 ¿Con qué alabanzas podré ensalzaros, oh mártires valerosísimos? El valor de vuestro ánimo y la perseverancia en la fe ¿con qué encomios podré ponderarlos? Sufristeis hasta la consecución de la gloria, pruebas durísimas; no cedisteis a los suplicios, sino que más bien ellos cedieron a vosotros. No fueron los tormentos los que dieron fin a vuestros dolores; fueron vuestras coronas. Si la cruel carnicería de los verdugos duró largo tiempo, no pudo rendir una fe siempre firme; no hizo más que enviar a Dios los hombres de Dios.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 @Commune/C1p:Responsory4
 
-[Lectio51]
+[Lectio5 in 2 loco]
 La multitud contempló admirada este combate celestial, divino y espiritual, lucha por Jesucristo; vio a los siervos de Cristo firmes, con palabra libre y mente pura, llenos de fuerza divina, sin armas terrenas, pero armados con las de una fe ardiente. Los atormentados eran más fuertes que sus atormentadores, y los garfios de hierro que azotaban y desgarraban sus miembros, fueron vencidos por los miembros azotados y desgarrados. No pudieron doblegar su fe inexpugnable los golpes redoblados, ni aun cuando, por estar tan desgarradas las carnes de los siervos de Dios, atormentasen en ellos, más las heridas que los miembros. La gloriosa sangre que manaba de sus heridas, debía extinguir el fuego de la persecución y mitigar los ardores del infierno.
 
-[Responsory51]
+[Responsory5 in 2 loco]
 @Commune/C2
 
-[Lectio61]
+[Lectio6 in 2 loco]
 ¡Oh, cuán grande espectáculo a los ojos del Señor! ¡Cuán sublime, cuán agradable a Dios, por la constancia de los soldados alistados en su milicia y consagrados a su servicio! Como nos dice el Espíritu Santo y nos enseña Él mismo en sus salmos: “Es preciosa en la presencia de Dios la muerte de los justos”. Verdaderamente es preciosa esta muerte que compra la inmortalidad con el precio de la sangre derramada, que adquiere la corona con la perfección de la virtud. ¡Cuán gozoso estuvo allí Cristo, cuán de buena gana peleó y venció en tales siervos suyos, Él, protector de la fe; Él, que retribuye a los que creen en Él, a proporción de su confianza. Estuvo presente en su combate; sostuvo a los que peleaban y defendían su nombre; los esforzó y dio ánimo. Y el que por nosotros venció una vez la muerte, vence siempre en nosotros.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Hijas de Jerusalén, venid y ved a los mártires con coronas, con las cuales les ha honrado el Señor. 
 * En el día de su triunfo y alegría, aleluya, 
 V. Porque ha reforzado los cerrojos de tus puertas, y bendecido en ti a tus hijos. 

--- a/web/www/horas/Espanol/Commune/C3.txt
+++ b/web/www/horas/Espanol/Commune/C3.txt
@@ -332,7 +332,7 @@ La habitación * de los santos es el reino celestial, y su descanso será eterno
 [Ant 3]
 Los santos se alegran * en el cielo: siguieron las huellas de Cristo, y porque le amaron hasta derramar su sangre, gozan con Él eternamente.	
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Lectura del santo Evangelio según San Lucas
 !Lc 6:17-23
 En aquel tiempo: Descendiendo Jesús del monte, se paró en un llano, juntamente con la compañía de sus discípulos y de una gran multitud de gentío de toda Judea, y de Jerusalén, y del país marítimo de Tiro y de Sidón. Y lo que sigue.
@@ -341,10 +341,10 @@ Homilía de San Ambrosio, Obispo.
 !Libro 5 sobre San Lucas, cap. 6, después del principio.
 Advierte diligentemente, de qué modo el Señor sube con los Apóstoles y desciende hacia las multitudes. ¿Cómo sino en un lugar humilde el pueblo podría ver a Cristo? No le sigue a lo más elevado, no sube a las cumbres. Al descender halla enfermos que no pueden permanecer en las alturas; de ahí que San Mateo nos diga  que en los lugares poco elevados fueron curados los enfermos. Es preciso, que cada uno de ellos sea curado, a fin de que, poco a poco, y a medida que recobre las fuerzas, pueda subir al monte. Nuestro Señor los cura a todos en un lugar muy bajo, es decir, los aparta del abismo de las pasiones y remedia su ceguera. Baja hasta nuestras heridas para que acercándosenos y enriqueciéndonos con su naturaleza, nos haga partícipes del reino celestial.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 “Bienaventurados los pobres, porque de ellos es el reino de Dios”. S. Lucas señala sólo cuatro bienaventuranzas evangélicas; mas S. Mateo, ocho. En estas ocho están aquellas cuatro, y en aquellas cuatro están estas ocho. S. Lucas lo refirió todo a las cuatro virtudes cardinales; S. Mateo,  con las ocho, nos revela un número místico. Muchos salmos tienen por título “para la Octava”, y nos ha sido ordenado que participemos de estas ocho bendiciones. Así como la Octava, o el número ocho, expresa el cumplimiento de nuestra esperanza, así también expresa  plenitud de las virtudes.
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. Esta es la verdadera hermandad, que con ningún combate pudo deshacerse: derramada la sangre siguieron al Señor: 
 * Despreciando los palacios reales, llegaron a los reinos celestiales. 
 V. ¡Cuán bueno y agradable es que los hermanos no tengan más que un corazón! 
@@ -352,6 +352,6 @@ R. Despreciando los palacios reales, llegaron a los reinos celestiales.
 &Gloria
 R. Despreciando los palacios reales, llegaron a los reinos celestiales.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Pero antes veamos lo que es más importante: “Bienaventurados, dice, los pobres, porque de ellos es el reino de los cielos”. Ambos evangelistas han puesto esta bienaventuranza como la primera. Y a la verdad es la primera en el orden, y como el origen y madre de las virtudes; ya que quien despreciare el siglo, éste merecerá lo eterno, y nadie podrá merecer el reino celestial si, permaneciendo cautivo de las concupiscencias mundanas, no tiene valor para librarse de ellas.
 &teDeum

--- a/web/www/horas/Espanol/Commune/C4.txt
+++ b/web/www/horas/Espanol/Commune/C4.txt
@@ -340,7 +340,7 @@ El Señor lo amó * y lo enalteció: lo vistió con un traje de honor y lo coron
 [Ant 3 summi Pontificis]
 Cuando era sumo pontífice * no temió nada en la tierra, sino que puso sus ojos en el reino de los cielos.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Del Libro del Eclesiástico 
 !Sir 44:1-5
 1 Alabemos a los varones ilustres, a nuestros mayores, a quienes debemos el ser. 
@@ -349,14 +349,14 @@ Del Libro del Eclesiástico
 4 Gobernaron al pueblo de su tiempo con la virtud de la prudencia, dando muy santas instrucciones a sus súbditos. 
 5 Con su habilidad inventaron tonos musicales, y compusieron los cánticos de las Escrituras.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 44:6-9
 6 Hombres ricos en virtudes, solícitos del decoro del Santuario, pacíficos en sus casas. 
 7 Todos éstos en sus tiempos alcanzaron gloria y honraron su siglo. 
 8 Los hijos que de ellos nacieron, dejaron un nombre que hace recordar sus alabanzas. 
 9 Mas hubo algunos, de los cuales no queda memoria, que perecieron como si nunca hubieran existido, así ellos como sus hijos, y aunque nacieron, fueron como si no hubieran nacido.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 44:10-15
 10 Pero fueron varones misericordiosos aquellos cuyas obras de piedad no han caído en olvido. 
 11 En su descendencia permanecerán sus bienes. 
@@ -365,7 +365,7 @@ Del Libro del Eclesiástico
 14 Sepultados en paz fueron sus cuerpos, y vive su nombre por todos los siglos. 
 15 Celebren los pueblos su sabiduría, y repítanse sus alabanzas en las asambleas sagradas.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Lectura del santo Evangelio según San Mateo
 !Mt 16:13-19
 En aquel tiempo, viniendo Jesús a los términos de Cesárea de Filipo, preguntó a sus discípulos: ¿Quién dicen los hombres que es el Hijo del hombre? Y lo que sigue. 
@@ -374,14 +374,14 @@ Homilía de San León, Papa.
 !Sermón 2º en el aniversario.
 Cuando el Señor, tal como leemos en el Evangelio, preguntó a sus discípulos qué decían los hombres, en medio de sus diversas especulaciones, sobre el Hijo del Hombre, sería Pedro bendito  quien contestó y dijo: Tú eres el Cristo, el Hijo del Dios viviente. Respondió Jesús: Bienaventurado eres, Simón, hijo de Jonás; porque no te lo reveló carne ni sangre, sino mi Padre que está en los cielos; y Yo también te digo que tú eres Pedro, y sobre esta roca edificaré mi Iglesia, y las puertas del infierno no prevalecerán contra ella; y te daré las llaves del reino de los cielos; y todo lo que ates en la tierra será atado en el cielo; y todo lo que desates en la tierra será desatado en el cielo. Pero la dispensación de la verdad se demora, y el bendito Pedro, perseverando en la fortaleza de la roca que ha recibido, no ha renunciado a la posición que asumió al frente de la Iglesia.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 En la Iglesia universal es como si Pedro todavía estuviera diciendo todos los días: Tú eres el Cristo, el Hijo del Dios viviente. Por cada lengua que confiesa al Señor se le enseña esa confesión por la enseñanza de Pedro. Esta es la Fe que vence al diablo y suelta las ataduras de sus prisioneros. Esta es la fe que hace libres a los hombres y los lleva al cielo, y las puertas del infierno son impotentes para prevalecer contra él. Esta es la roca que Dios fortificó con tales murallas de salvación, que el contagio de la herejía nunca podrá contagiarla, ni la idolatría y la incredulidad para vencerla. Celebramos la fiesta de hoy con una obediencia razonable, para que en mi persona humilde pueda ser honrado, el que sigue cuidando de todos los pastores y ovejas que se le han confiado, y que no pierde su dignidad, incluso en un sucesor indigno.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Cuando dirigimos nuestras exhortaciones a vuestros oídos piadosos, creed que le estáis oyendo hablar a través nuestro. Sí, es con su amor por vosotros con el  que os advertimos. Y sólo predicamos lo que él enseñó, rogando como lo hizo él: Doblegad vuestra mente; sed sobrios; sed santos en toda forma de vida; pasad el tiempo de vuestra peregrinación aquí en el temor de Dios. Mis discípulos, vosotros sois para mí como lo fueron para él los discípulos de San Pablo, a saber: mi corona y mi alegría; si es así, que su fe permanezca, aún en toda humildad y santidad, como en los primeros tiempos del Evangelio. Porque aunque toda la Iglesia esparcida en todo el mundo debería abundar en todas las virtudes, conviene en especial a vosotros, entre todos, sobresalir en la piedad, fundados como estáis en la misma ciudadela de la Roca Apostólica, que no solo ha sido redimido con el resto de los hombres por nuestro Señor Jesucristo, sino que ha sido instruido por el bendito Apóstol Pedro mucho más que todos los demás.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Lectura del santo Evangelio según San Mateo 
 !Mt 19:27-29
 En aquel tiempo: Dijo Pedro a Jesús: He ahí que nosotros lo hemos dejado todo y os hemos seguido; de consiguiente ¿qué nos daréis? Y lo que sigue.
@@ -390,18 +390,18 @@ Homilía de San Beda Venerable, Presbítero.
 !Homilía en el natalicio de San Benito.
 Dos son los órdenes de elegidos, que habrá en el juicio futuro: unos que juzgarán con el Señor, de quienes se hace mención en este lugar, que lo dejaron todo y le siguieron. El otro es el de los que han de ser juzgados por el Señor, los cuales, si bien es verdad que no lo dejaron todo, se servían, no obstante, de lo que tenían, para dar limosna cada día a los pobres de Cristo, por lo cual oirán en el juicio: Venid, benditos de mi Padre, poseed el reino que os está preparado desde el principio del mundo, pues tuve hambre, y me disteis de comer; tuve sed, y me disteis de beber.
 
-[Responsory73]
+[Responsory7 in 4 loco]
 R. Este es el que ha realizado grandes obras ante Dios, y toda la tierra está llena de su doctrina. 
 * El mismo interceda por los pecados de todos los pueblos. 
 V. Este es el que ha despreciado la vida del siglo, y ha llegado a los reinos celestes. 
 R. El mismo interceda por los pecados de todos los pueblos. 
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Mas también habrá allí dos órdenes de réprobos, según nos dice el Señor: el primero de aquellos que, iniciados en los misterios de la fe cristiana, han menospreciado el ejercicio de las obras de la fe, a los cuales en el juicio se les dirá: “Apartaos de mí, malditos, al fuego eterno que está preparado para el diablo y sus ángeles; pues tuve hambre, y no me disteis de comer". El segundo es de aquellos que, o no recibieron jamás la fe y los misterios de Cristo, o habiéndolos recibido los abandonaron por la apostasía, de los cuales se dice: El que no cree, ya está juzgado, porque no cree en el nombre del Unigénito Hijo de Dios.
 
-[Responsory83]
+[Responsory8 in 4 loco]
 @:Responsory8
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Después de haber recordado todo esto con el debido temor y espanto, fijemos mejor nuestra atención en las agradabilísimas promesas de nuestro Señor y Salvador. Consideremos cuán grandes sean las manifestaciones de su bondad. No solamente promete premios eternos a los que le siguen, sino que también les obsequia con dones eximios en la vida presente. “Y todo aquel, dice, que dejare la casa, o los hermanos, o las hermanas, o el padre, o la madre, o los hijos, o las posesiones por mi nombre, recibirá el céntuplo, y poseerá la vida eterna”. En verdad, quien renunciare a los afectos o a las posesiones terrenas para ser discípulo de Jesucristo, por esta renuncia adelantará en su amor y encontrará para recibirle con profundo afecto y compartir con él sus bienes, más hermanos de los que haya dejado.
 &teDeum

--- a/web/www/horas/Espanol/Commune/C4a.txt
+++ b/web/www/horas/Espanol/Commune/C4a.txt
@@ -171,7 +171,7 @@ $Per Dominum.
 [Ant 3]
 @:Ant 1
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Lectura del santo Evangelio según San Mateo 
 !Mt 5:13-19
 En aquel tiempo: Dijo Jesús a sus discípulos: Vosotros sois la sal de la tierra. Y si la sal se hace insípida, ¿con qué se le volverá el sabor? Y lo que sigue.
@@ -180,9 +180,9 @@ Homilía de San Juan Crisóstomo.
 !Homilía 15 sobre San Mateo, después del medio.
 Ved lo que dijo Jesús: “Vosotros sois la sal de la tierra”; con lo cual manifestó la necesidad de dar preceptos a los apóstoles. En efecto, dijo que no tan sólo habían de dar cuenta de su vida, sino de todo el mundo. No os envío a dos ciudades, a diez o veinte, ni a un solo pueblo, como enviaba a los profetas, sino a toda la tierra y a todos los mares, y a todo el mundo; a este mundo abatido bajo el peso de multitud de crímenes.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Al decir: “Vosotros sois la sal de la tierra”, muestra que toda la naturaleza humana se había vuelto insípida y corrompida por la fuerza de los pecados. Por lo mismo, exige de ellos aquellas virtudes que son tan necesarias y útiles para procurar la salud de muchos. Pues aquel que es pacífico y modesto, misericordioso y justo, no se limita a tener encerradas estas virtudes tan sólo dentro de sí mismo, sino que procura que estas excelentes fuentes manen también en utilidad de los otros. Aquel que tiene el corazón limpio y pacífico, y sufre la persecución por la justicia, ordena su vida para el bien de todos.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Por eso dijo, no penséis que habéis de ser conducidos a luchas fáciles, ni que debáis dar cuenta de cosas poco importantes, puesto que: “Vosotros sois la sal de la tierra”. Pero, ¿acaso los apóstoles curaron lo que estaba del todo corrompido? En manera alguna. Ya que de ningún modo puede darse que aquello que ya está corrompido, sea devuelto al estado primitivo con la aplicación de la sal. No hicieron esto, sino que, hallándose ya renovado y libre de podre lo que se les había confiado, echaban sal y lo conservaban en aquel estado en que lo recibieron del Señor. Y a la verdad, es propio de la virtud de Cristo librar de la corrupción de los pecados; pero impedir que no se recaiga en los mismos, ésta es misión y obra de los apóstoles.
 &teDeum

--- a/web/www/horas/Espanol/Commune/C5.txt
+++ b/web/www/horas/Espanol/Commune/C5.txt
@@ -277,7 +277,7 @@ R. Y le mostró el reino de Dios.
 [Ant 3]
 Este santo, despreciando el mundo * y los bienes de la tierra, acumuló con sus palabras y obras bienes para el cielo, donde él triunfa.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Del Libro de la Sabiduría 
 !Sab 4:7-14
 7 Pero el justo, si muriese prematuramente, estará en paz. 
@@ -289,7 +289,7 @@ Del Libro de la Sabiduría
 13 Llegado en poco tiempo a la perfección, vivió una larga vida. 
 14 Pues su alma era grata al Señor; por esto se dio prisa a sacarle de en medio de la maldad. 
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sab 4:14-19
 14 Los pueblos lo vieron, pero no lo entendieron, ni sobre ello reflexionaron; 
 15 que la gracia y la misericordia es para los elegidos, y la visitación para los santos. 
@@ -298,7 +298,7 @@ Del Libro de la Sabiduría
 18 Verán y se burlarán, pero el Señor se reirá de ellos. 
 19 Y después de esto vendrán a ser como cadáveres sin honor, y serán entre los muertos oprobio sempiterno; porque los quebrantará, reduciéndolos al silencio, y los sacudirá en sus cimientos, y serán del todo desolados.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sab 4, 19-20; 5, 1-5
 19 Y serán sumergidos en el dolor, y perecerá su memoria. 
 20 Verán llenos de espanto sus pecados, y sus crímenes se levantarán contra ellos, acusándolos. 
@@ -308,7 +308,7 @@ Del Libro de la Sabiduría
 4 Nosotros, insensatos, tuvimos su vida por locura, y su fin por deshonra. 
 5 ¡Cómo son contados entre los hijos de Dios y tienen su heredad entre los santos! 
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Lectura del santo Evangelio según San Lucas
 !Lc 12:32-34
 En aquel tiempo: Dijo Jesús a sus discípulos: No tenéis vosotros que temer, mi pequeñito rebaño, porque ha sido del agrado de vuestro Padre daros el reino. Y lo que sigue.
@@ -317,14 +317,14 @@ Homilía de S. Beda Venerable, Presbítero.
 !Libro 4, cap. 54 sobre S. Lucas 12.
 Da el nombre de rebaño pequeñito al de los elegidos, ya en comparación del gran número de los réprobos, o más bien por afecto a la humildad. Y esto es porque quiere que su Iglesia, por mucho que se extienda, crezca siempre en humildad hasta el fin del mundo, y que mediante la humildad llegue al reino prometido. Por esto, después de haber consolado dulcemente a esta Iglesia, a la que ordena que tan sólo busque el reino de Dios, le promete el reino que, en su infinita bondad, le dará el Padre.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Vended lo que poseéis y dad limosna. No temáis, dice, que militando por el reino de Dios, os falte lo necesario para vivir; antes vended lo que poseéis para dar limosna. Síguese dignamente este consejo, cuando después de haber dejado por Dios todas las cosas, con todo, dedícase uno a trabajos manuales para ganar el propio sustento y hacer limosna. De lo cual se gloriaba el Apóstol, diciendo: “Yo no he codiciado de nadie plata, ni oro, ni vestido, como vosotros mismos lo sabéis; porque cuanto ha sido menester para mí y para mis compañeros, todo me lo han suministrado estas manos”. Yo he hecho ver con toda mi conducta, que trabajando de esta suerte, es como se debe sostener a los débiles.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Haced para vosotros alforjas que no envejecen, dando limosnas, cuya recompensa permanece eternamente. No hay que interpretar este consejo en el sentido de que esté prohibido a los santos guardar algún dinero para emplearlo en su provecho o para darlo a los pobres, cuando el mismo Señor, a quien servían los Ángeles, con todo no desdeñó, para enseñar a la Iglesia naciente, el tener una bolsa; que conservaba las ofrendas de los fieles, y que las utilizaba para subvenir a las necesidades de los suyos o de otros indigentes. Pero no debemos servir a Dios por estas cosas, ni abandonar la justicia por temor a sufrir indigencia.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Lectura del Santo Evangelio según San Lucas
 !Lc 19:12-26
 En aquel tiempo: Dijo Jesús a sus discípulos esta parábola: Un hombre noble se marchó a un país lejano para conseguirse el título de rey, y volver después. Y lo que sigue.
@@ -333,9 +333,9 @@ Homilía de San Ambrosio, Obispo.
 !Libro 8 sobre el Evangelio de S. Lucas.
 Es bueno que, a punto de convocar a los gentiles, y de ordenar la destrucción de los judíos, que no querían que Cristo gobernara sobre ellos, propusiera esta parábola, no se fuera a decir que no dio oportunidad a los judíos de hacerse mejores. ¿Cómo van a devolver algo los que nada han recibido? No es cualquier cosa aquella moneda de plata que, al no encontrarla la mujer que cita antes el Evangelio (Lc 15, 8), encendió una lámpara y barrió la casa hasta que dio con ella.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Con una mina ganó uno diez, y el otro cinco. Parece que el de las cinco minas es el que obra rectamente, ya que cinco son los sentidos del cuerpo; y el de las diez, el doble que el otro, es el que obra rectamente y comprende los misterios de la doctrina. De ahí que Mateo hablara de cinco talentos y de dos talentos: cinco para las buenas obras, y dos para el misterio y las buenas obras. De modo que lo que es menos en número, tiene en sí más enjundia.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Y podemos también entender las diez minas por diez palabras, esto es, los diez Mandamientos, y las cinco minas, la enseñanza de la doctrina. Pero creo que un jurista debe ser perfecto en todo, pues el reino de Dios no consiste en palabras, sino en poder. Es bueno también, en lo tocante a los judíos, que Cristo se represente como aumentando el capital sólo el doble, pues no son éstas monedas de dinero, sino de gracia. Ganar dinero por la usura es una cosa, y otra muy distinta ganar por tal medio la enseñanza celestial. 
 &teDeum

--- a/web/www/horas/Espanol/Commune/C5a.txt
+++ b/web/www/horas/Espanol/Commune/C5a.txt
@@ -145,35 +145,35 @@ R. Y andará con firmes pasos.
 [Ant 3]
 @:Ant 1
 
-[Lectio11]
+[Lectio1 in 2 loco]
 @Commune/C5
 
-[Lectio21]
+[Lectio2 in 2 loco]
 @Commune/C5
 
-[Lectio31]
+[Lectio3 in 2 loco]
 @Commune/C5
 
-[Lectio71]
+[Lectio7 in 2 loco]
 @Commune/C5
 
-[Lectio81]
+[Lectio8 in 2 loco]
 @Commune/C5
 
-[Lectio91]
+[Lectio9 in 2 loco]
 @Commune/C5
 
-[Lectio72]
+[Lectio7 in 3 loco]
 @Commune/C5
 
-[Lectio82]
+[Lectio8 in 3 loco]
 @Commune/C5
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Y podemos también entender las diez minas por diez palabras, esto es, los diez Mandamientos, y las cinco minas, la enseñanza de la doctrina. Pero creo que un jurista debe ser perfecto en todo, pues el reino de Dios no consiste en palabras, sino en poder. Es bueno también, en lo tocante a los judíos, que Cristo se represente como aumentando el capital sólo el doble, pues no son éstas monedas de dinero, sino de gracia. Ganar dinero por la usura es una cosa, y otra muy distinta ganar por tal medio la enseñanza celestial. 
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Lectura del santo Evangelio según San Mateo
 !Mt 16:24-27
 En aquel tiempo: Dijo Jesús a sus discípulos: Si alguno quiere venir en pos de mí, niéguese a sí mismo, cargue con su cruz, y sígame. Y lo que sigue.
@@ -182,9 +182,9 @@ Homilía de San Gregorio, Papa.
 !Homilía 32 sobre el Evangelio.
 Porque nuestro Señor y Redentor vino al mundo como nuevo hombre, dio al mundo nuevos preceptos, pues  a nuestra antigua vida, alimentada por los vicios, impuso el deber de transformarse en una vida nueva. ¿qué pretendía el hombre viejo y carnal, sino retener lo suyo, arrebatando lo ajeno cuando le era posible, y deseándolo, si no podía? Mas el médico celeste dio remedios adecuados a cada uno de los vicios. Pues así como en el arte de la medicina, lo caliente se cura con lo frío y lo frío con lo caliente, así nuestro Señor opuso medicinas contrarias a los pecados, enseñando a los deshonestos continencia, generosidad a los avaros,  mansedumbre a los iracundos, y humildad a los soberbios.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Es verdad que al proponer nuevos mandamientos a los que le seguían, dijo: Si alguno no renuncia a todo lo que posee, no puede ser mi discípulo. Como si dijera: Los que siguiendo la vida antigua deseabais lo ajeno, si deseáis una vida nueva, dad de lo vuestro. Oigamos ahora lo que enseña: “El que quiera venir en pos de mí, niéguese a sí mismo”. Antes se nos ha dicho que renunciemos a nuestras cosas, ahora nos amonesta a que renunciemos a nosotros mismos. Algunas veces no es muy difícil que el hombre renuncie a lo que tiene, pero ciertamente lo es mucho dejarse a sí mismo. Es cosa pequeña sacrificar lo que tenemos, pero es cosa muy grande sacrificar lo que somos.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 El Señor ordenó a los que le seguían que renunciasen a todas las cosas, y esto porque cuantos nos preparamos para el combate de la fe, emprendemos una lucha contra los espíritus malignos. Ahora bien, éstos nada poseen de propio en este mundo; es preciso, pues, que luchemos desnudos con los que están desnudos. Pues si uno que está vestido pelea con otro que nada viste, será echado por tierra, ya que tiene de qué poderle asir. Y a la verdad, ¿qué son todas las cosas terrenas, sino como una especie de vestidos? De consiguiente, el que va a emprender una lucha contra el diablo, arroje de sí los vestidos para que no sucumba.
 &teDeum

--- a/web/www/horas/Espanol/Commune/C5a.txt
+++ b/web/www/horas/Espanol/Commune/C5a.txt
@@ -89,7 +89,7 @@ R. Y andará con firmes pasos.
 @Commune/C5
 
 [Responsory7]
-@Commune/C4:Responsory73
+@Commune/C4:Responsory7 in 4 loco
 
 [Lectio8]
 @Commune/C5

--- a/web/www/horas/Espanol/Commune/C6.txt
+++ b/web/www/horas/Espanol/Commune/C6.txt
@@ -311,7 +311,7 @@ R. El Señor te bendice eternamente.
 [Ant 3]
 @:Ant 1
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Del Libro del Eclesiástico
 !Sir 51:1-7
 1 Te doy gracias, Señor y Rey mío; te alabaré, Dios de mi salud. 
@@ -322,7 +322,7 @@ Del Libro del Eclesiástico
 6 de la asfixia de las llamas que me envolvían, y en medio del fuego no me quemé; y del profundo seno del sepulcro, 
 7 de la lengua malvada, de los discursos embusteros, de las saetas de la lengua mentirosa. 
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 51:8-12
 8 Estaba mi alma al borde de la muerte, 
 9 y mi vida próxima al profundo sepulcro. 
@@ -330,7 +330,7 @@ Del Libro del Eclesiástico
 11 Pero me acordé, Señor, de tu misericordia, de tu antigua conducta, 
 12 de que salvas a los que en ti esperan y los libras de todo mal. 
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 13 Y alcé entonces mi voz y te rogué a las mismas puertas del sepulcro. 
 14 Y clamé al Señor Altísimo: Señor, Tú eres mi padre, el campeón de mi salud; no me abandones en el día de la tribulación, en el día de la ruina y de la devastación. 

--- a/web/www/horas/Espanol/Sancti/01-16.txt
+++ b/web/www/horas/Espanol/Sancti/01-16.txt
@@ -23,13 +23,13 @@ Marcelo, romano, Papa desde el reinado de Constancio y Galerio hasta el de Majen
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Responsory8]
 R. Señor, Tú le preveniste con amorosas bendiciones. 

--- a/web/www/horas/Espanol/Sancti/01-20.txt
+++ b/web/www/horas/Espanol/Sancti/01-20.txt
@@ -22,10 +22,10 @@ Fabián, romano, Papa desde la época de Maximiano hasta la de Decio. Dividió l
 &teDeum
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Espanol/Sancti/01-21.txt
+++ b/web/www/horas/Espanol/Sancti/01-21.txt
@@ -33,7 +33,7 @@ V. El Señor la eligió sobre todas las demás.
 R. Y la hizo habitar en su tabernáculo.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Responsory1]
 R. Celebremos la fiesta de una Virgen muy santa, y recordemos de qué modo padeció la bienaventurada Inés; a los trece años de edad perdió la muerte, y halló la vida: 
@@ -42,7 +42,7 @@ V. Niña por los años, muy anciana por la madurez de su juicio.
 R. Porque solamente amó al Autor de la vida.
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Responsory2]
 R. Él ha rodeado mi diestra y mi cuello de piedras preciosas, ha puesto en mis orejas perlas de inapreciable valor.
@@ -51,7 +51,7 @@ V. Ha puesto una señal sobre mi rostro para que no admita fuera de Él otro ama
 R. Y me ha adornado con piedras preciosas muy resplandecientes. 
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Responsory3]
 R. Yo amo a Cristo; seré la esposa de Aquél cuya Madre es Virgen, cuyo Padre lo ha engendrado sin concurso de mujer y que ha hecho resonar en mis oídos acordes armoniosos. 

--- a/web/www/horas/Espanol/Sancti/01-26.txt
+++ b/web/www/horas/Espanol/Sancti/01-26.txt
@@ -23,10 +23,10 @@ Policarpo, discípulo del Apóstol San Juan, y por él ordenado obispo de Esmirn
 @Sancti/07-13:Lectio6
 
 [Lectio7]
-@Commune/C2:Lectio72
+@Commune/C2:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C2:Lectio82
+@Commune/C2:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C2:Lectio92
+@Commune/C2:Lectio9 in 3 loco

--- a/web/www/horas/Espanol/Sancti/02-05.txt
+++ b/web/www/horas/Espanol/Sancti/02-05.txt
@@ -44,7 +44,7 @@ V. El Señor la eligió sobre todas las demás.
 R. La hizo habitar en su tabernáculo.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Responsory1]
 R. Mientras la bienaventurada Águeda era cruelmente atormentada en uno de sus pechos, dijo al juez: 
@@ -53,7 +53,7 @@ V. Por lo que hace a mí, tengo en el fondo de mi alma íntegros mis pechos, los
 R. Impío, cruel y bárbaro tirano, ¿no te avergüenzas de cortar a una mujer lo mismo con que tu madre te alimentó?
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Responsory2]
 R. Águeda iba a la cárcel llena de gozo y gloriándose por ello, 
@@ -62,7 +62,7 @@ V. Siendo de nobilísima prosapia, gozábase en ser llevada a la cárcel por un 
 R. Como si fuese invitada a un convite; y recomendaba a Dios con preces su combate.
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Responsory3]
 R. ¿Quién eres tú, que viniste a mí para curar mis heridas? Yo soy el Apóstol de Cristo; no tengas acerca de mí ningún temor, hija mía: Él mismo me ha enviado a ti, 

--- a/web/www/horas/Espanol/Sancti/02-27.txt
+++ b/web/www/horas/Espanol/Sancti/02-27.txt
@@ -14,13 +14,13 @@ Oh Dios, que enseñaste al bienaventurado Gabriel el recuerdo asiduo de los dolo
 $Qui vivis
 
 [Lectio1](sed non rubrica 1960)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2](sed non rubrica 1960)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3](sed non rubrica 1960)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Gabriel nació en Asís, Umbría, de padres bien reputados. Llamado Francisco en memoria de su seráfico conciudadano, desde niño demostró una excelente índole. Ya adolescente, estudiando en Espoleto, siguió algún tanto la vanidad del mundo. Pero por un beneficio de la misericordia divina, la cual le invitaba a la perfección de la vida cristiana, y caído en una enfermedad, comenzó a desengañarse del mundo y a apetecer tan sólo los bienes celestiales. Le ayudó mucho a obedecer raudo al llamamiento de Dios, la contemplación de la imagen de la Virgen de Espoleto, llevada en procesión solemne fuera de la iglesia. De tal manera se inflamó su alma en la llama del divino amor, que se sintió movido a abrazar el Instituto de los Pasionistas. Tras haber vencido no pocas dificultades, en el retiro de Morrovalle, vistió gozoso el austero hábito, queriendo ser llamado Gabriel de la Virgen Dolorosa, a fin de recordar constantemente los gozos y dolores de la Virgen.

--- a/web/www/horas/Espanol/Sancti/03-04.txt
+++ b/web/www/horas/Espanol/Sancti/03-04.txt
@@ -23,13 +23,13 @@ v. Pastor eterno, que cuidas de tu rebaño con amor: guárdalo con tu protecció
 $Per Dominum.
 
 [Lectio1](sed non rubrica 1960)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2](sed non rubrica 1960)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3](sed non rubrica 1960)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Casimiro, hijo de Casimiro y de Isabel de Austria, reyes de Polonia, fue desde niño instruido por los mejores maestros en la piedad y bellas letras; sujetaba sus miembros con áspero cilicio y con ayunos. Despreciando la molicie del lecho real, dormía sobre el suelo, e iba secretamente, en la noche, a implorar la divina clemencia, postrado en tierra ante las puertas de los templos. Asiduo en la meditación de los sufrimientos de Cristo, acostumbraba a fijar su mente en Dios durante la Misa, y parecía estar arrebatado fuera de sí. 

--- a/web/www/horas/Espanol/Sancti/03-06.txt
+++ b/web/www/horas/Espanol/Sancti/03-06.txt
@@ -23,13 +23,13 @@ $Per Dominum
 Alabemos a Dios, nuestro Señor, * en la confesión de las bienaventuradas Perpetua y Felicidad.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Lectio4]
 Perpetua y Felicidad fueron detenidas en Africa en la persecución del emperador Severo, junto con Revocato, Saturnino y Secúndolo, y encerradas en una oscura cárcel; después se les juntó Sátiro. Eran catecúmenas, y poco después fueron bautizadas. A los pocos días las llevaron al foro con sus compañeros, y tras haber confesado gloriosamente la fe, el procurador Hilarión las condenó a las fieras. Descendieron gozosas a la cárcel, en donde diversas visiones robustecieron su valor para recibir la palma del martirio. A Perpetua no pudieron apartarla de la fe de Cristo ni las repetidas súplicas y las lágrimas de su anciano padre, ni el amor maternal hacia su hijito que pendía de sus pechos, ni la atrocidad del suplicio.

--- a/web/www/horas/Espanol/Sancti/03-10.txt
+++ b/web/www/horas/Espanol/Sancti/03-10.txt
@@ -19,10 +19,10 @@ Uno de los guardas estaba en vela mientras los demás dormían. Y vio que, estan
 Todos murieron en aquel suplicio, excepto el más joven, llamado Melitón. Y como viera su madre que, quebradas las piernas, aún vivía, le habló así: ‘‘Hijo mío, espera; sufre un poco; he ahí que Cristo está a la puerta ayudándote”. Y al ver que colocaban los cuerpos de los demás sobre unos carros para quemarlos, y dejaban el de su hijo, porque aquel grupo de impíos esperaban que si vivía, podrían inducirle a adorar a los ídolos, tomando a su propio hijo y llevándole sobre sus hombros, seguía los carros cargados con los mártires. Melitón entregó su alma a Dios en brazos de su madre; su cuerpo fue echado por ella a la hoguera en que los demás Mártires ardían. Así aquellos que habían estado unidos por la fe y el valor, tuvieron comunes exequias; y unidos llegaron al cielo. Quemados ya, sus huesos fueron arrojados a un arroyo; mas, habiéndose juntado en cierto lugar, fueron hallados íntegros e intactos, y fueron sepultados honoríficamente.
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Espanol/Sancti/03-21.txt
+++ b/web/www/horas/Espanol/Sancti/03-21.txt
@@ -9,13 +9,13 @@ vide C4;
 @Commune/C5:Oratio1:s/N\./Benito/
 
 [Lectio1]
-@Commune/C4:Lectio11
+@Commune/C4:Lectio1 in 2 loco
 
 [Lectio2]
-@Commune/C4:Lectio21
+@Commune/C4:Lectio2 in 2 loco
 
 [Lectio3]
-@Commune/C4:Lectio31
+@Commune/C4:Lectio3 in 2 loco
 
 [Lectio4]
 Benito, nacido en Nursia de noble linaje, fue instruido en Roma en las artes liberales. A fin de darse totalmente a Jesucristo, se retiró en una elevada gruta en Subiaco. Allí vivió desconocido tres años; sólo lo sabía un monje: Román, quien le servía para atender a lo que necesitaba para vivir. Habiendo el diablo excitado en Benito una violenta tentación de impureza, se revolcó entre las zarzas; así, lacerado el cuerpo, ahogó el hervor de la voluptuosidad con el dolor. Como la fama de su santidad se difundiese lejos, unos monjes le rogaron que les instruyese; pero no pudiendo soportar las reprensiones que merecían a causa de su vida licenciosa, determinaron envenenarle mediante una bebida. Pero, con la señal de la cruz, quebró el vaso que le ofrecían, y dejando el monasterio, volvió a la soledad.

--- a/web/www/horas/Espanol/Sancti/04-02.txt
+++ b/web/www/horas/Espanol/Sancti/04-02.txt
@@ -29,10 +29,10 @@ Francisco de Paula nació en Calabria; de joven ardió en amor por Dios y se ret
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Espanol/Sancti/04-22.txt
+++ b/web/www/horas/Espanol/Sancti/04-22.txt
@@ -25,11 +25,11 @@ Sotero, de Fondi en la Campania, sucedió al mártir Aniceto. Ordenó que las v�
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 

--- a/web/www/horas/Espanol/Sancti/04-23.txt
+++ b/web/www/horas/Espanol/Sancti/04-23.txt
@@ -13,13 +13,13 @@ Oh Dios, que nos alegras con los merecimientos e intercesión del bienaventurado
 $Per Dominum
 
 [Lectio4]
-@Commune/C2:Lectio41
+@Commune/C2:Lectio4 in 2 loco
 
 [Lectio5]
-@Commune/C2:Lectio51
+@Commune/C2:Lectio5 in 2 loco
 
 [Lectio6]
-@Commune/C2:Lectio61
+@Commune/C2:Lectio6 in 2 loco
 
 [Lectio94]
 The martyr George beareth among the Easterns the title of the holy and glorious~

--- a/web/www/horas/Espanol/Sancti/05-25.txt
+++ b/web/www/horas/Espanol/Sancti/05-25.txt
@@ -31,13 +31,13 @@ El Papa Gregorio VII, llamado Hildebrando, nació cerca de Savona en Toscana. Se
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Espanol/Sancti/06-13.txt
+++ b/web/www/horas/Espanol/Sancti/06-13.txt
@@ -22,13 +22,13 @@ $Per Dominum
 @:OratioText:s/ y Doctor//
 
 [Lectio1] (rubrica tridentina)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2] (rubrica tridentina)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3] (rubrica tridentina)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Antonio, natural de Lisboa, Portugal, nació de padres nobles, que lo educaron piadosamente. De joven, abrazó la vida de los Canónigos regulares. Pero trasladados a Coimbra los cuerpos de cinco mártires, Frailes Menores, que habían sido martirizados por la fe en Marruecos, su vista abrasó a Antonio de deseos de ser martirizado e ingresó en la Orden Franciscana. Movido por este impulso, se dirigió al país de los sarracenos, pero una enfermedad lo redujo a la impotencia y tuvo que regresar. Sucedió, que a pesar de navegar con rumbo a España, los vientos llevaron el navío en que viajaba a Sicilia.

--- a/web/www/horas/Espanol/Sancti/06-25.txt
+++ b/web/www/horas/Espanol/Sancti/06-25.txt
@@ -26,10 +26,10 @@ Guillermo, nacido de padres nobles en Vercelli, apenas con 14 años peregrinó a
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio73
+@Commune/C4:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C4:Lectio83
+@Commune/C4:Lectio8 in 4 loco
 
 [Lectio9]
-@Commune/C4:Lectio93
+@Commune/C4:Lectio9 in 4 loco

--- a/web/www/horas/Espanol/Sancti/06-26.txt
+++ b/web/www/horas/Espanol/Sancti/06-26.txt
@@ -56,7 +56,7 @@ A esta levadura se refiere la recomendación del Apóstol: Así pues, celebremos
 “Porque cuanto dijisteis a oscuras, se dirá a la luz del día”, puede entenderse, no sólo del tiempo futuro, cuando todos los secretos de los corazones se manifestarán a la luz, sino aun en el presente. Porque cuanto sufrieron los apóstoles, y cuanto hablaron en la oscuridad y en las tinieblas de los tormentos y de las cárceles, ahora en que es honrada la Iglesia por el mundo, se lee en público en sus actas. “Ni os amedrenten los que matan el cuerpo”. Si a los perseguidores de los santos, ya muertos los cuerpos, no les quedaba ya más que hacer contra ellos, fue mucha la malicia de los que arrojaron los miembros muertos de los mártires para ser despedazados por las fieras y las aves, siendo así que en manera alguna podían oponerse a que la omnipotencia de Dios, resucitándolos, los vivificase.
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Lectio9]
 Dos clases hay de perseguidores: unos que atormentan; otros que con fingimiento y engaño halagan. El Salvador, queriendo instruirnos y fortalecernos contra ambos, así como antes nos ordenó estar atentos contra la hipocresía de los fariseos, ahora nos enseña a no temer la muerte causada por los verdugos. Y esto porque tras la muerte no puede continuar ni la crueldad de éstos, ni la simulación de aquéllos. “¿No es verdad que cinco pajarillos se venden por dos cuartos?” Quiere decir: Si Dios no olvida a los más pequeños animales, ni a los pájaros que vuelan; vosotros que habéis sido hechos a imagen del Creador, no debéis temer a los que matan el cuerpo, puesto que quien gobierna los animales, no dejará de atender con cuidado a sus criaturas racionales.

--- a/web/www/horas/Espanol/Sancti/07-03.txt
+++ b/web/www/horas/Espanol/Sancti/07-03.txt
@@ -28,13 +28,13 @@ El papa León II, siciliano de origen, estaba muy versado en la ciencia de las s
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Espanol/Sancti/07-13.txt
+++ b/web/www/horas/Espanol/Sancti/07-13.txt
@@ -25,10 +25,10 @@ Anacleto, nacido en Atenas, gobernó la Iglesia durante el imperio de Trajano. D
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Espanol/Sancti/07-14.txt
+++ b/web/www/horas/Espanol/Sancti/07-14.txt
@@ -28,10 +28,10 @@ Nacido en Bagnorea, Toscana, Buenaventura ingresó en la Orden de San Francisco 
 &teDeum
 
 [Lectio7]
-@Commune/C4a:Lectio72
+@Commune/C4a:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C4a:Lectio82
+@Commune/C4a:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C4a:Lectio92
+@Commune/C4a:Lectio9 in 3 loco

--- a/web/www/horas/Espanol/Sancti/08-10.txt
+++ b/web/www/horas/Espanol/Sancti/08-10.txt
@@ -52,7 +52,7 @@ V. Grande es su gloria por la salvación que le has dado.
 R. Le revestiste de esplendor y de hermosura soberana.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Responsory1]
 R. Bien obró el Levita Lorenzo al devolver, con la señal de la cruz, la vista a los ciegos, 

--- a/web/www/horas/Espanol/Sancti/08-23.txt
+++ b/web/www/horas/Espanol/Sancti/08-23.txt
@@ -19,13 +19,14 @@ Siendo elegido, a pesar de su resistencia, general de su Orden, por su celo en e
 Constantemente brillaba en él la más tierna compasión para con los pobres, la cual se puso principalmente de manifiesto en una ocasion en que dio su propio vestido a un leproso, a quien encontró pidiendo limosna, casi desnudo, en un arrabal de Siena, y que quedó curado al momento de ponérselo. La admiración que despertó este milagro por doquiera, fue causa de que al reunirse los cardenales en Viterbo para elegir sucesor de Clemente IV, pusieran los ojos en Felipe, del cual conocían, por otra parte, su prudencia casi celestial. Pero al saberlo el varón de Dios, temiendo verse obligado a aceptar la carga del pontificado, se ocultó en el monte Tuniato, donde permaneció hasta que Gregorio X hubo sido proclamado Sumo Pontífice. Puede verse en aquel lugar un manantial llamado todavía Fuente de San Felipe, que debe a sus oraciones la virtud de curar a los enfermos. Por último, murió santamente en Todi, en el año 1285, abrazado al crucifijo, al que llamaba su libro. Junto a su sepulcro hubo ciegos que recobraron la vista, cojos que recobraron el andar y muertos que resucitaron. Ante la fama de estos y de otros muchos milagros, el Sumo Pontífice Clemente X le canonizó.
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco
+
 
 [Lectio Vigilia]
 !En la Vigilia de S. Bartolomé, Apóstol

--- a/web/www/horas/Espanol/Sancti/08-25.txt
+++ b/web/www/horas/Espanol/Sancti/08-25.txt
@@ -31,13 +31,13 @@ Por un tratado con los sarracenos, el rey y su ejército recobraron la libertad.
 Construyó muchos monasterios y hospicios para los pobres; socorría a los indigentes y visitaba con frecuencia a los enfermos, a los cuales los hacía cuidar a sus expensas, y les daba con sus propias manos lo que necesitaban. Vestía sencillamente, y castigaba su cuerpo con cilicios y ayunos. Surcó de nuevo el mar para combatir contra los sarracenos, pero cuando acababa de establecer su campamento frente al enemigo, murió de la peste, diciendo: “Entraré, Señor, en vuestra casa, os adoraré en vuestro templo santo y glorificaré vuestro nombre”. Su cuerpo se trasladó a París; se conserva y venera en la iglesia de San Dionisio. Su cabeza, se guarda en la Santa Capilla. Glorificado por grandes milagros, fue canonizado por el papa Bonifacio VIII.
 
 [Lectio7]
-@Commune/C5:Lectio72
+@Commune/C5:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C5:Lectio82
+@Commune/C5:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C5:Lectio92
+@Commune/C5:Lectio9 in 3 loco
 
 [Lectio93]
 @Sancti/08-26:Lectio93

--- a/web/www/horas/Espanol/Sancti/09-02.txt
+++ b/web/www/horas/Espanol/Sancti/09-02.txt
@@ -19,13 +19,13 @@ Su amor a la oración le movía a pasar noches enteras en vela; estando ocupado 
 Por una ardiente devoción a la Madre de Dios, edificó un gran templo en su honor, proclamándola patrona de Hungría. Ella, en pago, le introdujo en el cielo el mismo día de su Asunción, llamado por húngaros, según lo quiso este santo rey, el día de la Gran Soberana. Tras su muerte, su cuerpo difundía un suave perfume y un óleo celestial. Dispuso el Papa trasladarlo a un lugar más digno, al que fue llevado honoríficamente. Esta traslación fue acompañada de muchos milagros. El papa Inocencio III señaló como día de su fiesta el día cuarto de las nonas de septiembre, en memoria de la victoria que Leopoldo, emperador electo de los romanos y rey de Hungría, alcanzó en esa fecha contra los turcos, reconquistándoles, con la ayuda de Dios, la ciudad de Budapest.
 
 [Lectio7]
-@Commune/C5:Lectio72
+@Commune/C5:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C5:Lectio82
+@Commune/C5:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C5:Lectio92
+@Commune/C5:Lectio9 in 3 loco
 
 [Lectio94]
 Esteban, rey de Hungría, introdujo la fe de Cristo y la monarquía en su país. Obtuvo su corona real del Papa y, cuando fue ungido Rey, ofreció su reino a la Sede Apostólica. Fundó varias casas religiosas en Roma, en Jerusalén y en Constantinopla. En Hungría, con maravillosa devoción y generosidad, estableció la sede arzobispal de Estrigonia y otros diez obispados. Era famoso por su gran amor a los pobres y su constancia en la oración. Veneraba con fervor a la Madre de Dios, declarándola la Patrona de Hungría y construyendo una gran iglesia en su honor. A su vez, fue recibido en el cielo por la Virgen en la Fiesta de su Asunción, que en Hungría, por edicto suyo, se llamó el Día de la Gran Dama. Por decreto del Papa Inocencio XI, sin embargo, la fiesta de este santo Rey se lleva a cabo el día en que, con su ayuda, el ejército cristiano, en un combate reñido, recuperó la ciudadela fortificada de Budapest.

--- a/web/www/horas/Espanol/Sancti/09-10.txt
+++ b/web/www/horas/Espanol/Sancti/09-10.txt
@@ -19,13 +19,13 @@ De adulto, inscrito ya en la milicia clerical, y siendo canónigo, habiendo oíd
 Las asechanzas de Satanás, que no cesaba de atormentarle por distintos medios, hasta llegar a maltratarle a golpes, en nada disminuían su constancia en la oración. Durante los seis meses anteriores a su muerte, oyó todas las noches los conciertos angélicos, pregustando las delicias del Paraíso; penetrado de su dulzura, repetía las palabras del Apóstol: “Deseo morir, para vivir en Jesucristo”. Sus deseos se cumplieron el día cuatro de los idus de septiembre, como predijo a sus hermanos. Brilló con muchos milagros, aun tras su muerte, por los que, una vez comprobados, el Papa Eugenio IV le puso en el número de los Santos.
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco
 
 [Lectio94]
 Nicolás, llamado Tolentino por vivir mucho tiempo en la ciudad del mismo nombre, nació en la aldea de Santo Ángel, Ancona, de padres devotos que lo obtuvieron por la oración e intercesión de San Nicolás. De niño mostró muchas virtudes, especialmente de abstinencia. Militó entre el clero y fue canónigo. Escuchó un sermón de un predicador de los Ermitaños de San Agustín sobre el desprecio del mundo e ingresó de inmediato en los agustinos. Aquí cumplió la regla religiosa estrictamente; ayunando, vistiendo ropa áspera, mortificando su cuerpo con disciplinas y cadenas, y sobresalió en todas las demás virtudes. Nunca aflojó en su celo por la oración, a pesar de que fue atormentado de varias maneras por el diablo que, incluso, le golpeaba. Cada noche durante seis meses antes de su muerte, escuchaba melodías angelicales; y al fin, habiendo predicho el día de su muerte, se durmió en el Señor. Famoso por sus milagros antes y después de su muerte, fue inscrito entre los Santos por Eugenio IV.

--- a/web/www/horas/Espanol/Sancti/09-17.txt
+++ b/web/www/horas/Espanol/Sancti/09-17.txt
@@ -64,10 +64,10 @@ Francisco sabía que el sufrimiento es incompatible con la inmortalidad de un es
 Transformado en un hombre nuevo por este inaudito y sorprendente prodigio (era, en efecto, el primer caso de un hombre marcado, o mejor aún, adornado con las sagradas llagas), descendió de la montaña llevando en sí la imagen del Crucificado, esculpida, no en piedra ni en madera por un artista, sino en su propia carne por el dedo del Dios vivo. Como sabía que “es bueno mantener oculto el secreto del rey”, esforzábase aquel hombre, conocedor del misterio obrado en él por el Rey divino, en ocultar a los demás los estigmas. Mas a Dios corresponde revelar para gloria suya las grandes cosas por Él realizadas; así, el mismo Señor, que había impreso en secreto aquellas señales, quiso darlas a conocer por medio de milagros, haciendo que por los prodigios resplandeciera su virtud escondida y maravillosa. El aniversario de este hecho, tan digno de admiración, tan claramente comprobado, y enaltecido con grandes alabanzas y la concesión de favores especiales en las bulas pontificias, quiso el papa Benedicto XI que se celebrara una solemnidad, extendida más tarde por el Sumo Pontífice Paulo V a toda Iglesia, y destinada a encender en los corazones de los fieles el amor a Jesucristo crucificado.
 
 [Lectio7]
-@Commune/C2:Lectio73
+@Commune/C2:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C2:Lectio83
+@Commune/C2:Lectio8 in 4 loco
 
 [Responsory8]
 R. Líbreme Dios de gloriarme sino en la Cruz de nuestro Señor Jesucristo; 
@@ -78,7 +78,7 @@ R. Por quien el mundo está crucificado para mí, y yo lo estoy al mundo.
 R. Por quien el mundo está crucificado para mí, y yo lo estoy al mundo. 
 
 [Lectio9]
-@Commune/C2:Lectio93
+@Commune/C2:Lectio9 in 4 loco
 
 [Lectio94]
 Transformado en un hombre nuevo por este inaudito y sorprendente prodigio (era, en efecto, el primer caso de un hombre marcado, o mejor aún, adornado con las sagradas llagas), descendió de la montaña llevando en sí la imagen del Crucificado, esculpida, no en piedra ni en madera por un artista, sino en su propia carne por el dedo del Dios vivo. Como sabía que “es bueno mantener oculto el secreto del rey”, esforzábase aquel hombre, conocedor del misterio obrado en él por el Rey divino, en ocultar a los demás los estigmas. Mas a Dios corresponde revelar para gloria suya las grandes cosas por Él realizadas; así, el mismo Señor, que había impreso en secreto aquellas señales, quiso darlas a conocer por medio de milagros, haciendo que por los prodigios resplandeciera su virtud escondida y maravillosa. El aniversario de este hecho, tan digno de admiración, tan claramente comprobado, y enaltecido con grandes alabanzas y la concesión de favores especiales en las bulas pontificias, quiso el papa Benedicto XI que se celebrara una solemnidad, extendida más tarde por el Sumo Pontífice Paulo V a toda Iglesia, y destinada a encender en los corazones de los fieles el amor a Jesucristo crucificado.

--- a/web/www/horas/Espanol/Sancti/09-20.txt
+++ b/web/www/horas/Espanol/Sancti/09-20.txt
@@ -21,10 +21,10 @@ Volvió al lugar de la visión, como el Señor le había mandado, y le oyó anun
 En la expedición tuvo la alegría de recobrar a su esposa y a sus hijos. Entró victorioso en Roma en medio de aclamaciones. Habiéndosele, empero, ordenado poco después que sacrificara a los falsos dioses en acción de gracias por la victoria obtenida, se negó a ello con  firmeza. En vano se intentó por diversos medios obligarle a renegar de la fe de Cristo. Le echaron, junto con su mujer e hijos a los leones; pero éstos se mostraron mansos, lo que exasperó al Emperador, por lo cual mandó encerrar a los santos confesores en el interior de un toro de bronce candente, en donde, cantando las divinas  alabanzas, consumaron su martirio, el día doce de las calendas de octubre. Sus cuerpos, que fueron hallados intactos, recibieron religiosa sepultura de manos de los fieles, siendo más tarde trasladados a la iglesia levantada en su nombre.
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio Vigilia]
 !Conmemoración de la Vigilia de S. Mateo, Apóstol

--- a/web/www/horas/Espanol/Sancti/09-23.txt
+++ b/web/www/horas/Espanol/Sancti/09-23.txt
@@ -36,10 +36,10 @@ El Papa Lino, natural de Volterra, Toscana, fue el primero que después de San P
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Espanol/Sancti/09-27.txt
+++ b/web/www/horas/Espanol/Sancti/09-27.txt
@@ -24,13 +24,13 @@ Cosme y Damián, hermanos árabes, nacieron en Egea; ilustres doctores, bajo los
 &teDeum
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Espanol/Sancti/10-14.txt
+++ b/web/www/horas/Espanol/Sancti/10-14.txt
@@ -26,13 +26,13 @@ Calixto, romano, fue Papa durante el imperio de Antonino Heliogábalo. Fijó las
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Lectio7](rubrica tridentina)
 @Sancti/02-22:Lectio7

--- a/web/www/horas/Espanol/Sancti/10-19.txt
+++ b/web/www/horas/Espanol/Sancti/10-19.txt
@@ -23,10 +23,10 @@ Nacido de padres nobles en Alcántara, España, Pedro ingresó en la Orden de lo
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Espanol/Sancti/10-31.txt
+++ b/web/www/horas/Espanol/Sancti/10-31.txt
@@ -10,13 +10,13 @@ Laudes 2
 No Suffragium 
 
 [Lectio1]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio2]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio3]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco
 
 [Oratio]
 Multiplica, Señor, en nosotros la efusión de tu gracia, y haz que seamos merecedores, con una vida santa, de seguir en la felicidad eterna a aquellos cuya fiesta solemne anticipamos.

--- a/web/www/horas/Espanol/Sancti/11-13.txt
+++ b/web/www/horas/Espanol/Sancti/11-13.txt
@@ -23,10 +23,10 @@ Diego nació en San Nicolás del Puerto, diócesis de Sevilla, España. Desde su
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Espanol/Sancti/11-20.txt
+++ b/web/www/horas/Espanol/Sancti/11-20.txt
@@ -23,10 +23,10 @@ Félix, antes llamado Hugo, de la familia real de Valois en Francia, desde joven
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Espanol/Sancti/12-11.txt
+++ b/web/www/horas/Espanol/Sancti/12-11.txt
@@ -33,13 +33,13 @@ Estableció la pena del talión contra aquel que acusara a otro falsamente. Orde
 Dámaso, español eminente, aprendió en las Sagradas Escrituras. Convocó el primer Concilio de Constantinopla, donde abolió la herejía de Eunomio y Macedonio. Repitió la condena de Liberio sobre el Concilio de Rimini. Este concilio, debido a las intrigas de Valente y Ursacio, había condenado la fe de Nicea. Dámaso construyó dos basílicas: una a San Lorenzo, cerca del teatro de Pompeyo, la otra a la Ardeatina en las Catacumbas. Decidió, según costumbre en muchos lugares, que los Salmos deberían ser cantados día y noche en todas las iglesias por coros alternos, y que al final de cada Salmo debería repetirse: "Gloria al Padre, y al Hijo y al Espíritu Santo". Bajo su mando, San Jerónimo revisó la traducción del Nuevo Testamento para hacerlo fiel al texto griego. Descubrió muchos cuerpos de Santos mártires y celebró su memoria en versos. Tenía casi 80 años; famoso por su virtud, sabiduría y prudencia, se durmió en el Señor, durante el reinado de Teodosio el Grande.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Espanol/Sancti/12-16.txt
+++ b/web/www/horas/Espanol/Sancti/12-16.txt
@@ -18,16 +18,16 @@ El concilio se reunió en Milán, en el año siguiente. Fue invitado al concilio
 Cuánta fuese entonces para con él la crueldad y el insolente atrevimiento de los arrianos, lo muestran unas cartas llenas de valentía, piedad y religión, que desde Escitópolis envió al clero y pueblo de Vercelli y a algunas poblaciones vecinas. Ellas muestran también que jamás le pudieron amedrentar ni las amenazas ni crueldad, que ni con halagadoras promesas le pudieron conquistar. A causa de su constancia fue deportado a Capadocia, y al fin a la Tebaida superior de Egipto, sufriendo el destierro hasta la muerte de Constancio. Después, habiéndosele permitido reintegrarse a su rebaño, no lo hizo hasta después de haber asistido al concilio de Alejandría, a fin de reparar las pérdidas que había sufrido la fe. Recorrió después las provincias de Oriente para devolver la salud, como hábil médico, a los enfermos en la fe, instruyéndoles en la doctrina de la Iglesia. Luego, con el mismo objeto, pasó a la Iliria, y por último llegó a Italia, cesando allí el duelo dejado por su partida. Allí publicó los comentarios de Orígenes y de Eusebio de Cesárea sobre los Salmos, después de haberlos expurgado y vertido del griego al latín. Finalmente, dejó esta vida para recibir la corona de la gloria, merecida con tantos trabajos, en Vercelli, en tiempo de Valentiniano y Valente.
 
 [Lectio7]
-@Commune/C2:Lectio73
+@Commune/C2:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C2:Lectio83
+@Commune/C2:Lectio8 in 4 loco
 
 [Responsory8]
-@Commune/C2:Responsory8NonEffusorum
+@Commune/C2:Responsory8 non Effusorum
 
 [Lectio9]
-@Commune/C2:Lectio93
+@Commune/C2:Lectio9 in 4 loco
 
 [Lectio94]
 Eusebio nació en Cerdeña, lector de Roma, y más tarde obispo de Vercelli, luchó tan valientemente contra el arrianismo que su fe inconquistable le dio aliento y vida nueva al Papa. Debido a su profesión de fe católica, Eusebio fue enviado a Escitópolis por el emperador Constancio, donde sufrió hambre, sed, palizas y muchos otros tipos de tormento. Desde allí fue enviado a Capadocia y soportó las dificultades del exilio hasta la muerte de Constancio. Cuando se le permitió regresar a su propia Iglesia, Italia se quitó las vestiduras de luto. Aquí publicó su propia traducción latina expurgada de los comentarios griegos de Orígenes y los de Eusebio de Cesarea sobre todos los salmos. En Vercelli, durante el reinado de Valentiniano y Valente, entregó su alma al Señor.

--- a/web/www/horas/Espanol/Sancti/12-31.txt
+++ b/web/www/horas/Espanol/Sancti/12-31.txt
@@ -58,13 +58,13 @@ Así, pues, a instigación de Silvestre, el piadoso emperador confirmó con su e
 El mismo fijó el tiempo durante el cual los iniciados en las Órdenes debían ejercer las funciones de las mismas en la iglesia, antes de ascender a un grado superior. Prohibió a los seglares que acusaran públicamente a los clérigos, y no permitió a los clérigos que pleitearan ante un juez profano. Quiso que, excepto el sábado y el domingo, los restantes días de la semana se distinguieran con el nombre de Ferias, como ya antes se había empezado a practicar en la Iglesia, para dar a entender que los clérigos cada día, dejado el cuidado de todo lo demás, debían vacar únicamente al servicio de Dios. La admirable santidad de su vida y su benignidad para con los pobres, correspondieron a la celestial prudencia con que gobernaba la Iglesia. Procuró que los clérigos pobres vivieran juntamente con los ricos, y que a las sagradas vírgenes no les faltara lo necesario para la vida. Vivió en el Pontificado veinte años, diez meses y un día. Fue sepultado en el cementerio de Priscila, en la vía Salaria. Celebró siete ordenaciones en el mes de Septiembre, en las cuales creó cuarenta y dos presbíteros, veinticinco diáconos y setenta y cinco Obispos para diversos lugares. 
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Commemoratio 2]
 @Sancti/12-25:Octava

--- a/web/www/horas/Francais/Commune/C2.txt
+++ b/web/www/horas/Francais/Commune/C2.txt
@@ -306,7 +306,7 @@ R. Il croîtra comme le cèdre du Liban.
 [Ant 3]
 Si quelqu'un veut venir après Moi, * qu'il se renonce lui-même, qu'il porte sa croix et Me suive !
 
-[Lectio41]
+[Lectio4 in 2 loco]
 De la lettre de Saint Ciprien, Evêque et Martur, aux Martyrs et aux Confesseurs
 !Lib. 2. Epist. 6.
 Quelles louanges vous donnerai-je, ô généreux Martyrs ? De quelles paroles me servirai-je pour relever la grandeur de votre courage et la fermeté de votre foi ? Vous avez souffert jusqu'au bout de cruelles tortures et ce n'est pas vous qui avez cedé aux tourmens, mais ce sont les tourmens qui vont ont cédé. Vous avez trouvé dans la couronne du martyre la fin de vos douleurs que vous ne pouviez trouver dans des supplices sans fin. L'inhumanité des bourreaux en vous faisant souffrir si longtemps n'a pas tant servi à ébranler votre foi qu'à vous envoyer plutôt à Dieu comme des hommes de Dieu.

--- a/web/www/horas/Francais/Commune/C2.txt
+++ b/web/www/horas/Francais/Commune/C2.txt
@@ -186,7 +186,7 @@ R. Il n'a pas craint les menaces des juges, ni recherché les honneurs de la ter
 &Gloria
 R. Il n'a pas craint les menaces des juges, ni recherché les honneurs de la terre, mais il est arrivé heureusement au royaume du ciel.
 
-[Responsory8NonEffusorum]
+[Responsory8 non Effusorum]
 R. Le Seigneur lui a donné les bénédictions de Sa douceur :
 * Il a mis sur sa tête une couronne de pierres précieuses.
 V. Il Vous demandait la vie et Vous lui avez donné une vie longue pour toujours.
@@ -311,25 +311,25 @@ De la lettre de Saint Ciprien, Evêque et Martur, aux Martyrs et aux Confesseurs
 !Lib. 2. Epist. 6.
 Quelles louanges vous donnerai-je, ô généreux Martyrs ? De quelles paroles me servirai-je pour relever la grandeur de votre courage et la fermeté de votre foi ? Vous avez souffert jusqu'au bout de cruelles tortures et ce n'est pas vous qui avez cedé aux tourmens, mais ce sont les tourmens qui vont ont cédé. Vous avez trouvé dans la couronne du martyre la fin de vos douleurs que vous ne pouviez trouver dans des supplices sans fin. L'inhumanité des bourreaux en vous faisant souffrir si longtemps n'a pas tant servi à ébranler votre foi qu'à vous envoyer plutôt à Dieu comme des hommes de Dieu.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 R. Une lumière sans déclins, Seigneur,
 * Une éternité de temps éclairera Vos Saints, alléluia, alléluia.
 V. Une allégresse éternelle couronnera leur tête : ils seront comblés de joie et d'allegresse.
 R. Une éternité de temps éclairera Vos Saints, alléluia, alléluia.
 
-[Lectio51]
+[Lectio5 in 2 loco]
 Ceux qui étaient présents à ce spectacle ont vu avec admiration ce combat célèste, ce combat divin, ce combat spirituel, ce combat de Jésus Christ. Ils ont vu ses serviteurs confesser son nom à haute voix, avec une contenance assurée et un courage inébranlable : nus et désarmez au dehors, mais couverts au dedans des armes d'une foi à l'épreuve. Ceux qui étaient tourmentez ont fait paraitre plus de force que ceux qui les tourmentaient et les ongles de fer ont été vaincus par ceux dont ils déchiraient cruellement les membres. Les coups redoublés des fouets qui rouvraient plutôt les plaies des serviteurs de Dieu, qu'ils ne leur en faisaient de nouvelles, n'ont pas été capables de surmonter leur foi invincible ! Leur sang coulait de toutes parts pour éteindre en même temps le feu de la persécution et celui de l'enfer.
 
-[Responsory51]
+[Responsory5 in 2 loco]
 R. Les serviteurs de Dieu, alléluia,
 * Seront l'objet de Sa joie, alléluia.
 V. Le Seigneur jugera Son peuple et ses serviteurs.
 R. Seront l'objet de Sa joie, alléluia.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 O quel spectacle était ce aux yeux du Seigneur, combien grand, combien magnifique, combien agréable, de voir ainsi ses soldats remplis de zèle conserver inviolable la fidélité de leur serment. Car c'est ce que le Saint Esprit nous a appris lui-même par ces paroles du psaume : Que la mort des Saints est précieuse aux yeux du Seigneur. Cette mort-là est bien précieuse qui achette l'immortalité au prix du sang de celui qui la souffre et qui acquiert une couronne par l'effort d'une vertu consommée. Quelle joie alors pour notre Seigneur Jésus-Christ ? Avec quel plaisir a-t-il combattu et vaincu en la personne de tels serviteurs, lui qui était le protecteur de leur foi et qui communique ses grâces à ceux qui croient en lui à proportion de leur confiance ? Il a été présent à son combat, il a soutenu ses combattants et les défenseurs de son nom et de sa gloire : il les a fortifié, il les a animé. Car c'est celui qui a une fois vaincu la mort pour nous qui est tous les jours victorieux en nous.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Filles de Jérusalem, venez et voyez les Martyrs avec les couronnes qu'ils ont reçus du Seigneur :
 * En ce jour de solennité et d'allegrèsse, alléluia.
 V. Le Seigneur a fortifié les serrures de vos portes et il a béni vos enfants au milieu de vous.
@@ -337,7 +337,7 @@ R. En ce jour de solennité et d'allegrèsse, alléluia.
 &Gloria
 R. En ce jour de solennité et d'allegrèsse, alléluia.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Lecture du Saint Evangile selon Saint Jean
 !Joannes 15:5-10
 En ce temps-là. Jésus dit à ses disciples : Je suis la vigne, vous êtes les sarments. Celui qui demeure en moi, et en qui je demeure, porte beaucoup de fruits : car, séparés de moi, vous ne pouvez rien faire. Et le reste.
@@ -346,16 +346,16 @@ Sermon de Saint Augustin Evêque
 !Tract. 81 in Joan., sub med.
 Il veut nous empêcher de croire que, d'elle-même, la branche peut au moins porter quelque petit fruit ; aussi, après avoir dit : « Celui-là porte beaucoup de fruit », il n'ajoute pas : sans moi vous ne pouvez faire que peu de chose, mais il dit : « Vous ne pouvez rien faire». Donc on ne peut faire ni peu ni beaucoup sans celui sans lequel on ne peut rien faire. Bien que la branche n'ait porté que peu de fruit, le vigneron l'émonde afin qu'elle en porte davantage ; mais si elle ne demeure pas unie à la vigne, et si elle ne tire pas sa vie de la racine, elle ne pourra jamais porter de fruit, si petit qu'il soit. Jésus-Christ n'eût pu être la vigne, s'il n'eût été homme; et, cependant, il ne pourrait communiquer la grâce aux branches, s'il n'était aussi Dieu.
 
-[Responsory71]
+[Responsory7 in 2 loco]
 R. Je suis la vraie vigne et vous en êtes les branches :
 * Celui qui demeure en moi et en qui je demeure porte beaucoup de fruits, alléluia, alléluia.
 V. Je vous ai aimé comme mon Père m'a aimé.
 R. Celui qui demeure en moi et en qui je demeure porte beaucoup de fruits, alléluia, alléluia.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Sans cette grâce on ne peut donc vivre, mais la mort reste néanmoins au pouvoir du libre arbitre. Aussi le Christ dit-il : « Si quelqu'un ne demeure pas en moi, il sera jeté dehors comme une branche coupée ; et il séchera, et on le ramassera, et on le jettera au feu, et il sera brûlé ». Les branches de la vigne sont d'autant plus méprisables, si elles ne restent pas unies à la vigne, qu'elles sont plus glorieuses si elles y restent. Enfin, ainsi que le Seigneur le dit en parlant d'elles par le prophète Ezéchiel, lorsqu'elles sont coupées, elles ne sont d'aucune utilité pour l'usage du vigneron; elles ne peuvent être employées par le charpentier. Il n'y a que deux choses qui conviennent à ces branches : ou la vigne ou le feu; si elles sont unies à la vigne, elles ne seront pas jetées au feu; afin de n'être pas jetées au feu, qu'elles restent donc unies à la vigne.
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. Ses Nazaréens sont devenus blancs et purs, alléluia : ils ont brillés de lumière devant le Seigneur, alléluia.
 * Ils ont été semblables à du lait caillé, alléluia, alléluia.
 V. Ils sont plus blancs que la neige, plus purs que le lait, plus rouges que l'ancien ivoire et plus blancs que le saphire.
@@ -363,11 +363,11 @@ R. Ils ont été semblables à du lait caillé, alléluia, alléluia.
 &Gloria
 R. Ils ont été semblables à du lait caillé, alléluia, alléluia.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 « Si vous restez en moi », dit Notre-Seigneur, « et que mes paroles restent en vous, tout ce que vous voudrez vous le demanderez, et il vous sera accordé ». En demeurant en Jésus-Christ, que peuvent-ils vouloir que ce qui convient à Jésus-Christ ? Que peuvent-ils vouloir, en restant dans le Sauveur, que ce qui n'est pas étranger au salut ? En effet, autre chose est ce que nous voulons en tant que nous sommes en Jésus-Christ, autre chose est ce que nous voulons en tant que nous sommes encore dans ce monde. Par suite de notre demeure en ce monde, il nous arrive parfois de demander ce qui, à notre insu, ne nous est pas avantageux. Mais ne croyons pas que nous serons exaucés à cet égard, si nous restons en Jésus-Christ ; car, lorsque nous le prions, il ne nous accorde que ce qui nous est utile.
  &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Lecture du Saint Evangile selon Saint Matthieu
 !Matt 10:26-32
 En ce temps-là, Jésus dit à ses disciples : Il n’y a rien de caché qui ne se découvre, rien de secret qui ne finisse par être connu. Et le reste.
@@ -376,23 +376,23 @@ Homilía sancti Hilárii Epíscopi
 !Comment. in Matthaeum, can. 10 post medium
 Dóminus diem judícii osténdit, quæ abstrúsam voluntátis nostræ consciéntiam prodet : et ea quæ nunc occúlta existimántur, luce cognitiónis públicæ déteget. Ígitur non minas, non consília, non potestátes insectántium monet esse metuéndas : quia dies judícii nulla hæc fuísse, atque inánia revelábit. Et quod dico vobis in ténebris, dícite in lúmine : et quod in aure audítis, prædicáte super tecta. Non légimus Dóminum sólitum fuísse nóctibus sermocinári, et doctrínam in ténebris tradidísse : sed quia omnis sermo ejus carnálibus ténebræ sunt, et verbum ejus infidélibus nox est.
 
-[Responsory72]
+[Responsory7 in 3 loco]
 R. Coróna áurea super caput ejus :
 * Expréssa signo sanctitátis, glória honóris, et opus fortitúdinis.
 V. Quóniam prævenísti eum in benedictiónibus dulcédinis, posuísti in cápite ejus corónam de lápide pretióso.
 R. Expréssa signo sanctitátis, glória honóris, et opus fortitúdinis.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Ítaque id quod a se dictum est, cum libertáte fídei et confessiónis vult esse loquéndum. Idcírco quæ in ténebris dicta sunt prædicári jussit in lúmine : ut quæ secréto áurium commíssa sunt, super tecta, id est, excélso loquéntium præcónio audiántur. Constánter enim Dei ingerénda cognítio est, et profúndum doctrínæ evangélicæ secrétum in lúmine prædicatiónis apostólicæ revelándum : non timéntes eos, quibus cum sit licéntia in córpora, tamen in ánimam jus nullum est : sed timéntes pótius Deum, cui perdéndæ in gehénna et ánimæ et córporis sit potéstas.
 
-[Responsory82]
+[Responsory8 in 3 loco]
 @Commune/C2:Responsory8
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Nolíte timére eos qui occídunt corpus. Nullus ígitur córporum nostrórum casus est pertimescéndus, neque ullus interiméndæ carnis admitténdus est dolor : quando pro natúræ suæ atque oríginis conditióne resolúta, in substántiam spirituális ánimæ refundátur. Et quia doctrínis tálibus confirmátos opórtet líberam confiténdi Dei habére constántiam, étiam conditiónem, qua tenerémur, adjécit : negatúrum se eum Patri in cælis, qui se homínibus in terra negásset : eum porro qui conféssus coram homínibus se fuísset, a se in cælis confiténdum : qualésque nos nóminis sui testes homínibus fuissémus, tali nos apud Deum Patrem testimónio ejus usúros.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Lecture du Saint Evangile selon Saint Matthieu
 !Matt 16:24-27
 En ce temps-là, Jésus dit à ses disciples : Si quelqu'un veut venir après moi, qu'il renonce à lui-même, qu'il porte sa croix et me suive. Et le reste.
@@ -401,9 +401,9 @@ Homélie de Saint Grégoire, Pape.
 !Homilia 32 in Evang.
 Notre Rédempteur étant venu au monde comme un nouvel homme, il a aussi donné au monde de nouveaux précèptes. Et comme notre ancienne vie était pleine de vices et de péchés, il lui oppose une vie contraire et toute nouvelle. Et en effet que sait faire le viel homme, l'homme charnel, sinon de conserver avec attache ce qu'il avait, ravir avec injustice ce qu'il n'avait pas et le désirer avec ardeur l'orsqu'il ne lui était pas possible de la ravir ? Mais le médecin célèste est venu appliquer à chaque vice le remède qui lui est propre. Car comme dans la médecine on guérit par des remèdes froids les maladies qui viennent de chaleur, et par des remèdes chauds les maladies qui viennent de froid : ainsi le Seigneur nous a apporté des remèdes contraires à nos péchés en ordonnant la continence aux impudiques, la libéralité aux avares, la douceur aux coléreux et l'humilité aux orgueilleux.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 C'est pourquoi lorsqu'il a voulu proposer à ceux qui le suivaient ses nouveaux commandements, il a dit : Si l'on ne renonce à tout ce que l'on possède, on ne peut être mon disciple. Comme s'il eu dit clairement : Vous qui suivant le train de votre vie ancienne, désirez le bien d'autrui, agissez maintenant par l'esprit d une vie nouvelle en donnant votre propre bien. Mais voyons comme le Seigneur parle en cet Evangile : Si quelqu'un veut venir après moi, qu'il renonce à lui-même. Dans le passage que nous venons de citer, il est dit qu'il faut renoncer à son bien et dans celui-ci qu'il faut renoncer à soi-même. Et peut-être que ce n'est pas une chose fort difficile que d'abandonner son bien, mais elle l'est assurément beaucoup de s'abandonner soi-même. Car il faut un bien moindre effort pour renoncer à ce que l'on a, que pour renoncer à ce que l'on est.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Or le Seigneur commande à ceux qui viennent à lui de renoncer à toutes les choses qu'ils possèdent, parce que tous ceux qui entrent dans la carrière de la foi ont à combattre les esprits de ténèbres. Or ces esprits ne possèdent rien en propre dans ce monde. Il faut donc aussi être nu pour lutter contre des adversaires qui sont nus. Car si un homme qui est habillé lutter contre un autre qui ne l'est pas, il est bientôt renversé par terre en donnant prise sur lui par ses habits à son adversaire. Et comme l'on peut appeller toutes les choses de la terre des vêtements pour le corps, il est necéssaire que tous ceux qui entreprennent de combattre contre le démon, jettent ces vêtements, de crainte que l'adversaire des hommes ne s'en serve pour les renverser.
 &teDeum

--- a/web/www/horas/Francais/Commune/C2p.txt
+++ b/web/www/horas/Francais/Commune/C2p.txt
@@ -65,13 +65,13 @@ Il est juste et raisonnable, mes frères, qu'après avoir célébré dans l'Egli
 Annonçons, dis-je, aux Saints Martyrs, le mystère de la Pâque et de la résurrection : disons leur que le tombeau du Seigneur a été ouvert afin qu'ils espèrent que les leurs le seront aussi. Disons leur que son corps tout mort qu'il était a repris sa première vigueur et que le sang a coulé de nouveau dans ses veines, afin qu'ils attendent cette bienheureuse immortalité qui doit renimer leurs membres froids. Car ce qui a ressucité Jésus Christ, réssucitera aussi les Martyrs. Comme ils ont marché par la voie des souffrances, ils marcheront par le voie de la vie. Il est écrit dans le Psaume : "Vous m'avez fait connaitre les sentiers de la vie ", et cela est dit de la résurection du Sauveur, qui revenant du tombeau après la mort, commence à marcher par un chemin qui était inconnu auparavant.
 
 [Responsory5]
-@Commune/C2:Responsory51
+@Commune/C2:Responsory5 in 2 loco
 
 [Lectio6]
 Car avant l'avènement de Jésus Christ, les hommes ignoraient le chemin de la vie, qui n'avait pas encore été frayé par la résurrection de personne. Mais depuis que la résurrection du Seigneur l'a fait connaitre, plusieurs y ont marché, dont le Saint Evangéliste dit : Les Corps de plusieurs saints furent réssucités avec lui et entèrent dans la Sainte Cité. C'est pourquoi Jésus Christ réssucité ayant dit : "Vous m'avez fait connaitre les voies de la vie", nous pouvons aussi dire maintenant au Seigneur, Vous nous avez fait connaitre les voies de la vie. Car il nous les a fait connaitre, en effet, puisqu'il nous a découvert le sentier par lequel on arrive à la vie. Il m'a fait connaitre les voies de la vie lorsqu'il m'a appris à vivre selon la foi et à pratiquer la miséricorde, la justice, la charité : ces vertus étant autant de voies qui conduisent au salut.
 
 [Responsory6]
-@Commune/C2:Responsory61
+@Commune/C2:Responsory6 in 2 loco
 
 [Lectio7]
 Lecture du Saint Evangile selon Saint Jean.
@@ -137,24 +137,24 @@ Mais que veut dire : « Je suis la vraie vigne ? » En ajoutant le mot « vraie 
 [Ant 3]
 @Commune/C1p
 
-[Lectio41]
+[Lectio4 in 2 loco]
 De la lettre de Saint Ciprien, Evêque et Martur, aux Martyrs et aux Confesseurs
 !Lib. 2. Epist. 6.
 Quelles louanges vous donnerai-je, ô généreux Martyrs ? De quelles paroles me servirai-je pour relever la grandeur de votre courage et la fermeté de votre foi ? Vous avez souffert jusqu'au bout de cruelles tortures et ce n'est pas vous qui avez cedé aux tourmens, mais ce sont les tourmens qui vont ont cédé. Vous avez trouvé dans la couronne du martyre la fin de vos douleurs que vous ne pouviez trouver dans des supplices sans fin. L'inhumanité des bourreaux en vous faisant souffrir si longtemps n'a pas tant servi à ébranler votre foi qu'à vous envoyer plutôt à Dieu comme des hommes de Dieu.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 @Commune/C1p:Responsory4
 
-[Lectio51]
+[Lectio5 in 2 loco]
 Ceux qui étaient présents à ce spectacle ont vu avec admiration ce combat célèste, ce combat divin, ce combat spirituel, ce combat de Jésus Christ. Ils ont vu ses serviteurs confesser son nom à haute voix, avec une contenance assurée et un courage inébranlable : nus et désarmez au dehors, mais couverts au dedans des armes d'une foi à l'épreuve. Ceux qui étaient tourmentez ont fait paraitre plus de force que ceux qui les tourmentaient et les ongles de fer ont été vaincus par ceux dont ils déchiraient cruellement les membres. Les coups redoublés des fouets qui rouvraient plutôt les plaies des serviteurs de Dieu, qu'ils ne leur en faisaient de nouvelles, n'ont pas été capables de surmonter leur foi invincible ! Leur sang coulait de toutes parts pour éteindre en même temps le feu de la persécution et celui de l'enfer.
 
-[Responsory51]
+[Responsory5 in 2 loco]
 @Commune/C2
 
-[Lectio61]
+[Lectio6 in 2 loco]
 O quel spectacle était ce aux yeux du Seigneur, combien grand, combien magnifique, combien agréable, de voir ainsi ses soldats remplis de zèle conserver inviolable la fidélité de leur serment. Car c'est ce que le Saint Esprit nous a appris lui-même par ces paroles du psaume : Que la mort des Saints est précieuse aux yeux du Seigneur. Cette mort-là est bien précieuse qui achette l'immortalité au prix du sang de celui qui la souffre et qui acquiert une couronne par l'effort d'une vertu consommée. Quelle joie alors pour notre Seigneur Jésus-Christ ? Avec quel plaisir a-t-il combattu et vaincu en la personne de tels serviteurs, lui qui était le protecteur de leur foi et qui communique ses grâces à ceux qui croient en lui à proportion de leur confiance ? Il a été présent à son combat, il a soutenu ses combattants et les défenseurs de son nom et de sa gloire : il les a fortifié, il les a animé. Car c'est celui qui a une fois vaincu la mort pour nous qui est tous les jours victorieux en nous.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Filles de Jérusalem, venez et voyez les Martyrs avec les couronnes qu'ils ont reçus du Seigneur :
 * En ce jour de solennité et d'allegrèsse, alléluia.
 V. Le Seigneur a fortifié les serrures de vos portes et il a béni vos enfants au milieu de vous.

--- a/web/www/horas/Francais/Commune/C3.txt
+++ b/web/www/horas/Francais/Commune/C3.txt
@@ -332,7 +332,7 @@ Dans les Royaumes célestes * est l’habitation des saints et leur repos est to
 [Ant 3]
 Elles se réjouissent dans les cieux, * les âmes des saints qui ont suivi les traces du Christ. Et, parce qu’ils ont répandu leur sang pour Son amour, avec le Christ, ils exultent sans fin.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Lecture du saint Évangile selon saint Luc. .
 !Luc 6:17-23
 In illo témpore : Descéndens Jesus de monte, stetit in loco campéstri, et turba discipulórum ejus, et multitúdo copiósa plebis ab omni Judǽa, et Jerúsalem, et marítima, et Tyri, et Sidónis. Et réliqua.
@@ -340,10 +340,10 @@ _
 Homélie de saint Ambroise Évêque !Lib. 5. in Lucam. Cap. 6., post init.
 Advérte ómnia diligénter, quómodo et cum Apóstolis ascéndat et descéndat ad turbas. Quómodo enim turba nisi in húmili Christum vidéret ? Non séquitur ad excélsa, non ascéndit ad sublímia. Dénique ubi descéndit, invénit infírmos : in excélsis enim infírmi esse non possunt. Hinc étiam Matthǽus docet in inferióribus débiles esse sanátos. Prius enim unusquísque sanándus est, ut paulátim virtútibus procedéntibus ascéndere possit ad montem ; et ídeo quemque in inferióribus sanat, hoc est, a libídine révocat, injúriam cæcitátis avértit. Ad vúlnera nostra descéndit : ut usu quodam et cópia suæ natúræ, compartícipes nos fáciat esse regni cæléstis.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Beáti páuperes, quia vestrum est regnum Dei. Quátuor tantum beatitúdines sanctus Lucas Domínicas posuit, octo vero sanctus Matthǽus : sed in illis octo istæ quátuor sunt, et in quátuor istis illæ octo. Hic enim quátuor velut virtútes ampléxus est cardináles : ille in illis octo mýsticum númerum reserávit. Pro octáva enim multi inscribúntur Psalmi : et mandátum áccipis octo illis partem dare fortásse benedictiónibus. Sicut enim spei nostræ octáva perféctio est, ita octáva summa virtútum est.
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. Hæc est vera fratérnitas, quæ numquam pótuit violári certámine : qui effúso sánguine secúti sunt Dóminum :
 * Contemnéntes aulam régiam, pervenérunt ad regna cæléstia.
 V. Ecce quam bonum et quam jucúndum habitáre fratres in unum.
@@ -351,6 +351,6 @@ R. Contemnéntes aulam régiam, pervenérunt ad regna cæléstia.
 &Gloria
 R. Contemnéntes aulam régiam, pervenérunt ad regna cæléstia.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Sed prius quæ sunt amplióra videámus. Beáti, inquit, páuperes, quóniam vestrum est regnum Dei. Primam benedictiónem hanc utérque Evangelísta pósuit. Órdine enim prima est, et parens quædam generatióque virtútum : quia qui contempsérit sæculária, ipse merébitur sempitérna : nec potest quisquam méritum regni cæléstis adipísci, qui mundi cupiditáte pressus, emergéndi non habet facultátem.
 &teDeum

--- a/web/www/horas/Francais/Commune/C4.txt
+++ b/web/www/horas/Francais/Commune/C4.txt
@@ -340,7 +340,7 @@ Le Seigneur l'a aimé, * et l'a paré. Il l'a revêtu de la robe de gloire et l'
 [Ant 3 summi Pontificis]
 Tandis qu'il était Souverain Pontife, * il n'a craint rien de terrestre, mais il s'en est allé glorieux au royaume céleste.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 De libro Ecclesiastici
 !Sir 44:1-5
 1 Laudémus viros gloriósos, et paréntes nostros in generatióne sua.
@@ -349,14 +349,14 @@ De libro Ecclesiastici
 4 et imperántes in præsénti pópulo, et virtúte prudéntiæ pópulis sanctíssima verba :
 5 in perítia sua requiréntes modos músicos, et narrántes cármina Scripturárum :
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 44:6-9
 6 Hómines dívites in virtúte, pulchritúdinis stúdium habéntes, pacificántes in dómibus suis.
 7 Omnes isti in generatiónibus gentis suæ glóriam adépti sunt, et in diébus suis habéntur in láudibus.
 8 Qui de illis nati sunt reliquérunt nomen narrándi laudes eórum.
 9 Et sunt quorum non est memória : periérunt quasi qui non fúerint : et nati sunt quasi non nati, et fílii ipsórum cum ipsis.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 44:10-15
 10 Sed illi viri misericórdiæ sunt, quorum pietátes non defuérunt.
 11 Cum sémine eórum pérmanent bona :
@@ -365,7 +365,7 @@ De libro Ecclesiastici
 14 Córpora ipsórum in pace sepúlta sunt, et nomen eórum vivit in generatiónem et generatiónem.
 15 Sapiéntiam ipsórum narrent pópuli, et laudem eórum núntiet ecclésia.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Lecture du saint Évangile selon saint Matthieu
 !Matt 16:13-19
 In illo témpore : Venit Jesus in partes Cæsaréæ Philíppi, et interrogábat discípulos suos, dicens : Quem dicunt hómines esse Fílium hóminis ? Et réliqua.
@@ -374,14 +374,14 @@ Homélie de saint Léon, Pape.
 !Sermo 2 in anniversario assumpt. suæ ante medium
 Cum, sicut evangélica lectióne reserátum est, interrogásset Dóminus discípulos, quem ipsum (multis divérsa opinántibus) créderent ; respondissétque beátus Petrus, dicens : Tu es Christus Fílius Dei vivi; Dóminus ait : Beátus es, Simon Bar-Jona, quia caro et sanguis non revelávit tibi, sed Pater meus, qui in cælis est : et ego dico tibi, quia tu es Petrus, et super hanc petram ædificábo Ecclésiam meam, et portæ ínferi non prævalébunt advérsus eam. Et tibi dabo claves regni cælórum : et quodcúmque ligáveris super terram, erit ligátum et in cælis : et quodcúmque sólveris super terram, erit solútum et in cælis. Manet ergo disposítio veritátis, et beátus Petrus, in accépta fortitúdine petræ persevérans, suscépta Ecclésiæ gubernácula non relíquit.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 In univérsa namque Ecclésia, Tu es Christus Fílius Dei vivi, quotídie Petrus dicit ; et omnis lingua, quæ confitétur Dóminum, magistério hujus vocis imbúitur. Hæc fides diábolum vincit et captivórum ejus víncula dissólvit. Hæc érutos mundo, ínserit cælo, et portæ ínferi advérsus eam prævalére non possunt. Tanta enim divínitus soliditáte muníta est, ut eam neque hærética umquam corrúmpere právitas, nec pagána potúerit superáre perfídia. His ítaque modis, dilectíssimi, rationábile obséquio celebrétur hodiérna festívitas : ut in persóna humilitátis meæ ille intelligátur, ille honorétur, in quo et ómnium pastórum sollicitúdo, cum commendatárum sibi óvium custódia persevérat, et cujus étiam dígnitas in indígno heréde non déficit.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Cum ergo cohortatiónes nostras áuribus vestræ sanctitátis adhibémus, ipsum vobis, cujus vice fúngimur, loqui crédite : quia et illíus vos afféctu monémus, et non áliud vobis, quam quod dócuit, prædicámus ; obsecrántes, ut succíncti lumbos mentis vestræ, castam et sóbriam vitam in Dei timóre ducátis. Coróna mea, sicut Apóstolus ait, et gáudium vos estis, si fides vestra, quæ ab inítio Evangélii in univérso mundo prædicáta est, in dilectióne et sanctitáte permánserit. Nam licet omnem Ecclésiam, quæ in toto est orbe terrárum, cunctis opórteat florére virtútibus; vos tamen præcípue inter céteros pópulos decet méritis pietátis excéllere, quos in ipsa apostólicæ petræ arce fundátos, et Dóminus noster Jesus Christus cum ómnibus redémit, et beátus Apóstolus Petrus præ ómnibus erudívit.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Lecture du saint Évangile selon saint Matthieu
 !Matt 19:27-29
 In illo tempore : Dixit Petrus ad Jesum : Ecce nos reliquimus omnia, et secuti sumus te : quid ergo erit nobis ? Et reliqua.
@@ -390,18 +390,18 @@ De Homilía venerábilis Bedæ Presbýteri
 !In Natali S. Benedicti
 Duo sunt ordines electorum in judicio futuri : unus judicantium cum Domino, de quibus hoc loco memorat, qui reliquerunt omnia, et secuti sunt illum : alius judicandorum a Domino, qui non quidem omnia sua pariter reliquerunt, sed de his tamen quae habebant, quotidianas dare eleemosynas Christi pauperibus curabant : unde et audituri sunt in judicio : Venite benedicti Patris mei, possidete praeparatum vobis regnum a constitutione mundi. Esurivi enim, et dedistis mihi manducare : sitivi, et dedistis mihi bibere.
 
-[Responsory73]
+[Responsory7 in 4 loco]
 R. Voici celui qui, devant Dieu, a pratiqué de grandes vertus et, de tout son cœur, a loué le Seigneur :
 * A lui d’intercéder pour les péchés de tous les peuples.
 V. Voici l’homme sans reproche, adorateur de Dieu en vérité, s’abstenant de toute œuvre mauvaise et constant dans son innocence.
 R. A lui d’intercéder pour les péchés de tous les peuples.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Sed et reproborum duos ibi futuros ordines Domino narrante comperimus : unum eorum, qui fidei christianae mysteriis initiati, opera fidei exercere contemnunt, quibus in judicio testatur : Discedite a me maledicti in ignem aeternum, qui praeparatus est diabolo, et angelis ejus : esurivi enim, et non dedistis mihi manducare. Alterum eorum, qui fidem et mysteria Christi vel numquam suscepere, vel susceptam per apostasiam deseruere : de quibus dicit : Qui autem non credit, jam judicatus est : quia non credit in nomine unigeniti Filii Dei.
 
-[Responsory83]
+[Responsory8 in 4 loco]
 @:Responsory8
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Verum his cum timore et pavore debito paulisper commemoratis, ad laetissima potius Domini et Salvatoris nostri promissa convertamus auditum. Videamus quae tantae gratia pietatis : non aeternae tantummodo vitae praemia suis sequacibus, sed et praesentis munera pollicetur eximia. Et omnis, inquit, qui reliquerit domum, vel fratres, aut sorores, aut patrem, aut matrem, aut uxorem, aut filios, aut agros, propter nomen meum, centuplum accipiet, et vitam aeternam possidebit. Qui enim terrenis affectibus sive possessionibus pro Christi discipulatu renuntiaverit, quo plus in ejus amorem profecerit, eo plures inveniet, qui se interno suscipere affectu, et suis gaudeant sustentare substantiis.
 &teDeum

--- a/web/www/horas/Francais/Commune/C4a.txt
+++ b/web/www/horas/Francais/Commune/C4a.txt
@@ -171,7 +171,7 @@ $Per Dominum.
 [Ant 3]
 @:Ant 1
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Lecture du saint Évangile selon saint Matthieu
 !Matt 5:13-19
 En ce temps-là : Jésus dit à ses disciples : Vous êtes le sel de la terre. Mais si le sel s’affadit, avec quoi le salera-t-on ? Et le reste.
@@ -180,9 +180,9 @@ Homélie de saint Jean Chrysostome
 !Homilia 15 in Matthæum, sub medium
 Remarquez ce que dit Jésus-Christ : « Vous êtes le sel de la terre ». Il montre par là combien il est nécessaire qu’il donne ces préceptes à ses Apôtres. Car, ce n’est pas seulement, leur dit-il, de votre propre vie, mais de l’univers entier que vous aurez à rendre compte. Je ne vous envoie pas comme j’envoyais les Prophètes, à deux, à dix, ou à vingt villes ni à une seule nation, mais à toute la terre, à la mer, et au monde entier, à ce monde accablé sous le poids de crimes divers.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 « Vous êtes le sel de la terre », il montre que l’universalité des hommes était comme affadie et corrompue par une masse de péchés ; et c’est pourquoi il demande d’eux les vertus qui sont surtout nécessaires et utiles pour procurer le salut d’un grand nombre. Celui qui est doux, modeste, miséricordieux et juste, ne peut justement se borner à renfermer ces vertus en son âme, mais il doit avoir soin que ces sources excellentes coulent aussi pour l’avantage des autres. Ainsi celui qui a le cœur pur, qui est pacifique et qui souffre persécution pour la vérité, dirige-sa vie d’une manière utile à tous.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Ne croyez donc point, dit-il, que ce soit à de légers combats que vous serez conduits, et que ce soient des choses de peu d’importance dont il vous faudra prendre soin et rendre compte, « vous êtes le sel de la terre ». Quoi donc ? Est-ce que les Apôtres ont guéri ce qui était déjà entièrement gâté ? Non certes ; car il ne se peut faire que ce qui tombe déjà en putréfaction soit rétabli dans son premier état par l’application du sel. Ce n’est donc pas cela qu’ils ont fait, mais ce qui était auparavant renouvelé et à eux confié, ce qui était délivré déjà de cette pourriture, ils y répandaient le sel et le conservaient dans cet état de rénovation qui est une grâce reçue du Seigneur. Délivrer de la corruption du péché, c’est l’effet de la puissance du Christ ; empêcher que les hommes ne retournent au péché, voilà ce qui réclame les soins et les labeurs des Apôtres.
 &teDeum

--- a/web/www/horas/Francais/Commune/C5.txt
+++ b/web/www/horas/Francais/Commune/C5.txt
@@ -277,7 +277,7 @@ R. Et il lui a montré le royaume de Dieu.
 [Ant 3]
 Cet homme, méprisant le monde * et les choses de la terre, s’est assuré, triomphant, par sa parole et ses actes, des richesses dans le ciel.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 De libro Sapiéntiæ
 !Sap 4:7-14
 7 Justus si morte præoccupatus fúerit, in refrigerio erit ;
@@ -289,7 +289,7 @@ De libro Sapiéntiæ
 13 Consummátus in brevi, explévit témpora multa ;
 14 placita enim erat Deo ánima illíus : propter hoc properavit edúcere illum de médio iniquitátum.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sap 4:14-19
 14 Pópuli autem vidéntes, et non intelligentes, nec ponentes in præcordiis tália,
 15 quóniam grátia Dei et misericórdia est in sanctos ejus, et respéctus in eléctos illíus.
@@ -298,7 +298,7 @@ De libro Sapiéntiæ
 18 Vidébunt, et contemnent eum ; illos autem Dóminus irridébit.
 19 Et erunt post hæc decidentes sine honóre, et in contumélia inter mórtuos in perpétuum : quóniam disrumpet illos inflatos sine voce, et commovébit illos a fundaméntis, et usque ad suprémum desolabuntur.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sap 4:19-20 ; 5:1-5
 19 Et erunt geméntes, et memória illórum períbit.
 20 Vénient in cogitatióne peccatórum suórum timidi, et traducent illos ex adverso iniquitátes ipsórum.
@@ -308,7 +308,7 @@ De libro Sapiéntiæ
 4 Nos insensati, vitam illórum æstimabamus insaniam, et finem illórum sine honóre ;
 5 ecce quómodo computati sunt inter fílios Dei, et inter sanctos sors illórum est.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Lecture du saint Évangile selon saint Luc
 !Luc 12:32-34
 En ce temps-là : Jésus dit à ses disciples : Ne craignez point petit troupeau ; car il a plu à votre Père de vous donner le royaume. Et le reste.
@@ -317,14 +317,14 @@ Homélie de saint Bède le Vénérable, Prêtre
 !Lib. 4, Cap. 4, in Luc. 12
 Notre Seigneur appelle petit le troupeau des élus, soit à cause du très grand nombre des réprouvés, soit plutôt par affection pour l’humilité ; car il veut que son Église, quelque développement qu’elle prenne par le nombre de ses membres, croisse néanmoins en humilité jusqu’à la fin du monde, et parvienne dans l’humilité au royaume promis. C’est pourquoi, encourageant et consolant les labeurs de cette Église à laquelle il commande de chercher uniquement le royaume de Dieu, il promet à cette même Église le royaume que lui donnera le Père dans son infinie bonté.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 « Vendez ce que vous avez, et donnez l’aumône ». Ne craignez point, dit notre Seigneur, qu’en combattant pour le royaume de Dieu vous veniez à manquer des choses nécessaires à la vie ; vendez même, pour le donner en aumône, ce que vous possédez. On accomplit dignement ce conseil quand, après avoir méprisé une fois pour toutes, ses biens pour le Seigneur, on s’adonne ensuite au travail des mains afin de pouvoir se nourrir soi-même et faire l’aumône. C’est de quoi l’Apôtre se glorifie, en disant : « Je n’ai convoité ni l’or, ni l’argent, ni le vêtement de personne, comme vous le savez vous-mêmes ; parce que, à l’égard des choses dont moi et ceux qui sont avec moi avions besoin, ces mains y ont pourvu. Je vous ai montré en tout, que c’est en travaillant ainsi qu’il faut soutenir les faibles ».
 
-[Lectio91]
+[Lectio9 in 2 loco]
 « Faites-vous des bourses que le temps n’use point », c’est-à-dire en répandant des aumônes, car leur récompense demeurera éternellement. Il ne faut pas interpréter ce précepte en ce sens qu’il soit défendu aux saints de conserver quelque argent pour subvenir à leurs propres besoins ou à ceux des pauvres, puisque l’Évangile nous apprend que notre Seigneur lui-même, bien qu’ayant les Anges à son service, n’a pas dédaigné, pour instruire son Église naissante, d’avoir une bourse ; qu’il conservait les offrandes des fidèles, et qu’il en usait pour subvenir aux nécessités des siens ou d’autres indigents ; mais ce n’est pas à cause de ces biens qu’il faut s’attacher au service de Dieu ; ce n’est pas la crainte de la pauvreté qui doit faire jamais abandonner la justice.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Lecture du saint Évangile selon saint Luc.
 !Luc 19:12-26
 En ce temps-là : Jésus dit cette parabole à ses disciples : Un homme de grande naissance s’en alla en un pays lointain, pour prendre possession d’un royaume et revenir ensuite. Et le reste.
@@ -333,9 +333,9 @@ Homélie de saint Ambroise, Évêque
 !Lib. 8. in Lucam.
 Il était bon et dans l’ordre que, devant appeler les Gentils et décréter la perte des Juifs qui n’avaient point voulu que le Christ régnât sur eux, le Sauveur employât d’abord cette comparaison pour éviter que l’on ne vînt à dire : Il n’avait rien donné au peuple des Juifs qui pût le rendre meilleur : comment exiger quelque chose de qui n’a rien reçu ? Ce n’est vraiment pas d’une monnaie de médiocre valeur qu’il s’agit car cette femme dont l’Évangile parle plus haut, ne trouvant pas une drachme, allume sa lampe, la cherche en promenant sa lumière, et est félicitée quand elle est retrouvée.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 D’une mine unique, l’un des serviteurs a gagné dix mines et l’autre cinq. Peut-être ce dernier observe-t-il les préceptes de la morale, puisque les sens corporels sont au nombre de cinq ; l’autre a le double, c’est-à-dire qu’il approfondit les mystères de la loi et pratique la justice en ses mœurs. Aussi saint Matthieu a-t-il parlé de cinq talents et de deux talents : en sorte que l’accomplissement des préceptes moraux soit indiqué par les cinq talents et qu’en les deux autres talents nous voyions figurées, la connaissance des mystères de la foi et l’observation de la morale ; ce qui est moindre en nombre, se trouvant donc plus abondant en réalité.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Et ici, nous pouvons entendre, par les dix mines, les dix préceptes, c’est-à-dire la doctrine de la loi ; et par les cinq autres, les leçons de la morale dues au magistère. Mais je veux que celui qui enseigne, soit accompli en toutes choses : « car le royaume de Dieu ne consiste pas dans les paroles, mais dans la vertu. » Comme il parle de Juifs, c’est bien à propos qu’il dit que deux seulement ont apporté à leur maître de l’argent multiplié, non certes par l’usure, mais par les profits d’une bonne administration. Autre, en effet, est le produit usuraire de l’argent, autre le fruit retiré de la céleste doctrine.
 &teDeum

--- a/web/www/horas/Francais/Commune/C5a.txt
+++ b/web/www/horas/Francais/Commune/C5a.txt
@@ -89,7 +89,7 @@ R. Et non supplantabúntur gressus ejus.
 @Commune/C5
 
 [Responsory7]
-@Commune/C4:Responsory73
+@Commune/C4:Responsory7 in 4 loco
 
 [Lectio8]
 @Commune/C5

--- a/web/www/horas/Francais/Commune/C5a.txt
+++ b/web/www/horas/Francais/Commune/C5a.txt
@@ -145,35 +145,35 @@ R. Et non supplantabúntur gressus ejus.
 [Ant 3]
 @:Ant 1
 
-[Lectio11]
+[Lectio1 in 2 loco]
 @Commune/C5
 
-[Lectio21]
+[Lectio2 in 2 loco]
 @Commune/C5
 
-[Lectio31]
+[Lectio3 in 2 loco]
 @Commune/C5
 
-[Lectio71]
+[Lectio7 in 2 loco]
 @Commune/C5
 
-[Lectio81]
+[Lectio8 in 2 loco]
 @Commune/C5
 
-[Lectio91]
+[Lectio9 in 2 loco]
 @Commune/C5
 
-[Lectio72]
+[Lectio7 in 3 loco]
 @Commune/C5
 
-[Lectio82]
+[Lectio8 in 3 loco]
 @Commune/C5
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Et hic possumus decem mnas decem verba intelligere, id est, legis doctrinam ; quinque autem mnas, magisteria disciplinae. Sed legisperitum in omnibus volo esse perfectum; non enim in sermone, sed in virtute est regnum Dei. Bene autem, quia de Judaeis dicit, duo soli multiplicatam pecuniam deferunt, non utique aeris, sed dispensationis usuris. Alia est enim pecuniae foenebris, alia doctrinae caelestis usura.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Lectio sancti Evangelii secundum Matthaeum.
 !Matt 16:24-27
 In illo tempore : Dixit Jesus discipulis suis : Si quis vult post me venire, abneget semetipsum, et tollat crucem suam, et sequatur me. Et reliqua.
@@ -182,9 +182,9 @@ Homilia sancti Gregorii Papae.
 !Homilia 32. in Evang.
 Quia Dominus ac Redemptor noster novus homo venit in mundum, nova praecepta dedit mundo. Vitae etenim nostrae veteri in vitiis enutritae contrarietatem opposuit novitatis suae. Quid enim vetus, quid carnalis homo noverat, nisi sua retinere, aliena rapere, si posset ; concupiscere, si non posset ? Sed caelestis medicus singulis quibusque vitiis obviantia adhibet medicamenta. Nam sicut arte medicinae calida frigidis, frigida calidis curantur : ita Dominus noster contraria opposuit medicamenta peccatis, ut lubricis continentiam, tenacibus largitatem, iracundis mansuetudinem, elatis praeciperet humilitatem.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Certe cum se sequentibus nova mandata proponeret, dixit : Nisi quis renuntiaverit omnibus quae possidet, non potest meus esse discipulus. Ac si aperte dicat : Qui per vitam veterem aliena concupiscitis, per novae conversationis studium et vestra largimini. Quid vero in hac lectione dicat, audiamus : Qui vult post me venire, abneget semetipsum. Ibi dicitur, ut abnegemus nostra : hic dicitur, ut abnegemus nos. Et fortasse laboriosum non est homini relinquere sua ; sed valde laboriosum est relinquere semetipsum. Minus quippe est abnegare quod habet; valde autem multum est abnegare quod est.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Ad se autem nobis venientibus Dominus praecepit, ut renuntiemus nostris : quia quicumque ad fidei agonem venimus, luctamen contra malignos spiritus sumimus. Nihil autem maligni spiritus in hoc mundo proprium possident : nudi ergo cum nudis luctari debemus. Nam si vestitus quisque cum nudo luctatur, citius ad terram dejicitur, quia habet unde teneatur. Quid enim sunt terrena omnia, nisi quaedam corporis indumenta ? Qui ergo contra diabolum ad certamen properat, vestimenta abjiciat, ne succumbat.
 &teDeum

--- a/web/www/horas/Francais/Commune/C6.txt
+++ b/web/www/horas/Francais/Commune/C6.txt
@@ -299,15 +299,15 @@ R. C'est pourquoi Dieu vous a bénie pour toujours.
 [Ant 3]
 @:Ant 1
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Du livre de l’Ecclésiastique.
 !Sir 51:1-7
 Je vous glorifierai, Seigneur Roi, et je vous louerai, vous qui êtes mon Dieu, mon Sauveur. Je glorifierai votre nom, parce que vous m’êtes devenu un aide et un protecteur, et vous avez délivré mon corps de la perdition, du piège de la langue inique et des lèvres de ceux qui commettent le mensonge, et en présence de ceux qui se tenaient debout près de moi, vous m’êtes devenu un aide. Et vous m’avez délivré, selon la multitude des miséricordes de votre nom, des lions rugissants prêts à me dévorer ; des mains de ceux qui recherchaient mon âme, et des portes des tribulations qui m’ont environné ; de la violence de la flamme qui m’a environné et, au milieu du feu, je n’en ai pas senti la chaleur ; de la profondeur des entrailles de l’enfer, et de la langue souillée, et de la parole du mensonge ; d’un roi inique et de la langue injuste.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 51:8-12
 Jusqu’à la mort, mon âme louera le Seigneur ; car ma vie s’approchait de l’enfer, en bas. Ils m’ont environné de tous côtés, et il n’y avait personne qui me secourût. Je tournais mes regards vers le secours des hommes, et il n’en était point. Je me suis souvenu, Seigneur, de votre miséricorde et de votre œuvre, qui sont dès le commencement du monde ; parce que vous délivrez, Seigneur, ceux qui attendent avec patience et vous les sauvez des mains des nations.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 Vous avez élevé sur la terre mon habitation ; et à cause de la mort qui découlait sur moi j’ai fait des supplications. J’ai invoqué le Seigneur, Père de mon Seigneur, afin qu’il ne me laisse point sans secours au jour de ma tribulation et au temps des superbes. Je louerai votre nom sans cesse et je le glorifierai dans mes louanges, car ma prière a été exaucée. Et vous m’avez délivré de la perdition, et vous m’avez arraché au temps de l’iniquité. C’est pourquoi je vous glorifierai et je vous dirai une louange, et je bénirai le nom du Seigneur.

--- a/web/www/horas/Francais/Sancti/01-16.txt
+++ b/web/www/horas/Francais/Sancti/01-16.txt
@@ -46,13 +46,13 @@ Rome in the month of December twenty - five Priests, two Deacons, and twenty -~
 one Bishops for diverse Sees.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Responsory8]
 R. O Lord, thou hast prevented him with blessings of sweetness: 

--- a/web/www/horas/Francais/Sancti/01-20.txt
+++ b/web/www/horas/Francais/Sancti/01-20.txt
@@ -26,10 +26,10 @@ Le Romain Fabien qui gouverna l’Église, de Maximin à Dèce, en répartit les
 &teDeum
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Francais/Sancti/01-21.txt
+++ b/web/www/horas/Francais/Sancti/01-21.txt
@@ -33,7 +33,7 @@ V. Dieu l’a aimée et l’a préférée.
 R. Il l’a fait habiter dans sa tente.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Responsory1]
 R. Célébrons le jour de fête d’une très sainte Vierge ; rappelons à la mémoire comment souffrit la bienheureuse Agnès : à l’âge de treize ans, elle réduisit à rien la mort et trouva la vie :
@@ -42,7 +42,7 @@ V. C’était une enfant quant aux années, mais déjà très mûre quant à l�
 R. Parce qu’elle a aimé seulement l’auteur de la vie.
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Responsory2]
 R. Il a entouré ma droite et mon cou de pierres précieuses, il a fixé à mes oreilles des perles sans prix,
@@ -51,7 +51,7 @@ V. Il a gravé un signe sur ma face, afin que je n’admette point d’autre ama
 R. Et il m’a toute parée de joyaux brillants et étincelants comme la flamme.
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Responsory3]
 R. J’aime le Christ, j’entrerai dans l’intimité de celui dont la mère est vierge et dont le Père ne connaît pas de femme et dont les chants raisonnent pour moi en accords harmonieux :

--- a/web/www/horas/Francais/Sancti/01-26.txt
+++ b/web/www/horas/Francais/Sancti/01-26.txt
@@ -26,10 +26,10 @@ Les princes m'ont persécuté sans motif et vos paroles ont fait trembler mon c�
 C’est bien sans raison qu’il est persécuté, celui qui est accusé d’impiété auprès des impies et des infidèles, alors qu’il donne une leçon de foi. Mais celui qui est persécuté sans raison doit être vaillant et résolu. Comment donc le Psalmiste continue-t-il : Et mon cœur a tremblé à vos paroles ? Trembler, c’est le fait de la faiblesse, de la crainte et de la frayeur. Mais il y a une faiblesse qui sauve, une crainte qui sanctifie : Craignez le Seigneur, vous tous ses saints. Et : Bienheureux l'homme qui craint le Seigneur. Pourquoi bienheureux ? Parce quHl fait ses délices des commandements de Dieu.
 
 [Lectio7]
-@Commune/C2:Lectio72
+@Commune/C2:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C2:Lectio82
+@Commune/C2:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C2:Lectio92
+@Commune/C2:Lectio9 in 3 loco

--- a/web/www/horas/Francais/Sancti/02-05.txt
+++ b/web/www/horas/Francais/Sancti/02-05.txt
@@ -44,7 +44,7 @@ V. Dieu l’a choisie, et il l’a préférée.
 R. Dans son tabernacle, il la fait habiter.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Responsory1]
 R. Pendant qu’on torturait cruellement les seins de la bienheureuse Agathe, celle-ci dit au juge :
@@ -53,7 +53,7 @@ V. Mais, je conserve intacts en mon âme les seins que, dès mon enfance, j’ai
 R. Impie tyran, cruel et barbare, n’as-tu pas honte de mutiler chez une femme ce que toi-même as sucé chez ta mère ?
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Responsory2]
 R. Agathe, toute joyeuse et se glorifiant, se dirigeait vers la prison,
@@ -62,7 +62,7 @@ V. Étant d’une très noble naissance, elle se réjouissait d’être conduite
 R. Comme une invitée à un festin, et recommandait son épreuve à Dieu par ses prières.
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Responsory3]
 R. Qui es-tu, toi qui es venu vers moi pour guérir mes blessures ? Je suis l’Apôtre du Christ ; n’aie aucune inquiétude à cause de moi, ma fille. C’est lui-même qui m’a envoyé vers toi,

--- a/web/www/horas/Francais/Sancti/02-27.txt
+++ b/web/www/horas/Francais/Sancti/02-27.txt
@@ -14,13 +14,13 @@ O Dieu, qui avez appris au bienheureux Gabriel à vénérer assidûment les doul
 $Qui vivis
 
 [Lectio1](sed non rubrica 1960)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2](sed non rubrica 1960)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3](sed non rubrica 1960)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Gabriel né à Assise en Ombrie, de famille honorable, et appelé François en souvenir de son séraphique compatriote, manifesta dès l’enfance un excellent naturel. Pendant son adolescence, alors qu’il étudiait les lettres à Spolète, il parut quelque peu attiré par la vaine apparence et les pompes du monde. Mais par la grâce du Dieu miséricordieux qui déjà l’invitait à la perfection de la vie chrétienne, étant tombé malade, il commença de prendre en dégoût les vanités du siècle et de ne plus désirer que les biens immortels. Mais pour qu’il obéît plus promptement au Dieu qui l’appelait, il arriva qu’ayant contemplé l’image de la Bienheureuse Vierge qu’on portait en procession solennelle, hors de l’enceinte de l’église de Spolète, il en conçut une vive flamme d’amour divin et résolut d’entrer dans l’Institut des Clercs de la Passion de Jésus. C’est pourquoi, après avoir triomphé de grosses difficultés, il entra à la retraite de Morovallo, en reçut l’habit de deuil et choisit le nom de Gabriel de la Vierge des douleurs, pour honorer perpétuellement le souvenir des douleurs et des joies de la Vierge.

--- a/web/www/horas/Francais/Sancti/03-04.txt
+++ b/web/www/horas/Francais/Sancti/03-04.txt
@@ -26,13 +26,13 @@ v. O Dieu, qui nous réjouissez par l’anniversaire du bienheureux Lucien votre
 $Per Dominum.
 
 [Lectio1](sed non rubrica 1960)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2](sed non rubrica 1960)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3](sed non rubrica 1960)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Casimir, dont le père était Casimir et la mère Élisabeth d’Autriche, était issu des rois de Pologne. Dès l’enfance, sous la direction d’excellents maîtres, il fut formé à la piété et aux bonnes mœurs. Il domptait ses membres d’adolescent, par un rude cilice et les affaiblissait par des jeûnes continuels. Méprisant la mollesse du lit royal, il couchait sur la terre dure, et secrètement, au milieu de la nuit, prosterné contre terre, devant les portes des églises, il implorait la divine miséricorde. Assidu à méditer la passion du Christ, il avait coutume d’assister aux cérémonies de la Messe, avec un esprit tellement élevé en Dieu, qu’il semblait ravi hors de lui- même.

--- a/web/www/horas/Francais/Sancti/03-06.txt
+++ b/web/www/horas/Francais/Sancti/03-06.txt
@@ -23,13 +23,13 @@ $Per Dominum
 Louons notre Dieu * En honorant les bienheureuses Perpétue et Félicité.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Lectio4]
 Perpétue et Félicité, pendant la persécution de l’empereur Sévère, en Afrique, furent arrêtées avec Révocat, Saturnin et Secundulus et jetées dans une obscure prison ; ensuite on leur adjoignit Satyrus. Elles étaient encore catéchumènes, mais furent baptisées peu après. Au bout de peu de jours tirées de la prison et emmenées au forum avec leurs compagnons, elles furent, après une glorieuse confession de la foi, condamnées aux bêtes par le procurateur Hilarion. Du tribunal, elles redescendirent tout joyeuses en prison, où diverses visions les réconfortèrent et les remplirent d’ardeur pour la palme du martyre. Pour ce qui est de Perpétue, ni les prières instantes et les larmes d’un père accablé par l’âge, ni l’amour maternel envers un fils tout enfant suspendu à son sein, ni l’atrocité du supplice ne purent jamais la détourner de la foi au Christ.

--- a/web/www/horas/Francais/Sancti/03-10.txt
+++ b/web/www/horas/Francais/Sancti/03-10.txt
@@ -20,10 +20,10 @@ Tous moururent dans ce supplice, excepté Mélithon, le plus jeune. Sa mère, qu
 
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Francais/Sancti/04-02.txt
+++ b/web/www/horas/Francais/Sancti/04-02.txt
@@ -26,10 +26,10 @@ Dieu voulut attester la sainteté de son serviteur par de nombreux miracles, ent
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Francais/Sancti/04-22.txt
+++ b/web/www/horas/Francais/Sancti/04-22.txt
@@ -25,11 +25,10 @@ Soter, Fundis in Campánia natus, sancívit ne sacræ vírgines vasa sacra et pa
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
-
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Francais/Sancti/04-23.txt
+++ b/web/www/horas/Francais/Sancti/04-23.txt
@@ -13,13 +13,13 @@ vide C2;
 $Per Dominum
 
 [Lectio4]
-@Commune/C2:Lectio41
+@Commune/C2:Lectio4 in 2 loco
 
 [Lectio5]
-@Commune/C2:Lectio51
+@Commune/C2:Lectio5 in 2 loco
 
 [Lectio6]
-@Commune/C2:Lectio61
+@Commune/C2:Lectio6 in 2 loco
 
 [Lectio94]
 The martyr George beareth among the Easterns the title of the holy and glorious~

--- a/web/www/horas/Francais/Sancti/05-25.txt
+++ b/web/www/horas/Francais/Sancti/05-25.txt
@@ -31,13 +31,13 @@ Gregórius Papa séptimus, ántea Hildebrándus, Suánæ in Etrúria natus, doct
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Francais/Sancti/06-13.txt
+++ b/web/www/horas/Francais/Sancti/06-13.txt
@@ -22,13 +22,13 @@ $Per Dominum
 @:OratioText:s/ atque Doctóris//
 
 [Lectio1] (rubrica tridentina)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2] (rubrica tridentina)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3] (rubrica tridentina)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Antónius, Ulyssipóne in Lusitánia honéstis ortus paréntibus, et ab iis pie educátus, adoléscens, institútum canonicórum regulárium suscépit. Sed, cum córpora beatórum quinque Mártyrum fratrum Minórum Conímbriam transferéntur, qui paulo ante apud Marróchium pro Christi fide passi erant, martýrii desidério incénsus ad Franciscánum órdinam transívit.  Mox eódem ardóre impúlsus, ad Saracénos ire perréxit; sed, advérsa valetúdine afflíctus et redíre coáctus, cum navi ad Hispániæ líttora ténderet, ventórum vi in Sicíliam delátus est.

--- a/web/www/horas/Francais/Sancti/06-25.txt
+++ b/web/www/horas/Francais/Sancti/06-25.txt
@@ -26,10 +26,10 @@ Guliélmus, nobílibus paréntibus Vercéllis natus, vix quartum décimum ætát
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio73
+@Commune/C4:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C4:Lectio83
+@Commune/C4:Lectio8 in 4 loco
 
 [Lectio9]
-@Commune/C4:Lectio93
+@Commune/C4:Lectio9 in 4 loco

--- a/web/www/horas/Francais/Sancti/06-26.txt
+++ b/web/www/horas/Francais/Sancti/06-26.txt
@@ -56,7 +56,7 @@ De hoc fermento Apóstolus præcepit: Itaque epulemur, non in fermento veteri, n
 Verum quod sequitur: Quóniam quæ in ténebris dixistis, in lúmine dicéntur; non solum in futuro, quando cuncta cordium abscóndita proferéntur ad lucem, sed et in præsénti témpore potest congruenter accipi. Quóniam quæ inter ténebras quondam pressurárum carcerumque umbras vel locúti vel passi sunt Apóstoli; nunc, clarificáta per orbem Ecclésia, lectis eórum actibus, publice prædicántur. Ne terreámini ab his qui occídunt corpus. Si persecutores Sanctórum, occisis corpóribus, non habent ámplius quid contra illos agant: ergo supervacua furunt insánia, qui mortua Mártyrum membra, feris avibusque discerpenda projíciunt, cum nequaquam omnipoténtiæ Dei, quin ea resusictando vivíficet, obsistere possint.
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Lectio9]
 Duo autem sunt genera persecutórum: unum palam sæviéntium, álterum ficte fraudulenterque blandiéntium. Contra utrumque nos munire atque instítuere volens Salvator, et supra ab hypócrisi pharisæórum attendere, et hic a carnificum cæde præcipit non timére; quia videlicet, post mortem nec horum crudelitas nec illórum valeat simulátio durare. Nonne quinque pásseres veneunt dipondio? Si minutíssima, inquit, animália, et quæ quólibet per áëra ferúntur volatília, Deus oblivísci non potest; vos, qui ad imáginem facti estis Creatoris, non debetis terreri ab his qui occídunt corpus; quia, qui irrationabília animália gubernat, rationabília curare non désinit.

--- a/web/www/horas/Francais/Sancti/07-03.txt
+++ b/web/www/horas/Francais/Sancti/07-03.txt
@@ -28,13 +28,13 @@ Leo secúndus, Sículus, humánis et divínis lítteris Græce et Latíne doctus
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Francais/Sancti/07-13.txt
+++ b/web/www/horas/Francais/Sancti/07-13.txt
@@ -25,10 +25,10 @@ Anaclétus Atheniénsis, Trajáno imperatóre rexit Ecclésiam. Decrévit ut ep�
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Francais/Sancti/07-14.txt
+++ b/web/www/horas/Francais/Sancti/07-14.txt
@@ -28,10 +28,10 @@ Bonaventúra, Balneorégii in Etrúria natus adoléscens religiónem sancti Fran
 &teDeum
 
 [Lectio7]
-@Commune/C4a:Lectio72
+@Commune/C4a:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C4a:Lectio82
+@Commune/C4a:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C4a:Lectio92
+@Commune/C4a:Lectio9 in 3 loco

--- a/web/www/horas/Francais/Sancti/08-10.txt
+++ b/web/www/horas/Francais/Sancti/08-10.txt
@@ -52,7 +52,7 @@ V. Grande est sa gloire, par le salut que vous opérez.
 R. Vous l’avez couvert de gloire et de beauté.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Responsory1]
 R. Le Lévite Laurent a fait une œuvre bonne, lui qui a rendu la lumière aux aveugles par le signe de la croix,

--- a/web/www/horas/Francais/Sancti/08-23.txt
+++ b/web/www/horas/Francais/Sancti/08-23.txt
@@ -19,13 +19,13 @@ Le feu de la divine charité dont il brûlait et son zèle ardent pour l’exten
 On vit constamment briller en lui une tendre compassion envers les pauvres ; elle parut surtout avec éclat lorsque, dans un faubourg de Sienne, il donna son propre vêtement à un pauvre lépreux à peu près nu ; aussitôt que ce malheureux en fut couvert, il se trouva guéri de sa lèpre. Le bruit de ce miracle s’étant répandu de tous côtés, quelques-uns des Cardinaux réunis à Viterbe pour l’élection du successeur de Clément IV, jetèrent les yeux sur Philippe, dont ils connaissaient du reste la prudence toute céleste. A cette nouvelle, l’homme de Dieu craignant de se voir imposer la charge de pasteur suprême, s’enfuit sur le mont Tuniato, et y demeura caché jusqu’au moment où Grégoire fut proclamé souverain Pontife. En cet endroit se trouve une source d’eau qu’on appelle encore aujourd’hui Fontaine de Saint-Philippe, eau qui doit à ses prières la vertu de guérir les malades. Enfin il quitta très saintement cette vie, à Todi, l’an douze cent quatre-vingt-cinq, en embrassant le crucifix, qu’il appelait son livre. A son tombeau, des aveugles recouvrèrent la vue, des boiteux furent guéris et des morts ressuscitèrent. Devant l’éclat de ces prodiges et de beaucoup d’autres encore, le souverain Pontife Clément X l’inscrivit au nombre des Saints.
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco
 
 [Lectio Vigilia]
 !Pour la Vigile de S. Barthélemy Apôtre

--- a/web/www/horas/Francais/Sancti/08-25.txt
+++ b/web/www/horas/Francais/Sancti/08-25.txt
@@ -31,13 +31,13 @@ Louis IX, devenu roi de France à l’âge de douze ans, par la mort de son pèr
 Le saint roi construisit nombre de monastères et d’hospices pour les pauvres ; il secourait de ses largesses les indigents, visitait fréquemment les malades et, non content de les faire soigner à ses frais, leur donnait de ses propres mains ce dont ils avaient besoin. Simple dans ses habits, il n’épargnait pas à son corps les mortifications du ciliée et du jeûne. Louis IX traversa de nouveau la mer pour combattre les Sarrasins, mais au moment où il venait d’établir son camp en face de l’ennemi, il mourut de la peste en prononçant ces paroles : « J’entrerai dans votre maison, Seigneur, je vous adorerai dans votre saint temple et je glorifierai votre nom. » Son corps fut transporté à Paris ; il est conservé dans la célèbre église de Saint-Denis, où on le vénère. Quant à son chef, on le porta à la sainte Chapelle. Glorifié par d’éclatants miracles, il a été mis au nombre des Saints par le Pape Boniface VIII.
 
 [Lectio7]
-@Commune/C5:Lectio72
+@Commune/C5:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C5:Lectio82
+@Commune/C5:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C5:Lectio92
+@Commune/C5:Lectio9 in 3 loco
 
 [Lectio93]
 @Sancti/08-26:Lectio93

--- a/web/www/horas/Francais/Sancti/09-02.txt
+++ b/web/www/horas/Francais/Sancti/09-02.txt
@@ -19,13 +19,13 @@ Son amour de la prière l’amenait à veiller des nuits presque entières ; et 
 Animé d’une ardente dévotion envers la Mère de Dieu, il construisit une vaste église en son honneur, et l’établit patronne de la Hongrie. En retour, la Vierge Marie l’introduisit au ciel le jour même de son Assomption, que les Hongrois appellent le jour de la Grande Souveraine, d’après une institution de ce saint roi. Quand il fut mort, son corps répandit une odeur suave et une liqueur céleste. Le Pontife romain voulut qu’on le transférât dans un lieu plus digne de lui, où on l’ensevelit avec beaucoup d’honneur. Cette translation fut accompagnée de nombreux miracles de tous genres. Le jour de sa fête a été fixé, par le souverain Pontife Innocent XI, au quatre des nones de septembre, en mémoire d’une victoire éclatante : celle que l’armée de Léopold, empereur des Romains et roi de Hongrie, remporta à la même date sur les Turcs, leur reprenant, avec le secours de Dieu, la ville de Budapest.
 
 [Lectio7]
-@Commune/C5:Lectio72
+@Commune/C5:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C5:Lectio82
+@Commune/C5:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C5:Lectio92
+@Commune/C5:Lectio9 in 3 loco
 
 [Lectio94]
 Etienne, roi des Hongrois, introduisit en Hongrie la foi du Christ, avec le gouvernement royal. Après avoir obtenu la couronne, du Pontife Romain et avoir été sacré roi sur son ordre, il fit hommage de son royaume au Siège apostolique. Il fonda divers établissements hospitaliers à Rome, à Jérusalem et à Constantinople et, en Hongrie, l’archevêché de Strigonie, avec dix évêchés, sous l’inspiration d’une profonde piété et avec une munificence remarquable. Il brilla par une charité rare pour les pauvres et une application assidue à la prière. Il avait une très grande dévotion envers la Mère de Dieu ; et, ayant construit une vaste église en son honneur, il la proclama patronne de la Hongrie. En retour, la même Vierge le reçut au del, le jour même de son Assomption, jour que les Hongrois appellent, d’après l’institution du saint Roi, le jour de la Grande Dame. Cependant sa fête, d’après un décret du Pape Innocent XI, est célébrée au jour anniversaire où la puissante citadelle de BudaPest, grâce à l’assistance du saint Roi, fut recouvrée vaillamment par l’armée chrétienne.

--- a/web/www/horas/Francais/Sancti/09-10.txt
+++ b/web/www/horas/Francais/Sancti/09-10.txt
@@ -19,13 +19,13 @@ N’étant encore qu’adolescent, il s’enrôla dans la milice ecclésiastique
 Bien que Satan le fatiguât de ses ruses jusqu’à le frapper, l’assiduité de son application à la prière ne connut pas de défaillance. Toutes les nuits, durant les six derniers mois de son existence, il entendit des concerts angéliques dont la suavité lui faisait pressentir les joies du paradis et l’amenait à répéter fréquemment ces paroles de l’Apôtre : « Il me tarde de mourir pour être réuni au Christ. » Il prédit à ses frères le jour de sa mort, qui fut le quatre des ides de septembre. Des miracles nombreux, même après sa mort, rendirent son nom illustre. Ces miracles ayant été judiciairement et régulièrement constatés, le Pape Eugène IV le plaça au nombre des Saints.
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco
 
 [Lectio94]
 Nicolas, dit de Tolentino, à cause de son long séjour dans cette cité, naquit à Saint-Ange, ville de la Marche d’Ancône, de pieux parents qui l’obtinrent de Dieu, à la suite d’un vœu, par l’intercession de saint Nicolas. Enfant, il donna l’exemple de nombreuses vertus, de l’abstinence spécialement. Enrôlé plus tard dans la milice ecclésiastique et pourvu d’un canonicat, il entendit un jour un prédicateur de l’Ordre des Ermites de saint Augustin prêcher sur le mépris du monde. Enflammé par ce sermon, il entra de suite dans le même ordre. Il y observa si rigoureusement les règles de la vie religieuse, que, revêtu d’habits grossiers, domptant son corps par le jeûne, les disciplines et les chaînes de fer, il se distingua entre tous les autres par ses vertus. Son assiduité pour la prière, était sans relâche, bien qu’il fût persécuté de diverses manières par le démon et même parfois frappé de verges. Six mois avant de mourir, il entendit, chaque nuit, des concerts angéliques, et, enfin, après avoir annoncé son dernier jour, il s’endormit dans le Seigneur. Devenu célèbre par ses miracles pendant sa vie et après sa mort, il fut mis, par Eugène IV, au nombre des Saints.

--- a/web/www/horas/Francais/Sancti/09-17.txt
+++ b/web/www/horas/Francais/Sancti/09-17.txt
@@ -64,10 +64,10 @@ François savait bien que l’état d’infirmité et de souffrance est incompat
 Devenu donc un nouvel homme, grâce à la distinction glorieuse de ce prodige nouveau et surprenant (puisque, par un privilège singulier dont personne encore n’avait joui avant ce jour, il se trouva marqué, je dirai mieux, orné des sacrés stigmates). François descendit de la montagne, portant avec lui l’image du Crucifié non point tracée d’une main d’artisan sur des tables de pierre ou de bois, mais gravée sur sa propre chair par le doigt du Dieu vivant. Comme il savait très bien « qu’il est bon de tenir caché le secret d’un roi, » cet homme séraphique, conscient de l’œuvre mystérieuse, opérée en lui par le Roi [divin], s’efforçait de dissimuler ces marques sacrées. Mais parce que c’est à Dieu de révéler pour sa gloire les grandes choses qu’il fait, le Seigneur lui-même qui avait secrètement imprimé ces signes, les fit ouvertement découvrir par des miracles, en sorte que, la vertu cachée et merveilleuse des stigmates, devint manifeste par l’éclat des prodiges. Ce fait digne d’admiration, si bien constaté, et exalté par les bulles pontificales avec de grandes louanges et la publication de faveurs spéciales, le Pape Benoît XI voulut qu’on en célébrât l’anniversaire par une solennité que le souverain Pontife Paul V étendit à l’Église universelle, dans le but d’enflammer les cœurs des fidèles, d’amour pour le Christ crucifié.
 
 [Lectio7]
-@Commune/C2:Lectio73
+@Commune/C2:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C2:Lectio83
+@Commune/C2:Lectio8 in 4 loco
 
 [Responsory8]
 R. Pour moi, Dieu me garde de me glorifier autrement qu’en la Croix de Notre-Seigneur Jésus-Christ :
@@ -78,7 +78,7 @@ R. Par qui le monde est crucifié pour moi et moi crucifié pour le monde.
 R. Par qui le monde est crucifié pour moi et moi crucifié pour le monde.
 
 [Lectio9]
-@Commune/C2:Lectio93
+@Commune/C2:Lectio9 in 4 loco
 
 [Lectio94]
 François apparut, revêtu d’un privilège singulier, inconnu aux siècles antérieurs, quand il descendit de la montagne, marqué des sacrés Stigmates et portant sur lui l’image du Crucifié, non point tracée sur des tables de pierre ou de bois, par la main d’un artisan, mais gravée sur ses membres de chair, par le doigt du Dieu vivant. Comme cet homme séraphique savait qu’il est très bon de cacher le secret du roi, conscient d’avoir un secret royal, il dissimulait ce signe sacré autant qu’il le pouvait. Mais, parce que c’est le propre de Dieu de révéler, pour sa gloire, les grandes choses qu’il fait, le Seigneur lui- même, qui avait imprimé ces signes secrètement, les découvrit par certains miracles, de sorte que la vertu cachée et merveilleuse de ces Stigmates se manifesta par l’éclat des prodiges. — Ce fait extraordinaire, ayant été dûment constaté et mis en lumière dans les Bulles pontificales, avec de grandes louanges et faveurs, le Pape Benoît XI voulut en faire célébrer solennellement l’anniversaire, et, dans la suite, le Souverain Pontife Paul V étendit cette fête à l’Église universelle, pour que les cœurs des fidèles fussent enflammés de l’amour du Christ Crucifié.

--- a/web/www/horas/Francais/Sancti/09-20.txt
+++ b/web/www/horas/Francais/Sancti/09-20.txt
@@ -22,10 +22,10 @@ Eustache, qui portait aussi le nom de Placide, et que sa naissance, ses richesse
 Durant l’expédition qu’il dirigea, il eut la joie inespérée de recouvrer ses enfants et son épouse. Vainqueur, il entra dans Rome au milieu des acclamations de tous. Mais peu après, ayant reçu l’ordre de sacrifier aux faux dieux pour les remercier de sa victoire, il s’y refusa énergiquement. En vain essaya-t-on par divers moyens de lui faire renier la foi du Christ. On l’exposa aux lions avec sa femme et ses enfants ; la douceur que ces animaux montrèrent à leur égard ayant irrité l’Empereur, celui-ci ordonna d’enfermer les saints Confesseurs dans un taureau d’airain, rougi par le feu qui brûlait au-dessous. Consommant ainsi leur martyre et chantant les louanges divines, ils s’envolèrent vers la félicité éternelle, le douze des calendes d’octobre. Leurs corps, retrouvés intacts, furent religieusement ensevelis par les fidèles, puis transférés avec honneur dans l’église édifiée sous leur vocable.
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio Vigilia]
 !Commémoraison de la Vigile de St Matthieu, apôtre et évangéliste

--- a/web/www/horas/Francais/Sancti/09-23.txt
+++ b/web/www/horas/Francais/Sancti/09-23.txt
@@ -37,10 +37,10 @@ Le Pape saint Lin, né à Volterra en Toscane, gouverna l’Église immédiateme
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Francais/Sancti/09-27.txt
+++ b/web/www/horas/Francais/Sancti/09-27.txt
@@ -24,13 +24,13 @@ Les deux frères Côme et Damien, originaires d’Égée, en Arabie, étaient de
 &teDeum
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Francais/Sancti/10-14.txt
+++ b/web/www/horas/Francais/Sancti/10-14.txt
@@ -26,13 +26,13 @@ Le Romain Calixte gouverna l’Église sous l’empereur , Antonin Héliogabale.
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Lectio7](rubrica tridentina)
 @Sancti/02-22:Lectio7

--- a/web/www/horas/Francais/Sancti/10-19.txt
+++ b/web/www/horas/Francais/Sancti/10-19.txt
@@ -23,10 +23,10 @@ Pierre naquit à Alcantara, en Espagne, de parents nobles. A l’âge de seize a
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Francais/Sancti/10-31.txt
+++ b/web/www/horas/Francais/Sancti/10-31.txt
@@ -10,13 +10,13 @@ Laudes 2
 No Suffragium
 
 [Lectio1]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio2]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio3]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco
 
 [Oratio]
 Seigneur notre Dieu, multipliez envers nous l’effusion de votre grâce, et faites que, par une vie sainte, nous méritions de suivre dans la félicité éternelle ceux dont nous anticipons la fête solennelle.

--- a/web/www/horas/Francais/Sancti/11-13.txt
+++ b/web/www/horas/Francais/Sancti/11-13.txt
@@ -23,10 +23,10 @@ Didace, de Saint-Nicolas-du-Port, au diocèse de Séville, en Espagne, s’initi
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Francais/Sancti/11-20.txt
+++ b/web/www/horas/Francais/Sancti/11-20.txt
@@ -23,10 +23,10 @@ Félix, appelé d’abord Hugues, issu de la famille royale des Valois de France
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Francais/Sancti/12-11.txt
+++ b/web/www/horas/Francais/Sancti/12-11.txt
@@ -36,13 +36,13 @@ Il établit la peine du talion contre ceux qui accuse- seraient à faux quelqu�
 L’Espagnol Damase, homme remarquable et versé dans les Écritures, ayant convoqué le premier concile de Constantinople, y étouffa la criminelle hérésie d’Eunomius et de Macédonius. C’est lui aussi qui condamna de nouveau l’assemblée de Rimini, déjà rejetée précédemment par Libère, en laquelle, comme l’écrit saint Jérôme, par suite des ruses d’Ursace et surtout de Valens, on avait proclamé la condamnation de la foi de Nicée. Il édifia deux basiliques, l’une sous le vocable de saint Laurent, près du théâtre de Pompée, l’autre sur la voie d’Ardée, aux Catacombes. Il prescrivit que, selon l’usage déjà reçu en plusieurs endroits, les Psaumes seraient chantés dans toutes les églises, jour et nuit, à deux chœurs ; et, qu’à la fin de chaque Psaume, on dirait : Gloire au Père, et au Fils, et au Saint-Esprit. Par son ordre, saint Jérôme ramena le Nouveau Testament à la fidélité au texte grec. Il découvrit aussi de nombreux corps de saints Martyrs et célébra leur mémoire par des pièces de poésie. Célèbre par sa vertu, sa science et sa prudence, presque octogénaire, il s’endormit dans le Seigneur, sous le règne de Théodose l’Ancien.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Francais/Sancti/12-16.txt
+++ b/web/www/horas/Francais/Sancti/12-16.txt
@@ -19,16 +19,16 @@ Le concile se réunit à Milan l’année suivante. Eusèbe y fut invité par Co
 Quelle fut alors contre lui la cruauté des Ariens et leur insolence effrontée, nous le voyons dans d’importantes lettres, pleines de vigueur, de piété et de religion, qu’il écrivit, de Scythopolis, au clergé et au peuple de Verceil et à d’autres personnes des environs. On en déduit également que ni leurs menaces et cruauté inhumaine ne purent jamais le dissuader, ni leur ruse doucereuse de serpent l'attirer dans leur parti. De là, déporté en Cappadoce et enfin en Thébaïde, dans la Haute-Égypte, à cause de sa fermeté, il supporta les rigueurs de l'exil jusqu'à la mort de Constance. Il lui fut alors permis de rejoindre son troupeau ; mais il ne voulut point revenir avant de s'être rendu au synode d'Alexandrie pour y réparer le mal fait à la foi, et, à l’instar d'un habile médecin, il parcourut donc les provinces d'Orient, pour rendre complètement à la santé les faibles dans la foi qu'il instruisit dans la doctrine de l’Église. De là, dans un même but de rétablissement spirituel, il s'éloigna vers rillyrie et, enfin, revint en Italie, où, à son retour, celle-ci déposa ses vêtements de deuil. C’est là, que, dans la suite, il publia les commentaires d’Origène et d'Eusèbe de Césarée, sur tous les Psaumes, après les avoir expurgés et traduits du grec en latin. Enfin, illustré par tant d'actions remarquables, il alla^recevoir l’immortelle couronne de gloire, méritée par de si grandes fatigues, à Verceil, sous Valentinien et Valens.
 
 [Lectio7]
-@Commune/C2:Lectio73
+@Commune/C2:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C2:Lectio83
+@Commune/C2:Lectio8 in 4 loco
 
 [Responsory8]
-@Commune/C2:Responsory8NonEffusorum
+@Commune/C2:Responsory8 non Effusorum
 
 [Lectio9]
-@Commune/C2:Lectio93
+@Commune/C2:Lectio9 in 4 loco
 
 [Lectio94]
 Eusèbe, de nation Sarde, fut lecteur de l’Église romaine, puis évêque de Verceil. Il lutta contre l'arianisme avec un tel courage, que sa foi invincible soutint le Souverain Pontife Libère au point d'avoir été la consolation de sa vie. En témoignage de cette même foi catholique, il fut envoyé par l’empereur Constance à Scythopolis, où il souffrit la faim, la soif, les verges et divers supplices. De là, relégué en Cappadoce, il supporta les rigueurs de l’exil, jusqu’à la mort de Constance lui-même, après laquelle il lui fut permis de rejoindre son Église. L'Italie déposa alors ses vêtements de deuil. C’est là, que, dans la suite, il publia les commentaires d’Origène et d’Eusèbe de Césarée sur les Psaumes, après les avoir expurgés et traduit du grec en latin. Il s’en alla vers le Seigneur, recevoir l’immortelle couronne de gloire, méritée par de si grandes fatigues, à Verceil, sous Valentinien et Valens.

--- a/web/www/horas/Italiano/Commune/C2.txt
+++ b/web/www/horas/Italiano/Commune/C2.txt
@@ -185,7 +185,7 @@ R. Non ha avuto paura delle minacce dei giudici; non ha cercato la gloria di ter
 &Gloria
 R. Non ha avuto paura delle minacce dei giudici; non ha cercato la gloria di terreni onori, ma è giunto al regno celeste.
 
-[Responsory8NonEffusorum]
+[Responsory8 non Effusorum]
 R. Signore, lo hai prevenuto con le più dolci benedizioni, 
 * hai posto sul suo capo una corona di pietre preziose.
 V. Egli ti chiese la vita, e tu gli hai dato longevità nei secoli.
@@ -312,30 +312,30 @@ R. Crescerà come il cedro del Libano.
 [Ant 3]
 Chi vuol venire dietro a me, * rinneghi se stesso, prenda la sua croce e mi segua.  
 
-[Lectio41]
+[Lectio4 in 2 loco]
 Dalla lettera di san Cipriano vescovo e martore ai martiri e confessori.
 !Libro 2, Lettera 6.
 Con quali lodi vi esalterò, martiri fortissimi? Con quale canto della voce abbellirò la forza del vostro petto e la perseveranza della fide? Avete tollerato la tortura più dura fino al massimo della gloria:  non avete ceduto ai supplizi, ma piuttosto i supplizi hanno ceduto a voi. Le corone diedero ai dolori quella fine, che i tormenti non davano. A ciò la tortura continuò a lungo più severa, ma non da far cadere la fede stabile, ma da mandare più in fretta gli uomini di Dio a Dio.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 V. La luce perpetua risplenderà per i tuoi santi, o Signore,
 * e l'eternità dei secoli, alleluia, alleluia.
 V. Essi saranno incoronati di eterna letizia:  avranno gaudio e consolazione.
 R. E l'eternità dei secoli, alleluia, alleluia.
 
-[Lectio51]
+[Lectio5 in 2 loco]
 La moltitudine dei presenti vedette ed ammirò la battaglia celeste, la battaglia di Dio, battaglia spirituale, conflitto di Cristo: che i suoi servi stavano in piedi a voce libera, colla mente incorrotta,per potenza divina, nudi difatti contro i proiettili del mondo, ma armati con le armi della fede fervorosa. Stettero torturati più forti dei torturatori: le membra battute e dilaniate vinsero i battitori e gli uncini dilanianti. La piaga ulcerante a lungo ripetuta non poté superare la fede inespugnabile, benché, rotta la struttura delle viscere, venivano torturata nei servi di Dio non più le membra, ma le ferite! Il sangue fluiva, per estinguere l'incendio della persecuzione, per sopire le fiamme ed i fuochi della geenna con glorioso coagulo.
 
-[Responsory51]
+[Responsory5 in 2 loco]
 R. Nei suoi servi, alleluia,
 * Iddio si consolerà, alleluia.
 V. Il Signore giudicherà il suo popolo, e nei suoi servi.
 R. Iddio si consolerà, alleluia.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 O quale fu quello spettacolo per il Signore, quanto sublime, quanto grande, quanto gradito agli occhi di Dio per il giuramento e la devozione del suo soldato: come è scritto nei Salmi, dove lo Spirito Santo ci parla ed al contempo ci ammonisce: "Preziosa è agli occhi del Signore, la morte dei suoi santi." Preziosa è questa morte, che compra l'immortalità col prezzo del suo sangue; che ricevette la corona del culmine della virtù. Quanto lieto fu ivi Cristo, quanto volentieri compatte in tali suoi servi, e vinse da protettore della fede, dando tanto ai credenti, quanto credi di ottenere chi riceve! Fu presente alla sua battaglia, alzò i combattenti e proclamatori del suo nome, li confortò, li animò. E Colui che vinse una volta per noi la morte, sempre la vince in noi.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Figlie di Gerusalemme, venite e vedete i martiri con le corone con cui il Signore li ha incoronati
 * nel giorno della solennità e della gioia, alleluia.
 V.  Perché ha rafforzate le sbarre delle tue porte e ha benedetto in te i tuoi figli.
@@ -343,7 +343,7 @@ R. Nel giorno della solennità e della gioia, alleluia.
 &Gloria
 R. Nel giorno della solennità e della gioia, alleluia.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Dal Vangelo secondo Giovanni
 !Gio 15:5-11
 In quel tempo Gesù disse ai suoi discepoli: "Io sono la vite, voi i tralci: se uno rimane in me, ed io in lui, questi porta molto frutto; poiché senza di me non potete far nulla". (continua nella Messa del giorno) 
@@ -352,16 +352,16 @@ Omelia di s Agostino vescovo
 !Trattato 81 su Giovanni, a metà.
 Affinché nessuno pensasse che il tralcio possa, da solo produrre qualche frutto, sia pur piccolo, dopo aver detto: "Questi porta molto frutto", non aggiunse: "poiché senza di me potete fare poco", ma: "non potete far nulla". Dunque non si può fare né poco né molto, separati da colui senza del quale non si può far nulla.  Se il tralcio dà poco frutto, l'agricoltore lo pota, perché ne porti di più; ma, se non rimane attaccato alla vite e non è alimentato dalla radice, da se stesso non può dare il minimo frutto. Ora, sebbene Cristo non sarebbe vite se non fosse uomo, tuttavia egli non darebbe ai tralci questa virtù se non fosse anche Dio.
 
-[Responsory71]
+[Responsory7 in 2 loco]
 R. Io sono la vera vite voi i tralci: 
 * se uno rimane in me ed io in lui, questi porta molto frutto, alleluia, alleluia.
 V. Come il Padre ha amato me, così io ho amato voi.
 R. Se uno rimane in me ed io in lui, questi porta molto frutto, alleluia, alleluia.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Ma poiché senza questa grazia non si può vivere, cosicché anche la morte rimane in potere del libero arbitrio: "se uno, dice, non rimarrà in me, sarà gettato via come un tralcio che si secca e poi viene raccolto e gettato nel fuoco, dove brucia". I tralci dunque della vite sono tanto più spregevoli se non rimangono attaccati alla vite, quanto più sono pregevoli se vi rimangono. Infine, come dice il Signore di essi per bocca del profeta Ezechiele, essi se sono tagliati, non servono ad alcun uso agricolo e non sono adatti ad alcun lavoro di artigiano. Per il tralcio non c'è altra alternativa: la vite o il fuoco. Se non rimane nella vite, sarà gettato nel fuoco.  Dunque, per non essere gettato nel fuoco, deve rimanere attaccato alla vite.  
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. I suoi nazirei sono divenuti più candidi della neve, alleluia, e a Dio hanno dato splendore.
 * E come il latte si sono rassodati, alleluia, alleluia.
 V. Più candidi della neve, più bianchi del latte, più vermigli dell'avorio antico, più belli dello zaffiro.
@@ -369,11 +369,11 @@ R. E come il latte si sono rassodati, alleluia, alleluia.
 &Gloria
 R. E come il latte si sono rassodati, alleluia, alleluia.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 "Se rimarrete in me, dice, e le mie parole rimarranno in voi, chiederete quel che vorrete e vi sarà concesso". Rimanendo infatti in Cristo, cosa possono volere, se non ciò che piace a Cristo? Cosa possono volere, rimanendo nel Salvatore, se non ciò che non è contrario alla salvezza? Infatti, se siamo in Cristo vogliamo diversamente che se siamo ancora in questo mondo. Per il fatto che siamo ancora in questo mondo, può accaderci qualche volta di domandare ciò che ignoriamo esserci dannoso. Ma questo non avviene se rimaniamo in Cristo, il quale non concede, quando chiediamo, se non quello che ci conviene.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Dal Vangelo secondo Matteo
 !Matt 10:26-32
 In quel tempo, Gesù disse ai suoi discepoli: Poiché nulla v'è di nascosto che non debba essere rivelato, e niente d'occulto che non s'abbia a sapere. (continua nella Messa del giorno) 
@@ -383,13 +383,13 @@ Omelia di san Ilario vescovo
 Il Signore mostra il giorno del giudizio, che manifesterà la coscienza segreta della nostra volontà: e quelle cose che ora si stimano occulte, aprirà alla luce della cognizione pubblica. Quindi ammonisce che vanno temute le minacce, i consigli, i poteri dei persecutori: perché il giorno del giudizio rivelerà che queste erano state nulle e vane. "Dite in pieno giorno quello che io vi dico 
 all'oscuro: e predicate sui tetti quel che vi é stato detto in un orecchio." Non leggiamo che il Signore fosse solito fare discorsi di notte, e che avesse tramandato la dottrina nelle tenebre: ma che ogni suo discorso sono tenebre per i carnali, e il suo verbo è notte per gli infedeli.
 
-[Responsory72]
+[Responsory7 in 3 loco]
 @Commune/C2:Responsory7
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Pertanto ciò che è stato detto da Lui, vuole che sia enunciato con libertà di fede e confessione. Quindi ordinò che si predicassero nella luce le cose che sono state dette nelle tenebre: di modo che quelle cose che sono affidate al segreto degli orecchi, vengano udite sopra i tetti, ossia con la voce alta dei parlanti.  Infatti la cognizione di Dio va proposta di continuo, ed il profondo segreto della dottrina evangelica va rivelata nel lume della predicazione apostolica: non temendo quelli che, sebbene gli sia dato potere sui corpi, tuttavia non hanno alcun giurisdizione sull'anima: ma temendo piuttosto Dio, Che ha il potere di fare perire nella geenna sia il corpo che l'anima.
 
-[Responsory82]
+[Responsory8 in 3 loco]
 @Commune/C2:Responsory8
 
 [ResponsoryNonEffusorum]
@@ -400,11 +400,11 @@ R. Hai posto sul suo capo una corona di pietre preziose.
 &Gloria
 R. Hai posto sul suo capo una corona di pietre preziose.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Non temete coloro che uccidono il corpo. Niente che accade ai nostri corpi è da temere, e nessun dolore per l'uccisione della carne è da ammettere: quando in cambio della disciolta condizione della sua natura, viene rifondata nella sostanza dell'anima spirituale. E poiché è opportuno che i confermati in tali dottrine abbiano la libera costanza di confessare Dio, aggiunse anche la condizione per la quale fossimo legati: che Egli avrebbe negato davanti al Padre nei cieli colui che avesse negato Lui in terra: inoltre colui che lo avesse confessato davanti agli uomini, veniva confessato da Lui nei cieli: e quali noi fossimo stati testimoni del suo nome agli uomini, noi avremmo usufruito di tale testimonianza presso Dio Padre.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Dal Vangelo secondo Matteo
 !Matt 16:24-27
 In quel tempo Gesù disse ai suoi discepoli: Chi vuol venire dietro a me, rinneghi se stesso, e tolga la sua croce, e mi segua.  (continua nella Messa del giorno) 
@@ -413,9 +413,9 @@ Omelia di s. Gregorio papa
 !Omelia 32 sui Vangeli
 Poiché il Signore e Redentore nostro venne al mondo come un nuovo uomo, diede nuovi comandamenti al mondo. Infatti oppose alla nostra vita nutrita nei vizi la contrarietà della novità della sua. Cosa infatti l'uomo vecchio, cosa l'uomo carnale conosceva, se non tenere le sue cose, rubare le altrui, se poteva; desiderare, se non poteva?  Ma il medico celeste a ciascun singolo vizio adibisce medicamenti contrari. Infatti come coll'arte della medicina le cose calde si curano con le fredde e le fredde con le calde: cosi nostro Signore oppose medicine contrarie ai peccati, tanto da ordinare la continenza ai lussuriosi, la generosità ai tirchi, la mansuetudine agli iracondi, l'umiltà agli orgogliosi.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Difatti quando proponeva nuovi comandamenti a quelli che lo seguivano, disse: "Chiunque non rinunzia a tutto quel che possiede, non può essere mio discepolo". Come se volesse dire apertamente: voi che per la vita vecchia desiderate la roba d'altri, elargite per il desiderio di una nuovo modo di vivere anche la vostra. Ascoltiamo cosa dice in questa lezione: "Chi vuol venire dietro a me, rinneghi se stesso". Ivi si dice ché rinneghiamo la nostra roba: qui si dice ché rinneghiamo noi stessi. E forse non è faticoso all'uomo abbandonare la sua roba; ma è molto faticoso abbandonare sé stesso. È da una parte meno negare ciò che ha; molto dall'altra negare quel che è.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Ma il Signore ha comandato a noi che veniamo a Lui di rinunziare a noi: perché quanti veniamo alla gara della fede, ci impegniamo ad una lotta contro gli spiriti maligni. Infatti gli spiriti maligni non possiedono nulla di proprio in questo mondo: quindi dobbiamo lottare nudi con i nudi. Infatti se chiunque lottasse vestito con uno nudo, verrebbe più in fretta sbattuto a terra, perché ha onde venga afferrato. Che cosa infatti sono tutti beni terreni, se non certi indumenti del corpo? Chi dunque si avvicina alla contesa contro il diavolo, getti via gli indumenti, per non soccombere.
 &teDeum

--- a/web/www/horas/Italiano/Commune/C2p.txt
+++ b/web/www/horas/Italiano/Commune/C2p.txt
@@ -255,30 +255,30 @@ R. La morte dei suoi santi, alleluia.
 [Ant 3]
 Santi e giusti, * gioite nel Signore, alleluia, Iddio vi ha scelti per sua eredità, alleluia.
 
-[Lectio41]
+[Lectio4 in 2 loco]
 Dalla lettera di san Cipriano vescovo e martore ai martiri e confessori.
 !Libro 2, Lettera 6.
 Con quali lodi vi esalterò, martiri fortissimi? Con quale canto della voce abbellirò la forza del vostro petto e la perseveranza della fide? Avete tollerato la tortura più dura fino al massimo della gloria:  non avete ceduto ai supplizi, ma piuttosto i supplizi hanno ceduto a voi. Le corone diedero ai dolori quella fine, che i tormenti non davano. A ciò la tortura continuò a lungo più severa, ma non da far cadere la fede stabile, ma da mandare più in fretta gli uomini di Dio a Dio.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 V. La luce perpetua risplenderà per i tuoi santi, o Signore,
 * e l'eternità dei secoli, alleluia, alleluia.
 V. Essi saranno incoronati di eterna letizia:  avranno gaudio e consolazione.
 R. E l'eternità dei secoli, alleluia, alleluia.
 
-[Lectio51]
+[Lectio5 in 2 loco]
 La moltitudine dei presenti vedette ed ammirò la battaglia celeste, la battaglia di Dio, battaglia spirituale, conflitto di Cristo: che i suoi servi stavano in piedi a voce libera, colla mente incorrotta,per potenza divina, nudi difatti contro i proiettili del mondo, ma armati con le armi della fede fervorosa. Stettero torturati più forti dei torturatori: le membra battute e dilaniate vinsero i battitori e gli uncini dilanianti. La piaga ulcerante a lungo ripetuta non poté superare la fede inespugnabile, benché, rotta la struttura delle viscere, venivano torturata nei servi di Dio non più le membra, ma le ferite! Il sangue fluiva, per estinguere l'incendio della persecuzione, per sopire le fiamme ed i fuochi della geenna con glorioso coagulo.
 
-[Responsory51]
+[Responsory5 in 2 loco]
 R. Nei suoi servi, alleluia,
 * Iddio si consolerà, alleluia.
 V. Il Signore giudicherà il suo popolo, e nei suoi servi.
 R. Iddio si consolerà, alleluia.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 O quale fu quello spettacolo per il Signore, quanto sublime, quanto grande, quanto gradito agli occhi di Dio per il giuramento e la devozione del suo soldato: come è scritto nei Salmi, dove lo Spirito Santo ci parla ed al contempo ci ammonisce: "Preziosa è agli occhi del Signore, la morte dei suoi santi." Preziosa è questa morte, che compra l'immortalità col prezzo del suo sangue; che ricevette la corona del culmine della virtù. Quanto lieto fu ivi Cristo, quanto volentieri compatte in tali suoi servi, e vinse da protettore della fede, dando tanto ai credenti, quanto credi di ottenere chi riceve! Fu presente alla sua battaglia, alzò i combattenti e proclamatori del suo nome, li confortò, li animò. E Colui che vinse una volta per noi la morte, sempre la vince in noi.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Figlie di Gerusalemme, venite e vedete i martiri con le corone con cui il Signore li ha incoronati
 * nel giorno della solennità e della gioia, alleluia.
 V.  Perché ha rafforzate le sbarre delle tue porte e ha benedetto in te i tuoi figli.

--- a/web/www/horas/Italiano/Commune/C3.txt
+++ b/web/www/horas/Italiano/Commune/C3.txt
@@ -335,36 +335,6 @@ R. Gioiranno nel loro riposo.
 [Ant 3]
 Le anime dei Santi, * che hanno seguito le orme di Cristo, godono  nel cielo; e siccome per suo amore hanno versato il loro sangue, esultano con Cristo senza fine.
 
-[Lectio71]
-Lettura del santo Vangelo secondo Luca
-!Luca 6:17-23
-In quel tempo Gesù disse ai suoi discepoli: "Quando sentirete parlare di guerre e sommosse, non vi spaventate; bisogna che prima avvengano queste cose, ma la fine non verrà subito dopo. (continua nella Messa del giorno)
-_
-Omelia di s. Gregorio papa
-!Omelia 35 sui Vangeli.
-Il Signore e Redentore nostro annunzia i mali che precederanno la fine del mondo affinché, quando essi verranno, tanto meno perturbino quanto più saranno stati conosciuti prima. Infatti le frecce che sì prevedono feriscono meno; e i mali del mondo ci sembrano più tollerabili quando la previsione ci premunisce contro di essi, come uno scudo. Ecco dunque quello che dice: "Quando sentirete parlare di guerre e sommosse, non vi spaventate; bisogna che prima avvengano queste cose, ma la fine non verrà subito dopo". È necessario ponderare le parole del nostro Redentore, con le quali egli ci annunzia che dobbiamo patire sia all'esterno che all'interno. Le guerre infatti vengono fatte dai nemici, le sommosse dai cittadini. Per indicarci dunque che saremo turbati all'esterno e all'interno, ci dice che altro avremo a soffrire dai nemici e altro dai fratelli.  
-
-[Responsory7]
-R. I santi di Dio hanno perseverato nella fraternità a causa del comando del Signore e delle leggi paterne. 
-* Essi hanno sempre avuto un solo spirito e una sola fede.
-V. Quanto è bello e dolce che i fratelli dimorino insieme!
-R. Essi hanno sempre avuto un solo spirito e una sola fede.
-
-[Lectio8]
-Ma poiché, avvenuti questi mali, non seguirà subito la fine, aggiunge: "Si solleverà popolo contro popolo e regno contro regno; e vi saranno in diversi luoghi grandi terremoti, e pestilenze e carestie; e vi saranno fenomeni spaventosi e grandi segni dal cielo". L'ultima calamità sarà così preceduta da molte calamità; e con i frequenti mali che precederanno, vengono indicati i mali eterni, che seguiranno. Perciò, dopo le guerre e le sommosse, non seguirà subito la fine; perché devono precedere molti mali che, possano preannunciare il male che non avrà fine.  
-
-[Responsory8]
-R. Voi, miei santi, vivendo nella carne, avete sostenuto la battaglia: io 
-* vi darò la ricompensa per la vostra fatica.
-V. Venite, benedetti dal Padre mio, ricevete il regno.
-R. Vi darò la ricompensa per la vostra fatica.
-&Gloria
-R. Vi darò la ricompensa per la vostra fatica.
-
-[Lectio9]
-Però, dopo che si è parlato di tanti segni di perturbazione, è necessario prenderli brevemente in considerazione ad uno ad uno. Perché sta scritto che noi ne subiamo alcuni dal cielo, altri dalla terra, altri dagli elementi, altri dagli uomini. Dice infatti: "Si solleverà popolo contro popolo»: ecco lo scompiglio degli uomini; "vi saranno in diversi luoghi grandi terremoti": ecco l'ira che verrà dall'alto; "vi saranno pestilenze e": ecco la perturbazione nei corpi; "vi saranno fame e carestia": ecco la sterilità della terra; "e fenomeni spaventosi dal cielo e tempeste": ecco l'instabilità dell'atmosfera. Poiché dunque tutto deve essere distrutto, prima della distruzione tutto sarà sconvolto; e noi, che in tutto abbiamo peccato, in ogni cosa saremo puniti, perché si avveri quanto è stato detto: "E con lui combatterà l'universo contro gli insensati".  
-&teDeum
-
 [Ant Laudes]
 Quanti tormenti sopportarono tutti i Santi * per giungere con sicurezza alla palma del martirio!
 Colla palma * i Santi sono pervenuti al regno ed hanno meritato le corone della gloria dalla mano di Dio.

--- a/web/www/horas/Italiano/Commune/C3.txt
+++ b/web/www/horas/Italiano/Commune/C3.txt
@@ -484,7 +484,7 @@ R. Gioiranno nel loro riposo.
 [Ant 3]
 Le anime dei Santi, * che hanno seguito le orme di Cristo, godono  nel cielo; e siccome per suo amore hanno versato il loro sangue, esultano con Cristo senza fine.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Dal Vangelo secondo Luca
 !Luca 6:17-23
 In quel tempo, disceso Gesù con essi, si fermò alla pianura egli e la turba de' suoi discepoli, e una gran folla di popolo di tutta la Giudea, e di Gerusalemme, e del paese marittimo di Tiro e di Sidone. (continua nella Messa del giorno)
@@ -493,10 +493,10 @@ Omelia di s. Ambrogio vescovo
 !Libero 5 su Luca, cap. 6, dopo l'inizio.
 Fate bene attenzione a tutto, al modo in cui sale con i discepoli e discende alle folle. In che modo infatti la folla poteva vedere Cristo se non in basso? Non Lo segue sulle altezze, non sale ai vertici. Pertanto dove discende, trova gli infermi: sulle altezze infatti non ci possono essere infermi. Indi anche Matteo insegna che i debilitati furono sanati nei luoghi inferiori. Prima difatti va sanato ciascuno in modo che possa ascendere al monte pian piano con le forze che crescono; e quindi sana ciascuno nei luoghi inferiore, cioè, li richiama dalla lussuria, rimuove il danno della cecità. È sceso alle nostre ferite: affinché, con un certo uso ed abbondanza della sua natura, ci faccia essere compartecipi del regno dei cieli.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Beati voi poveri, perché vostro è il regno di Dio. San Luca pose soltanto quattro beatitudini del Signore, mentre san Matteo otto: ma in quelle otto ci stanno queste quattro, ed in queste quattro quelle otto. Questi infatti ha come abbracciato le quattro virtù cardinali: quello in quelle otto ha rivelato un numero mistico. Infatti molti Salmi hanno l'iscrizione "per l'ottava": e ricevi ordine di metterti in grado di partecipare in qualche modo a queste otto beatitudini. Come infatti l'ottava è la perfezione della nostra speranza, così l'ottava è la somma delle virtù.
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. Questa è la vera fratellanza che nella lotta non è mai venuta meno: sparso il sangue, hanno seguito il Signore.
 * Disprezzando gli onori reali, sono giunti al regno celeste.
 V. Quanto è bello e dolce che i fratelli dimorino insieme.
@@ -504,6 +504,6 @@ R. Disprezzando gli onori reali, sono giunti al regno celeste.
 &Gloria
 R. Disprezzando gli onori reali, sono giunti al regno celeste.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Ma prima guardiamo a quelle che sono più grandi. Beati, disse, i poveri, perché vostro è il regno di Dio. Entrambi gli evangelisti posero questa beatitudine. Infatti è la prima in ordine è una madre e la generazione delle virtù: poiché chi avrà disprezzato le cose del mondo, egli meriterà la vita eterna: né può alcuno meritare il regno dei cieli, che, oppresso dal desiderio del mondo, non ha la capacità di emergere. 
 &teDeum

--- a/web/www/horas/Italiano/Commune/C4.txt
+++ b/web/www/horas/Italiano/Commune/C4.txt
@@ -346,7 +346,7 @@ Mentre era * Sommo Pontefice, non temette le potenze terrene, ma salì gloriosam
 V. Il Signore condusse il giusto per le vie diritte.
 R. E gli mostrò il regno di Dio.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Lettura dal libro dell'Ecclesiastico
 !Sir 44:1-5
 1 Diamo lode agli nomini gloriosi ai maggiori nostri, da' quali siamo stati noi generati.
@@ -355,14 +355,14 @@ Lettura dal libro dell'Ecclesiastico
 4 Essi imperarono colla virtù della prudenza al popolo de' loro tempi ingiungendo precetti santissimi a' sudditi.
 5 Col loro sapere investigarono i musicali concerti, e dettarono i cantici delle Scritture.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 44:6-9
 6 Uomini ricchi di virtù, solleciti del decoro del santuario tranquilli nelle loro case.
 7 Tutti questi ai tempi loro fecer acquisto di gloria, e onorarono la loro età.
 8 Quelli che nacquer da questi, lasciarono un nome, che fa rammentare le loro laudi.
 9 Ma furonvi alcuni, de' quali è spenta la memoria, i quali perirono come so mai non fossero stati ed essi, e i loro figli con essi, benché nascessero furono come non nati.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 44:10-15
 10 Ma quelli furono uomini di misericordia, e le opere di loro pietà non sono andate in oblio.
 11 La loro stirpe resta posseditrice de' loro beni. 
@@ -371,7 +371,7 @@ Lettura dal libro dell'Ecclesiastico
 14 I loro corpi furon sepolti in pace, e il loro nome vive per tutti i secoli. 
 15 La loro sapienza è celebrata da' popoli, e le loro lodi sono ripetute nelle sacre adunanze.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Dal Vangelo secondo Matteo
 !Matt 16:13-19
 In quel tempo Gesù, venuto nella zona di Cesarea di Filippo, interrogava i suoi discepoli: "Chi dicono che sia il Figlio dell uomo?".  (continua nella Messa del giorno)
@@ -380,14 +380,14 @@ Omelia di s. Leone papa
 !Sermone 2, nell'anniversario della sua ascesa, prima di metà
 Come ci riferisce la lettura evangelica. Gesù lui interrogò i discepoli che cosa pensassero di in mezzo a tanti pareri diversi. E san Pietro rispose: "Tu sei il Cristo, il Figlio del Dio vivente". Allora il Signore gli disse: "Beato te, o Simone, figlio di Giona, perché questo non ti è stato rivelato dalla carne o dal sangue, ma dal Padre mio che sta nei cieli. Perciò io ti dico che tu sei Pietro e su questa pietra edificherò la mia Chiesa e le porte dell'inferno non prevarranno mai contro di essa. E a te darò le chiavi del regno dei cieli, e qualunque cosa avrai legata sulla terra, sarà legata anche nei cieli, e qualun que cosa avrai sciolta sulla terra, sarà sciolta anche nei cieli". L"ordine stabilito da Gesù Cristo rimane ancora; e san Pietro, che ha conservato fino ad oggi la solidità della pietra, non abbandonò mai il governo della Chiesa di cui fu incaricato.  
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Nella Chiesa intera, infatti, ogni giorno Pietro dice: "Tu sei il Cristo, il Figlio del Dio vivente"; ed ogni lingua che riconosce il Signore viene istruita col magistero di tale voce. Tale fede sconfigge il diavolo e scioglie i legami di coloro che egli tiene prigionieri. Essa fa entrare nel cielo coloro che ha strappato alla terra e le porte dell'inferno non possono prevalere contro di essa. È stata infatti per potenza divina munita di una tale saldezza che mai la potrà corrompere la malvagità degli eretici né la potrà superare la perfidia dei pagani. Con tali disposizioni dunque, dilettissimi, e con razionale ossequio si celebri la festività odierna: affinché nell'umiltà della mia persona venga riconosciuto e onoralo colui, nel quale continua la cura che tutti i pastori hanno nella custodia delle pecore loro affidate e la cui dignità non viene meno per l'indegnità dell'erede.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Mentre dunque rivolgiamo le nostre esortazioni all'orecchio  della vostra santità, pensate che vi parli colui, del quale facciamo le veci: sia perché vi esortiamo con lo stesso suo affetto, sia perché nient'altro predichiamo a voi se non quello che egli ha insegnato, scongiurandovi a vivere una vita casta e sobria e timorata di Dio, avendo cinto i fianchi del vostro spirito. Come dice l'Apostolo, siete mia gioia e mia corona, se la vostra fede, che dall'inizio del Vangelo è stata predicata in tutto il mondo, rimarrà nell'amore e nella santità. Infatti anche se è necessario che tutta la Chiesa, che è presente in tutta la terra, fiorisca di ogni virtù; tuttavia è conveniente che vi segnaliate tra gli altri popoli per i meriti della vostra pietà, perché voi, fondati sulla stessa roccia della pietra apostolica, siete stati redenti assieme agli altri dal Signore nostro Gesù Cristo, e siete stati istruiti più di tutti dal beato apostolo Pietro.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Dal Vangelo secondo Matteo
 !Matt 19:27-29
 In quel tempo Pietro disse a Gesù: "Ecco, noi abbiamo abbandonato tutto e ti abbiamo seguito; che ne avremo noi?". (continua nella Messa del giorno)
@@ -396,15 +396,15 @@ Omelia di s. Beda Venerabile presbitero
 !Per il giorno natale di San Benedetto
 Ci saranno due ordine di eletti nel giudizio: uno di giudicanti col Signore, dei quali questo passaggio parla, che abbandonarono ogni cosa, e Lo hanno seguito: l'altro di quelli che verranno giudicati dal Signore, che non non abbandonarono proprio tutte le loro cose in pari modo, ma tuttavia di quelle che avevano, si preoccupavano di dare elemosine ai poveri di Cristo: quindi anche essi saranno uditori nel giudizio: "Venite, benedetti dal Padre mio, prendete possesso del regno preparato a voi fin dalla fondazione del mondo: perché ebbi fame, e mi deste da mangiare: ebbi sete, e mi deste da bere."
 
-[Responsory73]
+[Responsory7 in 4 loco]
 @Commune/C5:Responsory7
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Ma impariamo, narrante il Signore, che ci saranno lì anche due ordini dei reprobi: uno di coloro, che iniziati ai misteri della fede cristiana, disprezzano esercitare le opere della fede, per i quali nel giudizio è testificato: "Via da me, maledetti, al fuoco eterno, che fu preparato pel diavolo e pei suoi angeli: poiché ebbi fame, e non mi deste da mangiare". L'altro di coloro, che non o non ricevettero mai la fede ed i misteri di Cristo, o abbandonarono la fede ricevuto per apostasia: de quali dice: "chi non crede, è stato già condannato: perché non crede nel nome dell'unigenito Figlio di Dio".
 
-[Responsory83]
+[Responsory8 in 4 loco]
 @Commune/C5:Responsory8
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Ora ricordato un poco questi con timore e giusta paura, convertiamo piuttosto l'udito alle lietissime promesse del Signore e Salvatore nostro. Vediamo quale sia la grazia di tanto grande pietà: promette ai suoi seguaci non solo i premi della vita eterna, ma anche doni eccelsi di quella presente "E chiunque, disse, avrà abbandonato la casa, o i fratelli, o le sorelle, o il padre, o la madre, o la moglie, o i figli, o i poderi per amor del mio nome, riceverà il centuplo, e possederà la vita eterna". Chi infatti avrà rinunziato agli affetti o ai possedimenti terreni per esser discepolo di Cristo, tanto più nell'amore di Lui avrà profittato, tanto più numerosi troverà, che gioiranno nell'accoglierlo con affetto interiore, e sostentare con le proprie sostanze.
 &teDeum

--- a/web/www/horas/Italiano/Commune/C4a.txt
+++ b/web/www/horas/Italiano/Commune/C4a.txt
@@ -260,7 +260,7 @@ R. E gli mostrò il regno di Dio.
 [Ant 3]
 O Dottore ottimo, * luminare della santa Chiesa, beato N., amante della legge divina, supplica per noi il Figlio di Dio.
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Dal Vangelo secondo Matteo
 !Matt 5:13-19
 In quel tempo, Gesù disse ai suoi discepoli: "Voi siete il sale della terra. Se il sale diventa insipido, con che cosa si salerà?".  (continua nella Messa del giorno) 
@@ -269,9 +269,9 @@ Sermone di s. Giovanni Crisostomo
 !15/A su Matteo
 Fate attenzione a ciò che disse, "Voi siete il sale della terra": tramite ciò mostra quanto necessariamente insegni queste cose. Non infatti, disse, solo della vostra vita, ma di tutto il mondo dovrete render conto. Non vi mando certo solo a due città, o a dieci, o a venti, come mandavo i profeti: ma ad ogni terra e fino al mare, e a tutto il mondo, e questo è oppresso da vari crimini.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Dicendo infatti, "Voi siete il sale della terra", mostra che tutta la natura degli uomini è vanificata, e corrotta dalla violenza dei peccati: e quindi richiede da loro quelle virtù, che massimamente sono necessarie ed utili per procurare la salvezza di molti. Infatti chi è mansueto e modesto, e misericordioso e giusto, non rinchiude solo dentro di sé queste cose fatte bene, ma farà defluire queste eccellenti fonti anche all'utilità degli altri. Quindi chi è puro di cuore e pacifico, e e sopporta la persecuzione per la verità, nondimeno stabilisce la vita per il bene comune.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Non pensate quindi, disse, che sarete condotti a facile battaglie, né che dovrete far conto di cose da poco. Voi siete il sale della terra. Cosa allora? Hanno medicato cose putrefatte? Per niente: né infatti è possibile che quelle cose che sono già corrotte siano riparate tramite la frizione del sale. Non fecero perciò questo, ma le cose prima rinnovate, ed a loro affidate, e già liberate da quella putrefazione, aspergevano di sale, e conservavano in quella novità, che avevano preso dal Signore. Certamente liberare dalla putredine del peccato, è proprio del potere di Cristo: ma ché non ritornino di nuovo a questi, è proprio della cura e del lavoro degli Apostoli.
 &teDeum

--- a/web/www/horas/Italiano/Commune/C5.txt
+++ b/web/www/horas/Italiano/Commune/C5.txt
@@ -289,7 +289,7 @@ R. E gli mostrò il regno di Dio.
 [Ant 3]
 Quest'uomo disprezzando il mondo * e trionfando sulle cose terrene, tesoreggiò ricchezze per il cielo con la parola e con l'opera.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Dal libro della Sapienza
 !Sap 4:7-14
 7 Il giusto, anche se muore prima del tempo, avrà riposo. 
@@ -301,7 +301,7 @@ Dal libro della Sapienza
 13 Giunto in breve alla maturità, aveva percorso un tempo lungo; 
 14 la sua anima era gradita a Dio e per questo egli si affrettò a liberarlo dalla malizia.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sap 4:14-19
 14 I popoli vedono e non comprendono, né fanno attenzione a questo: 
 15 che la grazia e la misericordia di Dio sono rivolte ai santi e la sua protezione è destinata ai suoi eletti. 
@@ -310,7 +310,7 @@ Dal libro della Sapienza
 18 Vedranno e lo disprezzeranno, ma il Signore riderà di loro.  
 19 In seguito, essi saranno un cadavere disonorato e ludibrio tra i morti, per sempre: poiché egli li schianterà nel loro orgoglio, rendendoli senza voce, e li distruggerà dalle fondamenta, e li ridurrà all'estremo della rovina.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sap 4:19-20; 5:1-5
 19 E gemeranno in mezzo ai dolori e il loro ricordo si perderà nell'oblio. 
 20 Si macereranno timorosi al ricordo dei peccati commessi e le loro iniquità si leveranno contro di loro per accusarli. 
@@ -320,7 +320,7 @@ Dal libro della Sapienza
 4 Noi, insensati, giudicavamo la loro vita una pazzia e la loro fine priva di onore; 
 5 ecco, invece, essi vengono annoverati tra i figli di Dio e tra i santi è la loro sorte.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Dal Vangelo secondo Luca
 !Luca 12:32-35
 In quel tempo Gesù disse ai suoi discepoli: "Non temete, piccolo gregge: poiché piacque al Padre vostro dare a voi il regno". (continua nella Messa del giorno)
@@ -329,14 +329,14 @@ Omelia di s. Beda venerabile presbitero
 !Libro 4, cap. 54, su Luca 12.
 Chiama piccolo il gregge degli eletti, o per comparazione del maggior numero dei dannati, o meglio per la devozione dell'umiltà: poiché, sebbene la sua Chiesa sia già estesa con quanta mai numerosità, tuttavia vuole che cresca fino alla fine del mondo in umiltà, e che raggiunga con l'umiltà il regno promesso. Pertanto, dopo aver consolato delicatamente le sue fatiche, colei a cui ha ordinato di cercare soltanto il regno di Dio, alla medesima promette con compiaciuta bontà il regno che verrà donato dal Padre.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 "Vendete le cose che possedete e datele in elemosina". Non temete, disse, che vengano a mancare ai combattenti per il regno di Dio le cose necessarie di questo mondo: che anzi vendete anche le cose possedute per l'elemosina. Ciò allora si fa degnamente, quando uno, una volta disprezzate tutte le sue cose per il Signore, nondimeno dopo di queste con il lavoro delle mani opera sia per avere il vitto sia perché possa dare elemosina. Donde si gloria l'Apostolo, dicendo: "Non ho io desiderato l'argento, e l'oro, le vesti di nessuno: conforme voi sapete che al bisogno mio e di quelli che sono con me servirono queste mani. In tutto vi ho dimostrato come così lavorando, conviene sostenere i deboli".
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Fatevi delle borse, che non invecchino: operando cioè elemosine, il compenso delle quali rimanga in eterno. Ove non è da ritenersi questo comandamento sia, che nessun denaro sia riservato dai santi, da utilizzarsi vuoi per gli usi loro, vuoi per quelli dei poveri: quando anche lo stesso Signore, a cui servivano gli angeli, tuttavia, per informare la sua Chiesa, si legge avesse avuto nascondigli, sia per conservare le offerte dei fedeli, sia per provvedere alle necessità dei suoi e agli altri indigenti; ma che non si serva a Dio per queste cose, e per timore della povertà non si tralasci la giustizia.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Dal Vangelo secondo Luca
 !Luca 19:12-25
 In quel tempo Gesù disse questa parabola ai sui discepoli: "Un nobile uomo andò in lontano paese a prendere possessi di un regno per poi tornare. (continua nella Messa del giorno)
@@ -345,9 +345,9 @@ Omelia di Sant'Ambrogio vescovo
 !Libro 8, su Luca     
 È un buon ordine che colui che avrebbe chiamato le genti e comandato che i seguaci della religione rabbinica periscano, premettesse questa comparazione, perché non si dicesse: non aveva dato nulla al popolo dei Giudei per cui potesse migliorarsi?  perché si esige da colui che nulla ricevette? Questa non è una mina da poco, sopra la quale la donna evangelica, poiché non l'ha trovata, ha acceso la lucerna, cerca, avendo avvicinato il lume, e si rallegra di aver trovato.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Pertanto da una singola mina uno ne fece dieci, un altro cinque. Forse questi aveva la moralità, perché cinque sono i sensi del corpo: quello il doppio, cioè la misticità della legge e la moralità della virtù. Onde anche Matteo pose cinque talenti e due talenti: in modo che ci sia la moralità nei cinque talenti, nei due entrambi, il mistico ed il morale. Così ciò che è inferiore di numero è di fatto più fecondo.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 E qui possiamo interpretare le dieci mine come le dieci parole, cioè, la dottrina della legge; ma cinque mine, gli insegnamenti della disciplina. Se voglio essere un perfetto esperto della legge in ogni cosa; non infatti solo nel parlare ma nella virtù è il regno di Dio. Ma bene, poiché parla dei Giudei, solo due riportano il denaro moltiplicato, con gli interessi non certo di metallo ma della amministrazione. Altro è infatti è l'interesse del denaro prestato, altro quello della dottrina celeste.
 &teDeum

--- a/web/www/horas/Italiano/Commune/C5a.txt
+++ b/web/www/horas/Italiano/Commune/C5a.txt
@@ -285,7 +285,7 @@ R. E gli mostrò il regno di Dio.
 [Ant 3]
 O Dottore ottimo, * luminare della santa Chiesa, beato N., amante della legge divina, supplica per noi il Figlio di Dio.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Dal libro della Sapienza
 !Sap 4:7-14
 7 Il giusto, anche se muore prima del tempo, avrà riposo. 
@@ -297,7 +297,7 @@ Dal libro della Sapienza
 13 Giunto in breve alla maturità, aveva percorso un tempo lungo; 
 14 la sua anima era gradita a Dio e per questo egli si affrettò a liberarlo dalla malizia.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sap 4:14-19
 14 I popoli vedono e non comprendono, né fanno attenzione a questo: 
 15 che la grazia e la misericordia di Dio sono rivolte ai santi e la sua protezione è destinata ai suoi eletti. 
@@ -306,7 +306,7 @@ Dal libro della Sapienza
 18 Vedranno e lo disprezzeranno, ma il Signore riderà di loro.  
 19 In seguito, essi saranno un cadavere disonorato e ludibrio tra i morti, per sempre: poiché egli li schianterà nel loro orgoglio, rendendoli senza voce, e li distruggerà dalle fondamenta, e li ridurrà all'estremo della rovina.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sap 4:19-20; 5:1-5
 19 E gemeranno in mezzo ai dolori e il loro ricordo si perderà nell'oblio. 
 20 Si macereranno timorosi al ricordo dei peccati commessi e le loro iniquità si leveranno contro di loro per accusarli. 
@@ -316,7 +316,7 @@ Dal libro della Sapienza
 4 Noi, insensati, giudicavamo la loro vita una pazzia e la loro fine priva di onore; 
 5 ecco, invece, essi vengono annoverati tra i figli di Dio e tra i santi è la loro sorte.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Dal Vangelo secondo Luca
 !Luca 12:32-35
 In quel tempo Gesù disse ai suoi discepoli: "Non temete, piccolo gregge: poiché piacque al Padre vostro dare a voi il regno". (continua nella Messa del giorno)
@@ -325,14 +325,14 @@ Omelia di s. Beda venerabile presbitero
 !Libro 4, cap. 54, su Luca 12.
 Chiama piccolo il gregge degli eletti, o per comparazione del maggior numero dei dannati, o meglio per la devozione dell'umiltà: poiché, sebbene la sua Chiesa sia già estesa con quanta mai numerosità, tuttavia vuole che cresca fino alla fine del mondo in umiltà, e che raggiunga con l'umiltà il regno promesso. Pertanto, dopo aver consolato delicatamente le sue fatiche, colei a cui ha ordinato di cercare soltanto il regno di Dio, alla medesima promette con compiaciuta bontà il regno che verrà donato dal Padre.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 "Vendete le cose che possedete e datele in elemosina". Non temete, disse, che vengano a mancare ai combattenti per il regno di Dio le cose necessarie di questo mondo: che anzi vendete anche le cose possedute per l'elemosina. Ciò allora si fa degnamente, quando uno, una volta disprezzate tutte le sue cose per il Signore, nondimeno dopo di queste con il lavoro delle mani opera sia per avere il vitto sia perché possa dare elemosina. Donde si gloria l'Apostolo, dicendo: "Non ho io desiderato l'argento, e l'oro, le vesti di nessuno: conforme voi sapete che al bisogno mio e di quelli che sono con me servirono queste mani. In tutto vi ho dimostrato come così lavorando, conviene sostenere i deboli".
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Fatevi delle borse, che non invecchino: operando cioè elemosine, il compenso delle quali rimanga in eterno. Ove non è da ritenersi questo comandamento sia, che nessun denaro sia riservato dai santi, da utilizzarsi vuoi per gli usi loro, vuoi per quelli dei poveri: quando anche lo stesso Signore, a cui servivano gli angeli, tuttavia, per informare la sua Chiesa, si legge avesse avuto nascondigli, sia per conservare le offerte dei fedeli, sia per provvedere alle necessità dei suoi e agli altri indigenti; ma che non si serva a Dio per queste cose, e per timore della povertà non si tralasci la giustizia.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Dal Vangelo secondo Luca
 !Luca 19:12-25
 In quel tempo Gesù disse questa parabola ai sui discepoli: "Un nobile uomo andò in lontano paese a prendere possessi di un regno per poi tornare. (continua nella Messa del giorno)
@@ -341,14 +341,14 @@ Omelia di Sant'Ambrogio vescovo
 !Libro 8, su Luca     
 È un buon ordine che colui che avrebbe chiamato le genti e comandato che i Giudei [n.d.t. l'autore si riferisce all'aderenza alla fede talmudica], che non vollero che Cristo regnasse sopra di sé, periscano, premettesse questa comparazione, perché non si dicesse: non aveva dato nulla al popolo dei Giudei per cui potesse migliorarsi?  perché si esige da colui che nulla ricevette? Questa non è una mina da poco, sopra la quale la donna evangelica, poiché non l'ha trovata, ha acceso la lucerna, cerca, avendo avvicinato il lume, e si rallegra di aver trovato.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Pertanto da una singola mina uno ne fece dieci, un altro cinque. Forse questi aveva la moralità, perché cinque sono i sensi del corpo: quello il doppio, cioè la misticità della legge e la moralità della virtù. Onde anche Matteo pose cinque talenti e due talenti: in modo che ci sia la moralità nei cinque talenti, nei due entrambi, il mistico ed il morale. Così ciò che è inferiore di numero è di fatto più fecondo.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 E qui possiamo interpretare le dieci mine come le dieci parole, cioè, la dottrina della legge; ma cinque mine, gli insegnamenti della disciplina. Se voglio essere un perfetto esperto della legge in ogni cosa; non infatti solo nel parlare ma nella virtù è il regno di Dio. Ma bene, poiché parla dei Giudei, solo due riportano il denaro moltiplicato, con gli interessi non certo di metallo ma della amministrazione. Altro è infatti è l'interesse del denaro prestato, altro quello della dottrina celeste.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Dal Vangelo secondo Matteo
 !Matt 16:24-27
 In quel tempo Gesù disse ai suoi discepoli: Chi vuol venire dietro a me, rinneghi se stesso, e tolga la sua croce, e mi segua.  (continua nella Messa del giorno) 
@@ -357,9 +357,9 @@ Omelia di s. Gregorio papa
 !Omelia 32 sui Vangeli
 Poiché il Signore e Redentore nostro venne al mondo come un nuovo uomo, diede nuovi comandamenti al mondo. Infatti oppose alla nostra vita nutrita nei vizi la contrarietà della novità della sua. Cosa infatti l'uomo vecchio, cosa l'uomo carnale conosceva, se non tenere le sue cose, rubare le altrui, se poteva; desiderare, se non poteva?  Ma il medico celeste a ciascun singolo vizio adibisce medicamenti contrari. Infatti come coll'arte della medicina le cose calde si curano con le fredde e le fredde con le calde: cosi nostro Signore oppose medicine contrarie ai peccati, tanto da ordinare la continenza ai lussuriosi, la generosità ai tirchi, la mansuetudine agli iracondi, l'umiltà agli orgogliosi.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Difatti quando proponeva nuovi comandamenti a quelli che lo seguivano, disse: "Chiunque non rinunzia a tutto quel che possiede, non può essere mio discepolo". Come se volesse dire apertamente: voi che per la vita vecchia desiderate la roba d'altri, elargite per il desiderio di una nuovo modo di vivere anche la vostra. Ascoltiamo cosa dice in questa lezione: "Chi vuol venire dietro a me, rinneghi se stesso". Ivi si dice ché rinneghiamo la nostra roba: qui si dice ché rinneghiamo noi stessi. E forse non è faticoso all'uomo abbandonare la sua roba; ma è molto faticoso abbandonare sé stesso. È da una parte meno negare ciò che ha; molto dall'altra negare quel che è.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Ma il Signore ha comandato a noi che veniamo a Lui di rinunziare a noi: perché quanti veniamo alla gara della fede, ci impegniamo ad una lotta contro gli spiriti maligni. Infatti gli spiriti maligni non possiedono nulla di proprio in questo mondo: quindi dobbiamo lottare nudi con i nudi. Infatti se chiunque lottasse vestito con uno nudo, verrebbe più in fretta sbattuto a terra, perché ha onde venga afferrato. Che cosa infatti sono tutti beni terreni, se non certi indumenti del corpo? Chi dunque si avvicina alla contesa contro il diavolo, getti via gli indumenti, per non soccombere.
 &teDeum

--- a/web/www/horas/Italiano/Commune/C6.txt
+++ b/web/www/horas/Italiano/Commune/C6.txt
@@ -319,7 +319,7 @@ R. Perciò Iddio ti ha benedetta in eterno.
 [Ant 3]
 Vieni, o sposa di Cristo, * ricevi la corona che il Signore ti ha preparata per l'eternità.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Dal libro dell'Ecclesiastico
 !Sir 51:1-7
 1 Ti loderò, o Signore mio re, e ti glorificherò, mio salvatore. 
@@ -330,7 +330,7 @@ Dal libro dell'Ecclesiastico
 6 dalle fiamme che mi avvolgevano rabbiosamente, dal fuoco da cui non fui bruciata, 
 7 dal profondo dell'inferno, dalla lingua impura e dalla parola menzognera, dal re iniquo e dalla calunnia di una lingua ingiusta.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 51:8-12
 8 L'anima mia si accostò quasi alla morte, 
 9 e la mia vita era vicina ai profondi inferi. 
@@ -338,7 +338,7 @@ Dal libro dell'Ecclesiastico
 11 Mi ricordai allora della tua misericordia, o Signore, e delle tue opere che sono dall'eternità, 
 12 e come tu salvi coloro che sperano in te, o Signore, e li liberi dalle mani dei nemici.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 13 E innalzai dalla terra la mia supplica e pregai per la liberazione dalla morte. 
 14 Invocai il Signore, padre del mio Signore, che non mi abbandonasse nel giorno della mia tribolazione e nell'ora dei superbi, quando più non resta aiuto.

--- a/web/www/horas/Italiano/Commune/C6b.txt
+++ b/web/www/horas/Italiano/Commune/C6b.txt
@@ -315,7 +315,7 @@ R. Perciò Iddio ti ha benedetta in eterno.
 [Ant 3]
 Vieni, o sposa di Cristo, * ricevi la corona che il Signore ti ha preparata per l'eternità.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Dal libro dell'Ecclesiastico
 !Sir 51:1-7
 1 Ti loderò, o Signore mio re, e ti glorificherò, mio salvatore. 
@@ -326,7 +326,7 @@ Dal libro dell'Ecclesiastico
 6 dalle fiamme che mi avvolgevano rabbiosamente, dal fuoco da cui non fui bruciata, 
 7 dal profondo dell'inferno, dalla lingua impura e dalla parola menzognera, dal re iniquo e dalla calunnia di una lingua ingiusta.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 51:8-12
 8 L'anima mia si accostò quasi alla morte, 
 9 e la mia vita era vicina ai profondi inferi. 
@@ -334,7 +334,7 @@ Dal libro dell'Ecclesiastico
 11 Mi ricordai allora della tua misericordia, o Signore, e delle tue opere che sono dall'eternità, 
 12 e come tu salvi coloro che sperano in te, o Signore, e li liberi dalle mani dei nemici.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 13 E innalzai dalla terra la mia supplica e pregai per la liberazione dalla morte. 
 14 Invocai il Signore, padre del mio Signore, che non mi abbandonasse nel giorno della mia tribolazione e nell'ora dei superbi, quando più non resta aiuto.

--- a/web/www/horas/Italiano/Sancti/01-16.txt
+++ b/web/www/horas/Italiano/Sancti/01-16.txt
@@ -23,13 +23,13 @@ Marcello, di Roma, tenne il pontificato dai tempi di Costanzo e Galeno fino a Ma
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Responsory8]
 R. Signore, lo hai prevenuto con le più dolci benedizioni, 

--- a/web/www/horas/Italiano/Sancti/01-26.txt
+++ b/web/www/horas/Italiano/Sancti/01-26.txt
@@ -24,10 +24,10 @@ Policarpo, discepolo dell'Apostolo Giovanni e ordinato da lui vescovo di Smirne,
 @Sancti/07-13:Lectio6
 
 [Lectio7]
-@Commune/C2:Lectio72
+@Commune/C2:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C2:Lectio82
+@Commune/C2:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C2:Lectio92
+@Commune/C2:Lectio9 in 3 loco

--- a/web/www/horas/Italiano/Sancti/02-05.txt
+++ b/web/www/horas/Italiano/Sancti/02-05.txt
@@ -41,7 +41,7 @@ V. L'ha eletta Iddio e l'ha prescelta.
 R. La fa abitare nella sua dimora.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Responsory1]
 R. Mentre la beata Agata veniva crudelmente martoriata in una mammella, disse al giudice:
@@ -50,7 +50,7 @@ V. Quanto a me conservo intatte dentro all'anima mia le mammelle che dall'infanz
 R. Empio, crudele e barbaro tiranno, non ti vergogni di recidere in una donna ciò che tu stesso hai succhiato dalla madre tua?
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Responsory2]
 R. Agata lietissima festante andava al carcere, 
@@ -59,7 +59,7 @@ V. Sortita di nobilissimi natali, si vedeva trascinata con gioia al carcere da u
 R. Quasi fosse invitata a un convito; e con preghiere raccomandava al Signore il suo combattimento.
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Responsory3]
 R. Chi sei tu, che sei venuto da me per guarire le mie ferite? Io sono l'Apostolo di Cristo non aver alcun timore di me, o figlia: lui stesso mi ha mandato a te. 

--- a/web/www/horas/Italiano/Sancti/02-27.txt
+++ b/web/www/horas/Italiano/Sancti/02-27.txt
@@ -11,13 +11,13 @@ O Dio che a S. Gabriele insegnasti a meditare assiduamente i dolori della tua do
 $Qui vivis
 
 [Lectio1](sed non rubrica 1960)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2](sed non rubrica 1960)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3](sed non rubrica 1960)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Gabriele, nato ad Assisi in Umbria da famiglia benestante, e chiamato Francesco in memoria del concittadino serafico, mostrò sin da bambino una egregia inclinazione d'animo. Da adolescente, mentre studiava lettere a Spoleto, sembrò essere implicato in poco nella vana apparenza e pompa del mondo. Ma per dono di Dio misericordioso, che lo invitava già alla perfezione della vita cristiana, essendo caduto in malattia, cominciò ad infastidirsi della vanità del mondo e desiderare solo i beni immortali. Ma affinché ottemperasse a ciò più in fretta, chiamandolo Dio, accadde che avendo ammirato la celeberrima icona della beatissima Vergine, che veniva trasportata in pompa solenne fuori delle mura della chiesa di Spoleto, concepisse la fiamma dell'amore divino, e decidesse al contempo di entrare l'Istituto dei Chierici della Passione di Gesù. Pertanto dopo aver combattuto con non piccole difficoltà, vestì lieto la lugubre veste nel convento di Morrovalle, e preferì esser chiamato Gabriele della Vergine addolorata: per ricordare in perpetuo la memoria delle gioie e dei dolori della Medesima.

--- a/web/www/horas/Italiano/Sancti/03-04.txt
+++ b/web/www/horas/Italiano/Sancti/03-04.txt
@@ -26,13 +26,13 @@ O Dio, che ci rallegri coll'annuale solennità dei tuo beato Martire e Pontefice
 $Per Dominum.
 
 [Lectio1](sed non rubrica 1960)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2](sed non rubrica 1960)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3](sed non rubrica 1960)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Casimiro, figlio di Casimiro, re di Polonia, e di Elisabetta d'Austria, istruito fin dall'infanzia da eccellenti maestri nella pietà e nelle belle arti, domava le giovani membra con aspro cilizio e le debilitava con assidui digiuni. Sdegnando la mollezza d'un letto regale dormiva sulla nuda terra, e se ne usciva segretamente, durante la notte, per implorare prostrato per terra davanti alle porte delle chiese la divina misericordia. Meditava continuamente la passione di Cristo, e soleva assistere alla santa Messa colla mente così elevata in Dio, da sembrare rapito fuor di sé.

--- a/web/www/horas/Italiano/Sancti/03-06.txt
+++ b/web/www/horas/Italiano/Sancti/03-06.txt
@@ -20,13 +20,13 @@ $Per Dominum
 Laudiamo il nostro Dio * nella confessione delle beate Perpetua e Felicita.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Lectio4]
 Perpetua e Felicita furono arrestate in Africa insieme con Revocato, Saturnino e Secundolo nella persecuzione dell'imperatore Severo, e rinchiuse in un carcere tenebroso; cui poi si aggiunse Satiro. Erano ancor catecumene, ma furono battezzate poco dopo. Passati pochi giorni, dal carcere furono, insieme coi compagni, condotte al foro, e dopo una gloriosa confessione furono dal procuratore Ilarione condannate alle fiere. Quindi giulive ritornarono nel carcere, dove vennero confortate con varie apparizioni ed infiammate alla palma del martirio. Né le preghiere reiterate né le lacrime del vecchio padre, né l'amore materno verso il suo bambino ancora lattante, né l'atrocità del supplizio poterono smuovere mai Perpetua dalla fede di Cristo.

--- a/web/www/horas/Italiano/Sancti/03-10.txt
+++ b/web/www/horas/Italiano/Sancti/03-10.txt
@@ -19,10 +19,10 @@ Mentre tutti gli altri custodi dormivano, il portinaio solo vegliava, il quale, 
 In questo supplizio morirono tutti, eccetto Melitone, il più giovane. La madre, presente, nel vederlo, dopo che gli furono spezzate le gambe, ancor vivo, così lo esortava: «Figlio, soffri ancora un po'; ecco, Cristo sta alla porta ad aiutarti». Al vedere poi porre sui carri i corpi degli altri per essere portati al rogo e lasciarsi il figlio suo, sperando l'empia turba di poter ricondurre il fanciullo al culto degli idoli, se fosse vissuto, la santa madre presolo sulle proprie spalle coraggiosa seguiva i carri che portavano i corpi dei Martiri. Melitone rese l'anima a Dio tra le braccia di lei, e il suo corpo fu posto dalla pia madre sullo stesso rogo degli altri Martiri; affinché quelli ch'erano stati sì strettamente uniti nella fede e nel coraggio, lo fossero ancora nello stesso funerale, e giungessero poi insieme nel cielo. Bruciati i corpi, le loro reliquie vennero gettate in un fiume, ma radunatesi miracolosamente in un luogo, e ritrovate salve ed intatte, furono sepolte in luogo onorevole.
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Italiano/Sancti/03-21.txt
+++ b/web/www/horas/Italiano/Sancti/03-21.txt
@@ -10,13 +10,13 @@ Signore, ci renda accetti l'intercessione dei beato Benedetto Abbate : affinché
 $Per Dominum
 
 [Lectio1]
-@Commune/C4:Lectio11
+@Commune/C4:Lectio1 in 2 loco
 
 [Lectio2]
-@Commune/C4:Lectio21
+@Commune/C4:Lectio2 in 2 loco
 
 [Lectio3]
-@Commune/C4:Lectio31
+@Commune/C4:Lectio3 in 2 loco
 
 [Lectio4]
 Benedetto, nato a Norcia da nobile famiglia ed istruito a Roma nelle discipline liberali, per darsi interamente a Gesù Cristo si ritirò in una profonda spelonca presso un luogo detto Subiaco ; nella quale si mantenne nascosto per tre anni senza che lo sapesse altri che il monaco Romano, che gli forniva il necessario alla vita. Un giorno avendo il diavolo eccitata in lui una violenta tentazione d'impurità, si ravvoltolò fra delle spine finché, tutto lacero nel corpo, il senso della voluttà fu soffocato nel dolore. Ma la fama della sua santità già sparsasi lungi da quella spelonca, alcuni monaci si misero sotto la sua condotta: non potendo però sopportare le sue riprensioni meritate per la loro vita licenziosa, risolsero di mettergli del veleno nella bevanda. Ma nel presentargli da bere, egli con un segno di croce mandò in frantumi il vaso e, abbandonato il monastero, ritornò nella solitudine.

--- a/web/www/horas/Italiano/Sancti/04-02.txt
+++ b/web/www/horas/Italiano/Sancti/04-02.txt
@@ -26,10 +26,10 @@ Francesco di Paola nacque in Calabria. Infiammato fin dall'adolescenza da un div
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Italiano/Sancti/04-22.txt
+++ b/web/www/horas/Italiano/Sancti/04-22.txt
@@ -25,10 +25,10 @@ Sotero, nato a Fondi, nella Campania, decretò che le sacre vergini non toccasse
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Italiano/Sancti/04-23.txt
+++ b/web/www/horas/Italiano/Sancti/04-23.txt
@@ -16,12 +16,12 @@ O Dio, che ci rallegri coi meriti e l'intercessione del tuo beato Martire Giorgi
 $Per Dominum
 
 [Lectio4]
-@Commune/C2:Lectio41
+@Commune/C2:Lectio4 in 2 loco
 
 [Lectio5]
-@Commune/C2:Lectio51
+@Commune/C2:Lectio5 in 2 loco
 
 [Lectio6]
-@Commune/C2:Lectio61
+@Commune/C2:Lectio6 in 2 loco
 
 [Lectio94]

--- a/web/www/horas/Italiano/Sancti/05-25.txt
+++ b/web/www/horas/Italiano/Sancti/05-25.txt
@@ -44,13 +44,13 @@ Papa Gregorio VII, di nome Ildebrando, nacque a Soana in Toscana. Grande innanzi
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Italiano/Sancti/06-25.txt
+++ b/web/www/horas/Italiano/Sancti/06-25.txt
@@ -26,10 +26,10 @@ San Guglielmo nacque a Vercelli da nobile famiglia. A quattordici anni si recò 
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio73
+@Commune/C4:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C4:Lectio83
+@Commune/C4:Lectio8 in 4 loco
 
 [Lectio9]
-@Commune/C4:Lectio93
+@Commune/C4:Lectio9 in 4 loco

--- a/web/www/horas/Italiano/Sancti/06-26.txt
+++ b/web/www/horas/Italiano/Sancti/06-26.txt
@@ -56,7 +56,7 @@ A questo lievito si riferisce il comando dell'Apostolo : « Orsù, celebriamo la
 Ma quel che segue: « Poiché le cose che avete detto all'oscuro saranno dette alla luce », può benissimo intendersi non solo del futuro, quanto tutti i segreti dei cuori saranno svelati alla luce, ma ancora del tempo presente. Infatti quanto a ciò che gli Apostoli hanno detto o sofferto nelle tenebre delle tribolazioni e nell'oscurità delle carceri, ora che la Chiesa è in onore per tutto il mondo, si proclama in pubblico colla lettura dei loro atti: « Non lasciatevi spaventare da quelli che uccidono il corpo ». Se i persecutori dei Santi, uccisi i loro corpi, non possono più far nulla contro di loro; stoltamente dunque essi infuriano contro le esanime membra dei Martiri gettandole a dilania re alle fiere e agli uccelli, ché giammai potranno impedire all'onnipotenza di Dio di vivificarle di nuovo, risuscitandole.
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Lectio9]
 Vi sono poi due sorta di persecutori : gli uni che incrudeliscono pubblicamente, gli altri che blandiscono furbescamente per ingannare. Il Salvatore volendoci armare e munire contro gli uni e gli altri, più sopra ci raccomanda di guardarci dall'ipocrisia dei farisei, e qui di non temere le stragi dei carnefici, essendo che dopo morte non può durare né la crudeltà di questi, né la simulazione di quelli.  «Cinque passeri non si vendono forse due soldi ?»  Se Dio, egli dice, non può dimenticare i più piccoli animali e gli uccelli che svolazzano liberamente per l'aria; voi, che siete stati fatti ad immagine del Creatore, non dovete lasciarvi spaventare da quelli che uccidono il corpo ; perché quegli che governa gli animali irragionevoli, non cessa di aver cura dei ragionevoli.

--- a/web/www/horas/Italiano/Sancti/06-26r.txt
+++ b/web/www/horas/Italiano/Sancti/06-26r.txt
@@ -56,7 +56,7 @@ A questo lievito si riferisce il comando dell'Apostolo : « Orsù, celebriamo la
 Ma quel che segue: « Poiché le cose che avete detto all'oscuro saranno dette alla luce », può benissimo intendersi non solo del futuro, quanto tutti i segreti dei cuori saranno svelati alla luce, ma ancora del tempo presente. Infatti quanto a ciò che gli Apostoli hanno detto o sofferto nelle tenebre delle tribolazioni e nell'oscurità delle carceri, ora che la Chiesa è in onore per tutto il mondo, si proclama in pubblico colla lettura dei loro atti: « Non lasciatevi spaventare da quelli che uccidono il corpo ». Se i persecutori dei Santi, uccisi i loro corpi, non possono più far nulla contro di loro; stoltamente dunque essi infuriano contro le esanime membra dei Martiri gettandole a dilania re alle fiere e agli uccelli, ché giammai potranno impedire all'onnipotenza di Dio di vivificarle di nuovo, risuscitandole.
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Lectio9]
 Vi sono poi due sorta di persecutori : gli uni che incrudeliscono pubblicamente, gli altri che blandiscono furbescamente per ingannare. Il Salvatore volendoci armare e munire contro gli uni e gli altri, più sopra ci raccomanda di guardarci dall'ipocrisia dei farisei, e qui di non temere le stragi dei carnefici, essendo che dopo morte non può durare né la crudeltà di questi, né la simulazione di quelli.  «Cinque passeri non si vendono forse due soldi ?»  Se Dio, egli dice, non può dimenticare i più piccoli animali e gli uccelli che svolazzano liberamente per l'aria; voi, che siete stati fatti ad immagine del Creatore, non dovete lasciarvi spaventare da quelli che uccidono il corpo ; perché quegli che governa gli animali irragionevoli, non cessa di aver cura dei ragionevoli.

--- a/web/www/horas/Italiano/Sancti/06-26t.txt
+++ b/web/www/horas/Italiano/Sancti/06-26t.txt
@@ -56,7 +56,7 @@ A questo lievito si riferisce il comando dell'Apostolo : « Orsù, celebriamo la
 Ma quel che segue: « Poiché le cose che avete detto all'oscuro saranno dette alla luce », può benissimo intendersi non solo del futuro, quanto tutti i segreti dei cuori saranno svelati alla luce, ma ancora del tempo presente. Infatti quanto a ciò che gli Apostoli hanno detto o sofferto nelle tenebre delle tribolazioni e nell'oscurità delle carceri, ora che la Chiesa è in onore per tutto il mondo, si proclama in pubblico colla lettura dei loro atti: « Non lasciatevi spaventare da quelli che uccidono il corpo ». Se i persecutori dei Santi, uccisi i loro corpi, non possono più far nulla contro di loro; stoltamente dunque essi infuriano contro le esanime membra dei Martiri gettandole a dilania re alle fiere e agli uccelli, ché giammai potranno impedire all'onnipotenza di Dio di vivificarle di nuovo, risuscitandole.
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Lectio9]
 Vi sono poi due sorta di persecutori : gli uni che incrudeliscono pubblicamente, gli altri che blandiscono furbescamente per ingannare. Il Salvatore volendoci armare e munire contro gli uni e gli altri, più sopra ci raccomanda di guardarci dall'ipocrisia dei farisei, e qui di non temere le stragi dei carnefici, essendo che dopo morte non può durare né la crudeltà di questi, né la simulazione di quelli.  «Cinque passeri non si vendono forse due soldi ?»  Se Dio, egli dice, non può dimenticare i più piccoli animali e gli uccelli che svolazzano liberamente per l'aria; voi, che siete stati fatti ad immagine del Creatore, non dovete lasciarvi spaventare da quelli che uccidono il corpo ; perché quegli che governa gli animali irragionevoli, non cessa di aver cura dei ragionevoli.

--- a/web/www/horas/Italiano/Sancti/07-03.txt
+++ b/web/www/horas/Italiano/Sancti/07-03.txt
@@ -31,13 +31,13 @@ Leone II, sommo Pontefice, Siciliano, dotto nelle scienze sacre e profane, posse
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Italiano/Sancti/07-13.txt
+++ b/web/www/horas/Italiano/Sancti/07-13.txt
@@ -26,10 +26,10 @@ Anacleto, Ateniese, governò la Chiesa sotto l'imperatore Traiano. Egli decretò
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Italiano/Sancti/07-14.txt
+++ b/web/www/horas/Italiano/Sancti/07-14.txt
@@ -29,10 +29,10 @@ San Bonaventura nacque a Bagnoregio. Ancora fanciullo entrò nell'ordine frances
 &teDeum
 
 [Lectio7]
-@Commune/C4a:Lectio72
+@Commune/C4a:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C4a:Lectio82
+@Commune/C4a:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C4a:Lectio92
+@Commune/C4a:Lectio9 in 3 loco

--- a/web/www/horas/Italiano/Sancti/08-23.txt
+++ b/web/www/horas/Italiano/Sancti/08-23.txt
@@ -19,13 +19,13 @@ Il fuoco della divina carità onde ardeva e lo zelo per la propagazione della fe
 Si vide costantemente risplendere in lui una tenera compassione verso i poveri, specialmente allorché presso Camiliano, villaggio nel territorio di Siena, diede il proprio vestito che portava addosso a un lebbroso nudo, che gli domandava l'elemosina. Questi, appena se l'ebbe messo, fu subito mondato dalla lebbra. La fama del qual miracolo sparsasi dappertutto, parecchi cardinali, riuniti a Viterbo per l'elezione del successore di Clemente IV, misero gli occhi su Filippo, di cui conoscevano del resto la prudenza tutta celeste. Saputolo l'uomo di Dio, temendo di vedersi imporre la carica di supremo pastore, rimase nascosto sul monte Tuniato finché non fu proclamato sommo Pontefice Gregorio X; e là esiste tuttora una sorgente, detta ancor oggi fontana di san Filippo, che deve alle sue preghiere la virtù di guarire i malati. Infine lasciò santissimamente questa vita nell'anno 1285 a Todi, abbracciato al Signore Crocifisso, che chiamava il suo libro. Sulla sua tomba i ciechi riebbero la vista, gli zoppi la sanità, i morti la vita. Celebre per questi ed altri moltissimi prodigi, il sommo Pontefice Clemente X l'iscrisse nel numero dei Santi.
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco
 
 [Lectio Vigilia]
 !Pro Vigilia S. Bartholomaei Apostoli

--- a/web/www/horas/Italiano/Sancti/08-25.txt
+++ b/web/www/horas/Italiano/Sancti/08-25.txt
@@ -31,13 +31,13 @@ Conchiuso un trattato coi Saraceni, il re e la sua armata furono lasciati liberi
 Edificò numerosi monasteri e ospizi per i poveri: soccorreva gl'indigenti colle sue liberalità: visitava frequentemente i malati, e non solo li faceva curare a sue spese, ma somministrava loro altresì colle proprie mani quello di cui abbisognavano. Vestiva semplicemente, e mortificava continuamente il suo corpo con cilizi e digiuni. Traversato di nuovo il mare per combattere i Saraceni e già stabilito il suo campo di fronte ad essi, morì di peste pronunziando queste parole: «Entrerò nella tua casa, ti adorerò nel tuo tempio santo e glorificherò il tuo nome» (Sal 5,8; 137,2). Il suo corpo fu poi trasportato a Parigi, e si conserva e venera nel celebre tempio di san Dionigi; ma il suo capo fu portato nella santa cappella. Glorificato da miracoli, egli fu inserito nel novero dei Santi da Papa Bonifacio VIII.
 
 [Lectio7]
-@Commune/C5:Lectio72
+@Commune/C5:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C5:Lectio82
+@Commune/C5:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C5:Lectio92
+@Commune/C5:Lectio9 in 3 loco
 
 [Lectio93]
 @Sancti/08-26:Lectio93

--- a/web/www/horas/Italiano/Sancti/09-02.txt
+++ b/web/www/horas/Italiano/Sancti/09-02.txt
@@ -19,13 +19,13 @@ L'amore della preghiera lo portava a vegliare la più gran parte delle notti; e,
 Animato da ardentissima devozione verso la Madre di Dio, costruì una vastissima chiesa in suo onore, e la dichiarò patrona dell'Ungheria; e la Vergine l'introdusse a sua volta in cielo il giorno medesimo della sua Assunzione, giorno che gli Ungheresi chiamano il giorno della Gran Signora, come aveva stabilito il santo re. Il suo corpo, che mandò un soavissimo odore e diede un liquore celeste, per ordine del Romano Pontefice fu poi trasferito in luogo più conveniente e riposto con maggior onore in mezzo a numerosi miracoli d'ogni genere. Il sommo Pontefice Innocenzo XI ne fissò la festa al 2 Settembre per l'insigne vittoria riportata, col soccorso di Dio, lo stesso giorno sui Turchi nell'assedio di Budapest dall'esercito di Leopolo Ieletto imperatore dei Romani e re d'Ungheria.
 
 [Lectio7]
-@Commune/C5:Lectio72
+@Commune/C5:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C5:Lectio82
+@Commune/C5:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C5:Lectio92
+@Commune/C5:Lectio9 in 3 loco
 
 [Lectio94]
 Stefano, re d'Ungheria, introdusse in Ungheria la fede di Cristo e il titolo di re. Ottenuta dal romano pontefice la corona reale, e consacrato re per ordine di lui, fece omaggio del suo regno alla sede apostolica. Con pietà e munificenza ammirabile fondò ospedali a Roma, a Gerusalemme e Costantinopoli. Eresse in Ungheria l'arcivescovado di Strigonia e dieci vescovadi. Grande fu la sua carità verso i poveri e l'assiduo amore per la preghiera. Animato da ardentissima devozione verso la Madre di Dio, costruì una vastissima chiesa in suo onore e la dichiarò patrona dell'Ungheria. La Vergine, a sua volta, l'introdusse in cielo il giorno medesimo della sua assunzione, giorno che gli Ungheresi chiamano della Gran Signora, come aveva stabilito il santo re. Il sommo pontefice Innocenzo XI ne fissò la festa al 2 settembre, giorno in cui l'esercito cristiano, col soccorso del santo re, ricuperò la città di Budapest che era stata assediata.

--- a/web/www/horas/Italiano/Sancti/09-10.txt
+++ b/web/www/horas/Italiano/Sancti/09-10.txt
@@ -19,13 +19,13 @@ Divenuto adulto e già ascrittosi alla milizia ecclesiastica e provvisto d'un ca
 Non tralasciò mai d'applicarsi assiduamente alla preghiera, benché vessato da satana con insidie in varie guise fino talvolta ad esserne flagellato. Infine, nei sei mesi prima di morire, udì tutte le notti concerti angelici; la cui soavità facendogli già pregustare le gioie del paradiso, ripeteva spesso le parole dell'Apostolo: «Bramo d'essere sciolto, e di essere con Cristo» (Philipp. 1,25). Da ultimo, predisse ai suoi confratelli il giorno della sua morte, che fu il 10 Settembre. Dopo morte fu illustrato da molti miracoli; i quali regolarmente e canonicamente constatati, fu iscritto da Papa Eugenio IV nel novero dei Santi.
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco
 
 [Lectio94]
 Nicola, detto da Tolentino per il suo lungo soggiorno in quella città, nacque nel paese di Sant'Angelo, nel Piceno, da pii genitori. Essi lo avevano avuto in seguito ad un voto fatto a Dio, intercessore san Nicola. Ancora fanciullo, diede esempio di molte virtù, specialmente della virtù dell'astinenza. Entrò nella gerarchia ecclesiastica e fu nominato canonico. Un giorno, assistendo ad una predica sul disprezzo del mondo, tenuta da un oratore dell'ordine degli Eremiti di sant'Agostino, fu così colpito da quella predica che entrò subito nel medesimo ordine. Con l'esatta osservanza della vita religiosa, mortificò il suo corpo con digiuni, vesti rozze, discipline, catene di ferro, e fu modello in tutte le virtù. Non tralasciò mai di applicarsi assiduamente alla preghiera, benché fosse tentato da Satana con insidie di vario genere, fino ad esserne flagellato. Nei sei mesi prima della sua morte, udì tutte le notti concerti angelici ed infine, dopo averne predetto il giorno, si addormentò nel Signore. Compì numerosi miracoli in vita e dopo la morte. Il papa Eugenio IV lo annoverò tra i santi.

--- a/web/www/horas/Italiano/Sancti/09-17.txt
+++ b/web/www/horas/Italiano/Sancti/09-17.txt
@@ -88,10 +88,10 @@ Egli sapeva bene, che la debolezza e la sofferenza sono incompatibili coll'immor
 Divenuto dunque Francesco un uomo nuovo, grazie a un nuovo e stupendo miracolo — dacché per un singolare privilegio, di cui nessuno per l'addietro era stato favorito, egli si trovò contrassegnato, o per dir meglio, ornato delle sacre Stimmate — discese dal monte portando con sé l'immagine del Crocifisso, non tracciata già da mano d'artefice su tavole di pietra o di legno, ma stampata sulla propria carne dal dito di Dio vivente. E siccome sapeva benissimo «che è bene tener celati i secreti d'un re» (Tob. 12,7), perciò l'uomo serafico, cosciente del segreto del gran re, nascondeva più ch'era possibile quei sacri segni. Ma perché è proprio di Dio il rivelare per sua gloria le grandi cose che fa, il Signore stesso, che aveva impresso segretamente quelle stimmate, le mostrò apertamente con alcuni miracoli; affinché con questi strepitosi prodigi apparisse manifesta la virtù meravigliosa nascosta nelle Stimmate. - Ora questo miracoloso avvenimento sì ben constatato ed esaltato con lodi e favori speciali nelle bolle pontificie, il Papa Benedetto XI volle che si celebrasse ogni anno con una festa; che poi il Pontefice Paolo V, ad accendere i cuori dei fedeli all'amore di Cristo crocifisso, estese a tutta la Chiesa.
 
 [Lectio7]
-@Commune/C2:Lectio73
+@Commune/C2:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C2:Lectio83
+@Commune/C2:Lectio8 in 4 loco
 
 [Responsory8]
 R. Lungi da me il gloriarmi d'altro, che della croce di nostro Signore Gesù Cristo; 
@@ -102,7 +102,7 @@ R. In grazia del quale il mondo è crocifisso per me, e io per il mondo.
 R. In grazia del quale il mondo è crocifisso per me, e io per il mondo.
 
 [Lectio9]
-@Commune/C2:Lectio93
+@Commune/C2:Lectio9 in 4 loco
 
 [Lectio94]
 Francesco apparve decorato con un singolare privilegio non concesso nei secoli precedenti, quando decorato con le sacre Stimmate discese dal monte, portando con se l'effigie del Crocifisso, non raffigurata su tavole di pietra o manufatti lignei, ma disegnata sulle membra di carne dal dito del Dio vivente. Siccome l'uomo serafico sapeva ottimamente che era buona cosa nascondere il sacramento del re, conscio del segreto regale, occultava davanti agli uomini quei sacri segni. In verità, poiché è tipico di Dio rivelare le grandi cose che fa per la sua gloria, il Signore stesso, che aveva impresso segretamente quei segni, mostrò apertamente certi miracoli tramite esse; affinché l'occulta e meravigliosa forza di quelle Stimmate apparisse manifesta per l'evidenza dei segni. Più avanti Papa Benedetto XI volle che la cosa meravigliosa e tanto attestata nei diplomi pontifici ed esaltata con importanti lodi e favori fosse celebrata con annua solennità; che poi il Pontefice massimo Paolo V propagò a tutta la Chiesa affinché i cuori dei fedeli fossero accesi nell'amore di Cristo crocifisso.

--- a/web/www/horas/Italiano/Sancti/09-20.txt
+++ b/web/www/horas/Italiano/Sancti/09-20.txt
@@ -22,10 +22,10 @@ Ritornato bentosto, come gli aveva ordinato il Signore, sul posto della visione 
 In quella spedizione ricuperati inaspettatamente i figli insieme colla moglie, entrò in Roma vincitore tra le acclamazioni di tutti. Ma di lì a poco ricevuto ordine di sacrificare ai falsi dèi per la riportata vittoria, si rifiutò energicamente. Dopo essersi cercato invano con vari mezzi di fargli rinnegare la fede di Cristo, venne esposto colla moglie e coi figli ai leoni. Ma questi si mantennero mansueti, onde l'imperatore irritato, fece rinchiudere quelli in un toro di bronzo arroventato, donde, terminando il martirio al canto delle divine lodi, se ne volarono alla felicità eterna il 20 di Settembre. I loro corpi sepolti religiosamente dai fedeli, vennero poi ritrovati intatti e trasferiti nella chiesa eretta sotto il loro nome.
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio Vigilia]
 !Commemorazione per la Vigilia di S. Matteo.

--- a/web/www/horas/Italiano/Sancti/09-23.txt
+++ b/web/www/horas/Italiano/Sancti/09-23.txt
@@ -37,10 +37,10 @@ Il papa Lino, nato a Volterra in Toscana, governò la Chiesa subito dopo san Pie
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Italiano/Sancti/09-27.txt
+++ b/web/www/horas/Italiano/Sancti/09-27.txt
@@ -24,13 +24,13 @@ Cosma e Damiano, fratelli arabi, nacquero in Egea; medici illustri, sotto gli im
 &teDeum
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Italiano/Sancti/10-14.txt
+++ b/web/www/horas/Italiano/Sancti/10-14.txt
@@ -26,13 +26,13 @@ Callisto, di Roma, governò la Chiesa sotto l'imperatore Antonino Eliogabalo. Eg
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Lectio7](rubrica tridentina)
 @Sancti/02-22:Lectio7

--- a/web/www/horas/Italiano/Sancti/10-19.txt
+++ b/web/www/horas/Italiano/Sancti/10-19.txt
@@ -23,10 +23,10 @@ Pietro nacque da nobili genitori ad Alcantara, in Spagna. A sedici anni entrò n
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Italiano/Sancti/10-31.txt
+++ b/web/www/horas/Italiano/Sancti/10-31.txt
@@ -10,13 +10,13 @@ Laudes 2
 No Suffragium 
 
 [Lectio1]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio2]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio3]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco
 
 [Oratio]
 Signore, Dio nostro, moltiplica su di noi la tua grazia: e concedici di conseguire con una santa vita la felicità di coloro, alla cui gloriosa, solennità ci prepariamo. 

--- a/web/www/horas/Italiano/Sancti/10-31v.txt
+++ b/web/www/horas/Italiano/Sancti/10-31v.txt
@@ -10,13 +10,13 @@ Laudes 2
 No Suffragium 
 
 [Lectio1]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio2]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio3]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco
 
 [Oratio]
 Signore, Dio nostro, moltiplica su di noi la tua grazia: e concedici di conseguire con una santa vita la felicità di coloro, alla cui gloriosa, solennità ci prepariamo. 

--- a/web/www/horas/Italiano/Sancti/11-13.txt
+++ b/web/www/horas/Italiano/Sancti/11-13.txt
@@ -24,10 +24,10 @@ San Diego nacque a San Nicolas del Puerto, nella diocesi di Siviglia, in Spagna.
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Italiano/Sancti/11-20.txt
+++ b/web/www/horas/Italiano/Sancti/11-20.txt
@@ -23,10 +23,10 @@ Felice, che prima aveva il nome di Ugo, nacque dalla famiglia reale dei Valois, 
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Italiano/Sancti/12-11.txt
+++ b/web/www/horas/Italiano/Sancti/12-11.txt
@@ -36,13 +36,13 @@ Stabilì la pena del taglione per coloro che avessero accusato un altro falsamen
 Damaso, oriundo dalla Spagna, uomo distinto ed erudito nelle sacre Scritture, indetto il primo concilio di Costantinopoli, estinse la nefanda eresia di Eunomio e di Macedonio. Condannò nuovamente il conciliabolo di Rimini, già precedentemente condannato da Liberio, nel quale, come scrisse san Girolamo, soprattutto per le frodi di Valente e di Ursacio fu proclamata la condanna della fede di Nicea. Edificò due basiliche: una sotto nome di san Lorenzo presso il teatro di Pompeo, l'altra sulla via Ardeatina nei pressi delle catacombe. Stabilì, come era già in uso in molti luoghi, che in tutte le chiese, giorno e notte, fossero cantati i salmi a due cori e alla fine di ogni salmo si dicesse: Gloria al Padre e al Figlio e allo Spirito Santo. Per suo ordine, san Girolamo tradusse fedelmente il nuovo Testamento secondo il testo greco. Ritrovò molti corpi di martiri e ne onorò la memoria con versi. Illustre per virtù, dottrina e prudenza, quasi ottuagenario, si addormentò nel Signore, sotto l'imperatore Teodosio il Grande.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Italiano/Sancti/12-16.txt
+++ b/web/www/horas/Italiano/Sancti/12-16.txt
@@ -18,16 +18,16 @@ E il concilio si radunò a Milano l'anno seguente, e Costanzo vi invitò pure Eu
 Le lettere importanti, piene di forza, pietà e religione che egli scrisse da Scitopoli ai clero e popolo di Vercelli e ad altri vicini, fanno vedere quale fu la crudeltà e l'insolenza sfrontata degli Ariani verso di lui; ed esse dimostrano altresì che né le loro minacce né i trattamenti inumani poterono abbatterlo mai, né la loro blanda e serpentina scaltrezza attirarlo dalla loro parte. Di là deportato in Cappadocia a cagione della sua fermezza, e da ultimo nella Tebaide dell'alto Egitto, sopportò i rigori dell'esilio fino alla morte di Costanzo: poi essendogli stato permesso di ritornare al suo gregge, non volle partirne se non dopo aver assistito al concilio radunato in Alessandria per riparare alle perdite della fede e quindi, a guisa d'abile medico, d'aver percorso le Provincie d'Oriente, restituendo a perfetta sanità quelli ch'erano infermi nella fede, con l'istruirli nella dottrina della Chiesa. Poi, continuando questa salutare missione, passò nell'IIliria, e infine giunse in Italia, la quale, al suo ritorno, mutò le sue vesti di duolo: qui pubblicò i commentari d'Origene e d'Eusebio di Cesarea sui Salmi, che egli aveva purgati e tradotti dal Greco in Latino; infine, illustre per tante eccellenti azioni, da Vercelli andò a ricevere l'immarcescibile corona di gloria meritata per tante sofferenze, sotto Valentiniano e Valente.
 
 [Lectio7]
-@Commune/C2:Lectio73
+@Commune/C2:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C2:Lectio83
+@Commune/C2:Lectio8 in 4 loco
 
 [Responsory8]
-@Commune/C2:Responsory8NonEffusorum
+@Commune/C2:Responsory8 non Effusorum
 
 [Lectio9]
-@Commune/C2:Lectio93
+@Commune/C2:Lectio9 in 4 loco
 
 [Lectio94]
 Eusebio, nato in Sardegna, fu dapprima lettore della Chiesa di Roma, poi vescovo di Vercelli. Egli combatté così virilmente contro l'arianesimo, che la sua invitta fede fu di conforto al sommo pontefice Liberio. Per la sua professione di fede cattolica fu esiliato a Scitopoli dall'imperatore Costanzo, dove soffrì la fame, la sete, le battiture e diversi altri supplizi. Relegato, quindi, in Cappadocia, sopportò i rigori dell'esilio fino alla morte dello stesso Costanzo, e quindi gli fu permesso di ritornare alla sua chiesa. Allora l'Italia mutò le vesti di lutto. Qui pubblicò i commentari a tutti i salmi di Origene e di Eusebio di Cesarea, che egli aveva corretti e tradotti dal greco in latino. A Vercelli, sotto gli imperatori Valentiniano e Valente, volò al Signore, a ricevere la incorruttibile corona di gloria, meritata con così grandi sofferenze.

--- a/web/www/horas/Italiano/Sancti/12-31.txt
+++ b/web/www/horas/Italiano/Sancti/12-31.txt
@@ -59,13 +59,13 @@ Così per opera di Silvestro, il pio imperatore confermò col suo esempio la fac
 Si vuole ancora ch'egli abbia prescritto a tutti gli ordinandi un certo tempo, durante il quale si dovessero esercitare nella Chiesa nell'ordine ricevuto prima d'essere elevati al grado superiore; che un laico non portasse accusa contro un chierico, e che un chierico non difendesse la sua causa davanti a un tribunale secolare. Ritenendo solo il nome di Sabato e di Domenica, volle che gli altri giorni della settimana fossero chiamati col nome di feria, come già per l'innanzi si era cominciato a fare nella Chiesa, per significare che i chierici, rigettata ogni altra cura terrena, devono attendere ogni giorno unicamente a Dio. La sua gran santità di vita e bontà verso i poveri risposero sempre a questa sapienza celeste colla quale governava la Chiesa. Onde provvide che i chierici poveri vivessero in comune con quei più ricchi, e che le sacre vergini fossero provviste delle cose necessarie alla vita. Visse nel pontificato 21 anni, 10 mesi e un giorno. Fu seppellito nel cimitero di Priscilla sulla via Salaria. Tenne sette ordinazioni nel mese di Dicembre, nelle quali creò 42 preti, 24 diaconi.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Commemoratio 2]
 @Sancti/12-25:Octava

--- a/web/www/horas/Latin/Commune/C2.txt
+++ b/web/www/horas/Latin/Commune/C2.txt
@@ -191,7 +191,7 @@ R. Qui minas júdicum non tímuit, nec terrénæ dignitátis glóriam quæsívit
 &Gloria
 R. Qui minas júdicum non tímuit, nec terrénæ dignitátis glóriam quæsívit, sed ad cæléstia regna pervénit.
 
-[Responsory8NonEffusorum]
+[Responsory8 non Effusorum]
 R. Dómine, prævenísti eum in benedictiónibus dulcédinis:
 * Posuísti in cápite ejus corónam de lápide pretióso.
 V. Vitam pétiit a te, et tribuísti ei longitúdinem diérum in sǽculum sǽculi.
@@ -313,30 +313,30 @@ R. Sicut cedrus Líbani multiplicábitur.
 [Ant 3]
 Qui vult veníre post me, * ábneget semetípsum, et tollat crucem suam, et sequátur me.
 
-[Lectio41]
+[Lectio4 in 2 loco]
 De Epístola sancti Cypriáni Epíscopi et Mártyris ad Mártyres et Confessóres
 !Lib. 2. Epist. 6.
 Quibus ego vos láudibus prǽdicem, fortíssimi Mártyres? robur péctoris vestri, et perseverántiam fídei, quo præcónio vocis exórnem? Tolerástis usque ad consummatiónem glóriæ duríssimam quæstiónem: nec cessístis supplíciis, sed vobis pótius supplícia cessérunt. Finem dolóribus, quem torménta non dabant, corónæ dedérunt. Laniéna grávior ad hoc diu perseverávit, non ut stantem fidem deíceret, sed ut hómines Dei ad Deum velócius mítteret.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 R. Lux perpétua lucébit Sanctis tuis, Dómine,
 * Et ætérnitas témporum, allelúja, allelúja.
 V. Lætítia sempitérna erit super cápita eórum: gáudium et exsultatiónem obtinébunt.
 R. Et ætérnitas témporum, allelúja, allelúja.
 
-[Lectio51]
+[Lectio5 in 2 loco]
 Vidit admírans præséntium multitúdo cæléste certamen, certámen Dei, certámen spiritále, prǽlium Christi: stetísse servos ejus voce líbera, mente incorrúpta, virtúte divína, telis quidem sæculáribus nudos, sed armis fídei ardéntis armátos. Stetérunt torti torquéntibus fortióres: et pulsántes ac laniántes úngulas, pulsáta ac laniáta membra vicérunt. Inexpugnábilem fidem superáre non pótuit sǽviens diu plaga repetíta, quamvis rupta compáge víscerum torqueréntur in servis Dei jam non membra, sed vúlnera. Fluébat sanguis, qui incéndium persecutiónis exstíngueret, qui flammas et ignes gehénnæ glorióso cruóre sopíret.
 
-[Responsory51]
+[Responsory5 in 2 loco]
 R. In servis suis, allelúja,
 * Consolábitur Deus, allelúja.
 V. Judicábit Dóminus pópulum suum, et in servis suis.
 R. Consolábitur Deus, allelúja.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 O quale illud fuit spectáculum Dómino, quam sublíme, quam magnum, quam Dei óculis sacraménto ac devotióne mílitis ejus accéptum: sicut scriptum est in Psalmis, Spíritu Sancto loquénte ad nos páriter et monénte: Pretiésa est in conspéctu Dómini mors justórum ejus. Pretiósa mors hæc est, quæ emit immortalitátem prétio sui sánguinis; quæ accépit corónam de consummatióne virtútis. Quam lætus illic Christus fuit, quam libens in tálibus servis suis et pugnávit, et vicit protéctor fídei, dans credéntibus tantum, quantum se credit cápere qui sumit! Certámini suo ádfuit, præliatóres atque assertóres sui nóminis eréxit, corroborávit, animávit. Et qui pro nobis mortem semel vicit, semper vincit in nobis.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Fíliæ Jerúsalem, veníte et vidéte Mártyres cum corónis, quibus coronávit eos Dóminus
 * In die solemnitátis et lætítiæ, allelúja.
 V. Quóniam confortávit seras portárum tuárum, benedíxit fílios tuos in te.
@@ -344,7 +344,7 @@ R. In die solemnitátis et lætítiæ, allelúja.
 &Gloria
 R. In die solemnitátis et lætítiæ, allelúja.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Léctio sancti Evangélii secúndum Joánnem
 !Joannes 15:5-10
 In illo témpore: Dixit Jesus discípulis suis: Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum: quia sine me nihil potéstis fácere. Et réliqua.
@@ -353,16 +353,16 @@ Homilía sancti Augustíni Epíscopi
 !Tract. 81 in Joan., sub med.
 Ne quisquam putáret saltem parvum áliquem fructum posse a semetípso pálmitem ferre: cum dixísset, Hic fert fructum multum; non ait, Quia sine me parum potéstis fácere; sed, Nihil potéstis fácere. Sive ergo parum, sive multum, sine illo fíeri non potest, sine quo nihil fíeri potest: quia etsi parum attúlerit palmes, eum purgat agrícola, ut plus áfferat; tamen nisi in vite mánserit, et víxerit de rádice, quantúmlibet fructum a semetípso non potest ferre. Quamvis autem Christus vitis non esset, nisi homo esset: tamen istam grátiam palmítibus non præbéret, nisi étiam Deus esset.
 
-[Responsory71]
+[Responsory7 in 2 loco]
 R. Ego sum vitis vera, et vos pálmites:
 * Qui manet in me, et ego in eo, hic fert fructum multum, allelúja, allelúja.
 V. Sicut diléxit me Pater, et ego diléxi vos.
 R. Qui manet in me, et ego in eo, hic fert fructum multum, allelúja, allelúja.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Verum quia ita sine ista grátia non potest vivi, ut et mors in potestáte sit líberi arbítrii: Si quis in me, inquit, non mánserit; mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet. Ligna ítaque vitis tanto sunt contemptibilióra si in vite non mánserint, quanto gloriosióra si mánserint. Dénique sicut de his étiam per Ezechiélem prophétam Dóminus dicit, præcísa nullis agricolárum úsibus prosunt, nullis fabrílibus opéribus deputántur. Unum de duóbus pálmiti congruit, aut vitis, aut ignis: si in vite non est, in igne erit: ut ergo in igne non sit, in vite sit.
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. Cándidi facti sunt Nazarǽi ejus, allelúja: splendórem Deo dedérunt, allelúja: 
 * Et sicut lac coaguláti sunt, allelúja, allelúja.
 V. Candidióres nive, nitidióres lacte, rubicundióres ébore antíquo, sapphíro pulchrióres.
@@ -370,11 +370,11 @@ R. Et sicut lac coaguláti sunt, allelúja, allelúja.
 &Gloria
 R. Et sicut lac coaguláti sunt, allelúja, allelúja.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Si manséritis in me, inquit, et verba mea in vobis mánserint: quodcúmque voluéritis petétis, et fiet vobis. Manéndo quippe in Christo, quid velle possunt, nisi quod cónvenit Christo? Quid velle possunt manéndo in Salvatóre, nisi quod non est aliénum a salúte? Áliud quippe vólumus quia sumus in Christo: et áliud vólumus quia sumus adhuc in hoc sǽculo. De mansióne namque hujus sǽculi nobis aliquándo subrépit, ut hoc petámus, quod nobis non expedíre nescímus. Sed absit ut fiat nobis, si manémus in Christo, qui non facit quando pétimus, nisi quod éxpedit nobis.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Léctio sancti Evangélii secúndum Matthǽum
 !Matt 10:26-32
 In illo témpore: Dixit Jesus discípulis suis: Nihil est opértum, quod non revelábitur; et occúltum, quod non sciétur. Et réliqua.
@@ -383,23 +383,23 @@ Homilía sancti Hilárii Epíscopi
 !Comment. in Matthaeum, can. 10 post medium
 Dóminus diem judícii osténdit, quæ abstrúsam voluntátis nostræ consciéntiam prodet: et ea quæ nunc occúlta existimántur, luce cognitiónis públicæ déteget. Ígitur non minas, non consília, non potestátes insectántium monet esse metuéndas: quia dies judícii nulla hæc fuísse, atque inánia revelábit. Et quod dico vobis in ténebris, dícite in lúmine: et quod in aure audítis, prædicáte super tecta. Non légimus Dóminum sólitum fuísse nóctibus sermocinári, et doctrínam in ténebris tradidísse: sed quia omnis sermo ejus carnálibus ténebræ sunt, et verbum ejus infidélibus nox est.
 
-[Responsory72]
+[Responsory7 in 3 loco]
 R. Coróna áurea super caput ejus:
 * Expréssa signo sanctitátis, glória honóris, et opus fortitúdinis.
 V. Quóniam prævenísti eum in benedictiónibus dulcédinis, posuísti in cápite ejus corónam de lápide pretióso.
 R. Expréssa signo sanctitátis, glória honóris, et opus fortitúdinis.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Ítaque id quod a se dictum est, cum libertáte fídei et confessiónis vult esse loquéndum. Idcírco quæ in ténebris dicta sunt prædicári jussit in lúmine: ut quæ secréto áurium commíssa sunt, super tecta, id est, excélso loquéntium præcónio audiántur. Constánter enim Dei ingerénda cognítio est, et profúndum doctrínæ evangélicæ secrétum in lúmine prædicatiónis apostólicæ revelándum: non timéntes eos, quibus cum sit licéntia in córpora, tamen in ánimam jus nullum est: sed timéntes pótius Deum, cui perdéndæ in gehénna et ánimæ et córporis sit potéstas.
 
-[Responsory82]
+[Responsory8 in 3 loco]
 @Commune/C2:Responsory8
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Nolíte timére eos qui occídunt corpus. Nullus ígitur córporum nostrórum casus est pertimescéndus, neque ullus interiméndæ carnis admitténdus est dolor: quando pro natúræ suæ atque oríginis conditióne resolúta, in substántiam spirituális ánimæ refundátur. Et quia doctrínis tálibus confirmátos opórtet líberam confiténdi Dei habére constántiam, étiam conditiónem, qua tenerémur, adjécit: negatúrum se eum Patri in cælis, qui se homínibus in terra negásset: eum porro qui conféssus coram homínibus se fuísset, a se in cælis confiténdum: qualésque nos nóminis sui testes homínibus fuissémus, tali nos apud Deum Patrem testimónio ejus usúros.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Léctio sancti Evangélii secúndum Matthǽum
 !Matt 16:24-27
 In illo témpore: Dixit Jesus discípulis suis: Si quis vult post me veníre, ábneget semetípsum, et tollat crucem suam, et sequátur me. Et réliqua.
@@ -408,9 +408,9 @@ Homilía sancti Gregórii Papæ
 !Homilia 32 in Evang.
 Quia Dóminus ac Redémptor noster novus homo venit in mundum, nova præcépta dedit mundo. Vitæ étenim nostræ véteri in vítiis enutrítæ contrarietátem oppósuit novitátis suæ. Quid enim vetus, quid carnális homo nóverat, nisi sua retinére, aliéna rápere, si posset; concupíscere, si non posset? Sed cæléstis médicus síngulis quibúsque vítiis obviántia ádhibet medicaménta. Nam sicut arte medicínæ cálida frígidis, frígida cálidis curántur: ita Dóminus noster contrária oppósuit medicaménta peccátis, ut lúbricis continéntiam, tenácibus largitátem, iracúndis mansuetúdinem, elátis præcíperet humilitátem.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Certe cum se sequéntibus nova mandáta propóneret, dixit: Nisi quis renuntiáverit ómnibus quæ póssidet, non potest meus esse discípulus. Ac si apérte dicat: Qui per vitam véterem aliéna concupíscitis, per novæ conversatiónis stúdium et vestra largímini. Quid vero in hac lectióne dicat, audiámus: Qui vult post me veníre, ábneget semetípsum. Ibi dícitur, ut abnegémus nostra: hic dícitur, ut abnegémus nos. Et fortásse laboriósum non est hómini relínquere sua; sed valde laboriósum est relínquere semetípsum. Minus quippe est abnegáre quod habet; valde autem multum est abnegáre quod est.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Ad se autem nobis veniéntibus Dóminus præcépit, ut renuntiémus nostris: quia quicúmque ad fídei agónem vénimus, luctámen contra malígnos spíritus súmimus. Nihil autem malígni spíritus in hoc mundo próprium póssident: nudi ergo cum nudis luctári debémus. Nam si vestítus quisque cum nudo luctátur, cítius ad terram dejícitur, quia habet unde teneátur. Quid enim sunt terréna ómnia, nisi quædam córporis induménta? Qui ergo contra diábolum ad certámen próperat, vestiménta abjíciat, ne succúmbat.
 &teDeum

--- a/web/www/horas/Latin/Commune/C2p.txt
+++ b/web/www/horas/Latin/Commune/C2p.txt
@@ -68,13 +68,13 @@ Dignum et cóngruum est, fratres, ut post lætítiam Paschæ, quam in Ecclésia 
 Annuntiémus inquam sanctis Martýribus Domínicæ Paschæ grátiam: ut dum sepultúræ illíus prædicámus reseráta claustra, et horum sepúlcra reseréntur: dum corpus illíus mortuum dícimus tepéntibus venis súbito viguísse, horum quoque membra jam frígida immortalitátis calóre foveántur. Éadem enim rátio Mártyres súscitat, quæ et Dóminum suscitávit. Nam sicut viam passiónis ejus expérti sunt, ita experiéntur et vitæ; scriptum est enim in Psalmo: Notas mihi fecísti vias vitæ. Hoc útique in resurrectióne ex persóna dícitur Salvatóris: ut qui, dum post mortem ab ínferis redit ad súperos, incípiat notam habére viam vitæ, quæ ante habebátur ignóta.
 
 [Responsory5]
-@Commune/C2:Responsory51
+@Commune/C2:Responsory5 in 2 loco
 
 [Lectio6]
 Ignóta enim erat ante Christi advéntum via vitæ, quæ nullíus adhuc resurgéntis fúerat temeráta vestígio. At ubi Dóminus resurréxit, nota facta, solo attríta est plurimórum: de quibus sanctus Evangelísta ait: Multórum córpora Sanctórum surrexérunt cum eo, et introiérunt in sanctam civitátem. Unde cum Dóminus in resurrectióne sua díxerit, Notas mihi fecísti vias vitæ: póssumus et nos jam dícere Dómino: Notas fecísti nobis vias vitæ. Ipse enim nobis notas fecit vias vitæ, qui nobis sémitam manifestávit ad vitam. Notas enim mihi fecit vias vitæ, cum me dócuit fidem, misericórdiam, justítiam, castitátem: his enim pervenítur itinéribus ad salútem.
 
 [Responsory6]
-@Commune/C2:Responsory61
+@Commune/C2:Responsory6 in 2 loco
 
 [Lectio7]
 @Sancti/10-27:Lectio1
@@ -134,24 +134,24 @@ Ignóta enim erat ante Christi advéntum via vitæ, quæ nullíus adhuc resurgé
 [Ant 3]
 @Commune/C1p
 
-[Lectio41]
+[Lectio4 in 2 loco]
 De Epístola sancti Cypriáni Epíscopi et Mártyris ad Mártyres et Confessóres.
 !Lib. 2. Epist. 8.
 Quibus ego vos láudibus prǽdicem, fortíssimi Mártyres? robur péctoris vestri, et perseverántiam fídei, quo præcónio vocis exórnem? Tolerástis usque ad consummatiónem glóriæ duríssimam quæstiónem: nec cessístis supplíciis, sed vobis pótius supplícia cessérunt. Finem dolóribus, quem torménta non dabant, corónæ dedérunt. Laniéna grávior ad hoc diu perseverávit, non ut stantem fidem dejíceret, sed ut hómines Dei ad Deum velócius mítteret.
 
-[Responsory41]
+[Responsory4 in 2 loco]
 @Commune/C1p:Responsory4
 
-[Lectio51]
+[Lectio5 in 2 loco]
 Vidit admírans præséntium multitúdo cæléste certámen, certámen Dei, certámen spiritále, prǽlium Christi: stetísse servos ejus voce líbera, mente incorrúpta, virtúte divína, telis quidem sæculáribus nudos, sed armis fídei ardéntis armátos. Stetérunt torti torquéntibus fortióres: et pulsántes ac laniántes úngulas, pulsáta ac laniáta membra vicérunt. Inexpugnábilem fidem superáre non pótuit sǽviens diu plaga repetíta, quamvis rupta compáge víscerum torqueréntur in servis Dei jam non membra, sed vúlnera. Fluébat sanguis, qui incéndium persecutiónis exstíngueret, qui flammas et ignes gehénnæ glorióso cruóre sopíret.
 
-[Responsory51]
+[Responsory5 in 2 loco]
 @Commune/C2
 
-[Lectio61]
+[Lectio6 in 2 loco]
 O quale illud fuit spectáculum Dómino, quam sublíme, quam magnum, quam Dei óculis sacraménto ac devotióne mílitis ejus accéptum: sicut scriptum est in Psalmis, Spíritu Sancto loquénte ad nos páriter et monénte: Pretiósa est in conspéctu Dómini mors justórum ejus. Pretiósa mors hæc est, quæ emit immortalitátem prétio sui sánguinis; quæ accépit corónam de consummatióne virtútis. Quam lætus illic Christus fuit, quam libens in tálibus servis suis et pugnávit, et vicit protéctor fídei, dans credéntibus tantum, quantum se credit cápere qui sumit! Certámini suo ádfuit, præliatóres atque assertóres sui nóminis eréxit, corroborávit, animávit. Et qui pro nobis mortem semel vicit, semper vincit in nobis.
 
-[Responsory61]
+[Responsory6 in 2 loco]
 R. Fíliæ Jerúsalem, veníte et vidéte Mártyres cum corónis, quibus coronávit eos Dóminus
 * In die solemnitátis et lætítiæ, allelúja.
 V. Quóniam confortávit seras portárum tuárum, benedíxit fílios tuos in te.

--- a/web/www/horas/Latin/Commune/C2p.txt
+++ b/web/www/horas/Latin/Commune/C2p.txt
@@ -136,7 +136,7 @@ Ignóta enim erat ante Christi advéntum via vitæ, quæ nullíus adhuc resurgé
 
 [Lectio41]
 De Epístola sancti Cypriáni Epíscopi et Mártyris ad Mártyres et Confessóres.
-!Lib. 2. Epist. 6.
+!Lib. 2. Epist. 8.
 Quibus ego vos láudibus prǽdicem, fortíssimi Mártyres? robur péctoris vestri, et perseverántiam fídei, quo præcónio vocis exórnem? Tolerástis usque ad consummatiónem glóriæ duríssimam quæstiónem: nec cessístis supplíciis, sed vobis pótius supplícia cessérunt. Finem dolóribus, quem torménta non dabant, corónæ dedérunt. Laniéna grávior ad hoc diu perseverávit, non ut stantem fidem dejíceret, sed ut hómines Dei ad Deum velócius mítteret.
 
 [Responsory41]

--- a/web/www/horas/Latin/Commune/C3.txt
+++ b/web/www/horas/Latin/Commune/C3.txt
@@ -370,7 +370,7 @@ In cæléstibus regnis * Sanctórum habitátio est, et in ætérnum réquies eó
 [Ant 3]
 Gaudent in cælis * ánimæ Sanctórum, qui Christi vestígia sunt secúti: et quia pro ejus amóre sánguinem suum fudérunt, ídeo cum Christo exsúltant sine fine.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Léctio sancti Evangélii secúndum Lucam.
 !Luc 6:17-23
 In illo témpore: Descéndens Jesus de monte, stetit in loco campéstri, et turba discipulórum ejus, et multitúdo copiósa plebis ab omni Judǽa, et Jerúsalem, et marítima, et Tyri, et Sidónis. Et réliqua.
@@ -379,10 +379,10 @@ Homilía sancti Ambrósii Epíscopi
 !Lib. 5. in Lucam. Cap. 6., post init.
 Advérte ómnia diligénter, quómodo et cum Apóstolis ascéndat et descéndat ad turbas. Quómodo enim turba nisi in húmili Christum vidéret? Non séquitur ad excélsa, non ascéndit ad sublímia. Dénique ubi descéndit, invénit infírmos: in excélsis enim infírmi esse non possunt. Hinc étiam Matthǽus docet in inferióribus débiles esse sanátos. Prius enim unusquísque sanándus est, ut paulátim virtútibus procedéntibus ascéndere possit ad montem; et ídeo quemque in inferióribus sanat, hoc est, a libídine révocat, injúriam cæcitátis avértit. Ad vúlnera nostra descéndit: ut usu quodam et cópia suæ natúræ, compartícipes nos fáciat esse regni cæléstis.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Beáti páuperes, quia vestrum est regnum Dei. Quátuor tantum beatitúdines sanctus Lucas Domínicas posuit, octo vero sanctus Matthǽus: sed in illis octo istæ quátuor sunt, et in quátuor istis illæ octo. Hic enim quátuor velut virtútes ampléxus est cardináles: ille in illis octo mýsticum númerum reserávit. Pro octáva enim multi inscribúntur Psalmi: et mandátum áccipis octo illis partem dare fortásse benedictiónibus. Sicut enim spei nostræ octáva perféctio est, ita octáva summa virtútum est.
 
-[Responsory81]
+[Responsory8 in 2 loco]
 R. Hæc est vera fratérnitas, quæ numquam pótuit violári certámine: qui effúso sánguine secúti sunt Dóminum:
 * Contemnéntes aulam régiam, pervenérunt ad regna cæléstia.
 V. Ecce quam bonum et quam jucúndum habitáre fratres in unum.
@@ -390,6 +390,6 @@ R. Contemnéntes aulam régiam, pervenérunt ad regna cæléstia.
 &Gloria
 R. Contemnéntes aulam régiam, pervenérunt ad regna cæléstia.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Sed prius quæ sunt amplióra videámus. Beáti, inquit, páuperes, quóniam vestrum est regnum Dei. Primam benedictiónem hanc utérque Evangelísta pósuit. Órdine enim prima est, et parens quædam generatióque virtútum: quia qui contempsérit sæculária, ipse merébitur sempitérna: nec potest quisquam méritum regni cæléstis adipísci, qui mundi cupiditáte pressus, emergéndi non habet facultátem.
 &teDeum

--- a/web/www/horas/Latin/Commune/C3.txt
+++ b/web/www/horas/Latin/Commune/C3.txt
@@ -286,7 +286,7 @@ Nunc, et per omne sǽculum.
 Amen.
 
 [HymnusM Laudes]
-@:Hymnus Laudes:s/Inténde/Appóne/ s/Mártyres/Martýribus/ s/Parcísque/Parcéndo/ s/Largítor indulgéntiæ/Donándo indulgéntiam/
+@:Hymnus Laudes:s/Inténde/Appóne/ s/inter Mártyres/in Martýribus,/ s/Parcísque/Parcéndo/ s/Largítor indulgéntiæ/Donándo indulgéntiam/ s/Nunc, et per omne sǽculum/Et nunc et in perpétuum/
 
 [Versum 2]
 V. Exsultábunt Sancti in glória.

--- a/web/www/horas/Latin/Commune/C4.txt
+++ b/web/www/horas/Latin/Commune/C4.txt
@@ -74,7 +74,7 @@ Trinus et unus.
 Amen.
 
 [Hymnus1M Vespera]
-@:HymnusM Vespera:s/Scándere cæli/Laudis honóres/
+@:HymnusM Vespera:s/Hódie/Hac die/ s/secréta/suprémos/ s/Scándere cæli/Laudis honóres/
 
 [Hymnus1 Vespera]
 @:Hymnus Vespera:s/beátas/suprémos/ s/Scándere sedes/Laudis honóres/ 
@@ -171,7 +171,7 @@ R. Tu es sacérdos in ætérnum secúndum órdinem Melchísedech.
 
 [Lectio4]
 Sermo sancti Maxími Epíscopi
-!Homilía 59, quæ est 2 de S. Eusebio Vercellensi
+!Homilía 78, quæ est 2 de S. Eusebio Vercellensi
 Ad sancti ac beatíssimi Patris nostri N., cujus hódie festa celebrámus, laudes addidísse áliquid, decerpsísse est; síquidem virtútem ejus grátia, non sermónibus exponénda est, sed opéribus comprobánda. Cum enim dicat Scriptúra: Glória patris est fílius sápiens; quantæ hujus sunt glóriæ, qui tantórum filiórum sapiéntia et devotióne lætátur? In Christo enim Jesu per Evangélium ipse nos génuit.
 
 [Responsory4]

--- a/web/www/horas/Latin/Commune/C4.txt
+++ b/web/www/horas/Latin/Commune/C4.txt
@@ -355,7 +355,7 @@ Amávit eum Dóminus, * et ornávit eum: stolam glóriæ índuit eum, et ad port
 [Ant 3 summi Pontificis]
 Dum esset Summus Póntifex, * terréna non métuit, sed ad cæléstia regna gloriósus migrávit.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 De libro Ecclesiastici
 !Sir 44:1-5
 1 Laudémus viros gloriósos, et paréntes nostros in generatióne sua.
@@ -364,14 +364,14 @@ De libro Ecclesiastici
 4 et imperántes in præsénti pópulo, et virtúte prudéntiæ pópulis sanctíssima verba:
 5 in perítia sua requiréntes modos músicos, et narrántes cármina Scripturárum:
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 44:6-9
 6 Hómines dívites in virtúte, pulchritúdinis stúdium habéntes, pacificántes in dómibus suis.
 7 Omnes isti in generatiónibus gentis suæ glóriam adépti sunt, et in diébus suis habéntur in láudibus.
 8 Qui de illis nati sunt reliquérunt nomen narrándi laudes eórum.
 9 Et sunt quorum non est memória: periérunt quasi qui non fúerint: et nati sunt quasi non nati, et fílii ipsórum cum ipsis.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 44:10-15
 10 Sed illi viri misericórdiæ sunt, quorum pietátes non defuérunt.
 11 Cum sémine eórum pérmanent bona:
@@ -380,7 +380,7 @@ De libro Ecclesiastici
 14 Córpora ipsórum in pace sepúlta sunt, et nomen eórum vivit in generatiónem et generatiónem.
 15 Sapiéntiam ipsórum narrent pópuli, et laudem eórum núntiet ecclésia.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Léctio sancti Evangélii secúndum Matthǽum
 !Matt 16:13-19
 In illo témpore: Venit Jesus in partes Cæsaréæ Philíppi, et interrogábat discípulos suos, dicens: Quem dicunt hómines esse Fílium hóminis? Et réliqua.
@@ -389,14 +389,14 @@ Homilía sancti Leónis Papæ
 !Sermo 2 in anniversario assumpt. suæ ante medium
 Cum, sicut evangélica lectióne reserátum est, interrogásset Dóminus discípulos, quem ipsum (multis divérsa opinántibus) créderent; respondissétque beátus Petrus, dicens: Tu es Christus Fílius Dei vivi; Dóminus ait: Beátus es, Simon Bar-Jona, quia caro et sanguis non revelávit tibi, sed Pater meus, qui in cælis est: et ego dico tibi, quia tu es Petrus, et super hanc petram ædificábo Ecclésiam meam, et portæ ínferi non prævalébunt advérsus eam. Et tibi dabo claves regni cælórum: et quodcúmque ligáveris super terram, erit ligátum et in cælis: et quodcúmque sólveris super terram, erit solútum et in cælis. Manet ergo disposítio veritátis, et beátus Petrus, in accépta fortitúdine petræ persevérans, suscépta Ecclésiæ gubernácula non relíquit.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 In univérsa namque Ecclésia, Tu es Christus Fílius Dei vivi, quotídie Petrus dicit; et omnis lingua, quæ confitétur Dóminum, magistério hujus vocis imbúitur. Hæc fides diábolum vincit et captivórum ejus víncula dissólvit. Hæc érutos mundo, ínserit cælo, et portæ ínferi advérsus eam prævalére non possunt. Tanta enim divínitus soliditáte muníta est, ut eam neque hærética umquam corrúmpere právitas, nec pagána potúerit superáre perfídia. His ítaque modis, dilectíssimi, rationábile obséquio celebrétur hodiérna festívitas: ut in persóna humilitátis meæ ille intelligátur, ille honorétur, in quo et ómnium pastórum sollicitúdo, cum commendatárum sibi óvium custódia persevérat, et cujus étiam dígnitas in indígno heréde non déficit.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Cum ergo cohortatiónes nostras áuribus vestræ sanctitátis adhibémus, ipsum vobis, cujus vice fúngimur, loqui crédite: quia et illíus vos afféctu monémus, et non áliud vobis, quam quod dócuit, prædicámus; obsecrántes, ut succíncti lumbos mentis vestræ, castam et sóbriam vitam in Dei timóre ducátis. Coróna mea, sicut Apóstolus ait, et gáudium vos estis, si fides vestra, quæ ab inítio Evangélii in univérso mundo prædicáta est, in dilectióne et sanctitáte permánserit. Nam licet omnem Ecclésiam, quæ in toto est orbe terrárum, cunctis opórteat florére virtútibus; vos tamen præcípue inter céteros pópulos decet méritis pietátis excéllere, quos in ipsa apostólicæ petræ arce fundátos, et Dóminus noster Jesus Christus cum ómnibus redémit, et beátus Apóstolus Petrus præ ómnibus erudívit.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Léctio sancti Evangélii secúndum Matthǽum
 !Matt 19:27-29
 In illo tempore: Dixit Petrus ad Jesum: Ecce nos reliquimus omnia, et secuti sumus te: quid ergo erit nobis? Et reliqua. 
@@ -405,18 +405,18 @@ De Homilía venerábilis Bedæ Presbýteri
 !In Natali S. Benedicti
 Duo sunt ordines electorum in judicio futuri: unus judicantium cum Domino, de quibus hoc loco memorat, qui reliquerunt omnia, et secuti sunt illum: alius judicandorum a Domino, qui non quidem omnia sua pariter reliquerunt, sed de his tamen quae habebant, quotidianas dare eleemosynas Christi pauperibus curabant: unde et audituri sunt in judicio: Venite benedicti Patris mei, possidete praeparatum vobis regnum a constitutione mundi. Esurivi enim, et dedistis mihi manducare: sitivi, et dedistis mihi bibere.
 
-[Responsory73]
+[Responsory7 in 4 loco]
 R. Iste est qui ante Deum magnas virtutes operatus est, et de omni corde suo laudavit Dominum:
 * Ipse intercedat pro peccatis omnium populorum.
 V. Ecce homo sine querela, verus Dei cultor, abstinens se ab omni opere malo, et permanens in innocentia sua.
 R. Ipse intercedat pro peccatis omnium populorum.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Sed et reproborum duos ibi futuros ordines Domino narrante comperimus: unum eorum, qui fidei christianae mysteriis initiati, opera fidei exercere contemnunt, quibus in judicio testatur: Discedite a me maledicti in ignem aeternum, qui praeparatus est diabolo, et angelis ejus: esurivi enim, et non dedistis mihi manducare. Alterum eorum, qui fidem et mysteria Christi vel numquam suscepere, vel susceptam per apostasiam deseruere: de quibus dicit: Qui autem non credit, jam judicatus est: quia non credit in nomine unigeniti Filii Dei.
 
-[Responsory83]
+[Responsory8 in 4 loco]
 @:Responsory8
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Verum his cum timore et pavore debito paulisper commemoratis, ad laetissima potius Domini et Salvatoris nostri promissa convertamus auditum. Videamus quae tantae gratia pietatis: non aeternae tantummodo vitae praemia suis sequacibus, sed et praesentis munera pollicetur eximia. Et omnis, inquit, qui reliquerit domum, vel fratres, aut sorores, aut patrem, aut matrem, aut uxorem, aut filios, aut agros, propter nomen meum, centuplum accipiet, et vitam aeternam possidebit. Qui enim terrenis affectibus sive possessionibus pro Christi discipulatu renuntiaverit, quo plus in ejus amórem profecerit, eo plures inveniet, qui se interno suscipere affectu, et suis gaudeant sustentare substantiis.
 &teDeum

--- a/web/www/horas/Latin/Commune/C4a.txt
+++ b/web/www/horas/Latin/Commune/C4a.txt
@@ -192,7 +192,7 @@ $Per Dominum.
 [Ant 3]
 @:Ant 1
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Léctio sancti Evangélii secúndum Matthǽum
 !Matt 5:13-19
 In illo témpore: Dixit Jesus discípulis suis: Vos estis sal terræ. Quod si sal evanúerit, in quo saliétur? Et réliqua.
@@ -201,9 +201,9 @@ Homilía sancti Joánnis Chrysóstomi
 !Homilia 15 in Matthæum, sub medium
 Atténdite quid díxerit, Vos estis sal terræ: per quod osténdit quam necessário ista præcípiat. Non enim de vestra, inquit, tantúmmodo vita, sed de univérso orbe vobis ratio reddénda est. Non ad duas quippe urbes, aut decem, aut vigínti, neque ad unam gentem vos mitto, sicut mittébam prophétas: sed ad omnem terram prorsus ac mare, totúmque mundum, et hunc váriis crimínibus oppréssum.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Dicéndo enim, Vos estis sal terræ, osténdit univérsam hóminum infatuátam esse natúram, et peccatórum vi corrúptam: et idcírco illas ab eis virtútes requírit, quæ máxime ad multórum salútem procurándam necessáriæ sunt atque útiles. Nam qui mansuétus est ac modéstus, et miséricors et justus, non intra se tantúmmodo hæc recte facta conclúdit, verum in aliórum quoque utilitátem præcláros hos fáciet efflúere fontes. Igitur qui corde mundo est atque pacíficus, et persecutiónem pro veritáte pátitur, nihilóminus in commúne cómmodum vitam instítuit.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Ne ígitur putétis, inquit, ad lévia vos ducéndos esse certámina, neque exiguárum rerum vobis ineúndam esse ratiónem. Vos estis sal terræ. Quid ígitur? Ipsine putrefácta medicáti sunt? Nequáquam: neque enim fíeri potest, ut ea quæ jam corrúpta sunt, salis perfricatióne reparéntur. Non ergo hoc fecérunt, sed ante renováta, sibíque trádita, atque ab illa jam putrédine liberáta, aspergébant sale, et in ea novitáte conservábant, quam a Dómino suscéperant. Liberáre quippe a putrédine peccatórum, Christi virtútis est: ut autem ad illa íterum non revertántur, Apostolórum curæ est ac labóris.
 &teDeum

--- a/web/www/horas/Latin/Commune/C5.txt
+++ b/web/www/horas/Latin/Commune/C5.txt
@@ -331,7 +331,7 @@ R. Et osténdit illi regnum Dei.
 [Ant 3]
 Hic vir despíciens mundum * et terréna, triúmphans, divítias cælo cóndidit ore, manu.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 De libro Sapiéntiæ
 !Sap 4:7-14
 7 Justus si morte præoccupatus fúerit, in refrigerio erit;
@@ -343,7 +343,7 @@ De libro Sapiéntiæ
 13 Consummátus in brevi, explévit témpora multa;
 14 placita enim erat Deo ánima illíus: propter hoc properavit edúcere illum de médio iniquitátum. 
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sap 4:14-19
 14 Pópuli autem vidéntes, et non intelligentes, nec ponentes in præcordiis tália,
 15 quóniam grátia Dei et misericórdia est in sanctos ejus, et respéctus in eléctos illíus.
@@ -352,7 +352,7 @@ De libro Sapiéntiæ
 18 Vidébunt, et contemnent eum; illos autem Dóminus irridébit.
 19 Et erunt post hæc decidentes sine honóre, et in contumélia inter mórtuos in perpétuum: quóniam disrumpet illos inflatos sine voce, et commovébit illos a fundaméntis, et usque ad suprémum desolabuntur.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sap 4:19-20; 5:1-5
 19 Et erunt geméntes, et memória illórum períbit.
 20 Vénient in cogitatióne peccatórum suórum timidi, et traducent illos ex adverso iniquitátes ipsórum.
@@ -362,7 +362,7 @@ De libro Sapiéntiæ
 4 Nos insensati, vitam illórum æstimabamus insaniam, et finem illórum sine honóre;
 5 ecce quómodo computati sunt inter fílios Dei, et inter sanctos sors illórum est.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Léctio sancti Evangélii secúndum Lucam
 !Luc 12:32-34
 In illo témpore: Dixit Jesus discípulis suis: Nolíte timére pusíllus grex, quia complácuit Patri vestro dare vobis regnum. Et réliqua.
@@ -371,14 +371,14 @@ Homilía sancti Bedæ Venerábilis Presbýteri
 !Lib. 4, Cap. 4, in Luc. 12
 Pusíllum gregem electórum, vel ob comparationem majóris numeri reproborum, vel pótius ob humilitátis devotiónem nóminat: quia vidélicet Ecclésiam suam quantalibet numerositate jam dilatatam, tamen usque ad finem mundi humilitáte vult crescere, et ad promíssum regnum humilitáte perveníre. Ideóque ejus labóres blande consolátus, quam regnum Dei tantum quærere præcipit, eídem regnum a Pátre dandum complacita benignitate promittit.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Vendite quæ possidetis, et date eleemosynam. Nolíte, inquit, timére, ne propter regnum Dei militantibus, hujus vitæ necessaria desint: quin étiam possessa propter eleemosynam vendite. Quod tunc digne fit, quando quis semel pro Dómino suis ómnibus spretis, nihilóminus post hæc labóre mánuum, unde et victum transigere, et eleemosynam dare queat, operátur. Unde gloriatur Apóstolus, dicens: Argéntum, et aurum, aut vestem nullius concupívi: ipsi scitis, quóniam ad ea quæ mihi opus erant, et his qui mecum sunt, ministraverunt manus istæ. Ómnia osténdi vobis, quóniam sic laborántes opórtet suscípere infirmos.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Fácite vobis sacculos qui non veterascunt: eleemósynas vidélicet operando quarum merces in ætérnum maneat. Ubi non hoc præcéptum esse putandum est, ut nil pecúniæ reservetur a sanctis, vel suis scílicet, vel páuperum usibus suggerendæ: cum et ipse Dóminus, cui ministrabant Ángeli, tamen ad informandam Ecclésiam suam loculos habuísse legatur, et a fidélibus oblata conservans, et suórum necessitátibus aliísque indigéntibus tribuens; sed ne Deo propter ista serviatur, et ob inópiæ timórem justítia deseratur.
 &teDeum
 
-[Lectio72]
+[Lectio7 in 3 loco]
 Léctio sancti Evangélii secúndum Lucam.
 !Luc 19:12-26
 In illo témpore: Dixit Jesus discípulis suis parábolam hanc: Homo quidam nóbilis ábiit in regiónem longinquam, accípere sibi regnum, et revérti. Et réliqua.
@@ -387,9 +387,9 @@ Homilía sancti Ambrósii Epíscopi.
 !Lib. 8. in Lucam.
 Bonus ordo, ut vocaturus gentes, et Judæos jussurus interfici, qui noluérunt regnáre supra se Christum, hanc præmitteret comparationem, ne dicerétur: Nihil déderat pópulo Judæórum, unde póterat mélior fíeri? ut quid ab eo qui nihil recépit, exigitur? Non mediocris ista est mna, quam supra múlier evangélica quia non invénit, lucérnam accéndit, lúmine quærit admoto, gratulatur inventam.
 
-[Lectio82]
+[Lectio8 in 3 loco]
 Dénique ex una decem mnas álius fecit, álius quinque. Fortásse iste moralia habet, quia quinque sunt córporis sensus: ille duplicia, id est, mystica legis, et moralia probitatis. Unde et Matthæus quinque talenta, et duo talenta pósuit: in quinque talentis ut sint moralia, in duóbus utrúmque, mysticum atque morale. Ita quod número inferius, re ubérius.
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Et hic póssumus decem mnas decem verba intellígere, id est, legis doctrínam; quinque autem mnas, magisteria disciplínæ. Sed legisperitum in ómnibus volo esse perféctum; non enim in sermóne, sed in virtúte est regnum Dei. Bene autem, quia de Judæis dicit, duo soli multiplicatam pecúniam deferunt, non útique æris, sed dispensatiónis usúris. Ália est enim pecúniæ fnebris, ália doctrínæ cæléstis usúra.
 &teDeum

--- a/web/www/horas/Latin/Commune/C5a.txt
+++ b/web/www/horas/Latin/Commune/C5a.txt
@@ -95,7 +95,7 @@ R. Et non supplantabúntur gressus ejus.
 @Commune/C5
 
 [Responsory7]
-@Commune/C4:Responsory73
+@Commune/C4:Responsory7 in 4 loco
 
 [Lectio8]
 @Commune/C5

--- a/web/www/horas/Latin/Commune/C5a.txt
+++ b/web/www/horas/Latin/Commune/C5a.txt
@@ -151,35 +151,35 @@ R. Et non supplantabúntur gressus ejus.
 [Ant 3]
 @:Ant 1
 
-[Lectio11]
+[Lectio1 in 2 loco]
 @Commune/C5
 
-[Lectio21]
+[Lectio2 in 2 loco]
 @Commune/C5
 
-[Lectio31]
+[Lectio3 in 2 loco]
 @Commune/C5
 
-[Lectio71]
+[Lectio7 in 2 loco]
 @Commune/C5
 
-[Lectio81]
+[Lectio8 in 2 loco]
 @Commune/C5
 
-[Lectio91]
+[Lectio9 in 2 loco]
 @Commune/C5
 
-[Lectio72]
+[Lectio7 in 3 loco]
 @Commune/C5
 
-[Lectio82]
+[Lectio8 in 3 loco]
 @Commune/C5
 
-[Lectio92]
+[Lectio9 in 3 loco]
 Et hic possumus decem mnas decem verba intelligere, id est, legis doctrinam; quinque autem mnas, magisteria disciplinae. Sed legisperitum in omnibus volo esse perfectum; non enim in sermone, sed in virtute est regnum Dei. Bene autem, quia de Judaeis dicit, duo soli multiplicatam pecuniam deferunt, non utique aeris, sed dispensationis usuris. Alia est enim pecuniae foenebris, alia doctrinae caelestis usura.
 &teDeum
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Lectio sancti Evangelii secundum Matthaeum.
 !Matt 16:24-27
 In illo tempore: Dixit Jesus discipulis suis: Si quis vult post me venire, abneget semetipsum, et tollat crucem suam, et sequatur me. Et reliqua.
@@ -188,9 +188,9 @@ Homilia sancti Gregorii Papae.
 !Homilia 32. in Evang.
 Quia Dominus ac Redemptor noster novus homo venit in mundum, nova praecepta dedit mundo. Vitae etenim nostrae veteri in vitiis enutritae contrarietatem opposuit novitatis suae. Quid enim vetus, quid carnalis homo noverat, nisi sua retinere, aliena rapere, si posset; concupiscere, si non posset? Sed caelestis medicus singulis quibusque vitiis obviantia adhibet medicamenta. Nam sicut arte medicinae calida frigidis, frigida calidis curantur: ita Dominus noster contraria opposuit medicamenta peccatis, ut lubricis continentiam, tenacibus largitatem, iracundis mansuetudinem, elatis praeciperet humilitatem.
 
-[Lectio83]
+[Lectio8 in 4 loco]
 Certe cum se sequentibus nova mandata proponeret,dixit: Nisi quis renuntiaverit omnibus quae possidet, non potest meus esse discipulus. Ac si aperte dicat: Qui per vitam veterem aliena concupiscitis, per novae conversationis studium et vestra largimini. Quid vero in hac lectione dicat, audiamus: Qui vult post me venire, abneget semetipsum. Ibi dicitur, ut abnegemus nostra: hic dicitur, ut abnegemus nos. Et fortasse laboriosum non est homini relinquere sua; sed valde laboriosum est relinquere semetipsum. Minus quippe est abnegare quod habet; valde autem multum est abnegare quod est.
 
-[Lectio93]
+[Lectio9 in 4 loco]
 Ad se autem nobis venientibus Dominus praecepit, ut renuntiemus nostris: quia quicumque ad fidei agonem venimus, luctamen contra malignos spiritus sumimus. Nihil autem maligni spiritus in hoc mundo proprium possident: nudi ergo cum nudis luctari debemus. Nam si vestitus quisque cum nudo luctatur, citius ad terram dejicitur, quia habet unde teneatur. Quid enim sunt terrena omnia, nisi quaedam corporis indumenta? Qui ergo contra diabolum ad certamen properat, vestimenta abjiciat, ne succumbat.
 &teDeum

--- a/web/www/horas/Latin/Commune/C6.txt
+++ b/web/www/horas/Latin/Commune/C6.txt
@@ -357,7 +357,7 @@ R. Proptérea benedíxit te Deus in ætérnum.
 [Ant 3]
 @:Ant 1
 
-[Lectio11]
+[Lectio1 in 2 loco]
 De libro Ecclesiástici
 !Sir 51:1-7
 1 Confitébor tibi, Dómine, Rex, et collaudábo te Deum Salvatórem meum.
@@ -368,7 +368,7 @@ De libro Ecclesiástici
 6 a pressúra flammæ, quæ circúmdedit me, et in médio ignis non sum æstuáta;
 7 de altitúdine ventris ínferi, et a lingua coinquináta, et a verbo mendácii, a rege iníquo, et a lingua injústa.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 51:8-12
 8 Laudábit usque ad mortem ánima mea Dóminum,
 9 et vita mea appropínquans erat in inférno deórsum.
@@ -376,7 +376,7 @@ De libro Ecclesiástici
 11 Memoráta sum misericórdiæ tuæ, Dómine, et operatiónis tuæ, quæ a sǽculo sunt:
 12 quóniam éruis sustinéntes te, Dómine, et líberas eos de mánibus géntium.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 13 Exaltásti super terram habitatiónem meam, et pro morte defluénte deprecáta sum.
 14 Invocávi Dóminum, Patrem Dómini mei, ut non derelínquat me in die tribulatiónis meæ, et in témpore superbórum, sine adjutório.

--- a/web/www/horas/Latin/CommuneM/C2.txt
+++ b/web/www/horas/Latin/CommuneM/C2.txt
@@ -40,16 +40,16 @@ R. Glóriam et magnum decórem impónes super eum.
 [Lectio4]
 @Commune/C2:Lectio3:s/32-/33-/ s/32 .*33 /33 /s
 
-[Lectio1NonPontificis]
+[Lectio1 NonPontificis]
 @Commune/C3:Lectio1
 
-[Lectio2NonPontificis]
+[Lectio2 NonPontificis]
 @Commune/C3:Lectio2
 
-[Lectio3NonPontificis]
+[Lectio3 NonPontificis]
 @Commune/C3:Lectio3
 
-[Lectio4NonPontificis]
+[Lectio4 NonPontificis]
 @Commune/C3:Lectio4
 
 [Responsory4]
@@ -148,32 +148,33 @@ _
 [Ant Vespera 3]
 @Commune/C2::s/112/115/ s/111/112/ s/110/111/
 
-[Lectio51]
+[Lectio5 in 2 loco]
+De Expositióne sancti Ambrósii Epíscopi in Psalmum centésimum décimum octávum!Sermo 21, n. 7 et 8
 Príncipes persecúti sunt me gratis: et a verbis tuis trepidávit cor meum. Bene hoc Martyr dicit, quod injúste persecutiónum torménta sustineat; qui nihil rapúerit, nullum violentus oppresserit, nullius sánguinem fuderit, nullius torum putaverit esse violándum; qui nihil légibus debeat, et gravióra latronum sustinere cogátur supplícia; qui loquátur juste, et non audiátur; qui loquátur plena salútis, et impugnétur, ut possit dicere: Cum loquébar illis, impugnábant me gratis.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 Gratis ígitur persecutiónem pátitur, qui impugnátur sine crimine; impugnátur ut noxius cum sit in tali confessióne laudábilis; impugnátur quasi veneficus, qui in nómine Dómini gloriátur, cum pietas virtútum ómnium fundaméntum sit. Vere frustra impugnátur, qui apud ímpios et infidos impietátis arcessitur, cum fidei sit magister.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Verum, qui gratis impugnátur, fortis debet esse et constans; quómodo ergo subtexuit: Et a verbis tuis trepidávit cor meum? Trepidare infirmitátis est, timoris atque formidinis. Sed est étiam infirmitas ad salútem, est étiam timor sanctórum: Timéte Dóminum, omnes sancti ejus; et, Beátus vir, qui timet Dóminum. Qua ratióne beatus? Quia in mandatis ejus cupit nimis.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Pone ergo Mártyrem inter perícula constitútum, cum inde immánitas bestiárum ad incutiéndum terrórem ínfremat, aliúnde stridor candéntium laminárum et flamma fornácis ardéntis exæstuet; ex parte ália pérsonent tractus grávium catenárum, hinc cárnifex cruéntus assístat: Pone, inquam, circumspectántem ómnia plena supplíciis, deínde cogitántem mandáta divína, illum ignem perpétuum, illud sine fine incéndium perfidórum, illam pœnæ recrudescéntis ærúmnam; trepidáre corde, ne, dum præséntibus cedat, perpétuis se dedat exítiis; perturbári ánimo, dum futúri judícii rhomphæam illam terríbilem quadam conspéctus spécie contuétur. Nonne ad hanc trepidatiónem fidúciæ viri constántis, æquális in eúmdem concúrrit efféctum confidéntia cupiéntis ætérna, et divína trepidántis?
 
-[Lectio91]
+[Lectio9 in 2 loco]
 @Commune/C2:Lectio73:s/Nam .*//s
 
-[Lectio101]
+[Lectio10 in 2 loco]
 @Commune/C2:Lectio73:s/.* Nam /Nam /s s/$/~/
 @Commune/C2:Lectio83:s/Quid vero .*//s
 
-[Lectio111]
+[Lectio11 in 2 loco]
 @Commune/C2:Lectio83:s/.* Quid vero /Quid vero /s
 
-[Lectio121]
+[Lectio12 in 2 loco]
 @Commune/C2:Lectio93:s/\&teDeum .*//s
 
-[LectioE1]
+[LectioE in 2 loco]
 Sequéntia ++ sancti Evangélii secúndum Matthǽum!Matt 16:24-27
 In illo témpore: Dixit Jesus discípulis suis:
 16:24 Si quis vult post me veníre, ábneget semetípsum, et tollat crucem suam, et sequátur me.
@@ -182,20 +183,20 @@ In illo témpore: Dixit Jesus discípulis suis:
 16:27 Fílius enim hóminis ventúrus est in glória Patris sui cum Angelis suis: et tunc reddet unicuíque secúndum ópera ejus.
 $Te decet
 
-[Lectio92]
+[Lectio9 in 3 loco]
 @Sancti/09-28:Lectio7:s/Ubíque .*//s
 
-[Lectio102]
+[Lectio10 in 3 loco]
 @Sancti/09-28:Lectio7:s/.* Ubíque /Ubíque /s s/$/~/
 @Sancti/09-28:Lectio8:s/Dei ígitur .*//s
 
-[Lectio112]
+[Lectio11 in 3 loco]
 @Sancti/09-28:Lectio8:s/.* Dei ígitur /Dei ígitur /s
 
-[Lectio122]
+[Lectio12 in 3 loco]
 @Sancti/09-28:Lectio9:s/\&teDeum .*//s
 
-[LectioE2]
+[LectioE in 3 loco]
 Sequéntia ++ sancti Evangélii secúndum Matthǽum!Matt 10:34-42
 In illo témpore: Dixit Jesus discípulis suis:
 10:34 Nolíte arbitrári, quia pacem vénerim míttere in terram: non veni pacem míttere, sed gládium. 
@@ -209,19 +210,19 @@ In illo témpore: Dixit Jesus discípulis suis:
 10:42 Et quicúmque potum déderit uni ex mínimis istis cálicem aquæ frígidæ tantum in nómine discípuli: amen, dico vobis, non perdet mercédem suam.
 $Te decet
 
-[Lectio93]
+[Lectio9 in 4 loco]
 @Commune/C2:Lectio72:s/Et quod .*//s
 
-[Lectio103]
+[Lectio10 in 4 loco]
 @Commune/C2:Lectio72:s/.* Et quod /Et quod /s
 
-[Lectio113]
+[Lectio11 in 4 loco]
 @Commune/C2:Lectio82
 
-[Lectio123]
+[Lectio12 in 4 loco]
 @Commune/C2:Lectio92:s/\&teDeum .*//s
 
-[LectioE3]
+[LectioE in 4 loco]
 Sequéntia ++ sancti Evangélii secúndum Matthǽum!Matt 10:26-32
 In illo témpore: Dixit Jesus discípulis suis: 
 10:26 Nihil est opértum, quod non revelábitur; et occúltum, quod non sciétur. 

--- a/web/www/horas/Latin/CommuneM/C2.txt
+++ b/web/www/horas/Latin/CommuneM/C2.txt
@@ -40,16 +40,16 @@ R. Glóriam et magnum decórem impónes super eum.
 [Lectio4]
 @Commune/C2:Lectio3:s/32-/33-/ s/32 .*33 /33 /s
 
-[Lectio1 NonPontificis]
+[Lectio1 non Pontificis]
 @Commune/C3:Lectio1
 
-[Lectio2 NonPontificis]
+[Lectio2 non Pontificis]
 @Commune/C3:Lectio2
 
-[Lectio3 NonPontificis]
+[Lectio3 non Pontificis]
 @Commune/C3:Lectio3
 
-[Lectio4 NonPontificis]
+[Lectio4 non Pontificis]
 @Commune/C3:Lectio4
 
 [Responsory4]
@@ -94,8 +94,8 @@ R. Vitam petiit a te, et tribuísti ei in sæculum sæculi.
 [Responsory10]
 @Commune/C2:Responsory8
 
-[Responsory10NonEffusorum]
-@Commune/C2:Responsory8NonEffusorum
+[Responsory10 non Effusorum]
+@Commune/C2:Responsory8 non Effusorum
 
 [Lectio11]
 @Commune/C3:Lectio8
@@ -118,15 +118,14 @@ R. Quam repromísit Deus diligéntibus se.
 v. Sequéntia sancti Evangélii secúndum Lucam
 !Luc 14:26-33
 In illo témpore: Dixit Jesus turbis: 
-14:26 Si quis venit ad me, et non odit patrem suum, et matrem, et uxórem, et fílios, et fratres, et soróres, adhuc autem et ánimam suam, non potest meus esse discípulus.
-14:27 Et qui non báiulat crucem suam, et venit post me, non potest meus esse discípulus.
-14:28 Quis enim ex vobis volens turrim ædificáre, non prius sedens cómputat sumptus, qui necessárii sunt, si hábeat ad perficiéndum,
-14:29 ne, posteáquam posúerit fundaméntum, et non potúerit perfícere, omnes qui vident, incípiant illúdere ei,
-14:30 dicéntes: Quia hic homo cœpit ædificáre, et non pótuit consummáre?
-14:31 Aut quis rex itúrus commíttere bellum advérsus álium regem, non sedens prius cógitat, si possit cum decem míllibus occúrrere ei, qui cum vigínti míllibus venit ad se?
-14:32 Alióquin adhuc illo longe agénte, legatiónem mittens rogat ea quæ pacis sunt.
-14:33 Sic ergo omnis ex vobis, qui non renúntiat ómnibus quæ póssidet, non potest meus esse discípulus.
-$Te decet
+Si quis venit ad me, et non odit patrem suum, et matrem, et uxórem, et fílios, et fratres, et soróres, adhuc autem et ánimam suam, non potest meus esse discípulus.
+Et qui non báiulat crucem suam, et venit post me, non potest meus esse discípulus.
+Quis enim ex vobis volens turrim ædificáre, non prius sedens cómputat sumptus, qui necessárii sunt, si hábeat ad perficiéndum,
+ne, posteáquam posúerit fundaméntum, et non potúerit perfícere, omnes qui vident, incípiant illúdere ei,
+dicéntes: Quia hic homo cœpit ædificáre, et non pótuit consummáre?
+Aut quis rex itúrus commíttere bellum advérsus álium regem, non sedens prius cógitat, si possit cum decem míllibus occúrrere ei, qui cum vigínti míllibus venit ad se?
+Alióquin adhuc illo longe agénte, legatiónem mittens rogat ea quæ pacis sunt.
+Sic ergo omnis ex vobis, qui non renúntiat ómnibus quæ póssidet, non potest meus esse discípulus.
 
 [Capitulum Laudes]
 @Commune/C2
@@ -162,26 +161,25 @@ Verum, qui gratis impugnátur, fortis debet esse et constans; quómodo ergo subt
 Pone ergo Mártyrem inter perícula constitútum, cum inde immánitas bestiárum ad incutiéndum terrórem ínfremat, aliúnde stridor candéntium laminárum et flamma fornácis ardéntis exæstuet; ex parte ália pérsonent tractus grávium catenárum, hinc cárnifex cruéntus assístat: Pone, inquam, circumspectántem ómnia plena supplíciis, deínde cogitántem mandáta divína, illum ignem perpétuum, illud sine fine incéndium perfidórum, illam pœnæ recrudescéntis ærúmnam; trepidáre corde, ne, dum præséntibus cedat, perpétuis se dedat exítiis; perturbári ánimo, dum futúri judícii rhomphæam illam terríbilem quadam conspéctus spécie contuétur. Nonne ad hanc trepidatiónem fidúciæ viri constántis, æquális in eúmdem concúrrit efféctum confidéntia cupiéntis ætérna, et divína trepidántis?
 
 [Lectio9 in 2 loco]
-@Commune/C2:Lectio73:s/Nam .*//s
+@Commune/C2:Lectio7 in 4 loco:s/Nam .*//s
 
 [Lectio10 in 2 loco]
-@Commune/C2:Lectio73:s/.* Nam /Nam /s s/$/~/
-@Commune/C2:Lectio83:s/Quid vero .*//s
+@Commune/C2:Lectio7 in 4 loco:s/.* Nam /Nam /s s/$/~/
+@Commune/C2:Lectio8 in 4 loco:s/Quid vero .*//s
 
 [Lectio11 in 2 loco]
-@Commune/C2:Lectio83:s/.* Quid vero /Quid vero /s
+@Commune/C2:Lectio8 in 4 loco:s/.* Quid vero /Quid vero /s
 
 [Lectio12 in 2 loco]
-@Commune/C2:Lectio93:s/\&teDeum .*//s
+@Commune/C2:Lectio9 in 4 loco:s/\&teDeum .*//s
 
 [LectioE in 2 loco]
 Sequéntia ++ sancti Evangélii secúndum Matthǽum!Matt 16:24-27
 In illo témpore: Dixit Jesus discípulis suis:
-16:24 Si quis vult post me veníre, ábneget semetípsum, et tollat crucem suam, et sequátur me.
-16:25 Qui enim volúerit ánimam suam salvam fácere, perdet eam: qui autem perdíderit ánimam suam propter me, invéniet eam.
-16:26 Quid enim prodest hómini, si mundum univérsum lucrétur, ánimæ vero suæ detriméntum patiátur? Aut quam dabit homo commutatiónem pro ánima sua?
-16:27 Fílius enim hóminis ventúrus est in glória Patris sui cum Angelis suis: et tunc reddet unicuíque secúndum ópera ejus.
-$Te decet
+Si quis vult post me veníre, ábneget semetípsum, et tollat crucem suam, et sequátur me.
+Qui enim volúerit ánimam suam salvam fácere, perdet eam: qui autem perdíderit ánimam suam propter me, invéniet eam.
+Quid enim prodest hómini, si mundum univérsum lucrétur, ánimæ vero suæ detriméntum patiátur? Aut quam dabit homo commutatiónem pro ánima sua?
+Fílius enim hóminis ventúrus est in glória Patris sui cum Angelis suis: et tunc reddet unicuíque secúndum ópera ejus.
 
 [Lectio9 in 3 loco]
 @Sancti/09-28:Lectio7:s/Ubíque .*//s
@@ -199,37 +197,35 @@ $Te decet
 [LectioE in 3 loco]
 Sequéntia ++ sancti Evangélii secúndum Matthǽum!Matt 10:34-42
 In illo témpore: Dixit Jesus discípulis suis:
-10:34 Nolíte arbitrári, quia pacem vénerim míttere in terram: non veni pacem míttere, sed gládium. 
-10:35 Veni enim separáre hóminem advérsus patrem suum, et fíliam advérsus matrem suam, et nurum advérsus socrum suam: 
-10:36 et inimíci hóminis doméstici ejus. 
-10:37 Qui amat patrem aut matrem plus quam me, non est me dignus: et qui amat fílium aut fíliam super me, non est me dignus. 
-10:38 Et qui non áccipit crucem suam, et séquitur me, non est me dignus. 
-10:39 Qui invénit ánimam suam, perdet illam: et qui perdíderit ánimam suam propter me, invéniet eam. 
-10:40 Qui récipit vos, me récipit: et qui me récipit, récipit eum, qui me misit. 
-10:41 Qui récipit prophétam in nómine prophétæ, mercédem prophétæ accípiet: et qui récipit justum in nómine justi, mercédem justi accípiet. 
-10:42 Et quicúmque potum déderit uni ex mínimis istis cálicem aquæ frígidæ tantum in nómine discípuli: amen, dico vobis, non perdet mercédem suam.
-$Te decet
+Nolíte arbitrári, quia pacem vénerim míttere in terram: non veni pacem míttere, sed gládium. 
+Veni enim separáre hóminem advérsus patrem suum, et fíliam advérsus matrem suam, et nurum advérsus socrum suam: 
+et inimíci hóminis doméstici ejus. 
+Qui amat patrem aut matrem plus quam me, non est me dignus: et qui amat fílium aut fíliam super me, non est me dignus. 
+Et qui non áccipit crucem suam, et séquitur me, non est me dignus. 
+Qui invénit ánimam suam, perdet illam: et qui perdíderit ánimam suam propter me, invéniet eam. 
+Qui récipit vos, me récipit: et qui me récipit, récipit eum, qui me misit. 
+Qui récipit prophétam in nómine prophétæ, mercédem prophétæ accípiet: et qui récipit justum in nómine justi, mercédem justi accípiet. 
+Et quicúmque potum déderit uni ex mínimis istis cálicem aquæ frígidæ tantum in nómine discípuli: amen, dico vobis, non perdet mercédem suam.
 
 [Lectio9 in 4 loco]
-@Commune/C2:Lectio72:s/Et quod .*//s
+@Commune/C2:Lectio7 in 3 loco:s/Et quod .*//s
 
 [Lectio10 in 4 loco]
-@Commune/C2:Lectio72:s/.* Et quod /Et quod /s
+@Commune/C2:Lectio7 in 3 loco:s/.* Et quod /Et quod /s
 
 [Lectio11 in 4 loco]
-@Commune/C2:Lectio82
+@Commune/C2:Lectio8 in 3 loco
 
 [Lectio12 in 4 loco]
-@Commune/C2:Lectio92:s/\&teDeum .*//s
+@Commune/C2:Lectio9 in 3 loco:s/\&teDeum .*//s
 
 [LectioE in 4 loco]
 Sequéntia ++ sancti Evangélii secúndum Matthǽum!Matt 10:26-32
 In illo témpore: Dixit Jesus discípulis suis: 
-10:26 Nihil est opértum, quod non revelábitur; et occúltum, quod non sciétur. 
-10:27 Quod dico vobis in ténebris, dícite in lúmine: et quod in aure audítis, prædicáte super tecta. 
-10:28 Et nolíte timére eos, qui occídunt corpus, ánimam autem non possunt occídere; sed pótius timéte eum, qui potest et ánimam et corpus pérdere in gehénnam. 
-10:29 Nonne duo pásseres asse véneunt: et unus ex illis non cadet super terram sine Patre vestro? 
-10:30 Vestri autem capílli cápitis omnes numerári sunt. 
-10:31 Nolíte ergo timére: multis passéribus melióres estis vos. 
-10:32 Omnis ergo, qui confitébitur me coram homínibus, confitébor et ego eum coram Patre meo, qui in coelis est.
-$Te decet
+Nihil est opértum, quod non revelábitur; et occúltum, quod non sciétur. 
+Quod dico vobis in ténebris, dícite in lúmine: et quod in aure audítis, prædicáte super tecta. 
+Et nolíte timére eos, qui occídunt corpus, ánimam autem non possunt occídere; sed pótius timéte eum, qui potest et ánimam et corpus pérdere in gehénnam. 
+Nonne duo pásseres asse véneunt: et unus ex illis non cadet super terram sine Patre vestro? 
+Vestri autem capílli cápitis omnes numerári sunt. 
+Nolíte ergo timére: multis passéribus melióres estis vos. 
+Omnis ergo, qui confitébitur me coram homínibus, confitébor et ego eum coram Patre meo, qui in coelis est.

--- a/web/www/horas/Latin/CommuneM/C2p.txt
+++ b/web/www/horas/Latin/CommuneM/C2p.txt
@@ -1,4 +1,4 @@
-@Commune/C1p
+@CommuneM/C2
 
 [Name]
 Commune unius Martyris Tempore Paschali
@@ -8,19 +8,19 @@ Psalmi Dominica
 Antiphonas horas
 
 [Ant Vespera]
-@Commune/C1p::s/112/115/
+@Commune/C1p
 
 [Capitulum Vespera]
 @CommuneM/C1p
 
-[Hymnus Vespera]
-@CommuneM/C2
+[Versum 1]
+@Commune/C1p
+
+[Ant 1]
+@Commune/C1p
 
 [Invit]
 @Commune/C2p
-
-[Hymnus Matutinum]
-@CommuneM/C2
 
 [Ant Matutinum]
 Stabunt justi * in magna constántia advérsus eos qui se angustiavérunt, allelúja.;;1
@@ -44,58 +44,151 @@ V. Lætítia sempitérna super cápita eórum, allelúja.
 R. Gáudium et exsultatiónem obtinébunt, allelúja.
 
 [Lectio1]
-@Commune/C2
+De libro Sapiéntiæ
+!Sap 5:1-4
+1 Stabunt justi in magna constántia advérsus eos qui se angustiavérunt, et qui abstulérunt labóres eórum.
+2 Vidéntes turbabúntur timóre horríbili, et mirabúntur in subitatióne insperátæ salútis:
+3 dicéntes intra se, pœniténtiam agéntes, et præ angústia spíritus geméntes: Hi sunt quos habúimus aliquándo in derísum, et in similitúdinem impropérii.
+4 Nos insensáti, vitam illórum æstimabámus insániam, et finem illórum sine honóre.
+
+[Responsory1]
+@Commune/C1p:Responsory1
 
 [Lectio2]
-@Commune/C2
+!Sap 5:5-7;14
+5 Ecce quómodo computáti sunt inter fílios Dei, et inter sanctos sors illórum est.
+6 Ergo errávimus a via veritátis, et justítiæ lumen non luxit nobis, et sol intelligéntiæ non est ortus nobis.
+7 Lassáti sumus in via iniquitátis et perditiónis, et ambulávimus vias diffíciles: viam autem Dómini ignorávimus.
+14 Tália dixérunt in inférno hi qui peccavérunt.
 
-[Lectio3]
-@Commune/C2
-
-[Lectio4]
-@Commune/C2p
-
-[Lectio5]
-@Commune/C2p
-
-[Responsory5]
-@Commune/C2:Responsory51
-
-[Lectio6]
-@Commune/C2p
-
-[Responsory6]
-@Commune/C2:Responsory61
-
-[Lectio7]
-@Commune/C2p
-
-[Responsory7]
-@Commune/C1p
-
-[Responsory7c]
+[Responsory2]
 @Commune/C1p:Responsory2
 
+[Lectio3]
+!Sap 5:16-17
+16 Justi autem in perpétuum vivent, et apud Dóminum est merces eórum, et cogitátio illórum apud Altíssimum.
+17 Ideo accípient regnum decóris, et diadéma speciéi de manu Dómini: quóniam déxtera sua teget eos, et bráchio sancto suo deféndet illos.
+
+
+[Responsory3]
+@Commune/C1p:Responsory3
+
+[Lectio4]
+!Sap 5:18-21
+18 Accípiet armatúram zelus illíus, et armábit creatúram ad ultiónem inimicórum.
+19 Induet pro thoráce justítiam, et accípiet pro gálea judícium certum:
+20 sumet scutum inexpugnábile æquitátem.
+21 Acuet autem duram iram in lánceam, et pugnábit cum illo orbis terrárum contra insensátos.
+
+[Responsory4]
+R. De ore prudéntis procédit mel, allelúja: dulcédo mellis est sub lingua ejus, allelúja:
+* Favus distíllans lábia ejus, allelúja, allelúja.
+V. Sapiéntia requiéscit in corde ejus, et prudéntia in sermóne oris illíus.
+R. Favus distíllans lábia ejus, allelúja, allelúja.
+
+[Lectio5]
+@Commune/C2p:Lectio4
+
+[Responsory5]
+@CommuneM/C1p
+
+[Lectio6]
+@Commune/C2p:Lectio5:s/Eadem .*//s
+
+[Responsory6]
+@Commune/C2p:Responsory51
+
+[Lectio7]
+@Commune/C2p:Lectio5:s/.* Eadem /Eadem /s
+
+[Responsory7]
+@Commune/C2p:Responsory61
+
 [Lectio8]
-@Commune/C2p
+@Commune/C2p:Lectio6
 
 [Responsory8]
-@Commune/C1p
+R. Lætábitur justus in Dómino, et sperábit in eo, et laudabúntur
+* Omnes recti corde, allelúja, allelúja.
+V. Lætamini in Dómino et exsultáte, justi, et gloriámini.
+R. Omnes recti corde, allelúja, allelúja.	
 
 [Lectio9]
-@Commune/C2p
+@Sancti/10-27:Lectio1
+
+[Responsory9]
+@Commune/C2:Responsory71
+
+[Lectio10]
+@Sancti/10-27:Lectio2:s/Sed cum .*//s
+
+[Responsory10]
+@Commune/C2:Responsory81
+
+[Lectio11]
+@Sancti/10-27:Lectio2:s/.* Sed cum /Sed cum /s s/$/~/
+@Sancti/10-27:Lectio3:s/Numquid .*//s
+
+[Responsory11]
+R. Fulgébunt justi sicut lílium:
+* Et sicut rosæ in Jéricho florébunt ante Dóminum, allelúja.
+V. Justi autem in perpétuum vivent, et apud Dóminum est merces eórum.
+R. Et sicut rosæ in Jéricho florébunt ante Dóminum, allelúja.
+
+[Lectio12]
+@Sancti/10-27:Lectio3:s/.* Numquid /Numquid /s
+
+[Responsory12]
+R. Gáudete, justi, in Dómino, allelúja:
+* Rectos decet collaudátio, allelúja, allelúja.
+V. Cantáte ei cánticum novum: bene psállite ei in vociferatióne.
+R. Rectos decet collaudátio, allelúja, allelúja.
+
+[LectioE]
+v. Sequéntia sancti Evangélii secúndum Joánnem
+!Joannes 15:1-7
+In illo témpore: Dixit Jesus discípulis suis: 
+15:1 Ego sum vitis vera, et Pater meus agrícola est.
+15:2 Omnem pálmitem in me non feréntem fructum, tollet eum, et omnem qui fert fructum, purgábit eum, ut fructum plus áfferat.
+15:3 Jam vos mundi estis propter sermónem quem locútus sum vobis.
+15:4 Manéte in me, et ego in vobis. Sicut palmes non potest ferre fructum a semetípso, nisi mánserit in vite, sic nec vos, nisi in me manséritis.
+15:5 Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum, quia sine me nihil potéstis fácere.
+15:6 Si quis in me non mánserit, mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet.
+15:7 Si manséritis in me, et verba mea in vobis mánserint, quodcúmque voluéritis petétis, et fiet vobis.
+$Te decet
+
+[Ant Laudes]
+@Commune/C1p
 
 [Capitulum Laudes]
 @CommuneM/C1p
 
 [HymnusM Laudes]
-@CommuneM/C2:Hymnus Laudes
+@Commune/C2:HymnusM Laudes
+
+[Versum2]
+@Commune/C1p
+
+[Ant2]
+@Commune/C1p
+
+[Lectio Prima]
+@Commune/C1p
+
+[Capitulum Tertia]
+@Commune/C1p
 
 [Responsory Tertia]
-@Commune/C1p:Versum 1
+@:Versum 1
+
+[Capitulum Sexta]
+@Commune/C1p
 
 [Responsory Sexta]
 @Commune/C1p:Responsory Tertia:8-9
+
+[Capitulum Nona]
+@Commune/C1p
 
 [Responsory Nona]
 @Commune/C1p:Responsory Sexta:8-9
@@ -106,14 +199,42 @@ R. Gáudium et exsultatiónem obtinébunt, allelúja.
 [Ant Vespera 3]
 @Commune/C1p::s/112/111/ s/115/112/ s/125/115/
 
-[LectioE]
-v. Sequéntia sancti Evangélii secúndum Joánnem
-!Joannes 15:1-7
-15:1 Ego sum vitis vera, et Pater meus agrícola est.
-15:2 Omnem pálmitem in me non feréntem fructum, tollet eum, et omnem qui fert fructum, purgábit eum, ut fructum plus áfferat.
-15:3 Jam vos mundi estis propter sermónem quem locútus sum vobis.
-15:4 Manéte in me, et ego in vobis. Sicut palmes non potest ferre fructum a semetípso, nisi mánserit in vite, sic nec vos, nisi in me manséritis.
+[Ant 3]
+@Commune/C1p
+
+[Lectio 5 in 2 loco]
+@Commune/C2p:Lectio41
+
+[Lectio 6 in 2 loco]
+@Commune/C2p:Lectio51:s/Inexpugnábilem .*//s
+
+[Lectio 7 in 2 loco]
+@Commune/C2p:Lectio51:s/.* Inexpugnábilem /Inexpugnábilem /s s/$/~/
+@Commune/C2p:Lectio61:s/Pretiósa est .*//s
+
+[Lectio 8 in 2 loco]
+@Commune/C2p:Lectio61:s/.* Pretiósa est /Pretiósa est /s
+
+[Lectio 9 in 2 loco]
+@Commune/C2:Lectio71:s/Quamvis .*//s
+
+[Lectio 10 in 2 loco]
+@Commune/C2:Lectio71:s/.* Quamvis /Quamvis /s s/$/~/
+@Commune/C2:Lectio81:s/Ligna .*//s
+
+[Lectio 11 in 2 loco]
+@Commune/C2:Lectio81:s/.* Ligna /Ligna /s
+
+[Lectio 12 in 2 loco]
+@Commune/C2:Lectio91
+
+[LectioE in 2 loco]
+v. Sequéntia ++ sancti Evangélii secúndum Joánnem!Joannes 5:5-11
+In illo témpore: Dixit Jesus discípulis suis: 
 15:5 Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum, quia sine me nihil potéstis fácere.
 15:6 Si quis in me non mánserit, mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet.
 15:7 Si manséritis in me, et verba mea in vobis mánserint, quodcúmque voluéritis petétis, et fiet vobis.
-$Te decet
+15:8 In hoc clarificátus est Pater meus, ut fructum plúrimum afferátis, et efficiámini mei discípuli.
+15:9 Sicut diléxit me Pater, et ego diléxi vos. Manéte in dilectióne mea.
+15:10 Si præcépta mea servavéritis, manébitis in dilectióne mea, sicut et ego Patris mei præcépta servávi, et máneo in eius dilectióne.
+15:11 Hæc locútus sum vobis: ut gáudium meum in vobis sit, et gáudium vestrum impleátur.

--- a/web/www/horas/Latin/CommuneM/C2p.txt
+++ b/web/www/horas/Latin/CommuneM/C2p.txt
@@ -96,13 +96,13 @@ R. Favus distíllans lábia ejus, allelúja, allelúja.
 @Commune/C2p:Lectio5:s/Eadem .*//s
 
 [Responsory6]
-@Commune/C2p:Responsory51
+@Commune/C2p:Responsory5 in 2 loco
 
 [Lectio7]
 @Commune/C2p:Lectio5:s/.* Eadem /Eadem /s
 
 [Responsory7]
-@Commune/C2p:Responsory61
+@Commune/C2p:Responsory6 in 2 loco
 
 [Lectio8]
 @Commune/C2p:Lectio6
@@ -117,13 +117,13 @@ R. Omnes recti corde, allelúja, allelúja.
 @Sancti/10-27:Lectio1
 
 [Responsory9]
-@Commune/C2:Responsory71
+@Commune/C2:Responsory7 in 2 loco
 
 [Lectio10]
 @Sancti/10-27:Lectio2:s/Sed cum .*//s
 
 [Responsory10]
-@Commune/C2:Responsory81
+@Commune/C2:Responsory8 in 2 loco
 
 [Lectio11]
 @Sancti/10-27:Lectio2:s/.* Sed cum /Sed cum /s s/$/~/
@@ -148,14 +148,13 @@ R. Rectos decet collaudátio, allelúja, allelúja.
 v. Sequéntia sancti Evangélii secúndum Joánnem
 !Joannes 15:1-7
 In illo témpore: Dixit Jesus discípulis suis: 
-15:1 Ego sum vitis vera, et Pater meus agrícola est.
-15:2 Omnem pálmitem in me non feréntem fructum, tollet eum, et omnem qui fert fructum, purgábit eum, ut fructum plus áfferat.
-15:3 Jam vos mundi estis propter sermónem quem locútus sum vobis.
-15:4 Manéte in me, et ego in vobis. Sicut palmes non potest ferre fructum a semetípso, nisi mánserit in vite, sic nec vos, nisi in me manséritis.
-15:5 Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum, quia sine me nihil potéstis fácere.
-15:6 Si quis in me non mánserit, mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet.
-15:7 Si manséritis in me, et verba mea in vobis mánserint, quodcúmque voluéritis petétis, et fiet vobis.
-$Te decet
+Ego sum vitis vera, et Pater meus agrícola est.
+Omnem pálmitem in me non feréntem fructum, tollet eum, et omnem qui fert fructum, purgábit eum, ut fructum plus áfferat.
+Jam vos mundi estis propter sermónem quem locútus sum vobis.
+Manéte in me, et ego in vobis. Sicut palmes non potest ferre fructum a semetípso, nisi mánserit in vite, sic nec vos, nisi in me manséritis.
+Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum, quia sine me nihil potéstis fácere.
+Si quis in me non mánserit, mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet.
+Si manséritis in me, et verba mea in vobis mánserint, quodcúmque voluéritis petétis, et fiet vobis.
 
 [Ant Laudes]
 @Commune/C1p
@@ -203,38 +202,38 @@ $Te decet
 @Commune/C1p
 
 [Lectio 5 in 2 loco]
-@Commune/C2p:Lectio41
+@Commune/C2p:Lectio4 in 2 loco
 
 [Lectio 6 in 2 loco]
-@Commune/C2p:Lectio51:s/Inexpugnábilem .*//s
+@Commune/C2p:Lectio5 in 2 loco:s/Inexpugnábilem .*//s
 
 [Lectio 7 in 2 loco]
-@Commune/C2p:Lectio51:s/.* Inexpugnábilem /Inexpugnábilem /s s/$/~/
-@Commune/C2p:Lectio61:s/Pretiósa est .*//s
+@Commune/C2p:Lectio5 in 2 loco:s/.* Inexpugnábilem /Inexpugnábilem /s s/$/~/
+@Commune/C2p:Lectio6 in 2 loco:s/Pretiósa est .*//s
 
 [Lectio 8 in 2 loco]
-@Commune/C2p:Lectio61:s/.* Pretiósa est /Pretiósa est /s
+@Commune/C2p:Lectio6 in 2 loco:s/.* Pretiósa est /Pretiósa est /s
 
 [Lectio 9 in 2 loco]
-@Commune/C2:Lectio71:s/Quamvis .*//s
+@Commune/C2:Lectio7 in 2 loco:s/Quamvis .*//s
 
 [Lectio 10 in 2 loco]
-@Commune/C2:Lectio71:s/.* Quamvis /Quamvis /s s/$/~/
-@Commune/C2:Lectio81:s/Ligna .*//s
+@Commune/C2:Lectio7 in 2 loco:s/.* Quamvis /Quamvis /s s/$/~/
+@Commune/C2:Lectio8 in 2 loco:s/Ligna .*//s
 
 [Lectio 11 in 2 loco]
-@Commune/C2:Lectio81:s/.* Ligna /Ligna /s
+@Commune/C2:Lectio8 in 2 loco:s/.* Ligna /Ligna /s
 
 [Lectio 12 in 2 loco]
-@Commune/C2:Lectio91
+@Commune/C2:Lectio9 in 2 loco
 
 [LectioE in 2 loco]
 v. Sequéntia ++ sancti Evangélii secúndum Joánnem!Joannes 5:5-11
 In illo témpore: Dixit Jesus discípulis suis: 
-15:5 Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum, quia sine me nihil potéstis fácere.
-15:6 Si quis in me non mánserit, mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet.
-15:7 Si manséritis in me, et verba mea in vobis mánserint, quodcúmque voluéritis petétis, et fiet vobis.
-15:8 In hoc clarificátus est Pater meus, ut fructum plúrimum afferátis, et efficiámini mei discípuli.
-15:9 Sicut diléxit me Pater, et ego diléxi vos. Manéte in dilectióne mea.
-15:10 Si præcépta mea servavéritis, manébitis in dilectióne mea, sicut et ego Patris mei præcépta servávi, et máneo in eius dilectióne.
-15:11 Hæc locútus sum vobis: ut gáudium meum in vobis sit, et gáudium vestrum impleátur.
+Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum, quia sine me nihil potéstis fácere.
+Si quis in me non mánserit, mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet.
+Si manséritis in me, et verba mea in vobis mánserint, quodcúmque voluéritis petétis, et fiet vobis.
+In hoc clarificátus est Pater meus, ut fructum plúrimum afferátis, et efficiámini mei discípuli.
+Sicut diléxit me Pater, et ego diléxi vos. Manéte in dilectióne mea.
+Si præcépta mea servavéritis, manébitis in dilectióne mea, sicut et ego Patris mei præcépta servávi, et máneo in eius dilectióne.
+Hæc locútus sum vobis: ut gáudium meum in vobis sit, et gáudium vestrum impleátur.

--- a/web/www/horas/Latin/CommuneM/C3.txt
+++ b/web/www/horas/Latin/CommuneM/C3.txt
@@ -133,33 +133,33 @@ _
 @Commune/C3::s/112/115/ s/111/112/ s/110/111/
 
 
-[Lectio51]
+[Lectio5 in 2 loco]
 Sermo sancti Joánnis Chrysóstomi
 !Sermo 1 de Martyribus, tom. 3.
 Nemo est, qui nesciat, Mártyrum glorias ad hoc divino consílio a Dei pópulis frequentári, ut et illis débitus honor dicétur, et nobis virtútis exémpla, favénte Christo, monstréntur; ut, dum hæc ita celebrári perspícimus, cognoscámus quanta eos glória máneat in cælis, quorum natalítia táliter celebrántur in terris; quo possímus, étiam ipsi, tálibus provocári exémplis, virtúte pari, devotióne consímili ac fide; ut, Christo præstánte, dimicáre et víncere hostem possímus, ut, parta victória, cum iísdem Sanctis in regnis cæléstibus triumphémus.
 
-[Lectio61]
+[Lectio6 in 2 loco]
 Quis est enim, qui eórum volens mérito copulári, nisi prius constántiam eórum téneat, sectétur fidem, imitétur virtútem passiónis; eórum glóriam páribus vitæ lineaméntis aut invéniat aut exquírat? Qui, etsi martýrio par esse non possit, tamen múneris tanti dignitáte se quisque bonis áctibus dignum præbeat. Adest enim clementíssimus Deus, qui desiderántibus suis aut martýrium præbeat, aut, sine martýrio, cum Sanctis præmia divína retríbuat.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Ut enim infirmátur peccátor advérsis, ita justus tentatiónibus roborátur. Sic dimicárunt advérsus peccátum Sancti; sic, et laborándo fortióres, et moriéndo victóres effécti sunt. Nullus athlétes sine certámine fórtior dici, nullus sine victória póterit coronári. Nemo miles sine prœlio hostem subjécit; nemo sine bello imperatórem proméruit.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Habes, christiáne, competéntia arma, quibus hostem expúgnes; habes fortíssima tela, quibus inimícum debelles. His te jamdúdum Dóminus per grátiam ímbuit, et póstmodum Apóstolus Paulus armávit. Hæc sunt arma, quibus dimicárunt Sancti, quorum virtútes díligis et victórias admiráris. Imitáre, christiáne, quos díligis Sanctos; et quorum virtútes frequéntas, eórum vitam et institúta sectáre. Esto talis de eórum exémplo; quia et hi de superiórum tales effécti sunt. Nec enim virtus ab eo póterit imitári cujúsquam, qui ejus vitam non fúerit imitátus.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 @Commune/C3:Lectio71:s/Hinc .*//s
 
-[Lectio101]
+[Lectio10 in 2 loco]
 @Commune/C3:Lectio71:s/.* Hinc /Hinc /s
 
-[Lectio111]
+[Lectio11 in 2 loco]
 @Commune/C3:Lectio81
 
-[Lectio121]
+[Lectio12 in 2 loco]
 @Commune/C3:Lectio91:s/\&teDeum .*//s
 
-[LectioE1]
+[LectioE in 2 loco]
 v. Sequéntia ++ sancti Evangélii secúndum Lucam
 !Luc 6:17-23
 In illo témpore:
@@ -170,3 +170,87 @@ In illo témpore:
 6:21 Beáti, qui nunc esurítis: quia saturabímini. Beáti, qui nunc fletis: quia ridébitis.
 6:22 Beáti éritis cum vos óderint hómines, et cum separáverint vos, et exprobráverint, et ejécerint nomen vestrum tamquam malum propter Fílium hóminis.
 6:23 Gaudéte in illa die, et exsultáte: ecce enim merces vestra multa est in cœlo.
+
+[Lectio9 in 3 loco]
+@Sancti/06-26:Lectio7
+
+[Lectio10 in 3 loco]
+@Sancti/06-26:Lectio8:s/Ne terreámini .*//s
+
+[Lectio11 in 3 loco]
+@Sancti/06-26:Lectio8:s/.* Ne terreámini /Ne terreámini /s
+
+[Lectio12 in 3 loco]
+@Sancti/06-26:Lectio9:s/\&teDeum .*//s
+
+[LectioE in 3 loco]
+@Sancti/06-26:LectioE
+
+[Lectio9 in 4 loco]
+@Sancti/09-19:Lectio7:s/Respondétur .*//s
+
+[Lectio10 in 4 loco]
+@Sancti/09-19:Lectio7:s/.* Respondétur /Respondétur /s
+
+[Lectio11 in 4 loco]
+@Sancti/09-19:Lectio8
+
+[Lectio12 in 4 loco]
+@Sancti/09-19:Lectio9:s/\&teDeum .*//s
+
+[LectioE in 4 loco]
+@Sancti/09-19:LectioE
+
+[Lectio9 in 5 loco]
+@Sancti/06-05:Lectio7:s/Beáti pacífici.*//s
+
+[Lectio10 in 5 loco]
+@Sancti/06-05:Lectio7:s/.* Beáti pacífici/Beáti pacífici/s
+
+[Lectio11 in 5 loco]
+@Sancti/06-05:Lectio8
+
+[Lectio12 in 5 loco]
+@Sancti/06-05:Lectio9:s/\&teDeum .*//s
+
+[LectioE in 5 loco]
+@Sancti/06-05:LectioE
+
+[Lectio9 in 6 loco]
+@CommuneM/C5:Lectio9 in 3 loco
+
+[Lectio10 in 6 loco]
+@CommuneM/C5:Lectio10 in 3 loco
+
+[Lectio11 in 6 loco]
+@CommuneM/C5:Lectio11 in 3 loco
+
+[Lectio12 in 6 loco]
+@CommuneM/C5:Lectio12 in 3 loco
+
+[LectioE in 6 loco]
+@CommuneM/C5:LectioE in 3 loco
+
+[Lectio9 in 7 loco]
+Léctio sancti Evangélii secúndum Lucam.
+!Luc 10:16-20
+In illo témpore: Dixit Jesus discípulis suis: Qui vos audit, me audit: et qui vos spernit. Et réliqua.
+_
+Homilía sancti Bedæ Venerábilis Presbýteri
+!Lib. 3 in Luc. cap. 10
+Ut in adiéndo quisque, vel spernéndo Evangélii prædicatóre non viles quasque persónas, sed Dóminum Salvatórem, immo ipsum Patrem spérnere se, vel audíre dísceret, ait: Qui vos audit, me audit: et qui von spernit, me spernit. Qui autem me spernit, spernit eum, qui me misit: quia procul dúbio in disípulo Magíster audítur et in fílio Pater honrátur. Potest et ita intélligi: Qui non facit misericórdiam uni de fráteribus meis mínimis, nec mihi facit: quia et ipse pro his formam servi, et páuperis hábitum suscépi.
+
+[Lectio10 in 7 loco]
+Revérsi sunt autem septuagínta duo cum gáudio, dicéntes: Dómine, étiam dæmónia subjiciúntur nobis in nómine tuo. Bene quidem conféssi sunt, deferéntes honórem nómini Christi, sed quia infírma adhuc fide gaudébant virtútibus, vide, quid áudiunt. Et ait illis: Vidébam sátanam, sicut fulgur, de cælo cadéntem: non modo vídeo, sed prius vidébam, quando córruit; quod autem ait: sicut fulgur, vel præcípitem de supérnis ad ima lapsum signíficat, vel quia dejéctus adhuc transfígúrat se in ángelum lucis.
+
+[Lectio11 in 7 loco]
+Ecce dedi vobis potestátem, calcándi supra serpéntes et scorpiónes, hoc est, omne genus immundórum spirítuum de obséssis corpóribus ejiciéndi: quamvis et ad lítteram rectíssime possit áccipi: síquidem et Paulus a vípera invásus, nihil advérsi pátitur. 
+
+[Lectio12 in 7 loco]
+Hoc sane inter serpéntes, qui dente, et scorpiónes, qui cauda nocent, distáre árbitror: quod serpéntes apérte sæviéntes, scorpiónes clánculo insidiántes, vel hómines, vel dæmones signíficent: serpéntes, qui inchoándis virtútibus venéna pravæ persuasiónis objíciunt: scorpiónes, qui consummátas virtútes ad finem vitiáre conténdunt. Verúmtamen in hoc nolíte gaudére, quia spíritus ejícere, sicut et virtútes álias fácere, intérdum non est ejus mériti, qui operátur; sed invocátio nóminis Christi hoc agit.
+
+
+[LectioE in 7 loco]
+Sequéntia ++ sancti Evangélii secúndum Lucam.
+!Luc 10:16-20
+In illo témpore: Dixit Jesus discípulis suis: Qui vos audit, me audit: et qui vos spernit, me spernit. Qui autem me spernit, spernit eum, qui misit me. Revérsi sunt autem septuagínta duo cum gáudio, dicéntes: Dómine, étiam dæmónia subjiciúntur nobis in nómine tuo. Et ait illis: Vidébam sátanam sicut fulgur de cœlo cadéntem. Ecce, dedi vobis potestátem calcandi supra serpéntes et scorpiónes, et super omnem virtútem inimíci: et nihil vobis nocébit. Verúmtamen in hoc nolíte gaudére, quia spíritus vobis subjiciúntur: gaudéte autem, quod nómina vestra scripta sunt in cœlis.

--- a/web/www/horas/Latin/CommuneM/C3.txt
+++ b/web/www/horas/Latin/CommuneM/C3.txt
@@ -99,18 +99,17 @@ R. Illi autem sunt in pace.
 v. Sequéntia ++ sancti Evangélii secúndum Lucam
 !Luc 21:9-19
 In illo témpore: Dixit Jesus discípulis suis:
-21:9 Cum autem audiéritis prœ́lia et seditiónes, nolíte terréri: opórtet primum hæc fíeri, sed nondum statim finis.
-21:10 Tunc dicébat illis: Surget gens contra gentem, et regnum advérsus regnum.
-21:11 Et terræmótus magni erunt per loca, et pestiléntiæ, et fames, terrorésque de cælo, et signa magna erunt.
-21:12 Sed ante hæc ómnia inícient vobis manus suas, et persequéntur tradéntes in synagógas et custódias, trahéntes ad reges et prǽsides propter nomen meum:
-21:13 contínget autem vobis in testimónium.
-21:14 Pónite ergo in córdibus vestris non præmeditári quemádmodum respondeátis:
-21:15 ego enim dabo vobis os et sapiéntiam, cui non póterunt resístere et contradícere omnes adversárii vestri.
-21:16 Tradémini autem a paréntibus, et frátribus, et cognátis, et amícis, et morte affícient ex vobis:
-21:17 et éritis ódio ómnibus propter nomen meum:
-21:18 et capíllus de cápite vestro non períbit.
-21:19 In patiéntia vestra possidébitis ánimas vestras.
-$Te decet
+Cum autem audiéritis prœ́lia et seditiónes, nolíte terréri: opórtet primum hæc fíeri, sed nondum statim finis.
+Tunc dicébat illis: Surget gens contra gentem, et regnum advérsus regnum.
+Et terræmótus magni erunt per loca, et pestiléntiæ, et fames, terrorésque de cælo, et signa magna erunt.
+Sed ante hæc ómnia inícient vobis manus suas, et persequéntur tradéntes in synagógas et custódias, trahéntes ad reges et prǽsides propter nomen meum:
+contínget autem vobis in testimónium.
+Pónite ergo in córdibus vestris non præmeditári quemádmodum respondeátis:
+ego enim dabo vobis os et sapiéntiam, cui non póterunt resístere et contradícere omnes adversárii vestri.
+Tradémini autem a paréntibus, et frátribus, et cognátis, et amícis, et morte affícient ex vobis:
+et éritis ódio ómnibus propter nomen meum:
+et capíllus de cápite vestro non períbit.
+In patiéntia vestra possidébitis ánimas vestras.
 
 [Capitulum Laudes]
 @Commune/C3
@@ -132,7 +131,6 @@ _
 [Ant Vespera 3]
 @Commune/C3::s/112/115/ s/111/112/ s/110/111/
 
-
 [Lectio5 in 2 loco]
 Sermo sancti Joánnis Chrysóstomi
 !Sermo 1 de Martyribus, tom. 3.
@@ -148,28 +146,28 @@ Ut enim infirmátur peccátor advérsis, ita justus tentatiónibus roborátur. S
 Habes, christiáne, competéntia arma, quibus hostem expúgnes; habes fortíssima tela, quibus inimícum debelles. His te jamdúdum Dóminus per grátiam ímbuit, et póstmodum Apóstolus Paulus armávit. Hæc sunt arma, quibus dimicárunt Sancti, quorum virtútes díligis et victórias admiráris. Imitáre, christiáne, quos díligis Sanctos; et quorum virtútes frequéntas, eórum vitam et institúta sectáre. Esto talis de eórum exémplo; quia et hi de superiórum tales effécti sunt. Nec enim virtus ab eo póterit imitári cujúsquam, qui ejus vitam non fúerit imitátus.
 
 [Lectio9 in 2 loco]
-@Commune/C3:Lectio71:s/Hinc .*//s
+@Commune/C3:Lectio7 in 2 loco:s/Hinc .*//s
 
 [Lectio10 in 2 loco]
-@Commune/C3:Lectio71:s/.* Hinc /Hinc /s
+@Commune/C3:Lectio7 in 2 loco:s/.* Hinc /Hinc /s
 
 [Lectio11 in 2 loco]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio12 in 2 loco]
-@Commune/C3:Lectio91:s/\&teDeum .*//s
+@Commune/C3:Lectio9 in 2 loco:s/\&teDeum .*//s
 
 [LectioE in 2 loco]
 v. Sequéntia ++ sancti Evangélii secúndum Lucam
 !Luc 6:17-23
 In illo témpore:
-6:17 Descéndes Jesus de monte, stetit in loco campéstri, et turba discipulórum ejus, et multitúdo copiósa plebis ab omni Judæa, et Jerúsalem, et marítima, et Tyri, et Sidósnis,
-6:18 qui vénerant ut audírent eum, et sanaréntur a languóribus suis. Et qui vexabántur a spirítibus immúndis, curabántur.
-6:19 Et omnis turba quærébat eum tángere: quia virtus de illo exibat, et sanábat omnes.
-6:20 Et ipse elevátis óculis in discípulos suos, dicébat: Beáti páuperes: quia vestrum est regnum Dei.
-6:21 Beáti, qui nunc esurítis: quia saturabímini. Beáti, qui nunc fletis: quia ridébitis.
-6:22 Beáti éritis cum vos óderint hómines, et cum separáverint vos, et exprobráverint, et ejécerint nomen vestrum tamquam malum propter Fílium hóminis.
-6:23 Gaudéte in illa die, et exsultáte: ecce enim merces vestra multa est in cœlo.
+Descéndes Jesus de monte, stetit in loco campéstri, et turba discipulórum ejus, et multitúdo copiósa plebis ab omni Judæa, et Jerúsalem, et marítima, et Tyri, et Sidósnis,
+qui vénerant ut audírent eum, et sanaréntur a languóribus suis. Et qui vexabántur a spirítibus immúndis, curabántur.
+Et omnis turba quærébat eum tángere: quia virtus de illo exibat, et sanábat omnes.
+Et ipse elevátis óculis in discípulos suos, dicébat: Beáti páuperes: quia vestrum est regnum Dei.
+Beáti, qui nunc esurítis: quia saturabímini. Beáti, qui nunc fletis: quia ridébitis.
+Beáti éritis cum vos óderint hómines, et cum separáverint vos, et exprobráverint, et ejécerint nomen vestrum tamquam malum propter Fílium hóminis.
+Gaudéte in illa die, et exsultáte: ecce enim merces vestra multa est in cœlo.
 
 [Lectio9 in 3 loco]
 @Sancti/06-26:Lectio7
@@ -199,7 +197,7 @@ In illo témpore:
 @Sancti/09-19:Lectio9:s/\&teDeum .*//s
 
 [LectioE in 4 loco]
-@Sancti/09-19:LectioE
+@Sancti/09-19
 
 [Lectio9 in 5 loco]
 @Sancti/06-05:Lectio7:s/Beáti pacífici.*//s
@@ -214,7 +212,7 @@ In illo témpore:
 @Sancti/06-05:Lectio9:s/\&teDeum .*//s
 
 [LectioE in 5 loco]
-@Sancti/06-05:LectioE
+@Sancti/06-05
 
 [Lectio9 in 6 loco]
 @CommuneM/C5:Lectio9 in 3 loco
@@ -248,7 +246,6 @@ Ecce dedi vobis potestátem, calcándi supra serpéntes et scorpiónes, hoc est,
 
 [Lectio12 in 7 loco]
 Hoc sane inter serpéntes, qui dente, et scorpiónes, qui cauda nocent, distáre árbitror: quod serpéntes apérte sæviéntes, scorpiónes clánculo insidiántes, vel hómines, vel dæmones signíficent: serpéntes, qui inchoándis virtútibus venéna pravæ persuasiónis objíciunt: scorpiónes, qui consummátas virtútes ad finem vitiáre conténdunt. Verúmtamen in hoc nolíte gaudére, quia spíritus ejícere, sicut et virtútes álias fácere, intérdum non est ejus mériti, qui operátur; sed invocátio nóminis Christi hoc agit.
-
 
 [LectioE in 7 loco]
 Sequéntia ++ sancti Evangélii secúndum Lucam.

--- a/web/www/horas/Latin/CommuneM/C3p.txt
+++ b/web/www/horas/Latin/CommuneM/C3p.txt
@@ -1,4 +1,4 @@
-@Commune/C1p
+@CommuneM/C2p
 
 [Name]
 Commune Plurimorum Martyrum Tempore Paschali
@@ -7,20 +7,11 @@ Commune Plurimorum Martyrum Tempore Paschali
 Psalmi Dominica
 Antiphonas horas
 
-[Ant Vespera]
-@Commune/C1p::s/112/115/
-
-[Capitulum Vespera]
-@CommuneM/C1p
-
 [Hymnus Vespera]
-@Commune/C3:Hymnus Laudes:s/Inténde/Appóne/ s/inter Mártyres/in Martýribus,/ s/Parcísque/Parcéndo/ s/Largítor indulgéntiæ/Donándo indulgéntiam/ s/Nunc, et per omne sǽculum/Et nunc et in perpétuum/
-
-[Invit]
-@Commune/C2p
+@Commune/C3:HymnusM Laudes
 
 [Hymnus Matutinum]
-@Commune/C3:Hymnus Matutinum
+@Commune/C3:HymnusM Matutinum
 
 [Ant Matutinum]
 Stabunt justi * in magna constántia advérsus eos qui se angustiavérunt, allelúja.;;1
@@ -43,39 +34,6 @@ Lux perpétua * lucébit Sanctis tuis, Dómine, et ætérnitas témporum, allel�
 V. Lætítia sempitérna super cápita eórum, allelúja.
 R. Gáudium et exsultatiónem obtinébunt, allelúja.
 
-[Lectio1]
-!Acts 8:12-19
-12 ergo fratres debitores sumus non carni ut secundum carnem vivamus
-13 si enim secundum carnem vixeritis moriemini si autem Spiritu facta carnis~
-mortificatis vivetis
-14 quicumque enim Spiritu Dei aguntur hii filii sunt Dei
-15 non enim accepistis spiritum servitutis iterum in timore sed accepistis~
-Spiritum adoptionis filiorum in quo clamamus Abba Pater
-16 ipse Spiritus testimonium reddit spiritui nostro quod sumus filii Dei
-17 si autem filii et heredes heredes quidem Dei coheredes autem Christi si tamen~
-conpatimur ut et conglorificemur
-18 existimo enim quod non sunt condignae passiones hujus temporis ad futuram~
-gloriam quae revelabitur in nobis
-19 nam expectatio creaturae revelationem filiorum Dei expectat
-
-[Lectio2]
-!Rom 8:28-34
-28 Scimus autem quoniam diligentibus Deum omnia cooperantur in bonum, iis qui secundum propositum vocati sunt sancti.
-29 Nam quos praescivit, et praedestinavit conformes fieri imaginis Filii sui, ut sit ipse primogenitus in multis fratribus.
-30 Quos autem praedestinavit, hos et vocavit: et quos vocavit, hos et justificavit: quos autem justificavit, illos et glorificavit.
-31 Quid ergo dicemus ad haec? si Deus pro nobis, qui contra nos?
-32 Qui etiam proprio Filio suo non pepercit, sed pro nobis omnibus tradidit illum: quomodo non etiam cum illo omnia nobis donavit?
-33 Quis accusabit adversus electos Dei? Deus qui justificat,
-34 quis est qui condemnet? Christus Jesus, qui mortuus est, immo qui et resurrexit, qui est ad dexteram Dei, qui etiam interpellat pro nobis.
-
-[Lectio3]
-!Rom 8:35-39
-35 Quis ergo nos separabit a caritate Christi? tribulatio? an angustia? an fames? an nuditas? an periculum? an persecutio? an gladius?
-36 (Sicut scriptum est: Quia propter te mortificamur tota die: aestimati sumus sicut oves occisionis.)
-37 Sed in his omnibus superamus propter eum qui dilexit nos.
-38 Certus sum enim quia neque mors, neque vita, neque angeli, neque principatus, neque virtutes, neque instantia, neque futura, neque fortitudo,
-39 neque altitudo, neque profundum, neque creatura alia poterit nos separare a caritate Dei, quae est in Christo Jesu Domino nostro.
-
 [MM Capitulum]
 !Sap 5:5
 Ecce quomodo computati sunt inter filios Dei, et inter sanctos sors illorum est. 
@@ -84,130 +42,37 @@ _
 V. Pretiosa in Conspectu Domini, alleluia
 R. Mors sanctorum ejus, alleluia
 
-[Lectio4]
-Sermo sancti Ambrosii Episcopi.
-!Serm. 22.
-Dignum et congruum est, fratres, ut post laetitiam Paschae, quam in Ecclesia~
-celebravimus, gaudia nostra cum sanctis Martyribus conferamus: et iis~
-annuntiemus Dominicae resurrectionis gloriam, qui consortes sunt Dominicae~
-passionis. Qui enim socii sunt contumeliae, debent et participes esse laetitiae.~
-Ita enim dicit beatus Apostolus: Sicut socii passionum estis, et resurrectionis~
-eritis: si tolerabimus, inquit, et conregnabimus. Qui ergo toleraverunt mala~
-propter Christimi, debent et gloriam habere cum Christo.
-
-[Lectio5]
-Annuntiomus inquam sanctis Martyribus Dominicae Paschae gratiam: ut dum~
-sepulturae illius praedicamus reserata claustra, et horum sepulcra reserentur:~
-dum corpus illius mortuum dicimus tepentibus venis subito viguisse, horum quoque~
-membra jam frigida immortalitatis calore foveantur. Eadem enim ratio Martyres~
-suscitat, quae et Dominum suscitavit. Nam sicut viam passionis ejus experti sunt,~
-ita experientur et vitae. Scriptum est enim in Psalmo: Notas mihi fecisti vias
-vitae. Hoc utique in resurrectione ex persona dicitur Salvatoris: ut qui, dum~
-post mortem ab inferis redit ad superos, incipiat notam habere viam vitae, quae~
-ante habebitur ignota.
-
-
-[Responsory5]
-@Commune/C2:Responsory51
-
-[Lectio6]
-Ignota enim erat ante Christi adventum via vitae, quae nullius adhuc resurgentis~
-fuerat temerata vestigio. At ubi Dominus resurrexit, nota facta, solo attrita~
-est plurimorum. De quibus sanctus Evangelista ait: Multorum corpora sanctorum~
-surrexerunt cum eo, et introierunt in sanctam civitatem. Unde cum Dominus in~
-resurrectione sua dixerit, Notas mihi fecisti vias vitae: possumus et nos jam~
-dicere Domino: Notas fecisti nobis vias vitae. Ipse enim nobis notas fecit vias
-vitae, qui nobis semitam manifestavit ad vitam. Notas enim mihi fecit vias vitae,~
-cum me docuit fidem, misericordiam, justitiam, castitatem. His enim pervenitur~
-itineribus ad salutem.
-
-
-[Responsory6]
-@Commune/C2:Responsory61
-
-[Lectio7]
-Lectio sancti Evangelii secundum Joannem.
-!Joannes 15:1-7
-In illo tempore: Dixit Jesus discipulis suis: Ego sum vitis vera: et Pater meus~
-agricola est. Et reliqua.
-_
-Homilia sancti Augustini Episcopi.
-!Tract. 80. in Joannem.
-Iste locus evangelicus, fratres, ubi se dicit Dominus vitem, et discipulos suos~
-palmites, secundum hoc dicit, quod est caput Ecclesiae, nosque membra ejus.~
-mediator Dei, et hominum homo Christus Jesus. Unius quippe naturae sunt vitis et~
-palmites. Propter quod cum esset Deus, cujus naturae non sumus, factus est homo,~
-ut in illo esset vitis humana natura, cujus et nos homines palmites esse~
-possemus.
-
-[Responsory7]
-R. Ego sum vitis vera, et vos palmites:
-* Qui manet in me, et ego in eo, hic fert fructum multum, alleluia, alleluia.
-V. Sicut dilexit me Pater, et ego dilexi vos.
-R. Qui manet in me, et ego in eo, hic fert fructum multum, alleluia, alleluia.
-
-[Responsory7c]
-R. Tristitia vestra, alleluia,
-* Convertetur in gaudium, alleluia, alleluia.
-V. Mundus autem gaudebit, vos vero contristabimini, sed tristitia vestra.
-R. Convertetur in gaudium, alleluia, alleluia.
-
-[Lectio8]
-Quid ergo est, Ego sum vitis vera? Numquid ut adderet, vera, hoc ad eam vitem~
-retulit, unde ista similitudo translata est? Sic enim dicitur vitis per~
-similitudinem, non per proprietatem: quemadmodum dicitur ovis, agnus, leo, petra,~
-lapis angularis, et cetera hujusmodi, quae magis ipsa sunt vera, ex quibus~
-ducuntur istae similitudines, non proprietates. Sed cum dicit, Ego sum vitis~
-vera: ab illa se utique discernit, cui dicitur: Quomodo conversa es in~
-amaritudinem vitis aliena? Nam quo pacto est vitis vera, quae exspectata est ut faceret uvam, fecit autem spinas?
-
-[Responsory8]
-R. Candidi facti sunt Nazaraei ejus, alleluia: splendorem Deo dederunt, alleluia:
-* Et sicut lac coagulati sunt, alleluia, alleluia.
-V. Candidiores nive, nitidiores lacte, rubicundiores ebore antiquo, sapphiro pulchriores.
-R. Et sicut lac coagulati sunt, alleluia, alleluia.
-&Gloria
-R. Et sicut lac coagulati sunt, alleluia, alleluia.
-
 [Lectio9]
-Ego sum, inquit, vitis vera: et Pater meus agricola est. Numquid unum sunt~
-agricola et vitis? Secundum hoc ergo vitis Christus, secundum quod ait: Pater~
-major me est. Secundum autem id, quod ait: Ego, et Pater unum sumus; et ipse~
-agricola est: nec talis, quales sunt, qui extrinsecus operando exhibent~
-ministerium: sed talis, ut det etiam intrinsecus incrementum. Nam neque qui~
-plantat est aliquid, neque qui rigat: sed, qui incrementum dat, Deus. Sed~
-utique Deus est Christus, quia Deus erat Verbum: unde ipse, et Pater unum sunt:~
-et, si Verbum caro factum est, quod non erat, manet quod erat.
+@CommuneM/C2p:Lectio9 in 2 loco
 
-R. Justorum animae in manu Dei sunt, et non tanget illos tormentum mortis. Visi~
-sunt oculis insipientium mori: illi autem sunt in pace.
-* Illi autem sunt in pace
-V. Deus tentavit eos, et invenit illos dignos se. 
-R. Illi autem sunt in pace
-&Gloria
-R. Illi autem sunt in pace
+[Lectio10]
+@CommuneM/C2p:Lectio10 in 2 loco
 
+[Lectio11]
+@CommuneM/C2p:Lectio11 in 2 loco
 
-[Capitulum Laudes]
-@CommuneM/C1p
+[Lectio12]
+@CommuneM/C2p:Lectio12 in 2 loco
 
 [HymnusM Laudes]
-@:Hymnus Vespera
+@Commune/C3:HymnusM Laudes
 
-[Responsory Tertia]
-@Commune/C1p:Versum 1
+[Oratio]
+@Commune/C3
 
-[Responsory Sexta]
-@Commune/C1p:Responsory Tertia:8-9
+[Oratio1]
+@Commune/C3
 
-[Responsory Nona]
-@Commune/C1p:Responsory Sexta:8-9
-
-[Ant Vespera 3]
-@Commune/C1p::s/112/111/ s/115/112/ s/125/115/
-
-[Versum 3]
-@:Versum 2
+[Oratio2]
+@Commune/C3
 
 [LectioE]
-@CommuneM/C2p
+v. Sequéntia ++ sancti Evangélii secúndum Joánnem!Joannes 5:5-11
+In illo témpore: Dixit Jesus discípulis suis: 
+15:5 Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum, quia sine me nihil potéstis fácere.
+15:6 Si quis in me non mánserit, mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet.
+15:7 Si manséritis in me, et verba mea in vobis mánserint, quodcúmque voluéritis petétis, et fiet vobis.
+15:8 In hoc clarificátus est Pater meus, ut fructum plúrimum afferátis, et efficiámini mei discípuli.
+15:9 Sicut diléxit me Pater, et ego diléxi vos. Manéte in dilectióne mea.
+15:10 Si præcépta mea servavéritis, manébitis in dilectióne mea, sicut et ego Patris mei præcépta servávi, et máneo in eius dilectióne.
+15:11 Hæc locútus sum vobis: ut gáudium meum in vobis sit, et gáudium vestrum impleátur.

--- a/web/www/horas/Latin/CommuneM/C3p.txt
+++ b/web/www/horas/Latin/CommuneM/C3p.txt
@@ -69,10 +69,10 @@ R. Mors sanctorum ejus, alleluia
 [LectioE]
 v. Sequéntia ++ sancti Evangélii secúndum Joánnem!Joannes 5:5-11
 In illo témpore: Dixit Jesus discípulis suis: 
-15:5 Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum, quia sine me nihil potéstis fácere.
-15:6 Si quis in me non mánserit, mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet.
-15:7 Si manséritis in me, et verba mea in vobis mánserint, quodcúmque voluéritis petétis, et fiet vobis.
-15:8 In hoc clarificátus est Pater meus, ut fructum plúrimum afferátis, et efficiámini mei discípuli.
-15:9 Sicut diléxit me Pater, et ego diléxi vos. Manéte in dilectióne mea.
-15:10 Si præcépta mea servavéritis, manébitis in dilectióne mea, sicut et ego Patris mei præcépta servávi, et máneo in eius dilectióne.
-15:11 Hæc locútus sum vobis: ut gáudium meum in vobis sit, et gáudium vestrum impleátur.
+Ego sum vitis, vos pálmites: qui manet in me, et ego in eo, hic fert fructum multum, quia sine me nihil potéstis fácere.
+Si quis in me non mánserit, mittétur foras sicut palmes, et aréscet, et cólligent eum, et in ignem mittent, et ardet.
+Si manséritis in me, et verba mea in vobis mánserint, quodcúmque voluéritis petétis, et fiet vobis.
+In hoc clarificátus est Pater meus, ut fructum plúrimum afferátis, et efficiámini mei discípuli.
+Sicut diléxit me Pater, et ego diléxi vos. Manéte in dilectióne mea.
+Si præcépta mea servavéritis, manébitis in dilectióne mea, sicut et ego Patris mei præcépta servávi, et máneo in eius dilectióne.
+Hæc locútus sum vobis: ut gáudium meum in vobis sit, et gáudium vestrum impleátur.

--- a/web/www/horas/Latin/CommuneM/C4.txt
+++ b/web/www/horas/Latin/CommuneM/C4.txt
@@ -5,9 +5,6 @@
 _
 @Commune/C4:Responsory Sexta:1-6
 
-[HymnusM Vespera]
-@Commune/C4::s/Hódie.*/Hac die lætus méruit suprémos/ s/Scándere.*/Laudis honóres./
-
 [Ant Matutinum]
 Beátus vir, * qui in lege Dómini meditátur: volúntas ejus pérmanet die ac nocte, et ómnia quæcúmque fáciet, semper prosperabúntur.;;1
 Beátus iste Sanctus, * qui confísus est in Dómino, prædicávit præcéptum Dómini, constitútus est in monte sancto ejus.;;2
@@ -29,9 +26,6 @@ Sint lumbi vestri * praecincti et lucernae ardentes in manibus vestris;;256;257;
 V. Tu es sacérdos in ætérnum.
 R. Secúndum órdinem Melchísedech.
 
-[HymnusM Matutinum]
-@Commune/C4:Hymnus1M Vespera
-
 [Lectio1]
 @Commune/C4:Lectio1:s/-7/-4/ s/5 .*//s
 
@@ -52,14 +46,27 @@ R. Ecce vere Israelíta, in quo dolus non est invéntus: † qui probátus repé
 V. Státuit ei Dóminus testaméntum sempitérnum, † et dedit illi sacerdótium magnum.
 R. Juxta órdinem Melchísedech.
 
+[Lectio5]
+@Commune/C4:Lectio4
+
 [Responsory5]
 @Commune/C4:Responsory4
+
+[Lectio6]
+@Commune/C4:Lectio5
 
 [Responsory6]
 @Commune/C4:Responsory5
 
+[Lectio7]
+@Commune/C4:Lectio6:s/ Dúplici .*//s
+
 [Responsory7]
 @Commune/C4:Responsory6
+
+[Lectio8]
+@Commune/C4:Lectio6:s/.* Dúplici /Dúplici /s s/$/~/
+Lauda ergo post perículum, prædica secúrum. Lauda navigántis felicitátem, sed cum pervénit ad portum; lauda ducis virtútem, sed cum perdúctus est ad triúmphum.
 
 [Responsory8]
 R. Justum dedúxit Dóminus per vias rectas, † et osténdit illi regnum Dei, et dedit illi sciéntiam sanctórum; 
@@ -67,20 +74,30 @@ R. Justum dedúxit Dóminus per vias rectas, † et osténdit illi regnum Dei, e
 V. Custodívit eum ab inimícis et a seductóribus tutávit illum.
 R. Honestávit illum in labóribus suis.
 
+[Lectio9]
+@Commune/C4:Lectio7:s/ Ecce .*//s
+
 [Responsory9]
 @Commune/C4:Responsory7
 
+[Lectio10]
+@Commune/C4:Lectio7:s/.* Ecce /Ecce /s s/$/~/
+@Commune/C4:Lectio8:s/ Sed homo .*//s
+
 [Responsory10]
-R. In médio Ecclésiæ apéruit os ejus, 
-* Et implévit eum Dóminus spíritu sapiéntiæ et intelléctus.
-V. Jucunditátem et exsultatiónem thesaurizávit super eum.
-R. Et implévit eum Dóminus spíritu sapiéntiæ et intelléctus.
+@Commune/C4:Responsory8
+
+[Lectio11]
+@Commune/C4:Lectio8:s/.* Sed homo /Sed homo /s
 
 [Responsory11]
 R. Iste sanctus digne in memóriam vértitur hóminum, qui ad gáudium tránsiit angelórum; † quóniam in hac peregrinatióne solo córpore constitútus, cogitatióne et aviditáte 
 * In illa aetérna patria conversátus est.
 V. Vinculis carnis absolútus taléntum.  sibi créditum Dómino suo duplicátum reportávit.
 R. In illa aetérna patria conversátus est.
+
+[Lectio12]
+@Commune/C4:Lectio9
 
 [Responsory12]
 R. Elégit te Dóminus sacerdótem sibi 
@@ -102,23 +119,81 @@ _
 [Responsory Nona]
 @Commune/C4:Responsory Sexta:8-9
 
-[Ant Vespera]
+[Ant Vespera 3]
 @Commune/C4:Ant Vespera:s/$/_/gm s/_/;;109/ s/_/;;111/ s/_/;;112/ s/_/;;131/ s/_//
 
 [Ant 3]
 @Commune/C4:Ant 3 summi Pontificis
 
 [LectioE]
-v. Sequéntia sancti Evangélii secúndum Matthǽum
+v. Sequéntia ++ sancti Evangélii secúndum Matthǽum
 !Matt 25:14-23
-25:14 Sicut enim homo péregre proficíscens, vocávit servos suos, et trádidit illis bona sua.
-25:15 Et uni dedit quinque talénta, álii autem duo, álii vero unum, unicuíque secúndum própriam virtútem: et proféctus est statim.
-25:16 Abiit autem qui quinque talénta accéperat, et operátus est in eis, et lucrátus est ália quinque.
-25:17 Simíliter et qui duo accéperat, lucrátus est ália duo.
-25:18 Qui autem unum accéperat, ábiens fodit in terram, et abscóndit pecúniam dómini sui.
-25:19 Post multum vero témporis venit dóminus servórum illórum, et pósuit ratiónem cum eis.
-25:20 Et accédens qui quinque talénta accéperat, óbtulit ália quinque talénta, dicens: Dómine, quinque talénta tradidísti mihi, ecce ália quinque superlucrátus sum.
+In illo témpore: Dixit Jesus discípulis suis parábolam hanc:
+Homo péregre proficíscens, vocávit servos suos, et trádidit illis bona sua.
+Et uni dedit quinque talénta, álii autem duo, álii vero unum, unicuíque secúndum própriam virtútem: et proféctus est statim.
+Abiit autem qui quinque talénta accéperat, et operátus est in eis, et lucrátus est ália quinque.
+Simíliter et qui duo accéperat, lucrátus est ália duo.
+Qui autem unum accéperat, ábiens fodit in terram, et abscóndit pecúniam dómini sui.
+Post multum vero témporis venit dóminus servórum illórum, et pósuit ratiónem cum eis.
+Et accédens qui quinque talénta accéperat, óbtulit ália quinque talénta, dicens: Dómine, quinque talénta tradidísti mihi, ecce ália quinque superlucrátus sum.
 25:21 Ait illi dóminus ejus: Euge serve bone, et fidélis: quia super pauca fuísti fidélis, super multa te constítuam: intra in gáudium dómini tui.
 25:22 Accéssit autem et qui duo talénta accéperat, et ait: Dómine, duo talénta tradidísti mihi, ecce ália duo lucrátus sum.
 25:23 Ait illi dóminus ejus: Euge serve bone, et fidélis: quia super pauca fuísti fidélis, super multa te constítuam: intra in gáudium dómini tui.
-$Te decet
+
+[Lectio1 in 2 loco]
+@Commune/C4:Lectio11:s/-5/-4/ s/5 .*//s
+
+[Lectio2 in 2 loco]
+@Commune/C4:Lectio11:s/.*!/!/s s/1-5/5-7/ s/^1 .*5 /5 /sm s/$/~/
+@Commune/C4:Lectio21:s/!.*// s/8 .*//s
+
+[Lectio3 in 2 loco]
+@Commune/C4:Lectio21:s/.*!/!/s s/6-9/8-11/ s/^6 .*8 /8 /sm s/$/~/
+@Commune/C4:Lectio31:s/!.*// s/12 .*//s
+
+[Lectio4 in 2 loco]
+@Commune/C4:Lectio31:s/.*!/!/s s/10-/12-/ s/^10 .*12 /12 /sm
+
+[Lectio5 in 2 loco]
+Sermo sancti Maxími Epíscopi
+!Homilía 78, de S. Eusebio 2, circa medio
+Beáti Patris N. mérita, jam in tuto pósita, secúri magnificémus; qui, gubernáculum fídei viríliter tenens, ánchoram spei tranquílla jam in statióne compósuit, et plenam cæléstibus divítiis et ætérnis mércibus navem, optáto in líttore, collocávit; qui contra omnes adversários scutum timóris Dei támdiu infatigabíliter ténuit, donec ad victóriam perveníret.
+
+[Lectio6 in 2 loco]
+Quid enim fuit totus vitæ illíus cursus, nisi uníus cum vígili hoste conflíctus? Quantis hic cæcis, a via veritátis errántibus et de summa jam in profúndum rupe pendéntibus, amíssum réddidit visum; et illum, quo Christus viderétur, reparávit intúitum?
+
+[Lectio7 in 2 loco]
+Quantórum áuribus surdis et infidelitátis obturatióne damnátis, ad percipiéndam vocem cæléstium mandatórum, pretiósum infúdit audítum; ut, vocánti Deo ad misericórdiam, respondérent per obediéntiam? Quantos intrínsecus vulnerátos, angélici oris arte et oratiónum, ab infirmitáte curávit?
+
+[Lectio8 in 2 loco]
+Quantos, per longam incúriam peccáto labe resolútos et quadam lepræ contgióne perfúsos, castigatiónibus et exhortatiónibus expiándo, Deo in se operánte, mundávit? Quantórum ánimas, vivéntes in córpore jam defúnctas et delictórum mole óbrutas ac sepúltas, ad emendatiónem tamquam ad lucem vocándo, Deo esuscitávit; ut, Dómini sui admirándus imitátor, jam mórtuas Deo, e contrário mortíficet, vitáli morte, peccáto?
+
+[Lectio9 in 2 loco]
+Léctio sancti Evangélii secúndum Matthǽum
+!Matt 24:42-47
+In illo témpore: Dixit Jesus discípulis suis: Vigiláte, quia nescítis qua hora Dóminus vester ventúrus sit. Et réliqua.
+_
+Homilía sancti Hilárii Epíscopi
+!Comment. in Matth., cap. 26 in fine‚
+Ut ignorántiam illam diéi ómnibus táciti, non sine útilis siléntii ratióne esse scirémus, vigiláre nos Dóminus propter advéntum furis admónuit, et oratíonum assiduitáte deténtos ómnibus præceptórum suórum opéribus inhærére. Furem enim esse osténdit zábulum, ad detrahénda ex nobis spólia pervígilem, et córporum nostrórum dómibus insidiántem: ut ea incuriósis nobis, et somno déditis, consiliórum suórum atque illecebrárum jáculis perfódiat. Parátos ígitur esse nos cónvenit: quia diéi ignorátio inténtam sollicitúdinem suspénsæ exspectatiónis exágitet.
+
+[Lectio10 in 2 loco]
+!Cap. 27
+Quisnam est fidélis servus et prudens, quem constítuit Dóminus super famíliam suam? Quamquam in commúne nos ad indeféssam vigilántiæ curam adhortétur: speciálem tamen pópuli princípibus, id est, epíscopis, in exspectatióne adventúque suo sollicitúdinem mandat. Hunc enim servum fidélem atque prudéntem, præpósitum famíliæ signíficat, cómmoda atque utilitátes commíssi sibi pópuli curántem. 
+
+[Lectio11 in 2 loco]
+Qui si dicto áudiens, et præcéptis obédiens erit, id est, si doctrínæ opportunitáte et veritáte infírma confírmet, disrúpta consólidet, depraváta convértat, et verbum vitæ in æternitátis cibum aléndæ famíliæ dispéndat, atque hæc agens, hisque ímmorans deprehendátur: glóriam a Dómino tamquam dispensátor fidélis et víllicus útilis consequétur, et super ómnia bona constituétur; id est, in Dei glória collocábitur, quia nihil sit ultra, quod mélius sit.
+
+[Lectio12 in 2 loco]
+Quod, si cóntuens longam Dei patiéntiam, quæ in proféctum humánæ salútis exténditur, advérsum consérvos insoléscet, et sæculi malus vitiísque se tradet, præséntium tantum curam in cultu ventris exércens; desperáta die Dóminus advéniet, eúmque a bonis, quæ spopónderat, dívidet, portionémque ejus cum hypócritis in pœnæ æternitáte constítuet: quia advéntum desperávit, quia mandátis non obtemperáverit, quia præséntibus studúerit, quia vita Géntium víxerit, quia desperatióne judícii commíssam sibi famíliam fame, siti, cæde vexáverit.
+
+[LectioE in 2 loco]
+v. Séquentia ++ sancti Evangélii secúndum Matthǽum
+!Matt 24:42-47
+In illo témpore: Dixit Jesus discípulis suis: 
+42 Vigiláte, quia nescítis qua hora Dóminus vester ventúrus sit. 
+43 Illud autem scitóte, quóniam si sciret paterfamílias qua hora fur ventúrus esset, vigiláret útique, et non síneret pérfodi domum suam.
+44 Ideo et vos estóte paráti: quia qua nescítis hora Fílius hóminis ventúrus est.
+45 Quis, putas, est fidélis servus, et prudens, quem constítuit dóminus suus super famíliam suam ut det illis cibum in témpore?
+46 Beátus ille servus, quem cum vénerit dóminus eius, invénerit sic faciéntem.
+47 Amen dico vobis, quóniam super ómnia bona sua constítuet eum.

--- a/web/www/horas/Latin/CommuneM/C4.txt
+++ b/web/www/horas/Latin/CommuneM/C4.txt
@@ -136,23 +136,23 @@ Simíliter et qui duo accéperat, lucrátus est ália duo.
 Qui autem unum accéperat, ábiens fodit in terram, et abscóndit pecúniam dómini sui.
 Post multum vero témporis venit dóminus servórum illórum, et pósuit ratiónem cum eis.
 Et accédens qui quinque talénta accéperat, óbtulit ália quinque talénta, dicens: Dómine, quinque talénta tradidísti mihi, ecce ália quinque superlucrátus sum.
-25:21 Ait illi dóminus ejus: Euge serve bone, et fidélis: quia super pauca fuísti fidélis, super multa te constítuam: intra in gáudium dómini tui.
-25:22 Accéssit autem et qui duo talénta accéperat, et ait: Dómine, duo talénta tradidísti mihi, ecce ália duo lucrátus sum.
-25:23 Ait illi dóminus ejus: Euge serve bone, et fidélis: quia super pauca fuísti fidélis, super multa te constítuam: intra in gáudium dómini tui.
+Ait illi dóminus ejus: Euge serve bone, et fidélis: quia super pauca fuísti fidélis, super multa te constítuam: intra in gáudium dómini tui.
+Accéssit autem et qui duo talénta accéperat, et ait: Dómine, duo talénta tradidísti mihi, ecce ália duo lucrátus sum.
+Ait illi dóminus ejus: Euge serve bone, et fidélis: quia super pauca fuísti fidélis, super multa te constítuam: intra in gáudium dómini tui.
 
 [Lectio1 in 2 loco]
-@Commune/C4:Lectio11:s/-5/-4/ s/5 .*//s
+@Commune/C4:Lectio1 in 2 loco:s/-5/-4/ s/5 .*//s
 
 [Lectio2 in 2 loco]
-@Commune/C4:Lectio11:s/.*!/!/s s/1-5/5-7/ s/^1 .*5 /5 /sm s/$/~/
-@Commune/C4:Lectio21:s/!.*// s/8 .*//s
+@Commune/C4:Lectio1 in 2 loco:s/.*!/!/s s/1-5/5-7/ s/^1 .*5 /5 /sm s/$/~/
+@Commune/C4:Lectio2 in 2 loco:s/!.*// s/8 .*//s
 
 [Lectio3 in 2 loco]
-@Commune/C4:Lectio21:s/.*!/!/s s/6-9/8-11/ s/^6 .*8 /8 /sm s/$/~/
-@Commune/C4:Lectio31:s/!.*// s/12 .*//s
+@Commune/C4:Lectio2 in 2 loco:s/.*!/!/s s/6-9/8-11/ s/^6 .*8 /8 /sm s/$/~/
+@Commune/C4:Lectio3 in 2 loco:s/!.*// s/12 .*//s
 
 [Lectio4 in 2 loco]
-@Commune/C4:Lectio31:s/.*!/!/s s/10-/12-/ s/^10 .*12 /12 /sm
+@Commune/C4:Lectio3 in 2 loco:s/.*!/!/s s/10-/12-/ s/^10 .*12 /12 /sm
 
 [Lectio5 in 2 loco]
 Sermo sancti Maxími Epíscopi
@@ -191,9 +191,9 @@ Quod, si cóntuens longam Dei patiéntiam, quæ in proféctum humánæ salútis 
 v. Séquentia ++ sancti Evangélii secúndum Matthǽum
 !Matt 24:42-47
 In illo témpore: Dixit Jesus discípulis suis: 
-42 Vigiláte, quia nescítis qua hora Dóminus vester ventúrus sit. 
-43 Illud autem scitóte, quóniam si sciret paterfamílias qua hora fur ventúrus esset, vigiláret útique, et non síneret pérfodi domum suam.
-44 Ideo et vos estóte paráti: quia qua nescítis hora Fílius hóminis ventúrus est.
-45 Quis, putas, est fidélis servus, et prudens, quem constítuit dóminus suus super famíliam suam ut det illis cibum in témpore?
-46 Beátus ille servus, quem cum vénerit dóminus eius, invénerit sic faciéntem.
-47 Amen dico vobis, quóniam super ómnia bona sua constítuet eum.
+Vigiláte, quia nescítis qua hora Dóminus vester ventúrus sit. 
+Illud autem scitóte, quóniam si sciret paterfamílias qua hora fur ventúrus esset, vigiláret útique, et non síneret pérfodi domum suam.
+Ideo et vos estóte paráti: quia qua nescítis hora Fílius hóminis ventúrus est.
+Quis, putas, est fidélis servus, et prudens, quem constítuit dóminus suus super famíliam suam ut det illis cibum in témpore?
+Beátus ille servus, quem cum vénerit dóminus eius, invénerit sic faciéntem.
+Amen dico vobis, quóniam super ómnia bona sua constítuet eum.

--- a/web/www/horas/Latin/CommuneM/C5.txt
+++ b/web/www/horas/Latin/CommuneM/C5.txt
@@ -1,12 +1,9 @@
-@Commune/C5
+@CommuneM/C4
 
 [Capitulum Vespera]
 @Commune/C5
 _
 @Commune/C5:Responsory Sexta:1-6
-
-[HymnusM Vespera]
-@Commune/C4::s/Hódie/Hac die/ s/Scándere cæli/Laudis honóres/
 
 [Capitulum Laudes]
 @Commune/C5
@@ -26,12 +23,12 @@ _
 @Commune/C5:Responsory Sexta:8-9
 
 [LectioE]
-v. Sequéntia sancti Evangélii secúndum Lucam
+v. Sequéntia ++ sancti Evangélii secúndum Lucam
 !Luc 12:35-40
-12:35 Sint lumbi vestri præcíncti, et lucérnæ ardéntes in mánibus vestris,
-12:36 et vos símiles homínibus exspectántibus dóminum suum quando revertátur a núptiis: ut, cum vénerit et pulsáverit, conféstim apériant ei.
-12:37 Beáti servi illi quos, cum vénerit dóminus, invénerit vigilántes: amen dico vobis, quod præcínget se, et fáciet illos discúmbere, et tránsiens ministrábit illis.
-12:38 Et si vénerit in secúnda vigília, et si in tértia vigília vénerit, et ita invénerit, beáti sunt servi illi.
-12:39 Hoc autem scitóte, quóniam si sciret paterfamílias, qua hora fur veníret, vigiláret útique, et non síneret pérfodi domum suam.
-12:40 Et vos estóte paráti: quia qua hora non putátis, Fílius hóminis véniet.
-$Te decet
+Sint lumbi vestri præcíncti, et lucérnæ ardéntes in mánibus vestris,
+et vos símiles homínibus exspectántibus dóminum suum quando revertátur a núptiis: ut, cum vénerit et pulsáverit, conféstim apériant ei.
+Beáti servi illi quos, cum vénerit dóminus, invénerit vigilántes: amen dico vobis, quod præcínget se, et fáciet illos discúmbere, et tránsiens ministrábit illis.
+Et si vénerit in secúnda vigília, et si in tértia vigília vénerit, et ita invénerit, beáti sunt servi illi.
+Hoc autem scitóte, quóniam si sciret paterfamílias, qua hora fur veníret, vigiláret útique, et non síneret pérfodi domum suam.
+Et vos estóte paráti: quia qua hora non putátis, Fílius hóminis véniet.
+

--- a/web/www/horas/Latin/CommuneM/C6.txt
+++ b/web/www/horas/Latin/CommuneM/C6.txt
@@ -61,7 +61,7 @@ $Deo gratias
 [Responsory Nona]
 @Commune/C6:Responsory Sexta:8-9
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 13 Exaltasti super terram habitationem meam, et pro morte defluente deprecatus~
 sum.

--- a/web/www/horas/Latin/Sancti/01-16.txt
+++ b/web/www/horas/Latin/Sancti/01-16.txt
@@ -24,10 +24,10 @@ Marcéllus Románus, a Constántio et Galério usque ad Maxéntium pontificátum
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Responsory8]
 R. Dómine, prævenísti eum in benedictiónibus dulcédinis: 
@@ -38,7 +38,7 @@ R. Posuísti in cápite ejus corónam de lápide pretióso.
 R. Posuísti in cápite ejus corónam de lápide pretióso.
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Lectio7](rubrica tridentina)
 @Commune/C2

--- a/web/www/horas/Latin/Sancti/01-20.txt
+++ b/web/www/horas/Latin/Sancti/01-20.txt
@@ -22,10 +22,10 @@ Fabiánus Románus, a Maximíno usque ad Décium regens Ecclésiam, septem diác
 &teDeum
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Latin/Sancti/01-21.txt
+++ b/web/www/horas/Latin/Sancti/01-21.txt
@@ -33,7 +33,7 @@ V. Elégit eam Deus, et præelégit eam.
 R. In tabernáculo suo habitáre facit eam.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Responsory1]
 R. Diem festum sacratíssimæ Vírginis celebrémus, quáliter passa sit beáta Agnes ad memóriam revocémus: tertiodécimo ætátis suæ anno mortem pérdidit, et vitam invénit: 
@@ -42,7 +42,7 @@ V. Infántia quidem computabátur in annis, sed erat senéctus mentis imménsa.
 R. Quia solum vitæ diléxit auctórem.
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Responsory2]
 R. Déxteram meam et collum meum cinxit lapidibus pretiósis, trádidit áuribus meis inæstimábiles margarítas, 
@@ -51,7 +51,7 @@ V. Pósuit signum in fáciem meam, ut nullum præter eum amatórem admíttam.
 R. Et circúmdedit me vernántibus atque coruscántibus gemmis.
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Responsory3]
 R. Amo Christum, in cujus thálamum introíbo, cujus mater virgo est, cujus pater féminam nescit, cujus mihi órgana modulátis vócibus cantant: 

--- a/web/www/horas/Latin/Sancti/01-26.txt
+++ b/web/www/horas/Latin/Sancti/01-26.txt
@@ -23,10 +23,10 @@ Polycárpus, Joánnis Apóstoli discípulus et ab eo Smyrnæ epíscopus ordinát
 @Sancti/07-13:Lectio6
 
 [Lectio7]
-@Commune/C2:Lectio72
+@Commune/C2:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C2:Lectio82
+@Commune/C2:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C2:Lectio92
+@Commune/C2:Lectio9 in 3 loco

--- a/web/www/horas/Latin/Sancti/02-05.txt
+++ b/web/www/horas/Latin/Sancti/02-05.txt
@@ -44,7 +44,7 @@ V. Elégit eam Deus, et præelégit eam.
 R. In tabernáculo suo habitáre facit eam.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Responsory1]
 R. Dum torquerétur beáta Agatha in mamílla gráviter, dixit ad júdicem: 
@@ -53,7 +53,7 @@ V. Ego enim hábeo mamíllas íntegras intus in ánima mea, quas ab infántia D�
 R. Impie, crudélis et dire tyránne, non es confúsus amputáre in fémina, quod ipse in matre suxísti?
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Responsory2]
 R. Agatha lætíssime et gloriánter ibat ad cárcerem, 
@@ -62,7 +62,7 @@ V. Nobilíssimis orta natálibus, ab ignóbili gaudens trahebátur ad cárcerem.
 R. Quasi ad épulas invitáta; et agónem suum Dómino précibus commendábat.
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Responsory3]
 R. Quis es tu, qui venísti ad me curáre vúlnera mea? Ego sum Apóstolus Christi: nihil in me dúbites, fília: ipse me misit ad te, 

--- a/web/www/horas/Latin/Sancti/02-27.txt
+++ b/web/www/horas/Latin/Sancti/02-27.txt
@@ -14,13 +14,13 @@ Deus, qui beátum Gabriélem dulcíssimæ Matris tuæ dolóres assídue recóler
 $Qui vivis
 
 [Lectio1](sed non rubrica 1960)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2](sed non rubrica 1960)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3](sed non rubrica 1960)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Gabriel, Assisii in Umbria, honesto genere natus, et Franciscus ob seráphici civis memóriam vocatus, egregiam animi índolem a púero osténdit. Adoléscens, cum Spoleti litteris operam daret, inani sæculi spécie et pompa aliquantulum állici visus est. Sed miserentis Dei munere, qui eum ad perfectiónem christianæ vitæ jamdúdum invitabat, cum in morbum incidísset, sæculi vanitátem fastidire cœpit, atque immortalia dumtáxat bona appétere. Quo autem citius Deo vocanti obtemperaret, factum est, ut insignem illam beatíssimæ Vírginis Icónem, solemni pompa extra Spoletinæ ecclésiæ septa delatam intúitus, divini amoris flammam conciperet, simulque Institutum Clericórum a Passióne Jesu amplecti statúeret. Itaque non exíguas difficultates eluctatus, in recessu Morrovallénsi, lúgubrem vestem lætus induit, et Gabriel a Vírgine perdolénte maluit appellari; ad ejusdem gaudiórum et dolórum memóriam perpetuo recoléndam.

--- a/web/www/horas/Latin/Sancti/03-04.txt
+++ b/web/www/horas/Latin/Sancti/03-04.txt
@@ -25,13 +25,13 @@ de ejúsdem étiam protectione gaudeámus.
 $Per Dominum.
 
 [Lectio1](sed non rubrica 1960)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2](sed non rubrica 1960)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3](sed non rubrica 1960)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Casimírus, patre Casimiro, matre Elisabetha Austriaca, Poloniæ regibus ortus, a~

--- a/web/www/horas/Latin/Sancti/03-06.txt
+++ b/web/www/horas/Latin/Sancti/03-06.txt
@@ -24,13 +24,13 @@ $Per Dominum
 Laudémus Deum nostrum * In confessióne beatárum Perpétuæ et Felicitátis.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Lectio2]
-@Commune/C6:Lectio21
+@Commune/C6:Lectio2 in 2 loco
 
 [Lectio3]
-@Commune/C6:Lectio31
+@Commune/C6:Lectio3 in 2 loco
 
 [Lectio4]
 Perpetua et Felicitas, in persecutione Severi imperatoris, in Africa, una cum~

--- a/web/www/horas/Latin/Sancti/03-10.txt
+++ b/web/www/horas/Latin/Sancti/03-10.txt
@@ -50,10 +50,10 @@ in profluentem, cum mirabiliter in unum confluxissent locum, salvæ et integræ~
 repertæ, honorifico sepulchro conditæ sunt.
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Latin/Sancti/03-21.txt
+++ b/web/www/horas/Latin/Sancti/03-21.txt
@@ -12,13 +12,13 @@ vide C4;
 @Commune/C5:Oratio1:s/N\./Benedícti/
 
 [Lectio1]
-@Commune/C4:Lectio11
+@Commune/C4:Lectio1 in 2 loco
 
 [Lectio2]
-@Commune/C4:Lectio21
+@Commune/C4:Lectio2 in 2 loco
 
 [Lectio3]
-@Commune/C4:Lectio31
+@Commune/C4:Lectio3 in 2 loco
 
 [Lectio4]
 Benedíctus, Núrsiæ nóbili génere ortus, Romæ liberálibus disciplínis erudítus, ut totum se Jesu Christo daret, ad eum locum, qui Sublácus dícitur, in altíssimam spelúncam penetrávit; in qua sic per triénnium delítuit, ut unus id sciret Románus mónachus, quo ad vitæ necessitátem minístro utebátur. Dum ígitur ei quodam die ardéntes ad libídinem faces a diábolo subjiceréntur, se in vépribus támdiu volutávit, dum, laceráto córpore, voluptátis sensus dolóre opprimerétur. Sed jam erumpénte ex illis látebris fama ejus sanctitátis, quidam mónachi se illi instituéndos tradidérunt: quorum vivéndi licéntia cum ejus objurgatiónes ferre non posset, venénum in potióne ei dare constítuunt. Verum, póculum ei præbéntibus, crucis signo vas confrégit, ac relícto monastério in solitúdinem se recépit.

--- a/web/www/horas/Latin/Sancti/04-02.txt
+++ b/web/www/horas/Latin/Sancti/04-02.txt
@@ -48,10 +48,10 @@ Francíscus Paulæ in Calábria natus est. Aduléscens, divíno ardóre succéns
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Latin/Sancti/04-22.txt
+++ b/web/www/horas/Latin/Sancti/04-22.txt
@@ -25,11 +25,10 @@ Soter, Fundis in Campánia natus, sancívit ne sacræ vírgines vasa sacra et pa
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
-
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Latin/Sancti/04-23.txt
+++ b/web/www/horas/Latin/Sancti/04-23.txt
@@ -13,13 +13,13 @@ Deus, qui nos beáti Geórgii Mártyris tui méritis et intercessióne lætífic
 $Per Dominum
 
 [Lectio4]
-@Commune/C2:Lectio41
+@Commune/C2:Lectio4 in 2 loco
 
 [Lectio5]
-@Commune/C2:Lectio51
+@Commune/C2:Lectio5 in 2 loco
 
 [Lectio6]
-@Commune/C2:Lectio61
+@Commune/C2:Lectio6 in 2 loco
 
 [Lectio94]
 The martyr George beareth among the Easterns the title of the holy and glorious~

--- a/web/www/horas/Latin/Sancti/05-25.txt
+++ b/web/www/horas/Latin/Sancti/05-25.txt
@@ -33,13 +33,13 @@ Gregórius Papa séptimus, ántea Hildebrándus, Suánæ in Etrúria natus, doct
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Latin/Sancti/06-13.txt
+++ b/web/www/horas/Latin/Sancti/06-13.txt
@@ -24,13 +24,13 @@ $Per Dominum
 @:OratioText:s/ atque Doctóris//
 
 [Lectio1] (rubrica tridentina)
-@Commune/C5:Lectio11
+@Commune/C5:Lectio1 in 2 loco
 
 [Lectio2] (rubrica tridentina)
-@Commune/C5:Lectio21
+@Commune/C5:Lectio2 in 2 loco
 
 [Lectio3] (rubrica tridentina)
-@Commune/C5:Lectio31
+@Commune/C5:Lectio3 in 2 loco
 
 [Lectio4]
 Antónius, Ulyssipóne in Lusitánia honéstis ortus paréntibus, et ab iis pie educátus, adoléscens, institútum canonicórum regulárium suscépit. Sed, cum córpora beatórum quinque Mártyrum fratrum Minórum Conímbriam transferéntur, qui paulo ante apud Marróchium pro Christi fide passi erant, martýrii desidério incénsus ad Franciscánum órdinam transívit.  Mox eódem ardóre impúlsus, ad Saracénos ire perréxit; sed, advérsa valetúdine afflíctus et redíre coáctus, cum navi ad Hispániæ líttora ténderet, ventórum vi in Sicíliam delátus est.

--- a/web/www/horas/Latin/Sancti/06-25.txt
+++ b/web/www/horas/Latin/Sancti/06-25.txt
@@ -26,10 +26,10 @@ Guliélmus, nobílibus paréntibus Vercéllis natus, vix quartum décimum ætát
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio73
+@Commune/C4:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C4:Lectio83
+@Commune/C4:Lectio8 in 4 loco
 
 [Lectio9]
-@Commune/C4:Lectio93
+@Commune/C4:Lectio9 in 4 loco

--- a/web/www/horas/Latin/Sancti/06-26.txt
+++ b/web/www/horas/Latin/Sancti/06-26.txt
@@ -58,7 +58,7 @@ De hoc fermento Apóstolus præcepit: Itaque epulemur, non in fermento veteri, n
 Verum quod sequitur: Quóniam quæ in ténebris dixistis, in lúmine dicéntur; non solum in futuro, quando cuncta cordium abscóndita proferéntur ad lucem, sed et in præsénti témpore potest congruenter accipi. Quóniam quæ inter ténebras quondam pressurárum carcerumque umbras vel locúti vel passi sunt Apóstoli; nunc, clarificáta per orbem Ecclésia, lectis eórum actibus, publice prædicántur. Ne terreámini ab his qui occídunt corpus. Si persecutores Sanctórum, occisis corpóribus, non habent ámplius quid contra illos agant: ergo supervacua furunt insánia, qui mortua Mártyrum membra, feris avibusque discerpenda projíciunt, cum nequaquam omnipoténtiæ Dei, quin ea resusictando vivíficet, obsistere possint.
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Lectio9]
 Duo autem sunt genera persecutórum: unum palam sæviéntium, álterum ficte fraudulenterque blandiéntium. Contra utrumque nos munire atque instítuere volens Salvator, et supra ab hypócrisi pharisæórum attendere, et hic a carnificum cæde præcipit non timére; quia videlicet, post mortem nec horum crudelitas nec illórum valeat simulátio durare. Nonne quinque pásseres veneunt dipondio? Si minutíssima, inquit, animália, et quæ quólibet per áëra ferúntur volatília, Deus oblivísci non potest; vos, qui ad imáginem facti estis Creatoris, non debetis terreri ab his qui occídunt corpus; quia, qui irrationabília animália gubernat, rationabília curare non désinit.

--- a/web/www/horas/Latin/Sancti/07-03.txt
+++ b/web/www/horas/Latin/Sancti/07-03.txt
@@ -28,13 +28,13 @@ Leo secúndus, Sículus, humánis et divínis lítteris Græce et Latíne doctus
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Latin/Sancti/07-13.txt
+++ b/web/www/horas/Latin/Sancti/07-13.txt
@@ -25,10 +25,10 @@ Anaclétus Atheniénsis, Trajáno imperatóre rexit Ecclésiam. Decrévit ut ep�
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Latin/Sancti/07-14.txt
+++ b/web/www/horas/Latin/Sancti/07-14.txt
@@ -28,10 +28,10 @@ Bonaventúra, Balneorégii in Etrúria natus adoléscens religiónem sancti Fran
 &teDeum
 
 [Lectio7]
-@Commune/C4a:Lectio72
+@Commune/C4a:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C4a:Lectio82
+@Commune/C4a:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C4a:Lectio92
+@Commune/C4a:Lectio9 in 3 loco

--- a/web/www/horas/Latin/Sancti/08-10.txt
+++ b/web/www/horas/Latin/Sancti/08-10.txt
@@ -52,7 +52,7 @@ V. Magna est glória ejus in salutári tuo.
 R. Glóriam et magnum decórem impónes super eum.
 
 [Lectio1]
-@Commune/C6:Lectio11
+@Commune/C6:Lectio1 in 2 loco
 
 [Responsory1]
 R. Levíta Lauréntius bonum opus operátus est, qui per signum crucis cæcos illuminávit, 

--- a/web/www/horas/Latin/Sancti/08-23.txt
+++ b/web/www/horas/Latin/Sancti/08-23.txt
@@ -21,13 +21,13 @@ Divinæ caritatis et catholicæ fidei dilatandæ ardore vehementer accensus, sui
 Effloruit in eo jugiter singularis erga pauperes misericordia, sed præcipue cum apud Camilianum agri Senensis vicum leproso nudo eleemosynam petenti propriam, qua indutus erat, vestem fuit elargitus: qua ille contectus, statim a lepra mundatus est. Cujus miraculi cum longe lateque fama manasset, nonnulli ex cardinalibus, qui Viterbium, Clemente quarto vita functo, pro successore deligendo convenerant, in Philippum, cujus cælestem étiam prudentiam perspectam habebant, intenderunt. Quo comperto vir Dei, ne forte pastoralis regiminis onus subire cogeretur, apud Tuniatum montem tamdiu delituit, donec Gregorius decimus Pontifex Maximus fuerit renuntiatus: ubi balneis, quæ étiam hodie sancti Philippi vocantur, virtutem sanandi morbos suis precibus impetravit. Denique Tuderti, anno millesimo ducentesimo octogesimo quinto in Christi Domini e cruce pendentis amplexu, quem suum appellabat librum, sanctissime ex hac vita migravit. Ad ejus tumulum cæci visum, claudi gressum, mortui vitam receperunt. Quibus aliisque plurimis fulgentem signis Clemens decimus Pontifex Maximus sanctorum numero adscripsit.
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco
 
 [Lectio Vigilia]
 !Pro Vigilia S. Bartholomæi Apostoli

--- a/web/www/horas/Latin/Sancti/08-25.txt
+++ b/web/www/horas/Latin/Sancti/08-25.txt
@@ -31,13 +31,13 @@ Rebus postea cum Saracenis compositis, liber rex exercitusque dimittitur. Quinqu
 Multa ædificavit monasteria, et pauperum hospitia: beneficentia egentes sublevabat: frequens visebat ægrotos, quibus ipse non solum suis sumptibus omnia suppeditabat, sed etiam, quæ opus erant, manibus ministrabat. Vestitu vulgari utebatur, cilicio ac jejunio corpus assidue affligebat. Sed cum iterum transmisisset, bellum Saracenis illaturus, jamque castra in eorum conspectu posuisset, pestilentia decessit in illa oratione: Introibo in domum tuam; adorabo ad templum sanctum tuum, et confitebor nomini tuo. Ejus corpus postea Lutétiam Parisiorum translatum est, quod in celebri sancti Dionysii templo asservatur et colitur; caput vero in sacra æde sanctæ Capellæ. Ipse clarus miraculis a Bonifacio Papa octavo in sanctorum numerum est relatus.
 
 [Lectio7]
-@Commune/C5:Lectio72
+@Commune/C5:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C5:Lectio82
+@Commune/C5:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C5:Lectio92
+@Commune/C5:Lectio9 in 3 loco
 
 [Lectio94]
 Ludovícus nonus, Gálliæ rex, in Blanchæ matris sanctíssima disciplína educátus, pro recuperánda possessióne Jerosolymórum mare cum ingénti exércitu traíciens, primo prǽlio Saracénos fugávit. Sed cum magna militum multitúdo ex pestiléntia perísset, victus ipse captúsque est. Rebus compósitis, liber dimíttitur. Plúrimos in Oriénte Christiános a barbarórum servitúte redémit, multos étiam infidéles ad Christi fidem convértit. In Gálliam revérsus, multa ædificávit monastéria et páuperum hospítia; beneficéntia egéntes sublevábat, frequens visébat ægrótos, eísque ministrábat; vestítu vulgári utebátur, cilício ac jejúnio corpus assídue affligébat. Cum íterum transmisísset, bellum Saracénis illatúrus, jamque castra in eórum conspéctu posuísset, pestiléntia decéssit in illa oratióne: Introíbo in domum tuam, adorábo ad templum sanctum tuum, et confitébor nómini tuo.

--- a/web/www/horas/Latin/Sancti/09-02.txt
+++ b/web/www/horas/Latin/Sancti/09-02.txt
@@ -19,13 +19,13 @@ Orándi studio noctes pene totas ducebat insomnes; atque in cæléstium rerum co
 Dei Genitricem, quam ardentíssime venerabátur, amplíssimo in ejus honórem constructo templo, Hungariæ patrónam instítuit; ab eádem vicíssim Vírgine recéptus in cælum ipso suæ Assumptiónis die, quem Húngari e sancti regis instituto Magnæ Dominæ diem appellant. Sacrum ejus corpus, suavíssimo fragrans odore, liquore cælésti scatens, inter multa et varia miracula, Romani Pontificis jussu, nobiliórem in locum translátum est atque honorificentius cónditum. Ejus autem festum Innocentius undecimus Pontifex maximus, quarto Nonas Septembris, ob insignem victoriam ab exercitu Leopoldi primi, Romanórum elécti imperatóris et Hungariæ regis, eádem die in Budæ expugnatióne, ope divina, e Turcis reportatam, celebrándum instituit.
 
 [Lectio7]
-@Commune/C5:Lectio72
+@Commune/C5:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C5:Lectio82
+@Commune/C5:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C5:Lectio92
+@Commune/C5:Lectio9 in 3 loco
 
 [Lectio94]
 Stéphanus, Hungarórum rex, in Hungáriam Christi fidem et régium nomen invéxit. Régia coróna a Románo Pontífice impetráta, ejúsque jussu rex inúnctus, regnum Sedi apostólicæ óbtulit. Vária pietátis domicília Romæ, Jerosólymis, Constantinópoli constítuit: in Hungária archiepiscopátum Strigoniénsem et episcopátus decem admirábili religióne et munificéntia fundávit. Exímia in páuperes caritáte et assíduo orándi stúdio enítuit. Dei Genetrícem quam ardentíssime venerabátur, amplíssimo in ejus honórem constrúcto templo, Hungáriæ patrónam instítuit; ab eádem vicíssim Vírgine recéptus in cælum ipso suæ Assumptiónis die, quem Húngari e sancti Regis institúto Magnæ Dóminæ diem appéllant. Ejus tamen festum ex constitutióne Innocéntii Papæ undécimi hac die potíssimum recólitur, quæ Budæ munitíssima arx, sancti Regis ope, ab exércitu christiáno strénue recuperáta fuit.

--- a/web/www/horas/Latin/Sancti/09-10.txt
+++ b/web/www/horas/Latin/Sancti/09-10.txt
@@ -19,13 +19,13 @@ Adulta ætate, jam clericali milítiæ adscriptus et canonicus factus, cum quoda
 Orándi assiduum studium, quamvis sátanæ insídiis varie vexátus et flagellis intérdum cæsus, non intermittebat. Demum, sex ante óbitum mensibus, singulis noctibus angelicum concentum audívit; cujus suavitate cum jam paradisi gaudia prægustaret, crebro illud Apóstoli repetebat: Cupio dissolvi, et esse cum Christo. Denique óbitus sui diem frátribus prædixit, qui fuit quarto Idus Septembris. Miraculis multis étiam post mortem cláruit; quibus rite et ordine cógnitis, ab Eugenio Papa quarto in Sanctórum númerum est relatus.
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco
 
 [Lectio94]
 Nicoláus, Tolentínas a diutúrno illíus civitátis domicílio appellátus, in óppido sancti Angeli in Picéno natus est piis paréntibus, qui illum ex voto, sancti Nicolái intercessióne, a Deo impetrárunt. Puer, multárum virtútum, abstinéntiæ in primis, spécimen dedit. Clericáli milítiæ dein adscríptus et canónicus factus, cum quodam die concionatórem órdinis Eremitárum sancti Augustíni de mundi contémptu dicéntem audísset, eo sermóne inflammátus, statim eúndem órdinem est ingréssus; in quo tam exáctam religiósæ vitæ ratiónem cóluit, ut jejúnio, rudi vestítu, verbéribus et áspera caténa corpus domáret, atque ómnibus áliis virtútibus prælucéret. Orándi assíduum stúdium, quamvis sátanæ insídiis várie vexátus et flagéllis intérdum cæsus, non intermittébat. Sex ante óbitum ménsibus, síngulis nóctibus angélicum concéntum audívit, et tandem, óbitus die prænuntiáto, obdormívit in Dómino. Miráculis in vita et post mortem clarus, ab Eugénio quarto in Sanctórum númerum relátus est.

--- a/web/www/horas/Latin/Sancti/09-17.txt
+++ b/web/www/horas/Latin/Sancti/09-17.txt
@@ -64,10 +64,10 @@ Intelléxit quidem, illo docénte interius qui et apparebat exterius, quod, lice
 Postquam ígitur novus homo Franciscus novo et stupéndo miraculo cláruit, cum singulari privilegio retroactis sæculis non concesso insignítus appáruit, sacris vidélicet Stigmátibus decoratus, descéndit de monte secum ferens Crucifixi effigiem, non in tábulis lapídeis vel ligneis manu figuratam artíficis, sed in carneis membris descriptam digito Dei vivi. Quóniam sacraméntum regis seraphicus vir abscóndere bonum esse optime norat, secreti regalis cónscius, signácula illa sacra pro viribus occultábat. Verum, quia Dei est ad glóriam suam magna revelare quæ facit, Dóminus ipse, qui signácula illa sacra pro viribus occultábat. Verum, quia Dei est ad glóriam suam magna revelare quæ facit, Dóminus ipse, qui signácula illa secrete impresserat, miracula quædam aperte per ipsa monstrávit; ut illórum occúlta et mira vis Stigmátum manifesta patéret claritate signórum. - Porro rem admirábilem ac tantopere testatam atque in pontificiis diplomátibus præcipuis laudibus et favóribus exáltatam, Benedíctus Papa undecimus anniversaria solemnitate celebrari vóluit; quam póstea Paulus quintus Pontifex maximus, ut corda fidelium in Christi crucifixi accenderéntur amórem, ad universam Ecclésiam propagávit.
 
 [Lectio7]
-@Commune/C2:Lectio73
+@Commune/C2:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C2:Lectio83
+@Commune/C2:Lectio8 in 4 loco
 
 [Responsory8]
 R. Mihi absit gloriari, nisi in cruce Dómini nostri Jesu Christi; 
@@ -78,7 +78,7 @@ R. Per quem mihi mundus crucifíxus est, et ego mundo.
 R. Per quem mihi mundus crucifíxus est, et ego mundo.
 
 [Lectio9]
-@Commune/C2:Lectio93
+@Commune/C2:Lectio9 in 4 loco
 
 [Lectio94]
 Francíscus singulári privilégio retroáctis sæculis non concésso insignítus appáruit, cum sacris Stigmátibus decorátus descéndit de monte, secum ferens Crucifíxi effígiem, non in tábulis lapídeis vel lígneis manu figurátam artíficis, sed in cárneis membris descríptam dígito Dei vivi. Quóniam sacraméntum regis seráphicus vir abscóndere bonum esse óptime norat, secréti regális cónscius, signácula illa sacra pro víribus occultábat. Verum, quia Dei est ad glóriam suam magna reveláre quæ facit, Dóminus ipse, qui signácula illa secréte imprésserat, mirácula quædam apérte per ipsa monstrávit; ut illórum occúlta et mira vis Stígmatum manifésta patéret claritáte signórum. - Porro rem admirábilem ac tantópere testátam atque in pontifíciis diplomátibus præcípuis láudibus et favóribus exaltátam, Benedíctus Papa undécimus anniversária solemnitáte celebrári vóluit; quam póstea Paulus quintus Póntifex máximus, ut corda fidélium in Christi crucifíxi accenderéntur amórem, ad univérsam Ecclésiam propagávit.

--- a/web/www/horas/Latin/Sancti/09-20.txt
+++ b/web/www/horas/Latin/Sancti/09-20.txt
@@ -22,10 +22,10 @@ Mox ad visiónis prístinæ locum, sicut ei Dóminus præceperat, regréssus, il
 Illa in expeditióne, liberis simul cum uxore insperato receptis, victor Urbem ingénti ómnium gratulatióne ingréditur.  Sed paulo post inánibus diis pro parta victoria sacrificáre jussus, constantíssime rénuit.  Cumque variis artibus ad Christi fidem ejurandam frustra tentarétur, una cum uxore et liberis, leónibus objícitur.  Horum mansuetúdine concitátus imperátor, æneum in taurum subjectis flámmis candéntem eos immítti jubet, ubi divinis in laudibus consummato martyrio, duodecimo Kalendas Octobris ad sempitérnam felicitátem convolárunt.  Quorum illæsa córpora, religióse a fidélibus sepúlta, póstmodum ad ecclésiam eórum nómine erectam honorofice transláta sunt.
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio Vigilia]
 !Commemoratio Pro Vigilia S. Matthæi.

--- a/web/www/horas/Latin/Sancti/09-23.txt
+++ b/web/www/horas/Latin/Sancti/09-23.txt
@@ -35,11 +35,11 @@ Thecla virgo, ex illustribus paréntibus Iconii nata, a Paulo Apóstolo fidei pr
 Linus Póntifex, Volatérris in Etrúria natus, primus post Petrum gubernávit Ecclésiam. Cujus tanta fides et sánctitas fuit, ut non solum dǽmones eíceret, sed étiam mórtuos revocáret ad vitam. Scripsit res gestas beáti Petri, et ea máxime quæ ab illo acta sunt contra Simónem magum. Sancívit ne qua múlier, nisi veláto cápite, in ecclésiam introíret. Huic Pontífici caput amputátum est ob constántiam fídei, jussu Saturníni ímpii et ingratíssimi consuláris, cujus fíliam a dǽmonum vexatióne liberáverat. Sepúltus est in Vaticáno prope sepúlcrum Príncipis Apostolórum, nono caléndas octóbris. Sedit annos úndecim, menses duos, dies vigínti tres, creátis, bis mense decémbri, epíscopis quíndecim, presbýteris decem et octo.
 &teDeum
 
-[Lectio7]
-@Commune/C4:Lectio71
+[[Lectio7]
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Latin/Sancti/09-27.txt
+++ b/web/www/horas/Latin/Sancti/09-27.txt
@@ -24,13 +24,13 @@ Cosmas et Damiánus, fratres Arabes, in Ægéa urbe nati, nóbiles médici, impe
 &teDeum
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Lectio9]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Latin/Sancti/10-14.txt
+++ b/web/www/horas/Latin/Sancti/10-14.txt
@@ -26,13 +26,13 @@ Callístus, Románus, prǽfuit Ecclésiæ, Antoníno Heliogábalo imperatóre. C
 &teDeum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Lectio7](rubrica tridentina)
 @Sancti/02-22:Lectio7

--- a/web/www/horas/Latin/Sancti/10-19.txt
+++ b/web/www/horas/Latin/Sancti/10-19.txt
@@ -23,10 +23,10 @@ Petrus Alcántaræ in Hispánia nobílibus paréntibus natus, décimo sexto æt�
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Latin/Sancti/10-31.txt
+++ b/web/www/horas/Latin/Sancti/10-31.txt
@@ -10,13 +10,13 @@ Laudes 2
 No Suffragium 
 
 [Lectio1]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio2]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio3]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco
 
 [Oratio]
 Dómine, Deus noster, multíplica super nos grátiam tuam: et, quorum prævenimus gloriósa solemnia, tríbue subsequi in sancta professióne lætítiam. 

--- a/web/www/horas/Latin/Sancti/11-13.txt
+++ b/web/www/horas/Latin/Sancti/11-13.txt
@@ -23,10 +23,10 @@ Dídacus, Hispánus, ex óppido sancti Nicolái de Portu diœcésis Hispalénsis
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Latin/Sancti/11-20.txt
+++ b/web/www/horas/Latin/Sancti/11-20.txt
@@ -23,10 +23,10 @@ Felix, Hugo ántea dictus, ex regáli Valesiórum família ortus in Gállia, ab 
 &teDeum
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Latin/Sancti/11-23.txt
+++ b/web/www/horas/Latin/Sancti/11-23.txt
@@ -96,10 +96,10 @@ Quibus concitátus Trajánus, misit illuc qui Cleméntem, alligáta ad ejus coll
 @:Responsory3o
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio7](rubrica tridentina)
 Léctio sancti Evangélii secúndum Matthǽum

--- a/web/www/horas/Latin/Sancti/12-11.txt
+++ b/web/www/horas/Latin/Sancti/12-11.txt
@@ -36,13 +36,13 @@ Pœnam taliónis constítuit iis, qui álterum falsi críminis accusássent. St�
 Dámasus Hispánus, vir egrégius et erudítus in Scriptúris sacris, indícto primo Constantinopolitáno concílio, nefáriam Eunómii et Macedónii hǽresim exstínxit. Ariminénsem convéntum, a Libério jam ante rejéctum, íterum condemnávit; in quo, ut scribit sanctus Hierónymus, Valéntis potíssimum et Ursácii fráudibus, damnátio Nicǽnæ fídei conclamáta est. Basílicas duas ædificávit: álteram sancti Lauréntii nómine ad theátrum Pompéji, álteram via Ardeatína ad Catacúmbas. Státuit, ut, quod plúribus jam locis erat in usu, Psalmi per omnes ecclésias diu noctúque ab altérnis caneréntur, et in fine cujúsque Psalmi dicerétur: Glória Patri, et Fílio, et Spirítui Sancto. Ejus jussu sanctus Hierónymus novum testaméntum Græcæ fídei réddidit. Multa étiam sanctórum Mártyrum córpora invénit, eorúmque memórias vérsibus exornávit. Virtúte, doctrína et prudéntia clarus, prope octogenárius, Theodósio senióre imperánte, obdormívit in Dómino.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Latin/Sancti/12-16.txt
+++ b/web/www/horas/Latin/Sancti/12-16.txt
@@ -18,16 +18,16 @@ Colléctum est Mediolani anno sequénti concílium, ad quod a Constantio invitá
 Quanta in eum tunc Arianórum crudelitas fúerit ac effrons inverecúndia, ostendunt graves litteræ plenæ róboris, pietátis ac religiónis, quas e Scythópoli scripsit ad Vercellensem clerum et pópulum, aliosque finítimos; e quibus étiam est explorátum, ipsórum nec minis, inhumanáque sævítia pótuisse umquam eum deterreri, nec serpentina blanda subtilitate ad eórum societátem perduci. Hinc in Cappadociam, postremoque ad superiores Ægypti Thebáidas pro constántia sua deportatus, exsilii rigores tulit ad mortem usque Constantii: post quam ad gregem suum reverti permissus, non prius redire vóluit, quam reparandis fidei jacturis ad Alexandrinam synodum sese conferret, postque médici præstántis instar, péragrans Oriéntis provincias, in fide infirmos ad integram valetúdinem restitúeret, eos instítuens in Ecclésiæ doctrina. Inde salubritate pari digresso in Illyricum, tandemque in Italiam delato, ad ejus réditum lúgubres vestes Italia mutávit: ubi postquam Psalmórum ómnium expurgatos a se commentarios Orígenis édidit, Eusebiíque Cæsareénsis, quos verterat de Græco in Latinum; demum tot egregie factis illustris ad immarcescíbilem glóriæ corónam tantis ærumnis proméritam, sub Valentiniáno et Valénte Vercellis migrávit.
 
 [Lectio7]
-@Commune/C2:Lectio73
+@Commune/C2:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C2:Lectio83
+@Commune/C2:Lectio8 in 4 loco
 
 [Responsory8]
-@Commune/C2:Responsory8NonEffusorum
+@Commune/C2:Responsory8 non Effusorum
 
 [Lectio9]
-@Commune/C2:Lectio93
+@Commune/C2:Lectio9 in 4 loco
 
 [Lectio94]
 Eusébius, natióne Sardus, Románæ urbis lector, post Vercellénsis epíscopus, advérsus Arianísmum sic viríliter dimicávit, ut ejus invícta fides Libérium summum Pontíficem ad vitæ solátium erígeret. Pro ejúsdem fídei cathólicæ confessióne a Constántio príncipe Scythópolim missus fuit, ubi famem, sitim, vérbera divérsaque supplícia est perpéssus. Inde in Cappadóciam relegátus, exsílii rigóres tulit usque ad mortem ipsíus Constántii, post quam ad ecclésiam suam revérti permíssus est. Tunc lúgubres vestes Itália mutávit; ubi, postquam Psalmórum ómnium expurgátos a se commentários Orígenis édidit, Eusebiíque Cæsareénsis, quos vérterat de Græco in Latínum; ad immarcescíbilem glóriæ corónam, tantis ærúmnis proméritam, sub Valentiniáno et Valénte Vercéllis migrávit ad Dóminum.

--- a/web/www/horas/Latin/Sancti/12-31.txt
+++ b/web/www/horas/Latin/Sancti/12-31.txt
@@ -56,13 +56,13 @@ Itaque, auctore Silvestro, pius imperátor quam christifidelibus publice templa 
 Idem præscripsisse traditur tempus ómnibus, qui ordínibus initiáti essent, exercéndi síngulos ordines in Ecclésia, antequam quisque ad altiórem gradum ascenderet; ut láicus clerico non inférret crimen, ne clericus apud profanum judicem causam diceret. Sábbati et Dominici diéi nómine retento, réliquos hebdómadæ dies feriárum nómine distinctos, ut jam ante in Ecclésia vocari cœperant, appellari vóluit, quo significarétur, quotídie clericos, abjecta ceterárum rerum cura, uni Deo prorsus vacare debére. Huic cælésti prudéntiæ, qua ecclésiam administrabat, insígnis vitæ sanctitas, et benignitas in páuperes perpetuo respóndit. Quo in genere providit, ut clericis copiosis egéntes conjungeret, et sacris virgínibus, quæ ad victum necessaria essent, suppeditaréntur. Vixit in pontificatu annos viginti unum, menses decem, diem unum. Sepultus est in cœmeterio Priscillæ, via Salaria. Fecit ordinatiónes septem mense Decembri, quibus creávit presbyteros quadragínta duos, diaconos viginti quinque, episcopos per diversa loca sexagínta quinque.
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Commemoratio 2]
 @Sancti/12-25:Octava

--- a/web/www/horas/Latin/SanctiM/03-21.txt
+++ b/web/www/horas/Latin/SanctiM/03-21.txt
@@ -110,7 +110,7 @@ V. Lex Dei ejus in corde ipsíus.
 R. Et non supplantabúntur gressus ejus.
 
 [Lectio1]
-@Commune/C4:Lectio11:s/-5/-4/ s/5 .*//s
+@Commune/C4:Lectio1 in 2 loco:s/-5/-4/ s/5 .*//s
 
 [Responsory1]
 R. Fuit vir vitæ venerábilis grátia Benedíctus et nómine, † ab ipso puerítæ suæ témpore cor gerens seníle
@@ -119,8 +119,8 @@ V. Recéssit ígitur sciénter néscius et sapiénter indóctus.
 R. Ætátem quippe móribus tránsiens nulli ánimum voluptáti dedit.
 
 [Lectio2]
-@Commune/C4:Lectio11:s/1-5/5-7/ s/1.*5/5/s
-@Commune/C4:Lectio21:2-3
+@Commune/C4:Lectio1 in 2 loco:s/1-5/5-7/ s/1.*5/5/s
+@Commune/C4:Lectio2 in 2 loco:2-3
 
 [Responsory2]
 R. Sanctus Benedíctus plus appétiit mala mundi pérpeti quam laudes; † pro Deo labóribus fatigári,
@@ -129,8 +129,8 @@ V. Divína namque prævéntus grátia magis ac magis ad supérna ánimo suspirá
 R. Quam vitæ hujus favóribus extólli.
 
 [Lectio3]
-@Commune/C4:Lectio21:s/6-9/8-11/ s/6.*8/8/s
-@Commune/C4:Lectio31:2-3
+@Commune/C4:Lectio2 in 2 loco:s/6-9/8-11/ s/6.*8/8/s
+@Commune/C4:Lectio3 in 2 loco:2-3
 
 [Responsory3]
 R. Inito consílio venénum vino miscuére: † quo obláto ex more ad benedicéndum Patri, vir Dei signo crucis édidit, † et vas pestíferi potus ita confráctum est,
@@ -139,7 +139,7 @@ V. Intelléxit prótinus vir dei quia potum mortis habúerat, † quod portáre 
 R. Ac si pro signo lápidem dedísset.
 
 [Lectio4]
-@Commune/C4:Lectio31:s/10-/12-/ s/10.*12/12/s
+@Commune/C4:Lectio3 in 2 loco:s/10-/12-/ s/10.*12/12/s
 
 [Responsory4]
 R. Dómine, non aspícias peccáta mea, sed fidem hujus hóminis, † qui rogat resuscitári fílium suum: † et redde in hoc corpúsculum ánimam quam tulísti. † Et compléta oratióne revíxit:

--- a/web/www/horas/Latin/SanctiM/08-10.txt
+++ b/web/www/horas/Latin/SanctiM/08-10.txt
@@ -34,10 +34,10 @@ Nisi granum frumenti * cadens, in terram mortuum fuerit, ipsum solum manet.
 @Sancti/08-10::14-15
 
 [Lectio1]
-@Commune/C6:Lectio11:s/7/3/ s/.4 .*//s
+@Commune/C6:Lectio1 in 2 loco:s/7/3/ s/.4 .*//s
 
 [Lectio2]
-@Commune/C6:Lectio11:s/:1/:4/ s/1 .*4 /4 /s
+@Commune/C6:Lectio1 in 2 loco:s/:1/:4/ s/1 .*4 /4 /s
 
 [Lectio3]
 @Sancti/08-10:Lectio2

--- a/web/www/horas/Latin/SanctiM/11-13.txt
+++ b/web/www/horas/Latin/SanctiM/11-13.txt
@@ -32,21 +32,21 @@ _
 @SanctiM/11-01:HymnusM Laudes:s/Cœtus.*Monachórum/Monachórum/s
 
 [Lectio1]
-@Commune/C4:Lectio11:s/-5/-4/ s/5 .*//s
+@Commune/C4:Lectio1 in 2 loco:s/-5/-4/ s/5 .*//s
 
 [Responsory1]
 @SanctiM/11-01:Responsory8
 
 [Lectio2]
-@Commune/C4:Lectio11:s/1-5/5-7/ s/1 .*5/5/s
-@Commune/C4:Lectio21:s/!.*// s/8 .*//s
+@Commune/C4:Lectio1 in 2 loco:s/1-5/5-7/ s/1 .*5/5/s
+@Commune/C4:Lectio2 in 2 loco:s/!.*// s/8 .*//s
 
 [Responsory2]
 @Commune/C1
 
 [Lectio3]
-@Commune/C4:Lectio21:s/6-9/8-11/ s/6 .*8/8/s
-@Commune/C4:Lectio31:s/!.*// s/12 .*//s
+@Commune/C4:Lectio2 in 2 loco:s/6-9/8-11/ s/6 .*8/8/s
+@Commune/C4:Lectio3 in 2 loco:s/!.*// s/12 .*//s
 
 [Responsory3]
 R. Haec est vera fratérnitas, quae numquam pótuit violári certámine: † qui, effúso súnguine secúti sunt Dóminum:
@@ -55,7 +55,7 @@ V. Ecce quam bonum et quam jucúndum habitáre fratres in unum!
 R. Contemnéntes aulam régiam, pervenérunt ad regna caeléstia.
 
 [Lectio4]
-@Commune/C4:Lectio31:s/10-/12-/ s/10 .*12/12/s
+@Commune/C4:Lectio3 in 2 loco:s/10-/12-/ s/10 .*12/12/s
 
 [Responsory4]
 @Commune/C3

--- a/web/www/horas/Magyar/Commune/C2.txt
+++ b/web/www/horas/Magyar/Commune/C2.txt
@@ -213,13 +213,13 @@ R. Fölfelé nő, mint a Libanon cédrusa.
 [Ant 3]
 Aki követni akar, * tagadja meg magát, vegye fel keresztjét minden nap és úgy kövessen.
 
-[Responsory72]
+[Responsory7 in 3 loco]
 @Commune/C2:Responsory7
 
-[Responsory82]
+[Responsory8 in 3 loco]
 @Commune/C2:Responsory8
 
-[Lectio73]
+[Lectio7 in 4 loco]
 Evangélium szent Máté Apostol kőnyvéből
 !Matt 16:24-27
 Azon időben így szólt Jézus a tanítványaihoz: Aki követni akar, tagadja meg magát, vegye keresztjét és kövessen. És így tovább.

--- a/web/www/horas/Magyar/Commune/C3.txt
+++ b/web/www/horas/Magyar/Commune/C3.txt
@@ -221,7 +221,7 @@ R. Ujjongjanak nyugvóhelyükön!
 [Ant 3]
 A mennyben örvendeznek * a szentek lelkei akik követték Krisztus útját; vérük Krisztus szeretetéért omlott, ezért boldogok Krisztusban mindörökké
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Evangélium szent Lukács Evangélista kőnyvéből
 !Luke 6:17-23
 Aztán Jézus lejött velük a hegyről és egy sík terepen megállt. Rengeteg tanítvány sereglett oda hozzá, s hatalmas tömeg gyűlt köré egész Júdeából, Jeruzsálemből, valamint a tíruszi és szidoni tengermellékről, És így tovább.

--- a/web/www/horas/Magyar/Commune/C4.txt
+++ b/web/www/horas/Magyar/Commune/C4.txt
@@ -239,7 +239,7 @@ R. Megmutatta neki Isten országát
 [Ant 3 summi Pontificis]
 Igazi főpap volt, a földiek nem tántoritották el, dicsőséggel ment a mennybe
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Olvasmány Jézus Sírák fia könyvéből
 !Sir 44:1-5
 1 Dicsérjük a dicső férfiakat, és atyáinkat nemzedékeikben.
@@ -248,14 +248,14 @@ Olvasmány Jézus Sírák fia könyvéből
 4 És parancsoltak az akkori népnek, és az okosság erejével szentséges igéket mondtak a népeknek.
 5 Tudományuk által föltalálták a zene mértékét, és irásban is szerzettek énekeket.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 44:6-9
 6 Hatalmas, gazdag emberek, figyelmet fordítók a szépre, s békeségesen élök házaikban.
 7 Ezek mindnyájan dicsőséget nyertek az ö népök nemzedékeinél, és már napjaikban dicsértettek.
 8 A kik tőlök születtek, nevet hagytak dicsőségök hirdetésére.
 9 És vannak, kiknek nincs emlékezetök; elenyésztek, mintha nem lettek volna; és születtek, mintha nem születtek volna, ök és fiaik velök.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 44:10-15
 10 De amazok irgalmas férfiak voltak, kiknek istenessége nem megyen feledésbe.
 11 Azok ivadékával megmaradnak a jók.
@@ -264,8 +264,8 @@ Olvasmány Jézus Sírák fia könyvéből
 14 Testeik békeségben temettettek el, és nevök él nemzedékröl nemzedékre.
 15 Bölcseségöket beszélik a népek, és dicséretöket hirdeti a gyülekezet.
 
-[Responsory73]
+[Responsory7 in 4 loco]
 @Commune/C5:Responsory7
 
-[Responsory83]
+[Responsory8 in 4 loco]
 @Commune/C5:Responsory8

--- a/web/www/horas/Magyar/Commune/C5.txt
+++ b/web/www/horas/Magyar/Commune/C5.txt
@@ -212,7 +212,7 @@ R. Megmutatja neki Isten országát
 [Ant 3]
 A férfi aki megveti * a világot és a földi dolgokat győzelmes, égi kincseket gyüjt szava és keze
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Olvasmány a Bölcsesség könyvéből
 !Wis 4:7-14
 7 Az igaznak azonban, ha időnap előtt hal is meg, nyugalomban lesz része.
@@ -224,7 +224,7 @@ Olvasmány a Bölcsesség könyvéből
 13 Aki korán tökéletes lett, nagy kort ért meg.
 14 Kedvét találta lelkében az Úr, azért sietett kimenteni a romlottság köréből.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Wis 4:14-19
 14 Látják ezt az emberek, de nem értik, és nem veszik szívükre,
 15 hogy kegyelem és irgalom vár az Úr választottaira és oltalom a szentjeire.
@@ -233,7 +233,7 @@ Olvasmány a Bölcsesség könyvéből
 18 Látják, és becsmérlőleg szólnak róla, de az Úr majd gúnyt űz belőlük.
 19 Akkor hullává lesznek, megvetetté, és gúnynak tárgyává a holtak közt örökre. Mert letaszítja őket, úgyhogy meg sem mukkannak, velejükig megrendíti őket, végső pusztulásra jutnak,
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Wis 4:19-20; 5:1-5
 19 gyötrődniük kell, és elenyészik az emlékük.
 20 Reszketve jelennek meg számot adni bűneikről, és gaztetteik vádlóként lépnek föl ellenük.
@@ -243,12 +243,12 @@ Olvasmány a Bölcsesség könyvéből
 4 "Ez az, akit egykor kinevettünk és akiből gúnyt űztünk. Mi esztelenek! Életmódját őrültségnek tartottuk és halálát dicstelennek.
 5 Hogy lehet az, hogy Isten fiai közé sorolták és a szentek között van az osztályrésze?
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Evangélium szent Lukács Evangélista kőnyvéből
 !Luke 12:32-35
 Ne félj, te kisded nyáj, hisz Atyátok úgy látta jónak, hogy nektek adja országát. És így tovább
 _
-[Lectio72]
+[Lectio7 in 3 loco]
 Evangélium szent Lukács Evangélista kőnyvéből
 !Luke 19:12-25
 Azon időben Jézus ezt a példabeszédet mondta tanitványainak: Egy főember kezdte messze földre indult, hogy királyságot szerezzen magának, s aztán visszatérjen. És így tovább.

--- a/web/www/horas/Magyar/Commune/C5a.txt
+++ b/web/www/horas/Magyar/Commune/C5a.txt
@@ -202,7 +202,7 @@ R. Megmutatja neki Isten országát
 [Ant 3]
 Igaz és kiválló tanitó, * Egyházunk fénye, N. az isteni Törvény tisztelője, imádkozzál érettünk Isten Fiához.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Olvasmány a Bölcsesség könyvéből
 !Wis 4:7-14
 7 Az igaznak azonban, ha időnap előtt hal is meg, nyugalomban lesz része.
@@ -214,7 +214,7 @@ Olvasmány a Bölcsesség könyvéből
 13 Aki korán tökéletes lett, nagy kort ért meg.
 14 Kedvét találta lelkében az Úr, azért sietett kimenteni a romlottság köréből.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Wis 4:14-19
 14 Látják ezt az emberek, de nem értik, és nem veszik szívükre,
 15 hogy kegyelem és irgalom vár az Úr választottaira és oltalom a szentjeire.
@@ -223,7 +223,7 @@ Olvasmány a Bölcsesség könyvéből
 18 Látják, és becsmérlőleg szólnak róla, de az Úr majd gúnyt űz belőlük.
 19 Akkor hullává lesznek, megvetetté, és gúnynak tárgyává a holtak közt örökre. Mert letaszítja őket, úgyhogy meg sem mukkannak, velejükig megrendíti őket, végső pusztulásra jutnak,
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Wis 4:19-20; 5:1-5
 19 gyötrődniük kell, és elenyészik az emlékük.
 20 Reszketve jelennek meg számot adni bűneikről, és gaztetteik vádlóként lépnek föl ellenük.
@@ -233,17 +233,17 @@ Olvasmány a Bölcsesség könyvéből
 4 "Ez az, akit egykor kinevettünk és akiből gúnyt űztünk. Mi esztelenek! Életmódját őrültségnek tartottuk és halálát dicstelennek.
 5 Hogy lehet az, hogy Isten fiai közé sorolták és a szentek között van az osztályrésze?
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Evangélium szent Lukács Evangélista kőnyvéből
 !Luke 12:32-35
 Ne félj, te kisded nyáj, hisz Atyátok úgy látta jónak, hogy nektek adja országát. És így tovább
 _
-[Lectio72]
+[Lectio7 in 3 loco]
 Evangélium szent Lukács Evangélista kőnyvéből
 !Luke 19:12-25
 Azon időben Jézus ezt a példabeszédet mondta tanitványainak: Egy főember kezdte messze földre indult, hogy királyságot szerezzen magának, s aztán visszatérjen. És így tovább.
 _
-[Lectio73]
+[Lectio7 in 4 loco]
 Evangélium szent Máté Apostol kőnyvéből
 !Matt 16:24-27
 Azon időben így szólt Jézus a tanítványaihoz: Aki követni akar, tagadja meg magát, vegye keresztjét és kövessen. És így tovább.

--- a/web/www/horas/Magyar/Commune/C6.txt
+++ b/web/www/horas/Magyar/Commune/C6.txt
@@ -206,7 +206,7 @@ R. Isten ezért megáldott mindörökre
 [Ant 3]
 Jőjj Krisztus jegyese * fogadd el koronádat melyet az Úr készített neked öröktől fogva
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Olvasmány Jézus Sírák fia könyvéből
 !Sir 51:1-7
 1 Jézusnak, Sirák fiának imádsága. Hálát adok neked, Uram Királyom! És dicsérlek téged, szabadító Istenemet.
@@ -217,7 +217,7 @@ Olvasmány Jézus Sírák fia könyvéből
 6 a láng égetésétöl, mely körölvett engem, és a töz közepett nem égtem meg,
 7 a pokol gyomrának mélységéböl, és a megfertözött nyelvtöl, és a hazug igétöl, az igazságtalan királytól és az álnok nyelvtöl.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 51:8-12
 8 Mindhalálig dicséri lelkem az Urat;
 9 mert életem közelgetett lefelé a pokolhoz.
@@ -225,7 +225,7 @@ Olvasmány Jézus Sírák fia könyvéből
 11 Ekkor megemlékeztem a te irgalmasságodról, Uram! és azokról, miket öröktöl fogva cselekedtél;
 12 hogy kimented, Uram, a te rád várakozókat, és kiszabadítod öket a pogányok kezeiböl.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 13 Felmagasztaltad a földön lakhelyemet és az elmúló halálért könyörögtem.
 14 Segítségöl hittam az Urat, az én Uram Atyját, hogy ne hagyjon engem háborúságom napján és a kevélyek idejében segítség nélkül.

--- a/web/www/horas/Magyar/Commune/C6b.txt
+++ b/web/www/horas/Magyar/Commune/C6b.txt
@@ -201,7 +201,7 @@ R. Isten ezért megáldott mindörökre
 [Ant 3]
 Jőjj Krisztus jegyese * fogadd el koronádat melyet az Úr készített neked öröktől fogva
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Olvasmány Jézus Sírák fia könyvéből
 !Sir 51:1-7
 1 Jézusnak, Sirák fiának imádsága. Hálát adok neked, Uram Királyom! És dicsérlek téged, szabadító Istenemet.
@@ -212,7 +212,7 @@ Olvasmány Jézus Sírák fia könyvéből
 6 a láng égetésétöl, mely körölvett engem, és a töz közepett nem égtem meg,
 7 a pokol gyomrának mélységéböl, és a megfertözött nyelvtöl, és a hazug igétöl, az igazságtalan királytól és az álnok nyelvtöl.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Sir 51:8-12
 8 Mindhalálig dicséri lelkem az Urat;
 9 mert életem közelgetett lefelé a pokolhoz.
@@ -220,7 +220,7 @@ Olvasmány Jézus Sírák fia könyvéből
 11 Ekkor megemlékeztem a te irgalmasságodról, Uram! és azokról, miket öröktöl fogva cselekedtél;
 12 hogy kimented, Uram, a te rád várakozókat, és kiszabadítod öket a pogányok kezeiböl.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Sir 51:13-17
 13 Felmagasztaltad a földön lakhelyemet és az elmúló halálért könyörögtem.
 14 Segítségöl hittam az Urat, az én Uram Atyját, hogy ne hagyjon engem háborúságom napján és a kevélyek idejében segítség nélkül.

--- a/web/www/horas/Magyar/Sancti/04-22.txt
+++ b/web/www/horas/Magyar/Sancti/04-22.txt
@@ -7,10 +7,10 @@ vide C3;
 OPapaeM=Soter and Caius;
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Magyar/Sancti/04-23.txt
+++ b/web/www/horas/Magyar/Sancti/04-23.txt
@@ -12,10 +12,10 @@ vide C2;
 9 lectiones
 
 [Lectio4]
-@Commune/C2:Lectio41
+@Commune/C2:Lectio4 in 2 loco
 
 [Lectio5]
-@Commune/C2:Lectio51
+@Commune/C2:Lectio5 in 2 loco
 
 [Lectio6]
-@Commune/C2:Lectio61
+@Commune/C2:Lectio6 in 2 loco

--- a/web/www/horas/Magyar/Sancti/05-25.txt
+++ b/web/www/horas/Magyar/Sancti/05-25.txt
@@ -11,10 +11,10 @@ CPapaM=Urban;
 @Commune/C2:Oratio Gregem
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Magyar/Sancti/06-25.txt
+++ b/web/www/horas/Magyar/Sancti/06-25.txt
@@ -9,10 +9,10 @@ vide C5;
 @Sancti/06-24:Octava
 
 [Lectio7]
-@Commune/C4:Lectio73
+@Commune/C4:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C4:Lectio83
+@Commune/C4:Lectio8 in 4 loco
 
 [Lectio9]
-@Commune/C4:Lectio93
+@Commune/C4:Lectio9 in 4 loco

--- a/web/www/horas/Magyar/Sancti/06-26.txt
+++ b/web/www/horas/Magyar/Sancti/06-26.txt
@@ -20,7 +20,7 @@ Touching this leaven the Apostle warneth us Therefore let us keep the feast, not
 the unleavened bread of sincerity and truth. (i Cor. v. 8.) For even as a little leaven doth infect the whole lump wherein it is put, and the savour thereof doth spread all abroad therein, so doth hypocrisy, when once it hath tainted the soul, drive out from it all sincerity and truth. The meaning, therefore, of this passage is this Beware, lest ye be as the hypocrites, for yet a little while, and all men shall see that ye are good, and they are evil.
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Commemoratio 1]
 @Sancti/06-24:Octava

--- a/web/www/horas/Magyar/Sancti/06-26r.txt
+++ b/web/www/horas/Magyar/Sancti/06-26r.txt
@@ -20,4 +20,4 @@ Touching this leaven the Apostle warneth us Therefore let us keep the feast, not
 the unleavened bread of sincerity and truth. (i Cor. v. 8.) For even as a little leaven doth infect the whole lump wherein it is put, and the savour thereof doth spread all abroad therein, so doth hypocrisy, when once it hath tainted the soul, drive out from it all sincerity and truth. The meaning, therefore, of this passage is this Beware, lest ye be as the hypocrites, for yet a little while, and all men shall see that ye are good, and they are evil.
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco

--- a/web/www/horas/Magyar/Sancti/06-26t.txt
+++ b/web/www/horas/Magyar/Sancti/06-26t.txt
@@ -20,7 +20,7 @@ Touching this leaven the Apostle warneth us Therefore let us keep the feast, not
 the unleavened bread of sincerity and truth. (i Cor. v. 8.) For even as a little leaven doth infect the whole lump wherein it is put, and the savour thereof doth spread all abroad therein, so doth hypocrisy, when once it hath tainted the soul, drive out from it all sincerity and truth. The meaning, therefore, of this passage is this Beware, lest ye be as the hypocrites, for yet a little while, and all men shall see that ye are good, and they are evil.
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Commemoratio 1]
 @Sancti/06-24:Octava

--- a/web/www/horas/Magyar/Sancti/07-03.txt
+++ b/web/www/horas/Magyar/Sancti/07-03.txt
@@ -14,10 +14,10 @@ OPapaC=Leo;
 @Sancti/06-29:Octava
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Magyar/Sancti/07-13.txt
+++ b/web/www/horas/Magyar/Sancti/07-13.txt
@@ -7,10 +7,10 @@ vide C2;
 OPapaM=Anacletus;
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Magyar/Sancti/07-13o.txt
+++ b/web/www/horas/Magyar/Sancti/07-13o.txt
@@ -7,10 +7,10 @@ vide C2;
 OPapaM=Anacletus;
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Magyar/Sancti/07-14.txt
+++ b/web/www/horas/Magyar/Sancti/07-14.txt
@@ -12,10 +12,10 @@ vide C4a;mtv
 9 lectiones
 
 [Lectio7]
-@Commune/C4a:Lectio72
+@Commune/C4a:Lectio7 in 3 loco
 
 [Lectio8]
-@Commune/C4a:Lectio82
+@Commune/C4a:Lectio8 in 3 loco
 
 [Lectio9]
-@Commune/C4a:Lectio92
+@Commune/C4a:Lectio9 in 3 loco

--- a/web/www/horas/Magyar/Sancti/08-23.txt
+++ b/web/www/horas/Magyar/Sancti/08-23.txt
@@ -6,13 +6,13 @@ vide C5;mtv
 9 lectiones
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco
 
 [Lectio Vigilia]
 !Pro Vigilia  S. Bartholomaei Apostoli

--- a/web/www/horas/Magyar/Sancti/09-17.txt
+++ b/web/www/horas/Magyar/Sancti/09-17.txt
@@ -93,10 +93,10 @@ testemen.
 18 A mi Urunk, Jézus Krisztus kegyelme legyen lelketekkel, testvérek! Amen.
 
 [Lectio7]
-@Commune/C2:Lectio73
+@Commune/C2:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C2:Lectio83
+@Commune/C2:Lectio8 in 4 loco
 
 R. Én azonban nem akarok mással dicsekedni, mint Urunk, Jézus Krisztus keresztjével. 
 * Általa keresztre szegezték nekem a világot, és engem is a világnak.
@@ -106,7 +106,7 @@ R. Általa keresztre szegezték nekem a világot, és engem is a világnak.
 R. Általa keresztre szegezték nekem a világot, és engem is a világnak.
 
 [Lectio9]
-@Commune/C2:Lectio93
+@Commune/C2:Lectio9 in 4 loco
 
 [Hymnus Laudes]
 {:H-Jesucoronacelsior:}v. Jézus, felséges korona,

--- a/web/www/horas/Magyar/Sancti/09-20.txt
+++ b/web/www/horas/Magyar/Sancti/09-20.txt
@@ -9,10 +9,10 @@ vide C3;
 9 lectiones
 
 [Lectio7]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio Vigilia]
 !Commemoration for the Eve of S. Matthaei.

--- a/web/www/horas/Magyar/Sancti/10-14.txt
+++ b/web/www/horas/Magyar/Sancti/10-14.txt
@@ -9,13 +9,13 @@ vide C3;
 9 lectiones
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Lectio7](rubrica tridentina)
 @Sancti/02-22:Lectio7

--- a/web/www/horas/Magyar/Sancti/10-19.txt
+++ b/web/www/horas/Magyar/Sancti/10-19.txt
@@ -6,10 +6,10 @@ vide C5;mtv
 9 lectiones
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Magyar/Sancti/10-31.txt
+++ b/web/www/horas/Magyar/Sancti/10-31.txt
@@ -10,10 +10,10 @@ Laudes 2
 No Suffragium 
 
 [Lectio1]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio2]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio3]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Magyar/Sancti/10-31v.txt
+++ b/web/www/horas/Magyar/Sancti/10-31v.txt
@@ -10,10 +10,10 @@ Laudes 2
 No Suffragium 
 
 [Lectio1]
-@Commune/C3:Lectio71
+@Commune/C3:Lectio7 in 2 loco
 
 [Lectio2]
-@Commune/C3:Lectio81
+@Commune/C3:Lectio8 in 2 loco
 
 [Lectio3]
-@Commune/C3:Lectio91
+@Commune/C3:Lectio9 in 2 loco

--- a/web/www/horas/Magyar/Sancti/11-13.txt
+++ b/web/www/horas/Magyar/Sancti/11-13.txt
@@ -6,10 +6,10 @@ vide C5;mtv
 9 lectiones
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Magyar/Sancti/11-20.txt
+++ b/web/www/horas/Magyar/Sancti/11-20.txt
@@ -6,10 +6,10 @@ vide C5;mtv
 9 lectiones
 
 [Lectio7]
-@Commune/C5:Lectio71
+@Commune/C5:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C5:Lectio81
+@Commune/C5:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C5:Lectio91
+@Commune/C5:Lectio9 in 2 loco

--- a/web/www/horas/Magyar/Sancti/12-11.txt
+++ b/web/www/horas/Magyar/Sancti/12-11.txt
@@ -19,10 +19,10 @@ Omit Preces
 @Sancti/12-08:Oratio
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco

--- a/web/www/horas/Polski/Commune/C4.txt
+++ b/web/www/horas/Polski/Commune/C4.txt
@@ -305,7 +305,7 @@ Umiłował go Pan * i przyozdobił go: szatą chwały przyodział go: u bram nie
 [Ant 3 summi Pontificis]
 Gdy był najwyższym kapłanem, * nie obawiał się niczego na ziemi, ale chwalebnie przeszedł do królestwa niebieskiego.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Z Księgi Ekklezjastyka.
 !Syr 44:1-5
 1 Wysławiajmy męże chwalebne i ojce nasze w rodzaju swoim.
@@ -314,14 +314,14 @@ Z Księgi Ekklezjastyka.
 4 i rozkazujący ludowi czasu swego i mocą roztropności ludziom naświętsze słowa.
 5 Umiejętnością swą wynajdowali śpiewania muzyckie i wiersze Pisma wykładali;
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Syr 44:6-9
 6 Ludzie bogaci w mocy, starający się o poczciwość, doma spokojnie mieszkający.
 7 Ci wszyscy w rodzajach narodu swego sławę otrzymali a za dni swoich byli w pochwaleniu.
 8 Którzy się z nich narodzili, zostawili imię, aby opowiadano chwały ich.
 9 A są, których nie masz pamiątki; zginęli jako ci, których nie było; i narodzili się, jakoby się nie rodzili, i synowie ich z nimi.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Syr 44:10-15
 10 Ale oni są ludzie miłosierdzia, których pobożności nie ustały.
 11 Z nasieniem ich trwają dobra,
@@ -330,5 +330,5 @@ Z Księgi Ekklezjastyka.
 14 Ciała ich są w pokoju pogrzebione, a sława ich żywię na pokolenie i pokolenie.
 15 Mądrość ich niech powiadają narodowie, a chwałę ich niech opowiada kościół.
 
-[Responsory83]
+[Responsory8 in 4 loco]
 @:Responsory8

--- a/web/www/horas/Polski/Commune/C5.txt
+++ b/web/www/horas/Polski/Commune/C5.txt
@@ -235,7 +235,7 @@ R. I okazał mu królestwo Boże.
 [Ant 3]
 Ten mąż, wzgardziwszy światem * i dobrami ziemskiemi, triumfuje, zebrawszy czynami i słowy skarby dla nieba.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Z Księgi Mądrości
 !Mdr 4:7-14
 7 Ale sprawiedliwy, jeśli śmiercią będzie uprzedzony, w ochłodzeniu będzie.
@@ -247,7 +247,7 @@ Z Księgi Mądrości
 13 Stawszy się za krótki czas doskonałym, przeżył czasów wiele:
 14 Spodobała się bowiem Bogu dusza jego, dlatego pokwapił się wywieść go spośrzód nieprawości;
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Mdr 4:14-19
 14 A ludzie widzieli, a nie rozumieli ani kładli w serca takich rzeczy,
 15 gdy łaska Boża i miłosierdzie jest ku świętym jego i wzgląd na wybrane jego.
@@ -256,7 +256,7 @@ Z Księgi Mądrości
 18 Ujżrzą i wzgardzą go, a z nich Pan naśmiewać się będzie.
 19 I będą potym upadający beze czci iw zelżeniu między umarłymi na wieki: bo je roztrąci nadęte bez głosu i z gruntu je wzruszy, i aż do wierzchu spustoszeni będą.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Mdr 4:19-20; 5:1-5
 19 I będą wzdychać, i pamiątka ich zginie.
 20 Przyjdą do rachowania grzechów swoich bojażliwi i strofować ich będą z przeciwia nieprawości ich.
@@ -266,7 +266,7 @@ Z Księgi Mądrości
 4 My głupi, mieliśmy żywot ich za szaleństwo i za sromotne ich dokończenie.
 5 Oto jako policzeni są między syny Boże i między świętymi dział ich jest.
 
-[Lectio71]
+[Lectio7 in 2 loco]
 Czytanie Ewangelii świętej według Łukasza
 !Łk 12:32-34
 Onego czasu: Rzekł Jezus uczniom swoim: «Nie lękaj się, trzódko mała, gdyż spodobało się Ojcu waszemu dać wam Królestwo. I tak dalej.
@@ -275,8 +275,8 @@ Homilia Wielebnego Bedy, Kapłana
 !Księga 4, rozdział 4, u Łukasza 12
 Mało trzodą Pan wybranych zowie abo z porównania większej liczby potępieńców, abo raczej dla uległości pokory. To jest że Pan chce, aby Kościoł jego jakąkolwiek wielkością rozmnożony aż do końca świata pokorą rósł, a do Królestwa obiecanego przez pokorę zaszedł. Przetoż jego łaskawie ciesząc i aby tylko Królestwa Bożego szukał przekazując temuż z Ojcowskiego upodobania Królestwa danie obieciał.
 
-[Lectio81]
+[Lectio8 in 2 loco]
 Przedajcie co macie a dajcie jałmużnę. Tu Pan mówi nie bójcie się, aby tym którzy na Królestwo Boże robią potrzeb żywota tego niedostało i owszem co macie na jałmużnę przedajcie. Co na ten czas przystojnie dzieje się kiedy kto raz dla Pana swego wszystkim pogardziwszy potym przedsie robotą ręczną z czego by się żywił i jałmużnę dawał wyrabia. Więc i Apostoł chwali się: srebra i złota abo sukna żadnego nie pragnąłem, sami wiecie bo na potrzeby moje i tych którzy są ze mną posługowały te ręce. Wszystkom wam ukazał że tak robiąc potrzeba przyjmować słabe.
 
-[Lectio91]
+[Lectio9 in 2 loco]
 Czyńcie sobie mieszki które nie wietrzeją, to jest: jałmużny czyniąc których zapłata trwa na wieki. Gdzie nie mamy rozumieć aby Pan przykazował aby święci pieniędzy nie chowali albo na potrzeby swe albo ubogich. Ponieważ i Pan sam któremu aniołowie służyli jednak aby nauczył kościół swój czytamy że mieszek miał i jałmużny wiernych chował i na swoje potrzeby i innych obracał. Ale tu Pan naucza, abyśmy nie dla tych rzeczy Bogu służyli i dla bojaźni niedostatku sprawiedliwości nie odbiegali.

--- a/web/www/horas/Polski/Commune/C6.txt
+++ b/web/www/horas/Polski/Commune/C6.txt
@@ -259,7 +259,7 @@ _
 V. Rozlała się wdzięczność po wargach twoich.
 R. Dlatego cię błogosławił Bóg na wieki.
 
-[Lectio11]
+[Lectio1 in 2 loco]
 Z Księgi Ekklezjastyka
 !Syr 51:1-7
 1 Wyznawać ci będę, Panie, Królu, i będę cię chwalił, Boga, Zbawiciela mego.
@@ -270,7 +270,7 @@ Z Księgi Ekklezjastyka
 6 od ucisku płomienia, który mię ogarnął, a w pośrzód ognia nie upaliłem się,
 7 z głębokości brzucha piekielnego i od języka splugawionego, i od słowa kłamliwego, od króla niezbornego i od języka niesprawiedliwego.
 
-[Lectio21]
+[Lectio2 in 2 loco]
 !Syr 51:8-12
 8 Będzie chwaliła aż do śmierci dusza moja Pana,
 9 a żywot mój przybliżał się na dół do piekła.
@@ -278,7 +278,7 @@ Z Księgi Ekklezjastyka
 11 Wspominałem na miłosierdzie twoje, Panie, i na sprawę twoję, które są od wieku.
 12 Bo wyrywasz czekających na cię, Panie, i wybawiasz je z rąk pogańskich.
 
-[Lectio31]
+[Lectio3 in 2 loco]
 !Syr 51:13-17
 13 Wywyższyłeś na ziemi mieszkanie moje i o spłynienie od śmierci prosiłem.
 14 Wzywałem Pana, Ojca Pana mego, aby mię nie opuszczał w dzień utrapienia mego i czasu pysznych, bez pomocy.

--- a/web/www/horas/Polski/Sancti/06-25.txt
+++ b/web/www/horas/Polski/Sancti/06-25.txt
@@ -13,11 +13,10 @@ $Per Dominum
 @Sancti/06-24:Octava2
 
 [Lectio7]
-@Commune/C4:Lectio73
+@Commune/C4:Lectio7 in 4 loco
 
 [Lectio8]
-@Commune/C4:Lectio83
+@Commune/C4:Lectio8 in 4 loco
 
 [Lectio9]
-@Commune/C4:Lectio93
-
+@Commune/C4:Lectio9 in 4 loco

--- a/web/www/horas/Polski/Sancti/06-26.txt
+++ b/web/www/horas/Polski/Sancti/06-26.txt
@@ -23,7 +23,7 @@ Prosimy Cię, Wszechmogący Boże, racz nas dzisiaj obdarzyć podwójną radośc
 $Per Dominum
 
 [Responsory8]
-@Commune/C3:Responsory81
+@Commune/C3:Responsory8 in 2 loco
 
 [Ant Laudes]
 @:Ant Vespera 3:s/;;.*//g

--- a/web/www/horas/Polski/Sancti/10-14.txt
+++ b/web/www/horas/Polski/Sancti/10-14.txt
@@ -13,13 +13,13 @@ Boże, który widzisz, że z powodu ułomności naszej upadamy, racz w miłosier
 $Per Dominum
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Lectio7](rubrica tridentina)
 @Sancti/02-22:Lectio7

--- a/web/www/horas/Polski/Sancti/12-11.txt
+++ b/web/www/horas/Polski/Sancti/12-11.txt
@@ -24,13 +24,13 @@ $Per Dominum
 @Sancti/12-08:Oratio
 
 [Lectio7]
-@Commune/C4:Lectio71
+@Commune/C4:Lectio7 in 2 loco
 
 [Lectio8]
-@Commune/C4:Lectio81
+@Commune/C4:Lectio8 in 2 loco
 
 [Lectio9]
-@Commune/C4:Lectio91
+@Commune/C4:Lectio9 in 2 loco
 
 [Ant 3] (rubrica divino aut rubrica 1955 aut rubrica 1960)
 @Commune/C4:Ant 3 summi Pontificis


### PR DESCRIPTION
This pull requests mainly resolves the naming conflicts in the Commune files (cf. #2752 )
In addition, it ensures the "mtv" changes by Cum nostra hac ætate for the Monastic versions by means of the code instead of doubling the hymn definitions.
Finally, it provides the basis for Offices of 12 lessons and responsories for the Monastic version for C2, C3, and C4 including the Lectiones in secundo vel ... loco.