### PR TITLE
Update 09-19.txt

### DIFF
--- a/web/www/horas/English/Martyrologium/09-19.txt
+++ b/web/www/horas/English/Martyrologium/09-19.txt
@@ -5,8 +5,8 @@ At Nocera, the holy martyrs Felix and Constance, who suffered under Nero.
 In Palestine, the holy martyrs Peleus, Nilus, and Elias, Bishops of Egypt, who, in the time of the persecution under the Emperor Diocletian, were, along with many other clerks, consumed with fire for Christ's sake. 
 On the same day, under the Emperor Probus, the holy martyrs Trophimus, Sabbatius, and Dorymedon. 
 Sabbatius was flogged to death at Antioch, by command of Atticus the President; Trophimus was sent to Synnada to the President Perennius, and there, after being put to many torments, he was beheaded along with the Senator Dorymedon. 
-At Cordova, in the persecution under the Arabs, (in the ninth century,) the holy Virgin and martyr Pomposa. 
+At Cordova, in the persecution under the Arabs, (in the ninth century,) the holy virgin and martyr Pomposa. 
 At Canterbury, holy Theodore, Archbishop of that city, who was sent into England by Pope Vitalian, and was a burning and a shining light for teaching and holiness. (We keep his feast upon the 26th day of this present month of September.) 
 At Tours, (in the fifth century,) the holy Confessor Eustochius, Bishop (of that see,) a man of many graces. 
 In the country of Langres, (in the sixth century,) the holy Priest and Confessor Sequanus. 
-At Barcelona, in Spain, the blessed Virgin Mary de Cervelhon, of the Order of St. Mary of Ransom, who, because of her ready help to them that call upon her, is commonly called Helpful Mary. 
+At Barcelona, in Spain, the blessed virgin Mary de Cervelhon, of the Order of St. Mary of Ransom, who, because of her ready help to them that call upon her, is commonly called Helpful Mary. 


### PR DESCRIPTION
Remove Capitalization of "virgin" as an adjective.  Although they appear to be capitalized in the Roman Breviary of 1908, these have to be typos since "martyr" and "confessor" are not capitalized in the same tract.  Indeed, at first glance, "the blessed Virgin Mary de Cervelhon" sounds like a Marian apparition.