### PR TITLE
Typos and punctuation

### DIFF
--- a/web/www/missa/English/Commune/C4a.txt
+++ b/web/www/missa/English/Commune/C4a.txt
@@ -6,11 +6,11 @@ Gloria
 
 [Introitus]
 !Sir 15:5
-v.  And in the midst of the church he shall open his mouth, and shall fill him with the spirit of wisdom and understanding, and shall clothe him with a robe of glory. 
+v.  In the midst of the assembly he opened his mouth; and the Lord filled him with the spirit of wisdom and understanding; He clothed him with a robe of glory.
 !Ps 91:2
-v.  It is good to give praise to the Lord: and to sing to thy name, O most High.
+v.  It is good to give thanks to the Lord, to sing praise to Your name, Most High.
 &Gloria
-v.  And in the midst of the church he shall open his mouth, and shall fill him with the spirit of wisdom and understanding, and shall clothe him with a robe of glory. 
+v.  In the midst of the assembly he opened his mouth; and the Lord filled him with the spirit of wisdom and understanding; He clothed him with a robe of glory.
 
 [Oratio]
 O God, who didst give blessed N. to be thy people minister in eternal~
@@ -74,5 +74,5 @@ v. The faithful and wise steward, whom his lord setteth over his family, to give
 
 [Postcommunio]
 ! Pro Doctore Pontifice.
-May blessed N. thy Bishop and illustrious Doctor intercede for us, O Lord, that this thy sacrifice may obtain for us salvation,
+May blessed N. thy Bishop and illustrious Doctor intercede for us, O Lord, that this thy sacrifice may obtain for us salvation.
 $Per Dominum

--- a/web/www/missa/English/Commune/C4ap.txt
+++ b/web/www/missa/English/Commune/C4ap.txt
@@ -6,11 +6,11 @@ Gloria
 
 [Introitus]
 !Sir 15:5
-v.  And in the midst of the church he shall open his mouth, and shall fill him with the spirit of wisdom and understanding, and shall clothe him with a robe of glory.  Allelúja, allelúja.
+v.  In the midst of the assembly he opened his mouth; and the Lord filled him with the spirit of wisdom and understanding; He clothed him with a robe of glory. Allelúja, allelúja.
 !Ps 91:2
-v.  It is good to give praise to the Lord: and to sing to thy name, O most High.
+v.  It is good to give thanks to the Lord, to sing praise to Your name, Most High.
 &Gloria
-v.  And in the midst of the church he shall open his mouth, and shall fill him with the spirit of wisdom and understanding, and shall clothe him with a robe of glory.  Allelúja, allelúja.
+v.  In the midst of the assembly he opened his mouth; and the Lord filled him with the spirit of wisdom and understanding; He clothed him with a robe of glory. Allelúja, allelúja.
 
 [Oratio]
 O God, who didst give blessed N. to be thy people minister in eternal~
@@ -52,11 +52,11 @@ $Per Dominum.
 v.  The faithful and wise steward, whom his lord setteth over his family: to give them their measure of wheat in due season.  Allelúja.
 
 [Postcommunio] Pro Doctore Pontifice.
-May blessed N. thy Bishop and illustrious Doctor intercede for us, O Lord, that this thy sacrifice may obtain for us salvation,
+May blessed N. thy Bishop and illustrious Doctor intercede for us, O Lord, that this thy sacrifice may obtain for us salvation.
 $Per Dominum
 
 [Postcommunio1] Pro Doctore non Pontifice.
-May blessed N. thy Confessor and illustrious Doctor intercede for us, O Lord, that this thy sacrifice may obtain for us salvation,
+May blessed N. thy Confessor and illustrious Doctor intercede for us, O Lord, that this thy sacrifice may obtain for us salvation.
 $Per Dominum
 
 [Lectio1]

--- a/web/www/missa/English/Commune/C5ap.txt
+++ b/web/www/missa/English/Commune/C5ap.txt
@@ -6,11 +6,11 @@ Gloria
 
 [Introitus]
 !Sir 15:5
-v. And in the midst of the church he shall open his mouth, and shall fill him with the spirit of wisdom and understanding, and shall clothe him with a robe of glory. Allelúja, allelúja.
+v. In the midst of the assembly he opened his mouth; and the Lord filled him with the spirit of wisdom and understanding; He clothed him with a robe of glory. Allelúja, allelúja.
 !Ps 91:2
-v. It is good to give praise to the Lord: and to sing to thy name, O most High.
+v. It is good to give thanks to the Lord, to sing praise to Your name, Most High.
 &Gloria
-v. And in the midst of the church he shall open his mouth, and shall fill him with the spirit of wisdom and understanding, and shall clothe him with a robe of glory.  Allelúja, allelúja.
+v. In the midst of the assembly he opened his mouth; and the Lord filled him with the spirit of wisdom and understanding; He clothed him with a robe of glory. Allelúja, allelúja.
 
 [Oratio]
 O God, who didst give blessed N. to be thy people minister in eternal salvation; grant, we pray, that that we who have him for teacher of life here on earth, may also deserve now that he is in heaven, to have him for an advocate.
@@ -46,7 +46,7 @@ $Per Dominum.
 v. The faithful and wise steward, whom his lord setteth over his family: to give them their measure of wheat in due season. Allelúja.
 
 [Postcommunio] Pro Doctore non Pontifice.
-May blessed N. thy Confessor and illustrious Doctor intercede for us, O Lord, that this thy sacrifice may obtain for us salvation,
+May blessed N. thy Confessor and illustrious Doctor intercede for us, O Lord, that this thy sacrifice may obtain for us salvation.
 $Per Dominum
 
 [Lectio1]

--- a/web/www/missa/English/Sancti/04-21.txt
+++ b/web/www/missa/English/Sancti/04-21.txt
@@ -22,5 +22,5 @@ $Per Dominum.
 
 [Postcommunio]
 ! Pro Doctore Pontifice.
-May blessed Anselm thy Bishop and illustrious Doctor intercede for us, O Lord, that this thy sacrifice may obtain for us salvation,
+May blessed Anselm thy Bishop and illustrious Doctor intercede for us, O Lord, that this thy sacrifice may obtain for us salvation.
 $Per Dominum


### PR DESCRIPTION
Introit was missing "Lord" so prayer was replaced with St Joseph missal version.

Comma in Post Communion was replaced with period as consistent in other sources.