### PR TITLE
Fix Triduum Gloria omittitur #3456

### DIFF
--- a/web/cgi-bin/horas/horas.pl
+++ b/web/cgi-bin/horas/horas.pl
@@ -324,7 +324,7 @@ sub triduum_gloria_omitted() {
   return
        $dayname[0] =~ /Quad6/i
     && $dayofweek > 3
-    && $tvesp == 3;
+    && $tvesp != 1;
 }
 
 #*** Gloria


### PR DESCRIPTION
The triduum routine checked for tvesp == 3  i.e. whether we are in 2nd Vespers to do say the Gloria on Sabbato Sancto Vespers and Complet pre-1955.

However, the correct check should be whether we are not in 1st Vespers. Because in Laudes and throughout the day, i.e. tvesp == 2, we are still in the Triduum.