### PR TITLE
Expand responsory at Ash Wednesday Mass

### DIFF
--- a/web/www/missa/English/Tempora/Quadp3-3.txt
+++ b/web/www/missa/English/Tempora/Quadp3-3.txt
@@ -60,8 +60,8 @@ _
 !Esther 13; Joel 2
 Let us amend for the better in those things in which we have sinned through ignorance: lest suddenly overtaken by the day of death, we seek space for penance, and are not able to find it. Hear O Lord, and have mercy: for we have sinned against thee.
 !Ps 78:9
-Help us, O God, our saviour: and for the glory of thy name, O Lord, deliver us: and forgive us our sins for thy name's sake: O Lord deliver us. Listen, O Lord.
-V. Glory be to the Father, and to the Son, * and to the Holy Ghost. Listen, O Lord.
+Help us, O God, our saviour: and for the glory of thy name, O Lord, deliver us: and forgive us our sins for thy name's sake: O Lord deliver us. Hear O Lord, and have mercy: for we have sinned against thee
+V. Glory be to the Father, and to the Son, * and to the Holy Ghost. Hear O Lord, and have mercy: for we have sinned against thee
 !Sacerdos vero, dum cantantur Antiphonæ et Responsorium, detecto capite, primo imponit cineres digniori Sacerdoti, a quo ipse accepit, deinde Ministris paratis, genibus flexis coram Altari, dicens:
 !Imposition of the Ashes.
 !Gen. 3:19 

--- a/web/www/missa/French/Tempora/Quadp3-3.txt
+++ b/web/www/missa/French/Tempora/Quadp3-3.txt
@@ -65,8 +65,8 @@ _
 !Esther 13; Joel 2
 Supprimons par nos progrès dans le bien les fautes dont nous nous sommes rendus coupables par ignorance, de crainte que surpris soudainement le jour de la mort, nous ne cherchions le temps de faire pénitence et ne puissions le trouver. Prêtez attention, Seigneur, et ayez pitié, parce que nous avons péché contre vous.
 !Ps 78:9
-Aidez-nous, ô Dieu, qui êtes notre Sauveur ; et délivrez-nous, Seigneur ! pour la gloire de votre nom. Prêtez attention, Seigneur.
-V. Gloire au Père, au Fils et au Saint Esprit. Prêtez attention, Seigneur.
+Aidez-nous, ô Dieu, qui êtes notre Sauveur ; et délivrez-nous, Seigneur ! pour la gloire de votre nom. Prêtez attention, Seigneur, et ayez pitié, parce que nous avons péché contre vous.
+V. Gloire au Père, au Fils et au Saint Esprit. Prêtez attention, Seigneur, et ayez pitié, parce que nous avons péché contre vous.
 !Pendant qu’on chante les antiennes et le répons, le prêtre, la tête découverte, impose d’abord les cendres au plus digne des prêtres, qui les lui avait imposées, ensuite aux ministres parés, à genoux devant l’autel, en disant :
 !Genesis 3:19
 Souviens-toi, ô homme, que tu es poussière et que tu retourneras en poussière.

--- a/web/www/missa/Italiano/Tempora/Quadp3-3.txt
+++ b/web/www/missa/Italiano/Tempora/Quadp3-3.txt
@@ -65,8 +65,8 @@ _
 !Esther 13; Joel 2
 Emendiamoci dai nostri peccati commessi per ignoranza: affinché, sorpresi improvvisamente dalla morte, non abbiamo a cercare tempo per fare penitenza senza trovarlo. * Ascóltaci, o Signore, e abbi pietà: perché abbiamo peccato contro di Te.
 !Ps 78:9
-Aiutaci, o Dio, nostra salvezza: e a gloria del Tuo Nome, liberaci, o Signore. Ascóltaci, o Signore,
-V. Glória al Padre, e a Figliuolo e allo Spirito Santo. Ascoltaci,  o Signore.
+Aiutaci, o Dio, nostra salvezza: e a gloria del Tuo Nome, liberaci, o Signore. Ascóltaci, o Signore, e abbi pietà: perché abbiamo peccato contro di Te.
+V. Glória al Padre, e a Figliuolo e allo Spirito Santo. Ascóltaci, o Signore, e abbi pietà: perché abbiamo peccato contro di Te.
 ! Mentre si cantano le Antifone e il Responsorio, il sacerdote, a capo scoperto, impone le ceneri ai presenti, genuflessi, dicendo:
 !Genesis 3:19
 Ricordati, o uomo, che sei polvere, e in polvere ritornerai.

--- a/web/www/missa/Latin/Tempora/Quadp3-3.txt
+++ b/web/www/missa/Latin/Tempora/Quadp3-3.txt
@@ -62,10 +62,10 @@ _
 _
 !Responsorium
 !Esther 13; Joël 2
