### PR TITLE
fix headings in generated missale files

### DIFF
--- a/standalone/tools/epubgen2/Ewebdia.pl
+++ b/standalone/tools/epubgen2/Ewebdia.pl
@@ -18,19 +18,6 @@ my $a = 4;
 our %fontOverrides=('red113bi'=>'<b>', 'black82'=>'<em>', 'red0i'=>'<span class="ri">', 'red63'=>'<span class="w">', 'red150bi'=>'<span class="a">');
 our %fontOverridesEnd=('red113bi'=>'</b>', 'black82'=>'</em>', 'red0i'=>'</span>', 'red63'=>'</span>', 'red150bi'=>'</span>');
 
-#*** htmlHead($title, $flag)
-# generated the standard head with $title
-sub htmlHead {
-  my $title = shift;
-  my $flag = shift;
-  if (!$title) {$title = ' ';}
-
-
-  print << "PrintTag";
-<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="la"><head> <meta http-equiv="Content-Type" content="text/html; charset=utf-8" /> <link href="s.css" rel="stylesheet" type="text/css"/><title>$title</title></head>
-PrintTag
-}
-
 #*** setup($name, $script)
 # generates an input table
 # $name is the command name listed above the table

--- a/standalone/tools/epubgen2/headline.pl
+++ b/standalone/tools/epubgen2/headline.pl
@@ -1,0 +1,104 @@
+# Shared code for EofficiumXhtml.pl and Emissa.pl to generate XHTML headers and navigation menu.
+
+# Outpus the entire navigation menu on the top of the files.
+# (Includes links to hours, link to previous and next day, title of the day and comment)
+sub headline {
+  htmlHead();
+  build_comment_line_xhtml();
+  outputHeadlineCommentAndDate();
+  navigationMenu();
+}
+
+# Generate XHTML header (including CSS link and HTML title).
+sub htmlHead {
+  print << "PrintTag";
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="la"><head> <meta http-equiv="Content-Type" content="text/html; charset=utf-8" /> <link href="s.css" rel="stylesheet" type="text/css"/><title>$title</title></head><body><div>
+PrintTag
+}
+
+sub outputHeadlineCommentAndDate {
+  my $daycolorclass = calculateDaycolor();
+  my @horasfilenames = split(',', strictparam('horasfilenames'));
+  my $firsthora = $horasfilenames[0];
+
+  my $daten = prevnext($date1, 1);
+  my $datep = prevnext($date1, -1);
+
+    print << "PrintTag";
+<p class="cen $daycolorclass">$headline<br />$comment</p>
+<p class="cen"><span class="c">$head</span>&nbsp;&nbsp;&nbsp;<a href="$datep-$firsthora.html">&darr;</a> $date1 <a href="$daten-$firsthora.html">&uarr;</a><br /></p>
+PrintTag
+}
+
+# Outputs the clickable navigation menu (Matutinum, Laudes, ..., Missa).
+#
+# Depends on parameters in the URL (horasnames, horasfilenames, horasindexlast).
+sub navigationMenu {
+     my @horasnames = split(',', strictparam('horasnames'));
+     my @horasfilenames = split(',', strictparam('horasfilenames'));
+     my $horasindexlast = strictparam('horasindexlast');
+
+     print '<p class="cen">';
+
+     unless ($horasindexlast == 0) {
+      for my $i ( 0 .. $horasindexlast ) {
+          $horasfilename = $horasfilenames[$i];
+          $horasname = $horasnames[$i];
+
+          print "<a href=\"$date1-$horasfilename.html\">$horasname</a>&nbsp;&nbsp;";
+          
+          #break line after every four items
+          if($i % 4 == 3) {
+              print "<br />";
+          }
+      }
+     }
+
+     print '</p>';
+}
+
+# Calculates $daycolorclass
+sub calculateDaycolor() {
+  my $daycolor =   ($commune =~ /(C1[0-9])/) ? "blue" :
+    ($dayname[1] =~ /(Quattuor|Feria|Vigilia)/i) ? "black" :
+    ($dayname[1] =~ /duplex/i) ? "red" :
+      "grey";
+
+  #convert $daycolor to $daycolorclass
+  my $daycolorclass=""; #rely on default being black font color
+  if($daycolor eq "blue") {$daycolorclass="rb";}
+  elsif($daycolor eq "gray") {$daycolorclass="rb";}
+  elsif($daycolor eq "red") {$daycolorclass="rd";}
+  return $daycolorclass;
+}
+
+#  Replacement for build_comment_line() from horascommon.pl
+#
+#  Sets $comment to the HTML for the comment line.
+sub build_comment_line_xhtml()
+{
+  our @dayname;
+  our ($comment, $marian_commem);
+
+  my $commentcolor = ($dayname[2] =~ /(Feria)/i) ? '' : ($marian_commem && $dayname[2] =~ /^Commem/) ? ' rb' : ' m';
+  $comment = ($dayname[2]) ? "<span class=\"s$commentcolor\">$dayname[2]</span>" : "";
+}
+
+# Calculate following / previous date.
+sub prevnext {
+  my $date1 = shift;
+  my $inc = shift;
+
+  $date1 =~ s/\//\-/g;
+  my ($month,$day,$year) = split('-',$date1);
+
+  my $d= date_to_days($day,$month-1,$year);
+
+  my @d = days_to_date($d + $inc);
+  $month = $d[4]+1;
+  $day = $d[3];
+  $year = $d[5]+1900;
+  return sprintf("%02i-%02i-%04i", $month, $day, $year);
+}
+
+1;

