### PR TITLE
Further St. Blaise corrections (English and Italiano)

### DIFF
--- a/web/www/horas/English/Sancti/02-03.txt
+++ b/web/www/horas/English/Sancti/02-03.txt
@@ -16,13 +16,13 @@ $Per Dominum
 This Blaise was chosen Bishop of the city of Sebaste in Armenia, in which place~
 he enjoyed a great reputation for virtue. When Diocletian began to make the~
 Christians the objects of his insatiable cruelty, the Saint hid himself in a~
-cave on Mount Argasus, where he lay till he was found by some of the soldiers of~
-Agricolaus the President, who were out hunting. He was brought before the~
-President, who commanded him to be thrown into irons. While he was in prison,~
-Blase healed many of the sick, who were brought to him on account of his~
+cave on Mount Argaeus, where he lay till he was found by some of the soldiers of~
+Agricolaus the governor, who were out hunting. He was brought before the~
+governor, who commanded him to be thrown into irons. While he was in prison,~
+Blaise healed many of the sick, who were brought to him on account of his~
 reputation of saintliness, and among others a boy who had been despaired of by~
-the physicians, and who was at the point of death, from a thorn which had become~
-fixed in his throat. Blase appeared twice before the President, but neither~
+the physicians, and who was at the point of death, from a fish bone which had become~
+fixed in his throat. Blaise appeared twice before the governor, but neither~
 cajolements nor threats could induce him to sacrifice to the gods. He was first~
 beaten with rods, and afterwards put on the rack, where his flesh was mangled~
 with iron combs. At last his head was cut off, whereby he finished a noble~

--- a/web/www/horas/Italiano/Sancti/02-03.txt
+++ b/web/www/horas/Italiano/Sancti/02-03.txt
@@ -1,8 +1,8 @@
 [Rank]
-S. Blasii Episcopi;;Simplex;;1.1;;vide C2
+S. Blasii Episcopi et Martyris;;Simplex;;1.1;;vide C2
 
 [RankNewcal]
-S. Blasii Episcopi;;Duplex optional;;2;;vide C2
+S. Blasii Episcopi et Martyris;;Duplex optional;;2;;vide C2
 
 [Rule]
 vide C2;


### PR DESCRIPTION
This makes the English reading spell Blaise consistently, and improves the translation:
- The _spina_ lodged in the boy's throat is usually understood to be a fish bone rather than a thorn.
- _Praeses_ here is the governor of the province.
- I think Argasus was an OCR error (recognizing æ as "as"), but I corrected it without checking the Marquis of Bute scans.

In Italian, it supplies the missing "et Martyris" in the feast title.