### PR TITLE
Missa Dom Quadragesima typo

### DIFF
--- a/web/www/missa/Latin/Tempora/Quad1-0.txt
+++ b/web/www/missa/Latin/Tempora/Quad1-0.txt
@@ -63,7 +63,7 @@ $Per Dominum
 Scápulis suis obumbrábit tibi Dóminus, et sub pennis ejus sperábis: scuto circúmdabit te véritas ejus.
 
 [Postcommunio]
-Qui nos, Dómine, sacraménti libátio sancta restáuret: et a vetustáte purgátos, in mystérii salutáris fáciat transíre consórtium.
+Tuis nos, Dómine, sacraménti libátio sancta restáuret: et a vetustáte purgátos, in mystérii salutáris fáciat transíre consórtium.
 $Per Dominum
 
 


### PR DESCRIPTION
Fix the typo. Took the correct Latin version from [this missal](https://archive.org/details/missale-romanum-1962/page/n144/mode/1up) :
![image](https://github.com/DivinumOfficium/divinum-officium/assets/100156521/1419fa62-a56a-4ef4-8d92-750149cc13c7)
