### PR TITLE
Update CompletoriumOP-English

### DIFF
--- a/web/www/horas/English/Ordinarium/CompletoriumOP.txt
+++ b/web/www/horas/English/Ordinarium/CompletoriumOP.txt
@@ -1,31 +1,25 @@
 #Incipit
 V. Sir, ask for a blessing.
-Blessing. May the almighty and merciful Lord grant us a peaceful night and a perfect end. Amen. 
+Benedictio. May the almighty and merciful Lord grant us a peaceful night and a perfect end. Amen. 
 
 #Lesson
 !1 Pet 5:8-9
-Brethren: Be sober, be watchful! Your adversary, the devil,~
-prowls around like a roaring lion, seeking someone to devour.~
-Resist him, firm in your faith. 
-V. Indeed, Lord have mercy on us.
-R. Thanks be to God.
+v. Brothers: Be sober and watch: because your adversary the devil,~
+as a roaring lion, goeth about seeking whom he may devour.~
+Whom resist ye, strong in faith: 
+$Tu autem
 
 V. Our help + is in the name of the Lord.
 R. Who made heaven and earth. 
 
 !Examination of Conscience or Our Father in secret.
-Our Father, who art in heaven, hallowed be thy name;~
-thy kingdom come; thy will be done on earth as it is~
-in heaven. Give us this day our daily bread;~
-and forgive us our trespasses as we forgive those~
-who trespass against us; and lead us not into temptation,~
-but deliver us from evil. Amen.
+$Pater noster
 
 $ConfiteorOP
 $MisereaturOP
 
-V. Revive us now, God our helper!
-R. Put an end to your greivance against us. 
+V. Turn us then, +++ O God, our saviour!
+R. And let thy anger cease from us. 
 $Deus in adjutorium
 &Alleluia
 
@@ -33,8 +27,9 @@ $Deus in adjutorium
 
 #Capitulum Responsory Versus
 !Jer 14:9
-v. You, O Lord, are in the midst of us, and we are called~
-by Your holy name; leave us no, O Lord our God.
+v. But thou, O Lord, art among us,~
+and thy name is called upon by us:~
+forsake us not, O Lord our God.
 R. Thanks be to God.
 _
 R.br. Into thy hands, O Lord, * do I commend my spirit.
@@ -46,21 +41,23 @@ R. Into thy hands, O Lord, * do I commend my spirit.
 
 #Hymnus
 _
-V. Guard us, Lord, as the apple of your eye.
-R. Hide us in the shadow of your wings.
+V. Keep us, Lord, as the apple of thine eye.
+R. Protect us under the shadow of thy wings.
 
 #Canticum Nunc dimittis
+Ant. Protect us, Lord, while we are awake and safeguard us while~
+we sleep; that we may keep watch with Christ, and rest in peace.
 &canticum(3)
 &Gloria
-Ant. Keep us safe, Lord, while we are awake and guard us as we sleep, that we may keep watch with Christ and rest in peace. 
+Ant. Protect us, Lord, while we are awake and safeguard us while~
+we sleep; that we may keep watch with Christ, and rest in peace.
 
 #Oratio
 &Dominus_vobiscum
 $Oremus		
-v. Visit this house, we beseech you, Lord, and drive~
-far away all snares of the enemy. May your holy angels~
- who dwell here, keep us in peace. And may your blessing~
- rest always upon us.
+v. Visit, we beseech thee, o Lord, this dwelling, and drive far~
+from it the snares of the enemy; let they holy angels dwell herein~
+to preserve us in peace, and let thy blessing be always upon us.
 $Per Dominum
 
 #Conclusio
@@ -71,37 +68,41 @@ the Son, and the Holy Spirit come down to us and remain forever.
 R. Amen.
 
 #Marian Antiphon 
-Hail, O Queen, mother of mercy;
-hail, our life, our delight and our hope!
-To you we cry, exiled children of eve;
-to you we send up our sighs, mourning and weeping,
-in this vale of tears.
+v. Hail holy Queen, Mother of Mercy, 
+our life, our sweetness, and our hope.  
+To thee do we cry, poor banished children of Eve.
+To thee do we send up our sighs, mourning and weeping
+in this valley of tears.
 _
-So then, our advocate,
-turn your eyes of mercy towards us,
-and after this our exile,
-show to us the blessed fruit of your womb, Jesus.
-O loving, O kind Virgin Mary.
+Turn then, most gracious Advocate,
+thine eyes of mercy toward us.
+And after this our exile show unto us
+the blessed fruit of thy womb, Jesus.
+O clement, O loving, O sweet Virgin Mary.  
 _
-V. Permit me to sing your praises, Holy Virgin!
-R. Strengthen then me against your enemies.
+V. Permit me to sing your praises, Holy Virgin! (Alleluia.)
+R. Strengthen then me against your enemies. (Alleluia.)
 _
 $Oremus
-_
-Grant, we beseech you, Lord God, that we of your household~
+v. Grant, we beseech you, Lord God, that we of your household~
 may enjoy unfailing health of mind and body, and, through~
 the glorious intercession of blessed Mary, ever Virgin, be~
 delivered from present sorrow to delight in joy eternal.~
 Through Christ the Lord. Amen.
 
 #Antiphon 
-Light of the Church, teacher of truth, rose of patience, ivory of chastity, you freely poured forth the waters of wisdom; preacher of grace, unite us with the blessed. (Alleluia.)
+v. Light of the Church, teacher of truth, rose of patience,~
+ivory of chastity, you freely poured forth the waters of wisdom;~
+ preacher of grace, unite us with the blessed. (Alleluia.)
 _
 V. Blessed Father, Dominic, pray for us. (Alleluia.)
 R. That we may be made worthy of the promises of Christ. (Alleluia.)
 _
 $Oremus
-Grant, we beseech You, almighty God, that we who are weighed down by the burden of our sins, may be relieved through the patronage of the blessed Dominic, Your confessor and our father. Through Christ our Lord. Amen.
+v. Grant, we beseech You, almighty God, that we who are weighed~
+down by the burden of our sins, may be relieved through the~
+patronage of the blessed Dominic, Your confessor and our father.~
+Through Christ our Lord. Amen.
 _
-May the souls of the faithful departed through the mercy of God rest in peace.
+V. May the souls of the faithful departed through the mercy of God rest in peace.
 R. Amen. 


### PR DESCRIPTION
Further changes to bring the style and formatting of the English CompletoriumOP into line with the rest of the formatting for the other Completorium 'editions' (Roman, etc). 

Changes were also made to try and use English translations not under copyright, as well.  I think the 1967 English translation of the Dominican Office is still under copyright, so I was trying to avoid any issues on that front.