### PR TITLE
Addressing the deeper cause of issue #3095

### DIFF
--- a/web/www/horas/English/Commune/C7a.txt
+++ b/web/www/horas/English/Commune/C7a.txt
@@ -50,6 +50,3 @@ v. Many daughters have gathered together riches: thou hast surpassed them all. F
 !Prov 31:20-21
 v. She hath opened her hand to the needy, and stretched out her hands to the poor. She shall not fear for her house in the cold of snow.
 $Deo gratias
-
-[Ant 2]
-@Commune/C7

--- a/web/www/horas/English/Commune/C7ap.txt
+++ b/web/www/horas/English/Commune/C7ap.txt
@@ -1,6 +1,0 @@
-[Name]
-Commune non Virginum non Martyrum Tempore Paschali
-
-[Rule]
-Psalmi Dominica
-Antiphonas horas

--- a/web/www/horas/Espanol/Commune/C7a.txt
+++ b/web/www/horas/Espanol/Commune/C7a.txt
@@ -44,9 +44,6 @@ De las Parábolas de Salomón
 30 Engañosa es la gracia, fugaz la belleza; la mujer que teme a Dios, ésa es de alabar. 
 31 Dadle los frutos del trabajo de sus manos, y alábenla sus hechos en las puertas. 
 
-[Ant 2]
-@Commune/C7
-
 [Lectio Prima]
 !Prov 31:29-30
 v. Muchas mujeres reunieron riquezas, pero tú les ganas a todas. Engañosa es la gracia, fugaz la hermosura; la mujer que respeta al Señor, ésa merece alabanza.

--- a/web/www/horas/Espanol/Commune/C7ap.txt
+++ b/web/www/horas/Espanol/Commune/C7ap.txt
@@ -1,9 +1,0 @@
-@Commune/C7p
-
-[Name]
-Commune non Virginum non Martyrum Tempore Paschali
-
-[Rule]
-Psalmi Dominica
-Antiphonas horas
-

--- a/web/www/horas/Francais/Commune/C7a.txt
+++ b/web/www/horas/Francais/Commune/C7a.txt
@@ -44,9 +44,6 @@ De Proverbes de Salomon
 30 Le charme est trompeur et la beauté s’évanouit ; seule, la femme qui craint le Seigneur mérite la louange.
 31 Célébrez-la pour les fruits de son travail : et qu’aux portes de la ville, ses œuvres disent sa louange !
 
-[Ant 2]
-@Commune/C7
-
 [Lectio Prima]
 !Prov 31:29-30
 v. Beaucoup de filles ont amassé des richesses, tu les as toutes surpassées. Trompeuse est la grâce et vaine est la beauté. C’est la femme craignant le Seigneur qui sera louée..

--- a/web/www/horas/Italiano/Commune/C7a.txt
+++ b/web/www/horas/Italiano/Commune/C7a.txt
@@ -47,9 +47,6 @@ Dalle parabole di Salomone
 30 Fallace è l'avvenenza e vana è la bellezza: la donna che teme il Signore, questa sarà lodata.
 31 Rendete omaggio al frutto delle sue mani e risuonino alle porte gli elogi delle sue opere.
 
-[Ant 2]
-@Commune/C7
-
 [Lectio Prima]
 !Prov 31:29-30
 v. Molte figliole hanno radunato ricchezze: ma tu le hai superate tutte. Fallace è l'avvenenza e vana è la bellezza: la donna che teme il Signore, quella avrà lode.  

--- a/web/www/horas/Italiano/Commune/C7ap.txt
+++ b/web/www/horas/Italiano/Commune/C7ap.txt
@@ -1,9 +1,0 @@
-@Commune/C7p
-
-[Name]
-Commune non Virginum non Martyrum  Tempore Paschali
-
-[Rule]
-Psalmi Dominica
-Antiphonas horas
-

--- a/web/www/horas/Latin/Commune/C6ap.txt
+++ b/web/www/horas/Latin/Commune/C6ap.txt
@@ -47,7 +47,7 @@ Prudéntes vírgines, * aptate vestras lámpades: ecce sponsus venit, exíte obv
 @Commune/C6a
 
 [Lectio Prima]
-@Commune/C6a
+@Commune/C6:Lectio Prima pro Martyre
 
 [Capitulum Nona]
 @:Lectio Prima

