### PR TITLE
renaming breviary version names:

### DIFF
--- a/web/cgi-bin/DivinumOfficium/RunTimeOptions.pm
+++ b/web/cgi-bin/DivinumOfficium/RunTimeOptions.pm
@@ -1,0 +1,58 @@
+package DivinumOfficium::RunTimeOptions;
+use utf8;
+use strict;
+use warnings;
+
+BEGIN {
+  require Exporter;
+  our $VERSION = 1.00;
+  our @ISA = qw(Exporter);
+  our @EXPORT_OK = qw(check_version check_horas check_language);
+}
+
+# private
+
+sub unequivocal {
+  my($value, $tablename) = @_;
+  my @values_array = horas::getdialog($tablename);
+
+  my @r = grep { /$value/ } @values_array;
+  if (@r == 1) { 
+    return $r[0]
+  } else { 
+    @r = grep { $_ eq $value } @values_array;
+    if (@r == 1) {
+      return $r[0]
+    } else {
+      return
+    }
+  }
+}
+
+use constant LEGACY_VERSION_NAMES => { 
+  'Tridentine 1570' => 'Tridentine - 1570',
+  'Tridentine 1910' => 'Tridentine - 1888',
+  'Rubrics 1960' => 'Rubrics 1960 - 1960',
+  'Newcalendar' => 'Rubrics 1960 - 2020 USA'};
+
+# exported
+
+sub check_version {
+  my $v = shift;
+
+  LEGACY_VERSION_NAMES->{$v} || unequivocal($v, 'versions')
+}
+
+sub check_horas {
+  my $h = shift;
+
+  map { unequivocal($_, 'horas') } split(/(?=\p{Lu}\p{Ll}*)/, $h);
+}
+
+sub check_language {
+  my $l = shift;
+
+  unequivocal($l, 'languages') =~ s/.*\///r;
+}
+
+1;

--- a/web/cgi-bin/horas/dialogcommon.pl
+++ b/web/cgi-bin/horas/dialogcommon.pl
@@ -40,6 +40,7 @@ sub getdialog {
     foreach (keys %_dialog) { chomp($_dialog{$_}) }
     $_dialog{'loaded'} = 1;
   }
