### PR TITLE
09-21 (Divino Afflatu and earlier rubrics).txt

### DIFF
--- a/web/www/horas/Latin/Sancti/09-21.txt
+++ b/web/www/horas/Latin/Sancti/09-21.txt
@@ -14,6 +14,15 @@ Antiphonas horas
 Beáti Apóstoli et Evangelístæ Matthǽi, Dómine, précibus adjuvémur: ut, quod possibílitas nostra non óbtinet, ejus nobis intercessióne donétur. 
 $Per Dominum
 
+[Lectio1]
+@Commune/C1a:Lectio1
+
+[Lectio2]
+@Commune/C1a:Lectio2
+
+[Lectio3]
+@Commune/C1a:Lectio3
+
 [Lectio4]
 Matthǽus, qui et Levi, Apóstolus et Evangelísta, Caphárnai cum ad telónium sedéret, a Christo vocátus, statim secútus est ipsum; quem étiam cum réliquis discípulis convívio excépit. Post Christi resurrectiónem, ántequam in provínciam proficiscerétur, quæ ei ad prædicándum obtígerat, primus in Judǽa, propter eos qui ex circumcisióne credíderant, Evangélium Jesu Christi Hebráice scripsit. Mox in Æthiópiam proféctus, Evangélium prædicávit, ac prædicatiónem multis miráculis confirmávit.
 


### PR DESCRIPTION
Fixing Sept 21, my first change which needs to be combined with the second change. (feast of St. Matthew) Matins 1st Nocturn readings for the editions of the Breviary earlier than 1960.