### PR TITLE
calendar inheritance

### DIFF
--- a/web/cgi-bin/DivinumOfficium/Directorium.pm
+++ b/web/cgi-bin/DivinumOfficium/Directorium.pm
@@ -30,10 +30,11 @@ sub load_data_data {
   if (@lines == 0) { die "Can't open $datafolder/data.txt"; }
   shift @lines;
   foreach (@lines) {
-    my($ver,$kal,$tra,$str) = split(/,/);
+    my($ver,$kal,$tra,$str,$base) = split(/,/);
     $_data{$ver}{kalendar} = $kal;
     $_data{$ver}{transfer} = $tra;
     $_data{$ver}{stransfer} = $str;
+    $_data{$ver}{base} = $base;
   }
   $_dCACHE{loaded} = 1;
 }
@@ -145,7 +146,11 @@ sub get_kalendar {
 
   load_kalendar($version) unless is_cached $cache_key;
 
-  $_dCACHE{$cache_key}{$day} || ''
+  my $rv = $_dCACHE{$cache_key}{$day};
+  return $rv if $rv;
+  my $ver = $_data{$version}{base};
+  return '' unless $ver;
+  return get_kalendar($ver, $day);
 }
 
 #*** get_transfer($year, $version, $key)
@@ -157,7 +162,11 @@ sub get_transfer {
 
   load_transfer($year, $version) unless is_cached $cache_key;
 
-  $_dCACHE{$cache_key}{$key} || ''
+  my $rv = $_dCACHE{$cache_key}{$key};
+  return $rv if $rv;
+  my $ver = $_data{$version}{base};
+  return '' unless $ver;
+  return get_transfer($year, $ver, $key);
 }
 
 #*** get_stransfer($year, $version, $key)
@@ -169,7 +178,11 @@ sub get_stransfer {
 
   load_transfer($year, $version, 'Stransfer') unless is_cached $cache_key;
 
-  $_dCACHE{$cache_key}{$key} || ''
+  my $rv = $_dCACHE{$cache_key}{$key};
+  return $rv if $rv;
+  my $ver = $_data{$version}{base};
+  return '' unless $ver;
+  return get_stransfer($year, $ver, $key);
 }
 
 #*** get_tempora($year, $version, $key)


### PR DESCRIPTION
This allows for local calendars (e.g. a Country or Religious Order) which generally follows the universal calendar, but with local feasts on particular days. Simplifies the calendar by allowing only the exceptions to be noted in the kalendaria, transfer and stransfer files.

read optional `$base` when reading data.txt
- after stransfer
- get kalendar, transfer or stransfer for a particular day/key,
  - if the version has no entry
  - and there is a base version specified,
  - check the base version

Sample: for Redemptorists, the feast of St Alphonsus would be 1st class:
`data.txt`:
```
...
Rubrics 1960,1960,1960,1960
Redemptorist,fssr,fssr,fssr,Rubrics 1960
...
```

`Kalendaria/fssr.txt`:
```
08-02=08-02r=S. Alphonsi Mariae de Ligorio Episc Conf et Eccles Doct=6=St Stephano Papae Martyris=1=
```
Then create a `Sancti/08-02r.txt`, with proper lessons/antiphons.