--- a/web/cgi-bin/horas/horas.pl
+++ b/web/cgi-bin/horas/horas.pl
@@ -13,7 +13,7 @@ my @lines;
 my $precesferiales;
 $a = 1;
 
-#*** horas($hora)
+#*** horas($hora, $supressHead)
 # collects and prints the officium for the given $hora
 # first let specials to fill the chapters
 # then break the text into units (separated by double newline)
@@ -21,6 +21,8 @@ $a = 1;
 #and prints the result
 sub horas {
   my $command = shift;
+  my $supressHead = shift || false;
+  
   $hora = $command;
   my $head = "Ad $command";
   $head =~ s/a$/am/;
@@ -28,7 +30,7 @@ sub horas {
     $hora = 'Vespera';
     $head = 'Ad Vesperas';
   }
-  print "<H2 ID='${hora}top'>$head</H2>\n" if ($0 !~ /Cofficium/);
+  unless ($supressHead) { print "<H2 ID='${hora}top'>$head</H2>\n" if ($0 !~ /Cofficium/); }
   our $canticum = 0;
   our $reciteindex = 0;
   our $recitelimit = 0;

--- a/web/cgi-bin/missa/Emissa.pl
+++ b/web/cgi-bin/missa/Emissa.pl
@@ -70,6 +70,7 @@ require "$Bin/../horas/horascommon.pl";
 require "$Bin/../horas/dialogcommon.pl";
 require "$Bin/../horas/webdia.pl";
 require "$Bin/../../../standalone/tools/epubgen2/Ewebdia.pl";
+require "$Bin/../../../standalone/tools/epubgen2/headline.pl";
 require "$Bin/ordo.pl";
 require "$Bin/propers.pl";
 
@@ -157,75 +158,23 @@ $setupsave =~ s/\r*\n*//g;
 $setupsave =~ s/\"/\~24/g;
 precedence();    #fills our hashes et variables
 
-# prepare title
-$daycolor = liturgical_color($dayname[1], $commune);
-build_comment_line();
-
 #prepare main pages
 $title = "Sancta Missa";
+$head     = $title;
 
 $command =~ s/(pray|change|setup)//ig;
-$title    = "Sancta Missa";
-$head     = $title;
 $headline = setheadline();
-headline($head);
+
+headline();
 
 $only = 1; # single-column
 ordo();
 
 #common end for programs
-if ($error) { print "<P ALIGN=CENTER><FONT COLOR=red>$error</FONT></P>\n"; }
-if ($debug) { print "<P ALIGN=center><FONT COLOR=blue>$debug</FONT></P>\n"; }
+if ($error) {print "<p class=\"cen rd\">$error</p>\n";}
+if ($debug) {print "<p class=\"cen rd\">$debug</p>\n";}
 
-#*** hedline($head) prints headlibe for main and pray
-sub headline {
-    my $head = shift;
-    $headline =~ s{!(.*)}{<FONT SIZE=1>$1</FONT>}s;
-  my $daten = prevnext($date1, 1);
-  my $datep = prevnext($date1, -1);
-    print << "PrintTag";
-<P ALIGN=CENTER><a href="$datep-9-Missa.html">&darr;</a>
-$date1
-<a href="$daten-9-Missa.html">&uarr;</a>
-<br />
-<a href="$date1-1-Matutinum.html">Matutinum</a>
-&nbsp;&nbsp;
-<a href="$date1-2-Laudes.html">Laudes</a>
-&nbsp;&nbsp;
-<a href="$date1-3-Prima.html">Prima</a>
-&nbsp;&nbsp;
-<a href="$date1-4-Tertia.html">Tertia</a>
-<br />
-<a href="$date1-5-Sexta.html">Sexta</a>
-&nbsp;&nbsp;
-<a href="$date1-6-Nona.html">Nona</a>
-&nbsp;&nbsp;
-<a href="$date1-7-Vespera.html">Vespera</a>
-&nbsp;&nbsp;
-<a href="$date1-8-Completorium.html">Completorium</a>
-<br />
-<FONT COLOR=$daycolor>$headline<BR></FONT>
-$comment<BR>
-<a href="$date1-9-Missa.html"><FONT COLOR=MAROON SIZE=+1><B><I>$head</I></B></FONT></a>
-</P>
-PrintTag
-}
-
-sub prevnext {
-  my $date1 = shift;
-  my $inc = shift;
-
-  $date1 =~ s/\//\-/g;
-  my ($month,$day,$year) = split('-',$date1);
-
-  my $d= date_to_days($day,$month-1,$year);
-
-  my @d = days_to_date($d + $inc);
-  $month = $d[4]+1;
-  $day = $d[3];
-  $year = $d[5]+1900;
-  return sprintf("%02i-%02i-%04i", $month, $day, $year);
-}
+print "</div></body></html>";
 
 # the sub is called from htmlhead
 sub horasjs {


### PR DESCRIPTION
Allow generating of standalone missale texts.

(Adds XHTML header that was missing in the implementation; document -m and -M switches in epubgen2.sh.)

See the newly generated missale and combined files on:
https://breviarium.srubarovi.cz/
