### PR TITLE
code: fix unstable include substitutions 

### DIFF
--- a/web/cgi-bin/horas/dialogcommon.pl
+++ b/web/cgi-bin/horas/dialogcommon.pl
@@ -274,7 +274,7 @@ sub setupstring($$$%) {
     # Iterate over all sections, resolving inclusions. We make sure we
     # do [Rule] first, if it exists: we need to use the rule to work
     # out some subsequent substitutions.
-    foreach my $key ((exists $sections{'Rule'}) ? 'Rule' : (), keys %sections) {
+    foreach my $key ((exists $sections{'Rule'}) ? 'Rule' : (), sort(keys(%sections))) {
       if ($key !~ /Commemoratio|LectioE/i || $missa) {
         1 while $sections{$key} =~ s/$inclusionregex/
           get_loadtime_inclusion(\%sections, $basedir, $lang,

--- a/web/www/horas/Latin/Sancti/08-03.txt
+++ b/web/www/horas/Latin/Sancti/08-03.txt
@@ -115,7 +115,6 @@ Alii istum volunt esse Zacharíam, qui occisus est a Joas rege Judæ inter templ
 
 [Capitulum Nona]
 @:Lectio Prima
-$Deo gratias
 
 [Versum 3]
 @Sancti/12-26


### PR DESCRIPTION
eg.:
- 8/18 vespera (trident & divino) - Sancti/08-15t:Versum 3 is missing!
- 9/15 major hymn (monastic) - wrong render instead of doxology
- 8/3 nona (trident) - sometimes double Deo gratias

+AMDG+