-Emendémus in mélius, quæ ignoránter peccávimus: ne, subito præoccupáti die mortis, quærámus spátium pæniténtiæ, et inveníre non possímus. Atténde, Dómine, et miserére: quia peccávimus tibi,
+Emendémus in mélius, quæ ignoránter peccávimus: ne, subito præoccupáti die mortis, quærámus spátium pæniténtiæ, et inveníre non possímus. Atténde, Dómine, et miserére: quia peccávimus tibi.
 !Ps 78:9
-Adjuva nos, Deus, salutáris noster: et propter honórem nóminis tui, Dómine, líbera nos. Atténde, Dómine,
-V. Glória Patri, et Fílio, et Spirítui Sancto. Atténde, Dómine.
+Adjuva nos, Deus, salutáris noster: et propter honórem nóminis tui, Dómine, líbera nos. Atténde, Dómine, et miserére: quia peccávimus tibi.
+V. Glória Patri, et Fílio, et Spirítui Sancto. Atténde, Dómine, et miserére: quia peccávimus tibi.
 !Sacerdos vero, dum cantantur Antiphonæ et Responsorium, detecto capite, primo imponit cineres digniori Sacerdoti, a quo ipse accepit, deinde Ministris paratis, genibus flexis coram Altari, dicens:
 !Genesis 3:19
 Memento, homo, quia pulvis es, et in púlverem revertéris.

--- a/web/www/missa/Polski/Tempora/Quadp3-3.txt
+++ b/web/www/missa/Polski/Tempora/Quadp3-3.txt
@@ -71,8 +71,8 @@ _
 !Est 13; Jl 2
 Zmieńmy na lepsze wszystko to, czym zgrzeszyliśmy w naszym zaślepieniu, abyśmy, gdy nas znienacka zaskoczy dzień śmierci, nie szukali czasu na pokutę, kiedy go już nie będziemy mogli znaleźć. * Wejrzyj na nas, Panie, i zmiłuj się: albowiem zgrzeszyliśmy przeciw Tobie.
 !Ps 78:9
-Wspomóż nas Boże, nasz Zbawicielu, i dla chwały imienia Twego wybaw nas, Panie. * Wejrzyj.
-V. Chwała Ojcu, i Synowi, i Duchowi Świętemu. * Wejrzyj.
+Wspomóż nas Boże, nasz Zbawicielu, i dla chwały imienia Twego wybaw nas, Panie. Wejrzyj na nas, Panie, i zmiłuj się: albowiem zgrzeszyliśmy przeciw Tobie.
+V. Chwała Ojcu, i Synowi, i Duchowi Świętemu. Wejrzyj na nas, Panie, i zmiłuj się: albowiem zgrzeszyliśmy przeciw Tobie.
 !Celebrans, podczas gdy śpiewane są antyfony i responsorium, najpierw nakłada popiół najwyższemu godnością kapłanowi, od którego otrzymał ów popiół, a w następnej kolejności kapłanom w ornatach, którzy przyklękają przed ołtarzem, i mówi:
 !Rdz 3:19
 Pamiętaj, człowiecze, że jesteś prochem i w proch się obrócisz.

--- a/web/www/missa/Portugues/Tempora/Quadp3-3.txt
+++ b/web/www/missa/Portugues/Tempora/Quadp3-3.txt
@@ -66,7 +66,7 @@ _
 Reparemos o mal que praticámos por ignorância, para que não aconteça que, surpreendidos pelo dia da morte, queiramos fazer penitência, mas já não tenhamos tempo! Ouvi-nos, Senhor, e tende misericórdia de nós, pois pecámos contra Vós.
 !Sl 78:9
 Auxiliai-nos, ó Deus, nosso Salvador, e, pela honra do vosso nomes, salvai-nos, Senhor. Ouvi-nos, Senhor, e tende misericórdia de nós, pois pecámos contra Vós.
-V. Glória ao Pai, e ao Filho e ao Espírito Santo. Ouvi-nos, Senhor.
+V. Glória ao Pai, e ao Filho e ao Espírito Santo. Ouvi-nos, Senhor, e tende misericórdia de nós, pois pecámos contra Vós.
 !Sacerdos vero, dum cantantur Antiphonæ et Responsorium, detecto capite, primo imponit cineres digniori Sacerdoti, a quo ipse accepit, deinde Ministris paratis, genibus flexis coram Altari, dicens:
 !Imposition of the Ashes.
 !Gen. 3:19 


### PR DESCRIPTION
At Ash Wednesday during imposition of ashes we chant a responsory. In all the languages on divinum officium including Latin the text was the same way it is printed in Missal: the refrain is given once, and then only the first couple words are repeated. We do expand introits, so I expanded this one as well.
![image](https://github.com/DivinumOfficium/divinum-officium/assets/100156521/d5bb2a99-9657-4f1e-81cc-ab01400bb3a9)
**Attention** As it was in all the versions like that, I'm a bit anxious that I may have misunderstood it.

**Note** In Spanish the "attende" is absent altogether from propers, it should be added