### PR TITLE
calendar inheritance

### DIFF
--- a/web/cgi-bin/DivinumOfficium/Directorium.pm
+++ b/web/cgi-bin/DivinumOfficium/Directorium.pm
@@ -194,7 +194,11 @@ sub get_tempora {
 
   load_tempora($version) unless is_cached $cache_key;
 
-  $_dCACHE{$cache_key}{$key} || ''
+  my $rv = $_dCACHE{$cache_key}{$key};
+  return $rv if $rv;
+  my $ver = $_data{$version}{base};
+  return '' unless $ver;
+  return get_tempora($ver, $key);
 }
 
 #*** transfered($tname | $sday, $year, $version)


### PR DESCRIPTION
overlooked get_tempora in [PR 3535](https://github.com/DivinumOfficium/divinum-officium/pull/3535)
- this simply adds the check for a base version to `get_tempora`, using the same method used for `get_kalendar` etc.