### PR TITLE
fix typo in aperi prayer

### DIFF
--- a/web/www/horas/Latin/Psalterium/Prayers.txt
+++ b/web/www/horas/Latin/Psalterium/Prayers.txt
@@ -161,7 +161,7 @@ In te, Dómine, sperávi: * non confúndar in ætérnum.
 
 [Ante]
 /:flexis genibus:/
-v. Apéri Dómine, os meum ad benedicéndum nomen sanctum tuum: munda quoque cor meum ab ómnibus vanis, pervérsis et aliénis cogitatiónibus; intelléctum illúmina, afféctum inflámma, ut digne, atténte ac devóte hoc Offícium recitáre váleam, et exaudíri mérear ante conspéctum divínæ Majestátis túæ. Per Christum Dóminum nostrum.
+v. Aperi Dómine, os meum ad benedicéndum nomen sanctum tuum: munda quoque cor meum ab ómnibus vanis, pervérsis et aliénis cogitatiónibus; intelléctum illúmina, afféctum inflámma, ut digne, atténte ac devóte hoc Offícium recitáre váleam, et exaudíri mérear ante conspéctum divínæ Majestátis túæ. Per Christum Dóminum nostrum.
 R. Amen.
 v. Dómine, in unióne illíus divínæ intentiónis, qua ipse in terris laudes Deo persolvísti, has tibi Horas (vel hanc tibi Horam) persólvo.
 

--- a/web/www/missa/Latin/Ordo/Prayers.txt
+++ b/web/www/missa/Latin/Ordo/Prayers.txt
@@ -168,7 +168,7 @@ In te, Dómine, sperávi: * non confúndar in ætérnum.
 
 [Ante]
 /:flexis genibus:/
-v. Apéri Dómine, os meum ad benedicéndum nomen sanctum tuum: munda quoque cor meum ab ómnibus vanis, pervérsis et aliénis cogitatiónibus; intelléctum illúmina, afféctum inflámma, ut digne, atténte ac devóte hoc Offícium recitáre váleam, et exaudíri mérear ante conspéctum divínæ Majestátis túæ. Per Christum Dóminum nostrum.
+v. Aperi Dómine, os meum ad benedicéndum nomen sanctum tuum: munda quoque cor meum ab ómnibus vanis, pervérsis et aliénis cogitatiónibus; intelléctum illúmina, afféctum inflámma, ut digne, atténte ac devóte hoc Offícium recitáre váleam, et exaudíri mérear ante conspéctum divínæ Majestátis túæ. Per Christum Dóminum nostrum.
 R. Amen.
 v. Dómine, in unióne illíus divínæ intentiónis, qua ipse in terris laudes Deo persolvísti, has tibi Horas (vel hanc tibi Horam) persólvo.
 


### PR DESCRIPTION
In "Aperi Dómine" the emphasis is on the first syllable, not the second. Usually, the accent is not put over the "A" either, because it is capitalized.