--- a/web/www/horas/Latin/Commune/C7a.txt
+++ b/web/www/horas/Latin/Commune/C7a.txt
@@ -61,9 +61,6 @@ De Parábolis Salomónis
 [Versum 2]
 @Commune/C6
 
-[Ant 2]
-@Commune/C7
-
 [Lectio Prima]
 !Prov 31:29-30
 v. Multæ fíliæ congregavérunt divítias: tu supergréssa es univérsas. Fallax grátia, et vana est pulchritúdo: múlier timens Dóminum, ipsa laudábitur. 

--- a/web/www/horas/Latin/Commune/C7ap.txt
+++ b/web/www/horas/Latin/Commune/C7ap.txt
@@ -1,4 +1,4 @@
-@Commune/C7p
+@Commune/C7
 
 [Name]
 Commune non Virginum non Martyrum Tempore Paschali
@@ -9,6 +9,9 @@ Antiphonas horas
 
 [Capitulum Vespera]
 @Commune/C7a
+
+[Ant 1]
+@Commune/C7p
 
 [Versum 1]
 @Commune/C6p
@@ -22,8 +25,29 @@ Antiphonas horas
 [Lectio2]
 @Commune/C7a
 
+[Responsory2]
+@Commune/C6p
+
 [Lectio3]
 @Commune/C7a
+
+[Responsory3]
+@Commune/C6p
+
+[Responsory4]
+@Commune/C6p
+
+[Responsory5]
+@Commune/C6p
+
+[Responsory6]
+@Commune/C7p
+
+[Responsory7]
+@Commune/C7p
+
+[Responsory8]
+@Commune/C7p
 
 [Capitulum Laudes]
 @:Capitulum Vespera
@@ -33,9 +57,6 @@ Antiphonas horas
 
 [Versum 2]
 @Commune/C6p
-
-[Ant 2]
-@Commune/C7
 
 [Lectio Prima]
 @Commune/C7a

--- a/web/www/horas/Magyar/Commune/C7a.txt
+++ b/web/www/horas/Magyar/Commune/C7a.txt
@@ -52,6 +52,3 @@ v. Sok asszony megmutatta, milyen derék, de te felülmúlod őket, mind valamen
 !Prov 31:20-21
 v. Kiterjeszti kezét az elnyomott fölé, a szűkölködőnek meg a karját nyújtja. Nem kell féltenie háza népét a hótól: egész háza népét ellátta kettős ruhával,
 $Deo gratias
-
-[Ant 2]
-@Commune/C7

--- a/web/www/horas/Magyar/Commune/C7ap.txt
+++ b/web/www/horas/Magyar/Commune/C7ap.txt
@@ -1,9 +1,0 @@
-@Commune/C7p
-
-[Name]
-Commune non Virginum non Martyrum Tempore Paschali
-
-[Rule]
-Psalmi Dominica
-Antiphonas horas
-

--- a/web/www/horas/Polski/Commune/C7a.txt
+++ b/web/www/horas/Polski/Commune/C7a.txt
@@ -51,9 +51,6 @@ Już zima minęła, * deszcz przeszedł, i przestał: wstań przyjaciółko moja
 Przyjdź wybrana moja, * a założę w tobie stolicę moją, alleluja.
 Ta jest piękna * pomiędzy córkami Jerozolimskiemi.
 
-[Ant 2]
-@Commune/C7
-
 [Lectio Prima]
 !Prz 31:29-30
 v. Wiele córek zebrało bogactwa: tyś przewyższyła wszystkie. Omylna wdzięczność i marna jest piękność: niewiasta bojąca się Boga, ta będzie chwalona.

--- a/web/www/horas/Polski/Commune/C7ap.txt
+++ b/web/www/horas/Polski/Commune/C7ap.txt
@@ -1,3 +1,0 @@
-[Name]
-Commune non Virginum non Martyrum Tempore Paschali
-


### PR DESCRIPTION
S. Monica had no Ant 2. But not because of the cleanup of C7a but because of the double cross-references I had introduced in C7ap.

Double checked with S. Monica (May 4, 2022 for Rubrics1960 and 2021 for DivinoAfflatu) that it works now in T. P.; and with S. Birgitta (October 8) also outside of T.P.

Merry Christmas!