+  chomp($_dialog{$name});
   if (wantarray) {
     return split(',', $_dialog{$name});
   } else { 

--- a/web/cgi-bin/horas/horas.pl
+++ b/web/cgi-bin/horas/horas.pl
@@ -575,7 +575,7 @@ sub psalm : ScriptFunc {
     $t .= "\n$lnum $line $rest";
   }
   $t .= "\n";
-  if ($version eq "Monastic" && $num == 129 && $hora eq 'Prima') { $t .= $prayers{$lang}->{Requiem}; }
+  if ($version =~ /Monastic/ && $num == 129 && $hora eq 'Prima') { $t .= $prayers{$lang}->{Requiem}; }
   elsif ($num != 210 && !$nogloria) { $t .= "\&Gloria\n"; }
   $t .= settone(0);
   return $t;

--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -142,7 +142,7 @@ sub getrank {
 				|| ($tn1{Rank} =~ /(Feria|Sabbato|infra octavam)/i && $tn1{Rank} !~ /in octava/i && $tn1{Rank} !~ /Dominica/i)
 				|| ($dayname[0] =~ /Pasc[07]/i && $dayofweek != 6)
 				|| ($version =~ /1955|1960/ && $tn1{Rank} =~ /Dominica Resurrectionis/i)
-			|| ($version =~ /(1955|1960|Newcal)/ && $tn1{Rank} =~ /Patrocinii S. Joseph/i)) { $tn1rank = $tn1{Rank}; }
+			|| ($version =~ /19(?:55|60)/ && $tn1{Rank} =~ /Patrocinii S. Joseph/i)) { $tn1rank = $tn1{Rank}; }
 		}
 		
 		if ($tn) {
@@ -167,7 +167,7 @@ sub getrank {
 		# before 1955, Ash Wednesday gave way at 2nd Vespers in concurrence to a Duplex
 		$trank =~ s/;;6/;;2/;
 	}
-	elsif ($hora =~ /Vespera/i && $dayname[0] =~ /(Quad[0-5]|Quadp)/ && $dayofweek == 0 && $version =~ /1570|1910/) {
+	elsif ($hora =~ /Vespera/i && $dayname[0] =~ /(Quad[0-5]|Quadp)/ && $dayofweek == 0 && $version =~ /trident/i) {
 		# before Divino Afflatu, the Sundays from Septuag to Judica gave way at 2nd Vespers in concurrence to a Duplex
 		$trank =~ s/;;5.6/;;2/;
 	}
@@ -230,7 +230,7 @@ sub getrank {
 		$srank = '';
 	}
 	
-	if ($version =~ /(1955|1960|Newcal)/) {
+	if ($version =~ /19(:?55|60)/) {
 		if ($srank =~ /vigil/i && $sday !~ /(06\-23|06\-28|08\-09|08\-14|12\-24)/) { $srank = ''; }
 		if ($srank =~ /(infra octavam|in octava)/i && nooctnat()) { $srank = ''; }
 	}		#else {if ($srank =~ /Simplex/i) {$srank = '';}}
@@ -290,7 +290,7 @@ sub getrank {
 		}
 		@crank = split(";;", $crank);
 		
-		if ($version =~ /(1955|1960|Newcal)/) {
+		if ($version =~ /19(?:55|60)/) {
 			if ($crank =~ /vigil/i && $sday !~ /(06\-23|06\-28|08\-09|08\-14|08\-24)/) { $crank = ''; }
 			if ($crank =~ /octav/i && $crank !~ /cum Octav/i && $crank[2] < 6) { $crank = ''; }
 		}
@@ -299,33 +299,33 @@ sub getrank {
 		
 		@crank = split(";;", $crank);
 		
-		if ($version !~ /1960|Newcal/ && $srank && $crank && ($tname =~ /Quadp3\-3/i || $tname =~ /Quad6\-[1-3]/i)) {
+		if ($version !~ /196/ && $srank && $crank && ($tname =~ /Quadp3\-3/i || $tname =~ /Quad6\-[1-3]/i)) {
 			$srank[2] = 1;
 		}
-		if ($version !~ /1960|Newcal/ && $crank && ($tname =~ /Quadp3\-2/i || $tname =~ /Quad6\-[1-3]/i)) { $crank[2] = 1; }
+		if ($version !~ /196/ && $crank && ($tname =~ /Quadp3\-2/i || $tname =~ /Quad6\-[1-3]/i)) { $crank[2] = 1; }
 		
 		if ($crank =~ /infra octav/i && $srank =~ /infra octav/i && $crank !~ /Dominica/i) { #infra octav concurrent with infra octav = crank deleted
 			$crank = '';
 			$cname = '';
 			@crank = undef;
 		}		#exception for nov 2
-		if ($srank =~ /vigilia/i && ($version !~ /(1960|Newcal)/ || $sname !~ /08\-09/)) { $srank[2] = 0; $srank = ''; }
+		if ($srank =~ /vigilia/i && ($version !~ /1960/ || $sname !~ /08\-09/)) { $srank[2] = 0; $srank = ''; }
 		
 		# Restrict I. Vespers in 1955/1960. In particular, in 1960, II. cl.
 		# feasts have I. Vespers if and only if they're feasts of the Lord.
 		if ( ($version =~ /1955/ && $crank[2] < 5)
-			|| ($version =~ /1960|Newcal|Monastic/i && $crank[2] < (($csaint{Rule} =~ /Festum Domini/i && $dayofweek == 6) ? 5 : 6)))
+			|| ($version =~ /196/i && $crank[2] < (($csaint{Rule} =~ /Festum Domini/i && $dayofweek == 6) ? 5 : 6)))
 		{
 			$crank = '';
 			@crank = ();
 		}
-		if ($trank[2] >= (($version =~ /(1955|1960|Newcal)/) ? 6 : 7) && $crank[2] < 6) { $crank = ''; @crank = undef; }
+		if ($trank[2] >= (($version =~ /19(?:55|60)/) ? 6 : 7) && $crank[2] < 6) { $crank = ''; @crank = undef; }
 		
 		if ($version !~ /1960|Trident/ && $hora =~ /Completorium/i && $month == 11 && $day == 1 && $dayofweek != 6) {
 			$crank[2] = 7;
 			$crank =~ s/;;[0-9]/;;7/;
 			$srank = '';
-		} elsif (($version !~ /1960|Newcal|Monastic/ || $dayofweek == 6)
+		} elsif (($version !~ /196/ || $dayofweek == 6)
 		&& $hora =~ /(Vespera|Completorium)/i
 		&& $month == 11
 		&& $srank =~ /Omnium Fidelium defunctorum/i
@@ -383,7 +383,7 @@ sub getrank {
 			}
 		}
 		
-		if ($tvesp == 1 && $version =~ /(1955|1960|Newcal)/) {
+		if ($tvesp == 1 && $version =~ /19(?:55|60)/) {
 			if ((($trank[2] >= 6 && $srank[2] < 5) || ($trank[2] >= 5 && $srank[2] < 3))
 				&& $srank[0] !~ /Octav.*?(Epiph|Nativ|Corporis|Cordis|Ascensionis)/i)
 			{
@@ -440,7 +440,7 @@ sub getrank {
 			&& $crank !~ /;;[2-7]/
 		&& $srank !~ /;;[5-7]/
 		&& $BMVSabbato == 1
-		&& $version !~ /(1960|Newcal)/
+		&& $version !~ /1960/
 		&& $saint{Rule} !~ /BMV/i
 		&& $trank !~ /;;[2-7]/
 		&& $srank !~ /in Octav/i)
@@ -453,7 +453,7 @@ sub getrank {
 	if ($trank[2] == 2 && $trank[0] =~ /infra octav/i) { $srank[2] += .1; } # Ensure that days infra Octavam are outranked by Semiduplex
 	if ($version =~ /trid/i && $trank[0] =~ /infra octavam Corp/i) { $trank[2] = 2.9; }
 	if ($tname =~/Epi1\-0/i && $srank[2] == 5.6) { $srank[2] = 2.9; } # Ensure that the infra Octavam Epi does not outrank the Sunday infra Octavam or the Feast of the Holy Family
-	if ($testmode =~ /seasonal/i && $version =~ /1960|Newcal/ && $srank[2] < 5 && $dayname[0] =~ /Adv/i) { $srank[2] = 1; }
+	if ($testmode =~ /seasonal/i && $version =~ /1960/ && $srank[2] < 5 && $dayname[0] =~ /Adv/i) { $srank[2] = 1; }
 	
 	# Flag to indicate whether office is sanctoral or temporal. Assume the
 	# latter unless we find otherwise.
@@ -464,7 +464,7 @@ sub getrank {
 	# Dispose of some cases in which the office can't be sanctoral:
 	# if we have no sanctoral office, or it was reduced to a
 	# commemoration by Cum nostra.
-	if (!$srank[2] || ($version =~ /(1955|1960|Monastic|Newcal)/i && $srank[2] <= 1.1)) {
+	if (!$srank[2] || ($version =~ /19(?:55|6)/i && $srank[2] <= 1.1)) {
 		
 		# Office is temporal; flag is correct.
 	}
@@ -546,7 +546,7 @@ sub getrank {
 		if (transfered($tname, $year, $version)) {		#&& !$vflag)
 			if ($hora !~ /Vespera|Completorium/i) { $dayname[2] = "Transfer $trank[0]"; }
 			$commemoratio = '';
-		} elsif ($version =~ /1960|Newcal|Monastic/i && $winner{Rule} =~ /Festum Domini/i && $trank =~ /Dominica/i) {
+		} elsif ($version =~ /196/i && $winner{Rule} =~ /Festum Domini/i && $trank =~ /Dominica/i) {
 			$trank = '';
 			@trank = undef;
 			
@@ -562,7 +562,7 @@ sub getrank {
 			}
 			$commemoratio = $tname;
 			
-			if ($cname && $version !~ /1960|Newcal|Monastic/) {
+			if ($cname && $version !~ /196/) {
 				{ $commemoratio1 = $cname; }		#{$commemoratio = $cname; $commemoratio1 = $tname;}
 			}
 			$comrank = $trank[2];
@@ -616,7 +616,7 @@ sub getrank {
 			&& $trank[2] < 2
 			&& $srank[0] !~ /Vigil/i
 			&& $BMVSabbato == 1
-			&& $version !~ /(1960|Newcal)/)
+			&& $version !~ /1960/)
 			)
 			)
 		{
@@ -906,7 +906,7 @@ sub precedence {
 		# In the feriae where the octave of the Epiphany used to be, the
 		# Mass is of the Epiphany ('Ecce advenit') before the Sunday, and
 		# of I. Sunday after the Epiphany ('In excelso throno') afterwards.
-		if ( $version =~ /1955|1960|Newcal/
+		if ( $version =~ /19(?:55|6)/
 			&& $missa
 			&& $dayname[0] =~ /Epi1/i
 			&& $winner =~ /01\-([0-9]+)/
@@ -919,7 +919,7 @@ sub precedence {
 		$rule = $winner{Rule};
 	}
 	
-	if ( $version !~ /(1960|Newcal|monastic)/i
+	if ( $version !~ /196/i
 		&& exists($winner{'Oratio Vigilia'})
 	&& $dayofweek != 0
 	&& $hora =~ /Laudes/i)
@@ -937,7 +937,7 @@ sub precedence {
 		$commemoratio1 = 'Sancti/01-04.txt';
 	}
 	
-	if ($version =~ /1960|Newcal/ && $winner{Rule} =~ /No Sunday commemoratio/i && $dayofweek == 0) {
+	if ($version =~ /1960/ && $winner{Rule} =~ /No Sunday commemoratio/i && $dayofweek == 0) {
 		$commemoratio = $commemoratio1 = $dayname[2] = '';
 	}
 	
@@ -945,12 +945,12 @@ sub precedence {
 		my $flag = ($commemoratio =~ /tempora/i && $tvesp == 1) ? 1 : 0;
 		%commemoratio = %{officestring($lang1, $commemoratio, $flag)};
 		
-		if ($version =~ /1960|Newcal/ && $winner{Rule} =~ /Festum Domini/ && $commemoratio{Rule} =~ /Festum Domini/i) {
+		if ($version =~ /1960/ && $winner{Rule} =~ /Festum Domini/ && $commemoratio{Rule} =~ /Festum Domini/i) {
 			$commemoratio = '';
 			%commemoratio = undef;
 			$dayname[2] = '';
 		}
-		if ($version =~ /Monastic|1960|Newcal/ && $commemoratio =~ /06-28r?/i && $dayofweek == 0) {
+		if ($version =~ /196/ && $commemoratio =~ /06-28r?/i && $dayofweek == 0) {
 			$commemoratio = '';
 			%commemoratio = undef;
 			$dayname[2] = '';
@@ -1107,7 +1107,7 @@ sub precedence {
 		&& $winner{Rank} !~ /(Beatæ|Sanctæ) Mariæ/i
 		)
 		|| $rule =~ /Laudes 2/i
-		|| ($winner{Rank} =~ /vigil/i && $version !~ /(1955|1960|Newcal)/)
+		|| ($winner{Rank} =~ /vigil/i && $version !~ /19(?:55|60)/)
 		)
 		? 2
 		: 1;
@@ -1143,7 +1143,7 @@ sub officestring($$;$) {
 		%s = %{setupstring($lang, $fname)};
 		return \%s;
 	}
-	$monthday = monthday($day, $month, $year, ($version =~ /1960|Monastic/) + 0, $flag);
+	$monthday = monthday($day, $month, $year, ($version =~ /196/) + 0, $flag);
 	
 	if (!$monthday) {
 		%s = %{setupstring($lang, $fname)};
@@ -1234,11 +1234,11 @@ sub setheadline {
 			'I. classis',
 			'I. classis'
 			);
-			$rankname = ($version !~ /1960|Monastic/i) ? $tradtable[$rank] : $newtable[$rank];
-			if ($version =~ /(1955|1960|Newcal)/ && $winner !~ /Pasc5-3/i && $dayname[1] =~ /feria/i) { $rankname = 'Feria'; }
+			$rankname = ($version !~ /196/i) ? $tradtable[$rank] : $newtable[$rank];
+			if ($version =~ /19(?:55|60)/ && $winner !~ /Pasc5-3/i && $dayname[1] =~ /feria/i) { $rankname = 'Feria'; }
 			
-			if ($name =~ /Dominica/i && $version !~ /1960|Monastic/i) {
-				if ($version !~ /1570|1910/) {
+			if ($name =~ /Dominica/i && $version !~ /196/i) {
+				if ($version !~ /trident/i) {
 					local $_ = getweek($day, $month, $year, $dayofweek == 6 && $hora =~ /(Vespera|Completorium)/i);
 					$rankname = (/Pasc[017]/i || /Pent01/i) ? 'Duplex I. classis'
 						: (/(Adv1|Quad[1-6])/i) ? 'Semiduplex Dominica I. classis'
@@ -1254,21 +1254,21 @@ sub setheadline {
 					: 'Semiduplex Dominica minor';
 				}
 			}
-		} elsif ($version =~ /1960|Newcal|Monastic/i && $dayname[0] =~ /Pasc[07]/i && $dayofweek > 0 && $winner !~ /Pasc7-0/) {
+		} elsif ($version =~ /196/i && $dayname[0] =~ /Pasc[07]/i && $dayofweek > 0 && $winner !~ /Pasc7-0/) {
 			$rankname = 'Dies Octavæ I. classis';		# Paschal & Pentecost Octave post 1960
-		} elsif ($version =~ /1960|Newcal|Monastic/i && $winner =~ /Pasc6-6/) {
+		} elsif ($version =~ /196/i && $winner =~ /Pasc6-6/) {
 			$rankname = 'I. classis';		# Vigilia Pentecostes
-		} elsif ($version =~ /1960|Newcal/i && $winner =~ /Pasc5-3/) {
-			$rankname = 'II. classis';	# Vigilia Asc
-		} elsif ($version =~ /1960|Newcal|Monastic/ && $month == 12 && $day > 16 && $day < 25 && $dayofweek > 0) {
+		} elsif ($version =~ /1960/i && $winner =~ /Pasc5-3/) {
+			$rankname = 'II. classi8s';	# Vigilia Asc
+		} elsif ($version =~ /196/ && $month == 12 && $day > 16 && $day < 25 && $dayofweek > 0) {
 			$rankname = 'II. classis';	# Week before Christmas
-		} elsif ($version =~ /(1570|1910|Divino|1955)/ && $rule =~ /C10/) {
+		} elsif ($version !~ /196/ && $rule =~ /C10/) {
 			$rankname = 'Simplex';	# BMV Sabbato
 			#} elsif ($version =~ /(1570|1910|Divino|1955)/ && $dayname[0] =~ /Quadp3/ && $dayofweek == 3) {
 			#$rankname = 'Feria privilegiata';
 			#} elsif ($version =~ /(1570|1910|Divino|1955)/ && (($dayname[0] =~ /Pasc6/ && $dayofweek == 5) || $name =~ /die infra|infra Octavam/i)) {
 			#$rankname = 'Semiduplex';
-		} elsif ($version =~ /(1570|1910|Divino|1955)/ && $dayname[0] =~ /Pasc[07]/i && $dayofweek > 0) {
+		} elsif ($version !~ /196/ && $dayname[0] =~ /Pasc[07]/i && $dayofweek > 0) {
 			$rankname = ($rank =~ 7) ? 'Duplex I. classis' : 'Semiduplex'; # Paschal & pentecost Octave pre 1960
 		} elsif ($version =~ /trid/i && $name =~ /^In Octava/i) {
 			$rankname = 'Duplex'; # all other Octaves pre Divino
@@ -1285,10 +1285,10 @@ sub setheadline {
 				: 'Semiduplex Vigilia I. classis' ;
 			#} elsif ($version =~ /(1570|1910|Divino|1955)/ && $dayname[0] =~ /Quad/i && $dayname[0] !~ /Quad6-4|5|6/i && $dayofweek > 0) {
 			#$rankname = 'Simplex';
-		} elsif ($version =~ /(1570|1910|Divino|1955)/ && $dayname[0] =~ /07-04/i && $dayofweek > 0) {
+		} elsif ($version !~ /196/ && $dayname[0] =~ /07-04/i && $dayofweek > 0) {
 			$rankname = ($rank =~ 7) ? 'Duplex I. classis' : 'Semiduplex'; # TODO: what is this? Independecne Day????
 		} else {	# Default for Ferias
-			if ($version !~ /1960|Monastic/i) {
+			if ($version !~ /196/i) {
 				$rankname = ($rank < 2) ? 'Ferial' : ($rank < 3) ? 'Feria major' : 'Feria privilegiata';
 			} else {
 				my @ranktable = (
@@ -1436,7 +1436,7 @@ sub nooctnat {
 sub spell_var {
 	my $t = shift;
 	
-	if (our $version =~ /1960|Praedicatorum|Newcalendar|Monastic/) {
+	if (our $version =~ /196/) {
 		# substitute i for j
 		# but not in html tags!
 		my @parts = split(/(<[^<>]*>)/, $t);

--- a/web/cgi-bin/horas/kalendar.pl
+++ b/web/cgi-bin/horas/kalendar.pl
@@ -22,6 +22,7 @@ use lib "$Bin/..";
 use DivinumOfficium::Main qw(liturgical_color);
 use DivinumOfficium::Directorium qw(dirge);
 use DivinumOfficium::Date qw(ydays_to_date);
+use DivinumOfficium::RunTimeOptions qw(check_version);
 
 #*** common variables arrays and hashes
 our $error;
@@ -98,8 +99,8 @@ $setupsave = savesetup(1);
 $setupsave =~ s/\r*\n*//g;
 
 my @ver;
-push(@ver, strictparam('version') || 'Rubrics 1960');
-push(@ver, strictparam('version2') || 'Divino Afflatu') if ($compare);
+push(@ver, check_version(strictparam('version') || 'Rubrics 1960'));
+push(@ver, check_version(strictparam('version2') || 'Divino Afflatu')) if ($compare);
 
 my ($xmonth, $xday, $xyear) = split('-', strictparam($date_arg) || gettoday());
 my $kmonth = strictparam('kmonth') || $xmonth;

--- a/web/cgi-bin/horas/officium.pl
+++ b/web/cgi-bin/horas/officium.pl
@@ -25,6 +25,8 @@ use locale;
 use lib "$Bin/..";
 use DivinumOfficium::Main qw(liturgical_color);
 use DivinumOfficium::Date qw(prevnext);
+use DivinumOfficium::RunTimeOptions qw(check_version check_horas check_language);
+
 $error = '';
 $debug = '';
 
@@ -110,16 +112,22 @@ set_runtime_options('parameters'); # priest, lang1 ... etc
 
 if ($command =~ s/changeparameters//) { getsetupvalue($command); }
 
+$version = check_version($version);
+$lang1 = check_language($lang1);
+$lang2 = check_language($lang2);
+
 our $plures = strictparam('plures');
 my @horas = ();
 if ($command =~ s/^pray//) {
   $command =~ s/SanctaMissa//;
   @horas = split(/(?=\p{Lu}\p{Ll}+)/, $command);
-  if (@horas > 1 && $votive ne 'C9') {
-    $plures = join('', @horas);
-  }
   if ($horas[0] eq 'Omnes') { 
     @horas = gethoras($votive eq 'C9');
+  } elsif ($horas[0] ne 'Plures') {
+    @horas = map { check_horas($_); } @horas;
+    if (@horas > 1 && $votive ne 'C9') {
+      $plures = join('', @horas);
+    }
   }
 }
 our $hora = (@horas > 0) ? $horas[0] : '';
@@ -129,9 +137,10 @@ setcookies("horasg$cookies_suffix", 'general');
 
 if ($Ck) {
   $version1 = $version; # save value for use in horas
+  $version2 = check_version($version2);
   $version2 ||= $version;
-  if ($version eq $version2) { $version2 = 'Divino Afflatu'; }
-  if ($version eq $version2) { $version2 = 'Rubrics 1960'; }
+  if ($version eq $version2) { $version2 = 'Divino Afflatu - 1954'; }
+  if ($version eq $version2) { $version2 = 'Rubrics 1960 - 1960'; }
   $lang1 = $lang2 = $langc;
 }
 

--- a/web/cgi-bin/horas/specials.pl
+++ b/web/cgi-bin/horas/specials.pl
@@ -1128,7 +1128,7 @@ sub oratio {
     || ($winner{Rank} =~ /Quattuor/i && $version !~ /1960|Monastic/i && $hora =~ /Vespera/i))
   {
     my $name = "$dayname[0]-0";
-    if ($name =~ /(Epi1|Nat)/i && $version ne 'Monastic') { $name = 'Epi1-0a'; }
+    if ($name =~ /(Epi1|Nat)/i && $version !~ /monastic/i) { $name = 'Epi1-0a'; }
     %w = %{setupstring($lang, subdirname('Tempora', $version) . "$name.txt")};
   }
 
@@ -2273,8 +2273,8 @@ sub loadspecial {
   my $str = shift;
   my @s = split("\n", $str);
 
-  # Un-double the antiphons, except in 1960 or Dominican.
-  unless ($version =~ /1960|Monastic|Praedicatorum/) {
+  # Un-double the antiphons, except in 1960
+  unless ($version =~ /196/) {
     my $i;
     my $ant = 0;
 

--- a/web/cgi-bin/horas/specmatins.pl
+++ b/web/cgi-bin/horas/specmatins.pl
@@ -340,7 +340,7 @@ sub psalmi_matutinum {
 	# we've already returned.
 	if ($dayname[0] =~ /Pasc[1-6]/i && $version !~ /Trident/i) {    #??? ex
 		my $tde =
-		($version =~ /1960/ && ($dayname[0] =~ /Pasc6/i || ($dayname[0] =~ /Pasc5/i && $dayofweek > 3))) ? '1' : '';
+		($version =~ /196/ && ($dayname[0] =~ /Pasc6/i || ($dayname[0] =~ /Pasc5/i && $dayofweek > 3))) ? '1' : '';
 		my $i;
 		
 		if ($tde) {
@@ -717,7 +717,7 @@ sub lectio : ScriptFunc {
 	
 	# TODO: There seems to be a mismatch between taking care of a conflict of Die VII infra 8vam Immaculata Conceptio. and Q.T. in Adventum
 	# The lessons are repeated from the feast day 12-08 unless it is Feria IV Q.T.?
-	if($version =~ /(1570|1910|Divino)/i && $month == 12 && $day == 14 && $dayofweek !~ 3){ $w{"Lectio$num"} = $c{"Lectio$num"};}
+	if($version =~ /(Trident|Divino)/i && $month == 12 && $day == 14 && $dayofweek !~ 3){ $w{"Lectio$num"} = $c{"Lectio$num"};}
 	
 	#scriptura1960
 	if ( $num < 3
@@ -982,7 +982,7 @@ sub lectio : ScriptFunc {
 				$s = (columnsel($lang)) ? $scriptura{"Responsory$na 1960"} : $scriptura2{"Responsory$na 1960"};
 			}
 		} else {
-			if ($version eq "Monastic" && $dayofweek != 0 && $month == 1 && $day > 6 && $day < 13) {
+			if ($version =~ /monastic/i && $dayofweek != 0 && $month == 1 && $day > 6 && $day < 13) {
 				$na += 4 if ($dayofweek == 2 || $dayofweek == 5) ;
 				if ($dayofweek == 3) { # Saturday dont work due C10 || $dayofweek == 6 ) {
 					$na += 1 if ($na > 1);
@@ -1225,7 +1225,7 @@ use constant {
 sub gettype1960 {
 	my $type = LT1960_DEFAULT;
 	
-	if ($version =~ /1960|Monastic|Newcal/i && $votive !~ /(C9|Defunctorum)/i) {
+	if ($version =~ /196/i && $votive !~ /(C9|Defunctorum)/i) {
 		if ($dayname[1] =~ /post Nativitatem/i) {
 			$type = LT1960_OCTAVEII;
 		} elsif ($rank < 2 || $dayname[1] =~ /(feria|vigilia|die)/i) {

--- a/web/cgi-bin/missa/missa.pl
+++ b/web/cgi-bin/missa/missa.pl
@@ -165,6 +165,13 @@ PrintTag
 PrintTag
 }
 
+# translate from new breviary version names
+$version =~ s/ -//;
+$version =~ s/1888/1910/;
+$version =~ s/ 1954//;
+$version =~ s/ 196.$//;
+$version =~ s/Rubrics 1960 - 2020 USA/1960 Newcalendar/;
+$version =~ s/Ordo Praedicatorum/Dominican/;
 
 if ($pmode =~ /(main|missa)/i) {
   #common widgets for main and hora

--- a/web/www/horas/Latin/Sancti/06-25.txt
+++ b/web/www/horas/Latin/Sancti/06-25.txt
@@ -18,7 +18,7 @@ Dei autem monitu, qui eidem apparuit, a proposito revocatur, utilior ac fructuos
 [Lectio6]
 Aliis deínde monasteriis erectis, clarior in dies Gulielmi facta sanctitas multos ad eum undique viros perducit, sanctitatis odore, et miraculorum fama allectos. Nam muti loquelam, surdi auditum, aridi vigorem, varioque et immedicabili morbo laborantes, sanitatem ipsius intercessione receperunt. Aquam in vinum convertit, aliaque complura mirabilia patravit: inter quæ illud non silendum, quod, muliercula ad ejus castitatem tentandam missa, in ardentibus prunis humi stratis illæsum se volutavit De qua re certior factus Rogerius Neapolis rex, in summam viri Dei venerationem adducitur. Demum tempore sui obitus regi, aliisque prænuntiato, innumeris virtutibus et miraculis clarus obdormivit in Domino, anno salutis millesimo centesimo quadragesimo secundo.
 
-[Commemoratio 2](rubrica 1910 aut rubrica divino)
+[Commemoratio 2](rubrica 1888 aut rubrica divino)
 @Sancti/06-24:Octava
 
 [Lectio94]

--- a/web/www/horas/Latin/Sancti/06-26.txt
+++ b/web/www/horas/Latin/Sancti/06-26.txt
@@ -80,7 +80,7 @@ Isti sunt * duæ olívæ, et duo candelábra lucéntia ante Dóminum; habent pot
 [Commemoratio 2](rubrica 1570)
 @Sancti/06-24:Octava
 
-[Commemoratio](rubrica 1910 aut rubrica divino)
+[Commemoratio](rubrica 1888 aut rubrica divino)
 @Sancti/06-24:Octava
 
 [Lectio94]

--- a/web/www/horas/Latin/Sancti/06-27.txt
+++ b/web/www/horas/Latin/Sancti/06-27.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 Quarta die infra Octavam Nativitatis S. Joannis Baptistæ;;Semiduplex;;2;;vide Sancti/06-24
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/06-28.txt
+++ b/web/www/horas/Latin/Sancti/06-28.txt
@@ -53,7 +53,7 @@ Nos autem precámur non perseverare eos in fóvea quam ipsi fodérunt, sed legit
 Irenǽus, non longe ab urbe Smyrna natus, jam inde a púero sese Polycárpo, Joánnis Evangelístæ discípulo eidémque epíscopo Smyrnæórum, tradíderat in disciplínam. Polycárpo in cælum martýrii glória subláto, cum incredíbili stúdio flagráret discéndi quæ dógmata depósiti loco custodiénda céteri accepíssent, quos Apóstoli institúerant; horum quam pótuit plures convénit, quæque ab iísdem audívit, mémori mente ténuit, ea deínceps opportúne advérsus hǽreses allatúrus. In Gálliam proféctus, Ecclésiæ Lugdunénsis présbyter a Photíno epíscopo est constitútus; cui cum successísset, tam felíciter munus óbiit episcopátus, ut sapiéntia, oratióne exemplóque suo non modo brevi cives lugdunénses omnes, sed multos étiam aliárum Galliárum úrbium íncolas superstitiónem atque errórem abiecísse, dedisséque christiánæ milítiæ nómina víderit. Multa scripsit, quorum magna pars intércidit iniúria témporum. Exstant ejus advérsus hǽreses libri quinque, in quorum tértio libro grave imprímis atque præclárum de Romána Ecclésia, deque illíus episcopórum successióne, divínæ traditióni fidéli, perpétua, certíssima custóde, testimónium dixit. Atque ad hanc, dixit, Ecclésiam propter potiórem principalitátem necésse est omnem conveníre Ecclésiam, hoc est eos qui sunt úndique fidéles. Martýrio coronátus, migrávit in cælum anno salútis ducentésimo secúndo.
 &teDeum
 
-[Commemoratio 2](rubrica 1910 aut rubrica divino)
+[Commemoratio 2](rubrica 1888 aut rubrica divino)
 @Sancti/06-24:Octava
 
 [Oratio Vigilia]

--- a/web/www/horas/Latin/Sancti/06-29.txt
+++ b/web/www/horas/Latin/Sancti/06-29.txt
@@ -240,7 +240,7 @@ $Oremus
 Deus, qui hodiérnam diem Apostolórum tuórum Petri et Pauli martyrio consecrásti: da Ecclésiæ tuæ, eórum in ómnibus sequi præcéptum; per quos religiónis sumpsit exordium.
 $Per Dominum
 
-[Octava 11](rubrica 1570 aut rubrica 1910)
+[Octava 11](rubrica tridentina)
 !Commemoratio Octavæ S. Petri
 Ant. Tu es Pastor óvium * Princeps Apostolorum, tibi traditæ sunt claves regni cælorum.
 _

--- a/web/www/horas/Latin/Sancti/07-04.txt
+++ b/web/www/horas/Latin/Sancti/07-04.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 Sexta die infra Octavam Ss. Apostolorum Petri et Pauli;;Semiduplex;;2;;vide C1
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/07-06.txt
+++ b/web/www/horas/Latin/Sancti/07-06.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 In Octava Ss. Apostolorum Petri et Pauli;;Duplex majus;;4;;vide C1
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/08-10.txt
+++ b/web/www/horas/Latin/Sancti/08-10.txt
@@ -209,7 +209,7 @@ $Oremus
 v. Da nobis, quǽsumus, omnípotens Deus: vitiórum nostrorum flammas exstínguere; qui beáto Lauréntio tribuísti tormentórum suórum incéndia superáre.
 $Per Dominum
 
-[Commemoratio 3] (rubrica 1570 aut rubrica 1910)
+[Commemoratio 3] (rubrica tridentina)
 !Commemoratio Ss. Mártyrum Tiburtii et Susannæ
 Ant. Istórum est enim regnum cælórum qui contempsérunt vitam mundi, et pervenérunt ad prǽmia regni, et lavérunt stolas suas in sánguine Agni.
 _

--- a/web/www/horas/Latin/Sancti/08-17.txt
+++ b/web/www/horas/Latin/Sancti/08-17.txt
@@ -17,7 +17,7 @@ Caritáte in Deum fervens, integras sæpe noctes fundéndis précibus castigand�
 [Lectio6]
 Sanctíssime viri studium erga proximórum salútem maximis Deus miraculis illustrávit. Inter quæ illud insigne, quod Vándalum fluvium prope Visogradum aquis redundántem, nullo navigio usus, trajecit, sociis quoque expanso super undas pallio traductis. Admirábili vitæ genere ad quadragínta prope annos post professiónem perducto, mortis die suis frátribus prænuntiáto, ipso assumptæ Vírginis festo, Horis canonicis persolutis, sacramentis ecclesiásticis summa cum veneratióne perceptis, iis verbis: In manus tuas, Dómine; spíritum Deo réddidit, anno salútis millesimo ducentésimo quinquagesimo septimo. Quem miraculis, étiam post óbitum, illustrem, Clemens Papa octavus in Sanctórum númerum rétulit.
 
-[Commemoratio 2](rubrica divino aut rubrica 1910)
+[Commemoratio 2](rubrica divino aut rubrica 1888)
 @Sancti/08-15:Octava
 _
 @Sancti/08-10:Octava

--- a/web/www/horas/Latin/Sancti/08-18.txt
+++ b/web/www/horas/Latin/Sancti/08-18.txt
@@ -1,10 +1,10 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 Quarta die infra Octavam S. Assumptionis Beatæ Mariæ Virginis;;Semiduplex;;2.5;;vide Sancti/08-15
 
 [Rank] (rubrica 1960)
 S. Agapiti Martyris;;Simplex;;1.1;;vide C2
 
-[Rule](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rule](rubrica tridentina aut rubrica divino)
 vide Sancti/08-15;
 9 lectiones;
 Doxology=Nat

--- a/web/www/horas/Latin/Sancti/08-20.txt
+++ b/web/www/horas/Latin/Sancti/08-20.txt
@@ -11,7 +11,7 @@ vide C5a;
 [Oratio]
 @Commune/C4:Oratio2:s/N\./Bernárdum/
 
-[Commemoratio](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Commemoratio](rubrica tridentina aut rubrica divino)
 @Sancti/08-15:Octava
 
 [Lectio4]

--- a/web/www/horas/Latin/Sancti/08-21.txt
+++ b/web/www/horas/Latin/Sancti/08-21.txt
@@ -14,7 +14,7 @@ de tua virtúte confídimus, cæléstis grátiæ auxílio cuncta nobis adversán
 vincámus.
 $Per Dominum
 
-[Commemoratio](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Commemoratio](rubrica tridentina aut rubrica divino)
 @Sancti/08-15:Octava
 
 [Invit]

--- a/web/www/horas/Latin/Sancti/09-10.txt
+++ b/web/www/horas/Latin/Sancti/09-10.txt
@@ -31,5 +31,5 @@ Orándi assiduum studium, quamvis sátanæ insídiis varie vexátus et flagellis
 Nicoláus, Tolentínas a diutúrno illíus civitátis domicílio appellátus, in óppido sancti Angeli in Picéno natus est piis paréntibus, qui illum ex voto, sancti Nicolái intercessióne, a Deo impetrárunt. Puer, multárum virtútum, abstinéntiæ in primis, spécimen dedit. Clericáli milítiæ dein adscríptus et canónicus factus, cum quodam die concionatórem órdinis Eremitárum sancti Augustíni de mundi contémptu dicéntem audísset, eo sermóne inflammátus, statim eúndem órdinem est ingréssus; in quo tam exáctam religiósæ vitæ ratiónem cóluit, ut jejúnio, rudi vestítu, verbéribus et áspera caténa corpus domáret, atque ómnibus áliis virtútibus prælucéret. Orándi assíduum stúdium, quamvis sátanæ insídiis várie vexátus et flagéllis intérdum cæsus, non intermittébat. Sex ante óbitum ménsibus, síngulis nóctibus angélicum concéntum audívit, et tandem, óbitus die prænuntiáto, obdormívit in Dómino. Miráculis in vita et post mortem clarus, ab Eugénio quarto in Sanctórum númerum relátus est.
 &teDeum
 
-[Commemoratio] (rubrica 1910)
+[Commemoratio] (rubrica 1888)
 @Sancti/09-08:Octava

--- a/web/www/horas/Latin/Sancti/09-13.txt
+++ b/web/www/horas/Latin/Sancti/09-13.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 Sexta die infra Octavam Nativitatis Beatæ Mariæ Virginis;;Semiduplex;;2;;vide C11
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/09-14.txt
+++ b/web/www/horas/Latin/Sancti/09-14.txt
@@ -109,5 +109,5 @@ O Crux benedícta, * quæ sola fuísti digna portáre Regem cælórum et Dóminu
 Sancta Crux Dómini, ab Hélena in monte Calváriæ collocáta índeque a Chósroa Persárum rege abláta, ab Heraclío imperatóre, post trinam victóriam in Persas obténtam, recépta est, et suis húmeris in eum montem reláta, quo eam Salvátor túlerat. Quod factum illústri miráculo commendátum est. Nam Heraclíus, ut erat auro et gemmis ornátus, insístere coáctus est in porta, quæ ad Calváriæ montem ducébat. Quo enim magis prógredi conabátur, eo magis retinéri videbátur. Cumque ea re et ipse Heraclíus et réliqui omnes obstupéscerent, Zacharías, Jerosolymórum antístes, Vide, inquit, imperátor, ne isto triumpháli ornátu in Cruce ferénda parum Jesu Christi paupertátem et humilitátem imitére. Tunc Heraclíus, abjécto amplíssimo vestítu detractísque cálceis ac plebéjo amíctu indútus, réliquum viæ fácile confécit. Itaque Exaltatiónis sanctæ Crucis solémnitas, quæ hac die quotánnis celebrabátur, ob ejus rei memóriam illústrior habéri cœpit.
 &teDeum
 
-[Commemoratio 2](rubrica 1910)
+[Commemoratio 2](rubrica 1888)
 @Sancti/09-08:Octava

--- a/web/www/horas/Latin/Sancti/11-03.txt
+++ b/web/www/horas/Latin/Sancti/11-03.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 Tertia die infra Octavam Omnium Sanctorum;;Semiduplex;;2;;vide Sancti/11-01
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/11-05.txt
+++ b/web/www/horas/Latin/Sancti/11-05.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 Quinta die infra Octavam Omnium Sanctorum;;Semiduplex;;2;;vide Sancti/11-01
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/11-06.txt
+++ b/web/www/horas/Latin/Sancti/11-06.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 Sexta die infra Octavam Omnium Sanctorum;;Semiduplex;;2;;vide Sancti/11-01
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/11-07.txt
+++ b/web/www/horas/Latin/Sancti/11-07.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 Septima die infra Octavam Omnium Sanctorum;;Semiduplex;;2;;vide Sancti/11-01
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/11-08.txt
+++ b/web/www/horas/Latin/Sancti/11-08.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 In Octava Omnium Sanctorum;;Duplex majus;;4.1;;vide Sancti/11-01
 
 [Rank](rubrica 1955)

--- a/web/www/horas/Latin/Sancti/11-15.txt
+++ b/web/www/horas/Latin/Sancti/11-15.txt
@@ -24,13 +24,13 @@ Ut scientiárum thesáuris alios ditaret, lector Hildeshémii, deinceps Friburgi
 [Lectio6]
 Tot inter gravíssima munia, religiosæ vitæ exemplis præfulgens, a frátribus Prior Teutoníæ provinciæ eléctus est.  Anágniam vocatus, Gulielmum, Ordines mendicántes ímpio ausu impetentem, coram summo Pontifice Alexandro quarto retudit, qui Episcopum Ratisbonensem eum póstea constítuit.  Curæ sui gregis Albertus se totum impendit, morum humilitate ac paupertátis amóre studiosíssime reténtis.  Dimisso officio, ad episcopalis tamen ordinis labóres promptus atque álacer per Germaniam et finítimas regiónes spiritualia ministrávit.  Consília requiréntibus quam recta ac salutifera sollicite præbebat, et in sedandis discordiis tam prudentem se osténdit, ut eum non solum Colónia pacis conciliatórem noverit, verum étiam ad díssitas regiónes Præláti ac viri príncipes árbitrum componéndis dissidiis eum sæpe advocáverint.  A sancto Ludovíco, Francórum rege, relíquiis Christi Passiónis, quam devotíssime Albertus colebat, donatus est.  In altero Concílio Lugdunénsi negotia gravióra peregit.  Tandem, senio consumptus, docére déstitit.  Contemplatióni exínde intentus, in gáudium Dómini sui intrávit anno millesimo ducentésimo octogesimo.  Sacros honores in diœcesibus plúribus atque in Ordine Prædicatórum ei, Romanórum Pontificum auctoritate, jam antea tributos, Pius Papa undecimus cumulans, sancti Alberti Magni festum, addito Doctoris titulo, Sacrórum Rituum Congregatiónis votum libentíssime excípiens, ad Ecclésiam universam exténdit ; et eum Pius duodecimus cultórum scientiárum naturalium cælestem apud Deum Patronum constítuit.
 
-[Lectio7](rubrica 1570 aut rubrica 1910)
+[Lectio7](rubrica tridentina)
 @Commune/C4a:Lectio7
 
-[Lectio8](rubrica 1570 aut rubrica 1910)
+[Lectio8](rubrica tridentina)
 @Commune/C4a:Lectio8
 
-[Lectio9](rubrica 1570 aut rubrica 1910)
+[Lectio9](rubrica tridentina)
 @Commune/C4a:Lectio9
 
 [Lectio7]

--- a/web/www/horas/Latin/Sancti/11-17.txt
+++ b/web/www/horas/Latin/Sancti/11-17.txt
@@ -4,7 +4,7 @@ S. Gregorii Thaumaturgi Episcopi et Confessoris;;Semiduplex;;2;;vide C4
 [Rank] (rubrica 1570)
 S. Gregorii Thaumaturgi Episcopi et Confessoris;;Simplex;;1.1;;vide C4
 
-[Rank] (rubrica 1910 aut rubrica 1960)
+[Rank] (rubrica 1960)
 S. Gregorii Thaumaturgi Episcopi et Confessoris;;Duplex;;3;;vide C4
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/12-09-da.txt
+++ b/web/www/horas/Latin/Sancti/12-09-da.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 De II die infra Octavam Concept. Immac. Beatæ Mariæ Virginis;;Semiduplex;;2.5;;vide Sancti/12-08
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/12-09.txt
+++ b/web/www/horas/Latin/Sancti/12-09.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 De II die infra Octavam Concept. Immac. Beatæ Mariæ Virginis;;Semiduplex;;2.5;;vide Sancti/12-08
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/12-10.txt
+++ b/web/www/horas/Latin/Sancti/12-10.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 De III die infra Octavam Conceptionis Immaculatæ Beatæ Mariæ Virginis;;Semiduplex;;2.5;;vide Sancti/12-08
 
 [Rank](rubrica 1955)

--- a/web/www/horas/Latin/Sancti/12-11t.txt
+++ b/web/www/horas/Latin/Sancti/12-11t.txt
@@ -11,7 +11,7 @@ vide C4;
 [Oratio]
 @Sancti/12-11:Oratio
 
-[Commemoratio 2] (rubrica 1910)
+[Commemoratio 2] (rubrica 1888)
 !Commemoratio Diei infra Octavam Immaculatæ Conceptionis B.M.V.
 @Sancti/12-08:Oratio
 

--- a/web/www/horas/Latin/Sancti/12-12.txt
+++ b/web/www/horas/Latin/Sancti/12-12.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 De V die infra Octavam Concept. Immac. Beatæ Mariæ Virginis;;Semiduplex;;2.5;;vide Sancti/12-08
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/12-13.txt
+++ b/web/www/horas/Latin/Sancti/12-13.txt
@@ -25,7 +25,7 @@ In tua patiéntia * possedísti ánimam tuam, Lúcia, sponsa Christi: odísti qu
 [Oratio]
 @Commune/C7::s/N\./Lúciæ Vírginis et Mártyris tuæ/
 
-[Commemoratio 2] (rubrica 1910 aut rubrica divino)
+[Commemoratio 2] (rubrica 1888 aut rubrica divino)
 !Commemoratio Diei infra Octavam Immaculatæ Conceptionis B.M.V.
 @Sancti/12-08:Oratio
 

--- a/web/www/horas/Latin/Sancti/12-14.txt
+++ b/web/www/horas/Latin/Sancti/12-14.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 De VII die infra Octavam Concept. Immac. Beatæ Mariæ Virginis;;Semiduplex;;2.5;;vide Sancti/12-08
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/12-15.txt
+++ b/web/www/horas/Latin/Sancti/12-15.txt
@@ -1,4 +1,4 @@
-[Rank](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Rank](rubrica tridentina aut rubrica divino)
 In Octava Concept. Immac. Beatæ Mariæ Virginis;;Duplex majus;;4;;vide Sancti/12-08
 
 [Rule]

--- a/web/www/horas/Latin/Sancti/12-27.txt
+++ b/web/www/horas/Latin/Sancti/12-27.txt
@@ -154,11 +154,11 @@ R. Et scimus quia verum est testimónium ejus.
 [Commemoratio 3]
 @Sancti/12-25:Octava
 
-[Commemoratio 2] (rubrica trident)
+[Commemoratio 2] (rubrica tridentina)
 @Sancti/12-25:Octava
 @Sancti/12-26:Octava
 
-[Commemoratio 3] (rubrica trident)
+[Commemoratio 3] (rubrica tridentina)
 @Sancti/12-25:Octava
 @Sancti/12-26:Octava
 

--- a/web/www/horas/Latin/Sancti/12-28.txt
+++ b/web/www/horas/Latin/Sancti/12-28.txt
@@ -204,12 +204,12 @@ Amen.
 [Commemoratio 3]
 @Sancti/12-25:Octava
 
-[Commemoratio 2] (rubrica trident)
+[Commemoratio 2] (rubrica tridentina)
 @Sancti/12-25:Octava
 @Sancti/12-26:Octava
 @Sancti/12-27:Octava
 
-[Commemoratio 3] (rubrica trident)
+[Commemoratio 3] (rubrica tridentina)
 @Sancti/12-25:Octava
 @Sancti/12-26:Octava
 @Sancti/12-27:Octava

--- a/web/www/horas/Latin/Sancti/12-29.txt
+++ b/web/www/horas/Latin/Sancti/12-29.txt
@@ -89,13 +89,13 @@ Verum ab utróque se dissidére osténdit Christus: ab illis quidem, qui in ali�
 [Commemoratio 3]
 @Sancti/12-25:Octava
 
-[Commemoratio 2] (rubrica trident)
+[Commemoratio 2] (rubrica tridentina)
 @Sancti/12-25:Octava
 @Sancti/12-26:Octava
 @Sancti/12-27:Octava
 @Sancti/12-28:Octava
 
-[Commemoratio 3] (rubrica trident)
+[Commemoratio 3] (rubrica tridentina)
 @Sancti/12-25:Octava
 @Sancti/12-26:Octava
 @Sancti/12-27:Octava

--- a/web/www/horas/Latin/Tabulae/data.txt
+++ b/web/www/horas/Latin/Tabulae/data.txt
@@ -1,9 +1,18 @@
 version,kalendar,transfer,stransfer
-Tridentine 1570,1570,1570,1570
-Tridentine 1910,1888,1910,1910
-Divino Afflatu,1954,DA,DA,DA
-Reduced 1955,1955,1960,DA,1955
-Rubrics 1960,1960,1960,1960
-1960 Newcalendar,NC,Newcal,Newcal
-Monastic,M,M,XXXX
+Tridentine - 1570,1570,1570,1570
+Tridentine - 1888,1888,1910,1910
+Divino Afflatu - 1954,1954,DA,DA,DA
+Reduced - 1955,1955,1960,DA,1955
+Rubrics 1960 - 1960,1960,1960,1960
+Rubrics 1960 - 2020 USA,NC,Newcal,Newcal
+Monastic - 1963,M,M,XXXX
+Ordo Praedicatorum - 1962,1967OP,1960,XXXX
+# - missa still uses old names
+Tridentine 1570,1570,1570,1570                                                                  │ GMT
+Tridentine 1910,1888,1910,1910                                                                  │Set-Cookie:missag=%27Rubrics%201960%27%3B%3B%3B%27regular%27%3B%3B%3B%27English%27%3B%3B%3B%27
+Divino Afflatu,1954,DA,DA,DA                                                                    │Hodie%27%3B%3B%3B%271%27%3B%3B%3B%270%27%3B%3B%3Boooobb%3B%3B%3B; path=/; expires=Tue, 05-Nov-
+Reduced 1955,1955,1960,DA,1955                                                                  │2024 12:00:56 GMT
+Rubrics 1960,1960,1960,1960                                                                     │<h1>Software error:</h1>
+1960 Newcalendar,NC,Newcal,Newcal                                                               │<pre>Can't load tempora for unknown version Rubrics 1960 at /home/m/h/bre/divinum-officium/web
+Monastic,M,M,XXXX                                                                               │/cgi-bin/missa/../DivinumOfficium/Directorium.pm line 84.
 Ordo Praedicatorum,1967OP,1960,XXXX

--- a/web/www/horas/Latin/Tempora/Adv1-0.txt
+++ b/web/www/horas/Latin/Tempora/Adv1-0.txt
@@ -8,7 +8,7 @@ Antiphonas horas
 [Ant Vespera]
 @:Ant Laudes
 
-[Ant Vespera](rubrica 1570 aut rubrica 1910)
+[Ant Vespera](rubrica tridentina)
 @Psalterium/Psalmi major:Daya6 Vespera
 
 [Ant Vespera 3]

--- a/web/www/horas/Latin/Tempora/Adv2-0.txt
+++ b/web/www/horas/Latin/Tempora/Adv2-0.txt
@@ -11,7 +11,7 @@ Antiphonas horas
 [Ant Vespera]
 @:Ant Laudes
 
-[Ant Vespera](rubrica 1570 aut rubrica 1910)
+[Ant Vespera](rubrica tridentina)
 @Psalterium/Psalmi major:Daya6 Vespera
 
 [Ant Vespera 3]

--- a/web/www/horas/Latin/Tempora/Adv3-0.txt
+++ b/web/www/horas/Latin/Tempora/Adv3-0.txt
@@ -11,7 +11,7 @@ Antiphonas horas
 [Ant Vespera]
 @:Ant Laudes
 
-[Ant Vespera](rubrica 1570 aut rubrica 1910)
+[Ant Vespera](rubrica tridentina)
 @Psalterium/Psalmi major:Daya6 Vespera
 
 [Ant Vespera 3]

--- a/web/www/horas/Latin/Tempora/Adv4-0.txt
+++ b/web/www/horas/Latin/Tempora/Adv4-0.txt
@@ -11,7 +11,7 @@ Antiphonas horas
 [Ant Vespera]
 @:Ant Laudes
 
-[Ant Vespera](rubrica 1570 aut rubrica 1910)
+[Ant Vespera](rubrica tridentina)
 @Psalterium/Psalmi major:Daya6 Vespera
 
 [Ant Vespera 3]

--- a/web/www/horas/Latin/Tempora/Pasc6-0.txt
+++ b/web/www/horas/Latin/Tempora/Pasc6-0.txt
@@ -5,7 +5,7 @@ Dominica infra Octavam Ascensionis;;Semiduplex;;5;;ex Tempora/Pasc5-4
 Dominica post Ascensionem;;Semiduplex;;5;;vide Tempora/Pasc5-4
 
 [Rule]
-ex Tempora/Pasc5-4;(rubrica 1570 aut rubrica 1910 aut rubrica divino)
+ex Tempora/Pasc5-4;(rubrica tridentina aut rubrica divino)
 9 lectiones
 Doxology=Asc
 StJamesRule=John,Rev
@@ -25,7 +25,7 @@ Cum vénerit Paráclitus, * quem ego mittam vobis Spíritum veritátis, qui a Pa
 Omnípotens sempitérne Deus: fac nos tibi semper et devótam gérere voluntátem; et majestáti tuæ sincéro corde servíre.
 $Per Dominum
 
-[Ant Matutinum](rubrica 1570 aut rubrica 1910 aut rubrica divino)
+[Ant Matutinum](rubrica tridentina aut rubrica divino)
 @Tempora/Pasc5-4:Ant Matutinum
 
 [Commemoratio 1]

--- a/web/www/horas/Latin/Tempora/Quad1-0.txt
+++ b/web/www/horas/Latin/Tempora/Quad1-0.txt
@@ -3,7 +3,7 @@ Dominica I in Quadragesima;;I classis Semiduplex;;6
 
 [Rule]
 9 lectiones
-Symbolum Athanasium(rubrica 1570 aut rubrica 1910)
+Symbolum Athanasium(rubrica tridentina)
 
 [Versum 1]
 V. Angelis suis Deus mandávit de te.

--- a/web/www/horas/Latin/Tempora/Quad2-0.txt
+++ b/web/www/horas/Latin/Tempora/Quad2-0.txt
@@ -3,7 +3,7 @@ Dominica II in Quadragesima;;I classis Semiduplex;;6
 
 [Rule]
 9 lectiones
-Symbolum Athanasium(rubrica 1570 aut rubrica 1910)
+Symbolum Athanasium(rubrica tridentina)
 
 [Ant 1]
 Visiónem quam vidístis, * némini dixéritis, donec a mórtuis resúrgat Fílius hóminis.

--- a/web/www/horas/Latin/Tempora/Quad3-0.txt
+++ b/web/www/horas/Latin/Tempora/Quad3-0.txt
@@ -3,7 +3,7 @@ Dominica III in Quadragesima;;I classis Semiduplex;;6
 
 [Rule]
 9 lectiones
-Symbolum Athanasium(rubrica 1570 aut rubrica 1910)
+Symbolum Athanasium(rubrica tridentina)
 
 [Ant 1]
 @Tempora/Quad2-6:Ant 3
@@ -147,7 +147,7 @@ Adhǽsit ánima mea * post te, Deus meus.
 Vim virtútis suæ * oblítus est ignis: ut púeri tui liberaréntur illǽsi.
 Sol et luna * laudáte Deum: quia exaltátum est nomen ejus solíus.
 
-[Ant Laudes] (rubrica 1570 aut rubrica 1910)
+[Ant Laudes] (rubrica tridentina)
 Fac benígne * in bona voluntáte tua, ut ædificéntur, Dómine, muri Jerúsalem.
 Dóminus * mihi adjútor est, non timébo quid fáciat mihi homo.
 Deus, misereatur nostri, * et benedicat nobis.

--- a/web/www/horas/Latin/Tempora/Quad4-0.txt
+++ b/web/www/horas/Latin/Tempora/Quad4-0.txt
@@ -3,7 +3,7 @@ Dominica IV in Quadragesima;;I classis Semiduplex;;6
 
 [Rule]
 9 lectiones
-Symbolum Athanasium(rubrica 1570 aut rubrica 1910)
+Symbolum Athanasium(rubrica tridentina)
 
 [Ant 1]
 Nemo te condemnávit, múlier? * Nemo, Dómine. Nec ego te condemnábo: jam ámplius noli peccáre.

--- a/web/www/horas/Latin/Tempora/Quad5-0.txt
+++ b/web/www/horas/Latin/Tempora/Quad5-0.txt
@@ -6,7 +6,7 @@ Dominica I Passionis;;I classis Semiduplex;;6
 
 [Rule]
 9 lectiones
-Symbolum Athanasium(rubrica 1570 aut rubrica 1910)
+Symbolum Athanasium(rubrica tridentina)
 
 [Ant 1]
 @Tempora/Quad4-6:Ant 3

--- a/web/www/horas/Latin/Tempora/Quad6-0.txt
+++ b/web/www/horas/Latin/Tempora/Quad6-0.txt
@@ -3,7 +3,7 @@ Dominica in Palmis;;I classis Semiduplex;;6
 
 [Rule]
 9 lectiones
-Symbolum Athanasium(rubrica 1570 aut rubrica 1910)
+Symbolum Athanasium(rubrica tridentina)
 
 [Ant 1]
 Pater juste, * mundus te non cognóvit: ego autem novi te, quia tu me misísti.

--- a/web/www/horas/Latin/Tempora/Quad6-3.txt
+++ b/web/www/horas/Latin/Tempora/Quad6-3.txt
@@ -54,7 +54,7 @@ Tu autem, Dómine, * scis omne consílium eórum advérsum me in mortem.
 Omnes inimíci mei * audiérunt malum meum: Dómine, lætáti sunt, quóniam tu fecísti.
 Fac, Dómine, * judícium injúriam patiéntibus: et vias peccatórum dispérde.
 
-[Ant Laudes](rubrica monastica aut rubrica 1570 aut rubrica 1910)
+[Ant Laudes](rubrica monastica aut rubrica tridentina)
 Líbera me * de sanguínibus, Deus, Deus meus: et exsultábit lingua mea justítiam tuam.
 Contumélias * et terróres passus sum ab eis: et Dóminus mecum est tamquam bellátor fortis.
 Ipsi vero * in vanum quæsierunt animam meam, introibunt in inferiora terræ.

--- a/web/www/horas/Latin/Tempora/Quadp1-0.txt
+++ b/web/www/horas/Latin/Tempora/Quadp1-0.txt
@@ -6,7 +6,7 @@ Dominica in Septuagesima;;Semiduplex;;5
 
 [Rule]
 9 lectiones
-Symbolum Athanasium(rubrica 1570 aut rubrica 1910)
+Symbolum Athanasium(rubrica tridentina)
 Invit2
 
 [Capitulum Vespera]

--- a/web/www/horas/Latin/Tempora/Quadp2-0.txt
+++ b/web/www/horas/Latin/Tempora/Quadp2-0.txt
@@ -6,7 +6,7 @@ Dominica in Sexagesima;;Semiduplex;;5
 
 [Rule]
 9 lectiones
-Symbolum Athanasium(rubrica 1570 aut rubrica 1910)
+Symbolum Athanasium(rubrica tridentina)
 Invit2
 
 [Capitulum Vespera]

--- a/web/www/horas/Latin/Tempora/Quadp3-0.txt
+++ b/web/www/horas/Latin/Tempora/Quadp3-0.txt
@@ -6,7 +6,7 @@ Dominica in Quinquagesima;;Semiduplex;;5
 
 [Rule]
 9 lectiones
-Symbolum Athanasium(rubrica 1570 aut rubrica 1910)
+Symbolum Athanasium(rubrica tridentina)
 Invit2
 
 [Capitulum Vespera]

--- a/web/www/horas/horas.dialog
+++ b/web/www/horas/horas.dialog
@@ -34,7 +34,7 @@ Votive~>$votive~>Optionmenu~>votives;;
 Latin,Dansk,Deutsch,English,Español/Espanol,Français/Francais,Italiano,Magyar,Polski,Português/Portugues,Latin-Bea,Polski-Newer
 
 [versions]
-Tridentine 1570,Tridentine 1910,Divino Afflatu,Reduced 1955,Rubrics 1960,1960 Newcalendar,Monastic,Ordo Praedicatorum
+Tridentine - 1570,Tridentine - 1888,Divino Afflatu - 1954,Reduced - 1955,Rubrics 1960 - 1960,Rubrics 1960 - 2020 USA,Monastic - 1963,Ordo Praedicatorum - 1962
 
 [votives]
 Hodie,Dedicatio/C8,Defunctorum/C9,Parvum B.M.V./C12

--- a/web/www/horas/horas.setup
+++ b/web/www/horas/horas.setup
@@ -22,7 +22,7 @@ bbtbbbtcccccnnbbb
 
 [general]
 $expand='all';;
-$version='Rubrics 1960';;
+$version='Rubrics 1960 - 1960';;
 $lang2='English';;
 $votive='';;
 
@@ -32,7 +32,7 @@ oooo
 [generalc]
 $expand='all';;
 $version='Divino Afflatu';;
-$version2='Rubrics 1960';;
+$version2='Rubrics 1960 - 1960';;
 $langc='Latin';;
 $accented='plain';;
 


### PR DESCRIPTION
Tridentine 1570         Tridentine - 1570
Tridentine 1910         Tridentine - 1888
Divino Afflatu          Divino Afflatu - 1954
Reduced 1955            Reduced - 1955
Rubrics 1960            Rubrics 1960 - 1960
1960 Newcalendar        Rubrics 1960 - 2020 USA
Monastic                Monastic - 1963
Ordo Praedicatorum      Ordo Praedicatorum - 1962

apart from being more informative this also improves "Newcalendar" and
"Ordo Praedicatorum",

also introduce validating runtime parameters as version, hora & lang

+AMDG+
