### PR TITLE
Revert Quad6-6 unintentional change

### DIFF
--- a/web/www/missa/Latin/Tempora/Quad6-6.txt
+++ b/web/www/missa/Latin/Tempora/Quad6-6.txt
@@ -68,8 +68,8 @@ _
 _
 !!Prophetiæ
 ! Completa benedictione Cerei, Diaconus, depositis albis, sumit violacea paramenta, et vadit ad Celebrantem: qui exuitur Pluviali, et sumit Manipulum et Casulam violacei coloris. Postea leguntur Prophetiæ sine titulo, nec in earum fine respondetur Deo grátias, et Celebrans legit eas submissa voce ad Altare in cornu Epistolæ. In fine Prophetiarum dicuntur Orationes modo subscripto. Ante, vel interim dum Prophetiæ leguntur, Presbyteri catechizent catechumenos baptizandos, et præparent ad baptismum.
-!!Prophetia Prima
-!!Gen 2:1-2.
+!Prophetia Prima
+!Gen 2:1-2.
 In princípio creavit Deus cœlum et terram. Terra autem erat inánis et vácua, et ténebræ erant super fáciem abýssi: et Spíritus Dei ferebátur super aquas. Dixítque Deus: Fiat lux. Et facta est lux. Et vidit Deus lucem, quod esset bona: et divísit lucem a ténebris. Appellavítque lucem Diem, et ténebras Noctem: factúmque est véspere et mane, dies unus. Dixit quoque Deus: Fiat firmaméntum in médio aquárum: et dívidat aquas ab aquis. Et fecit Deus firmaméntum, divisítque aquas, quæ erant sub firmaménto, ab his, quæ erant super firmaméntum. Et factum est ita. Vocavítque Deus firmaméntum, Cœlum: et factum est véspere et mane, dies secúndus. Dixit vero Deus: Congregéntur aquæ, quæ sub cœlo sunt, in locum unum: et appáreat árida. Et factum est ita. Et vocávit Deus áridam, Terram: congregationésque aquárum appellávit Maria. Et vidit Deus, quod esset bonum. Et ait: Gérminet terra herbam viréntem et faciéntem semen, et lignum pomíferum fáciens fructum juxta genus suum, cujus semen in semetípso sit super terram. Et factum est ita. Et prótulit terra herbam viréntem et faciéntem semen juxta genus suum, lignúmque fáciens fructum, et habens unumquódque seméntem secúndum spéciem suam. Et vidit Deus, quod esset bonum. Et factum est véspere et mane, dies tértius. Dixit autem Deus: Fiant luminária in firmaménto cœli, et dívidant diem ac noctem, et sint in signa et témpora et dies et annos: ut lúceant in firmaménto cœli, et illúminent terram. Et factum est ita. Fecítque Deus duo luminária magna: lumináre majus, ut præésset diéi: et lumináre minus, ut præésset nocti: et stellas. Et pósuit eas in firmaménto cœli, ut lucérent super terram, et præéssent diéi ac nocti, et divíderent lucem ac ténebras. Et vidit Deus, quod esset bonum. Et factum est véspere et mane, dies quartus. Dixit étiam Deus: Prodúcant aquæ réptile ánimæ vivéntis, et volátile super terram sub firmaménto cæli. Creavítque Deus cete grándia, et omnem ánimam vivéntem atque motábilem, quam prodúxerant aquæ in spécies suas, et omne volátile secúndum genus suum. Et vidit Deus, quod esset bonum. Benedixítque eis, dicens: Créscite et multiplicámini, et repléte aquas maris: avésque multiplicéntur super terram. Et factum est véspere et mane, dies quintus. Dixit quoque Deus: Prodúcat terra ánimam vivéntem in génere suo: juménta et reptília, et béstias terræ secúndum spécies suas. Factúmque est ita. Et fecit Deus béstias terræ juxta spécies suas, et juménta, et omne réptile terræ in génere suo. Et vidit Deus, quod esset bonum, et ait: Faciámus hóminem ad imáginem et similitúdinem nostram: et præsit píscibus maris et volatílibus cœli, et béstiis universæque terræ, omníque réptili, quod movétur in terra. Et creávit Deus hóminem ad imáginem suam: ad imáginem Dei creávit illum, másculum et féminam creávit eos. Benedixítque illis Deus, et ait: Créscite et multiplicámini, et repléte terram, et subjícite eam, et dominámini píscibus maris et volatílibus cœli, et univérsis animántibus, quæ movéntur super terram. Dixítque Deus: Ecce, dedi vobis omnem herbam afferéntem semen super terram, et univérsa ligna, quæ habent in semetípsis seméntem géneris sui, ut sint vobis in escam: et cunctis animántibus terræ, omníque vólucri cœli, et univérsis, quæ movéntur in terra, et in quibus est ánima vivens, ut hábeant ad vescéndum. Et factum est ita. Vidítque Deus cuncta, quæ fécerat: et erant valde bona. Et factum est véspere et mane, dies sextus. Igitur perfécti sunt cœli et terra, et omnis ornátus eórum. Complevítque Deus die séptimo opus suum, quod fécerat: et requiévit die séptimo ab univérso ópere, quod patrárat.
 ! Et non respondetur Deo grátias, ne ad ceteras quidem Prophetias.
 _
@@ -82,8 +82,8 @@ Deus, qui mirabíliter creásti hóminem et mirabílius redemísti: da nobis, qu
 $Per Dominum
 _
 _
-!!Prophetia Secunda
-!!Gen. 5; 6; 7 et 8.
+!Prophetia Secunda
+!Gen. 5; 6; 7 et 8.
 Noë vero cum quingentórum esset annórum, génuit Sem, Cham et Japheth. Cumque cœpíssent hómines multiplicári super terram et fílias procreássent, vidéntes fílii Dei fílias hóminum, quod essent pulchræ, accepérunt sibi uxóres ex ómnibus, quas elégerant. Dixítque Deus: Non permanébit spíritus meus in hómine in ætérnum, quia caro est: erúntque dies illíus centum vigínti annórum. Gigántes autem erant super terram in diébus illis. Postquam enim ingréssi sunt fílii Dei ad fílias hóminum illæque genuérunt, isti sunt poténtes a sǽculo viri famósi. Videns autem Deus, quod multa malítia hóminum esset in terra, et cuncta cogitátio cordis inténta esset ad malum omni témpore, pænítuit eum, quod hóminem fecísset in terra. Et tactus dolóre cordis intrínsecus: Delébo, inquit, hóminem, quem creávi, a fácie terræ, ab hómine usque ad animántia, a réptili usque ad vólucres cœli; pænitet enim me fecísse eos. Noë vero invénit grátiam coram Dómino. Hæ sunt generatiónes Noë: Noë vir justus atque perféctus fuit in generatiónibus suis, cum Deo ambulávit. Et génuit tres fílios, Sem, Cham et Japheth. Corrúpta est autem terra coram Deo et repléta est iniquitáte. Cumque vidísset Deus terram esse corrúptam (omnis quippe caro corrúperat viam suam super terram), dixit ad Noë: Finis univérsæ carnis venit coram me: repléta est terra iniquitáte a fácie eórum, et ego dispérdam eos cum terra. Fac tibi arcam de lignis lævigátis: mansiúnculas in arca fácies, et bitúmine línies intrínsecus et extrínsecus. Et sic fácies eam: Trecentórum cubitórum erit longitúdo arcæ, quinquagínta cubitórum latitúdo, et trigínta cubilórum altitúdo illíus. Fenéstram in arca fácies, et in cúbito consummábis summitátem ejus: óstium autem arcæ pones ex látere: deórsum cenácula et trístega fácies in ea. Ecce, ego addúcam aquas dilúvii super terram, ut interfíciam omnem carnem, in qua spíritus vitæ est subter cœlum. Univérsa, quæ in terra sunt, consuméntur. Ponámque fœdus meum tecum: et ingrédiens arcam tu et fílii tui, uxor tua et uxóres filiórum tuórum tecum. Et ex cunctis animántibus univérsæ carnis bina indúces in arcam, ut vivant tecum: masculíni sexus et feminíni. De volúcribus juxta genus suum, et de juméntis in génere suo, et ex omni réptili terræ secúndum genus suum: bina de ómnibus ingrediántur tecum, ut possint vívere. Tolles ígitur tecum ex ómnibus escis, quæ mandi possunt, et comportábis apud te: et erunt tam tibi quam illis in cibum. Fecit ígitur Noë ómnia, quæ præcéperat illi Deus. Erátque sexcentórum annórum, quando dilúvii aquæ inundavérunt super terram. Rupti sunt omnes fontes abýssi magnæ, et cataráctæ cœli apértæ sunt: et facta est plúvia super terram quadragínta diébus et quadragínta nóctibus. In artículo diei illíus ingréssus est Noë, et Sem et Cham et Japheth, fílii ejus, uxor illíus et tres uxóres filiórum ejus cum eis in arcam: ipsi, et omne ánimal secúndum genus suum, univérsaque juménta in génere suo, et omne, quod movétur super terram in génere suo, cunctúmque volátile secúndum genus suum. Porro arca ferebátur super aquas. Et aquæ prævaluérunt nimis super terram: opertíque sunt omnes montes excélsi sub univérso cœlo. Quíndecim cúbitis áltior fuit aqua super montes, quos operúerat. Consúmptaque est omnis caro, quæ movebátur super terram, vólucrum, animántium, bestiárum, omniúmque reptílium, quæ reptant super terram. Remánsit autem solus Noë, et qui cum eo erant in arca. Obtinuerúntque aquæ terram centum quinquagínta diébus. Recordátus autem Deus Noë, cunctorúmque animántium et ómnium jumentórum, quæ erant cum eo in arca, addúxit spíritum super terram, et imminútæ sunt aquæ. Et clausi sunt fontes abýssi et cataráctæ cœli: et prohíbitæ sunt plúviæ de cœlo. Reversæque sunt aquæ de terra eúntes et redeúntes: et cœpérunt mínui post centum quinquagínta dies. Cumque transíssent quadragínta dies, apériens Nœ fenéstram arcæ, quam fécerat, dimísit corvum, qui egrediebátur, et non revertebátur, donec siccaréntur aquæ super terram. Emísit quoque colúmbam post eum, ut vidéret, si jam cessássent aquæ super fáciem terræ. Quæ cum non invenísset, ubi requiésceret pes ejus, revérsa est ad eum in arcam: aquæ enim erant super univérsam terram: extendítque manum et apprehénsam íntulit in arcam. Exspectátis autem ultra septem diébus áliis, rursum dimisit colúmbam ex arca. At illa venit ad eum ad vésperam, portans ramum olívæ viréntibus fóliis in ore suo. Intelléxit ergo Noë, quod cessássent aquæ super terram. Exspectavítque nihilminus septem álios dies: et emísit colúmbam, quæ non est revérsa ultra ad eum. Locútus est autem Deus ad Noë, dicens: Egrédere de arca, tu et uxor tua, fílii tui et uxóres filiórum tuórum tecum. Cuncta animántia, quæ sunt apud te, ex omni carne, tam in volatílibus quam in béstiis et univérsis reptílibus, quæ reptant super terram, educ tecum, et ingredímini super terram: créscite et multiplicámini super eam. Egréssus est ergo Noë et fílii ejus, uxor illíus et uxóres filiórum ejus cum eo. Sed et ómnia animántia, juménta et reptília, quæ reptant super terram, secúndum genus suum, egréssa sunt de arca. Ædificávit autem Noë altáre Dómino: et tollens de cunctis pecóribus et volúcribus mundis, óbtulit holocáusta super altáre. Odoratúsque est Dóminus odórem suavitátis.
 _
 _
@@ -94,8 +94,8 @@ Deus, incommutábilis virtus et lumen ætérnum: réspice propítius ad totíus 
 $Qui tecum
 _
 _
-!!Prophetia Tertia
-!!Gen 22:1-19.
+!Prophetia Tertia
+!Gen 22:1-19.
 In diébus illis: Tentávit Deus Abraham, et dixit ad eum: Abraham, Abraham. At ille respóndit: Adsum. Ait illi: Tolle fílium tuum unigénitum, quem diligis, Isaac, et vade in terram visiónis: atque ibi ófferes eum in holocáustum super unum móntium, quem monstrávero tibi. Igitur Abraham de nocte consúrgens, stravit ásinum suum: ducens secum duos júvenes et Isaac, fílium suum. Cumque concidísset ligna in holocáustum, ábiit ad locum, quem præcéperat ei Deus. Die autem tértio, elevátis óculis, vidit locum procul: dixítque ad púeros suos: Exspectáte hic cum ásino: ego et puer illuc usque properántes, postquam adoravérimus, revertémur ad vos. Tulit quoque ligna holocáusti, et impósuit super Isaac, fílium suum: ipse vero portábat in mánibus ignem et gládium. Cumque duo pérgerent simul, dixit Isaac patri suo: Pater mi. At ille respóndit: Quid vis, fili? Ecce, inquit, ignis et ligna: ubi est víctima holocáusti? Dixit autem Abraham: Deus providébit sibi víctimam holocáusti, fili mi. Pergébant ergo páriter: et venérunt ad locum, quem osténderat ei Deus, in quo ædificávit altáre et désuper ligna compósuit: cumque alligásset Isaac, fílium suum, pósuit eum in altare super struem lignórum. Extendítque manum et arrípuit gládium, ut immoláret fílium suum. Et ecce, Angelus Dómini de cœlo clamávit, dicens: Abraham, Abraham. Qui respóndit: Adsum. Dixítque ei: Non exténdas manum tuam super púerum neque fácias illi quidquam: nunc cognóvi, quod times Deum, et non pepercísti unigénito fílio tuo propter me. Levávit Abraham óculos suos, vidítque post tergum aríetem inter vepres hæréntem córnibus, quem assúmens óbtulit holocáustum pro fílio. Appellavítque nomen loci illíus, Dóminus videt. Unde usque hódie dícitur: In monte Dóminus vidébit. Vocávit autem Angelus Dómini Abraham secúndo de cœlo, dicens: Per memetípsum jurávi, dicit Dóminus: quia fecísti hanc rem, et non pepercísti fílio tuo unigénito propter me: benedícam tibi, et multiplicábo semen tuum sicut stellas cœli et velut arénam, quæ est in lítore maris: possidébit semen tuum portas inimicórum suórum, et benedicéntur in sémine tuo omnes gentes terræ, quia obœdísti voci meæ. Revérsus est Abraham ad púeros suos, abierúntque Bersabée simul, et habitávit ibi.
 _
 _
@@ -106,13 +106,13 @@ Deus, fidélium Pater summe, qui in toto orbe terrárum, promissiónis tuæ fíl
 $Per Dominum
 _
 _
-!!Prophetia Quarta
-!!Exodi 14:24-31; 15:1
+!Prophetia Quarta
+! Exodi 14:24-31; 15:1
 In diébus illis: Factum est in vigília matutina, et ecce, respíciens Dóminus super castra Ægyptiórum per colúmnam ignis et nubis, interfécit exércitum eórum: et subvértit rotas cúrruum, ferebantúrque in profúndum. Dixérunt ergo Ægýptii: Fugiámus Israélem: Dóminus enim pugnat pro eis contra nos. Et ait Dóminus ad Móysen: Exténde manum tuam super mare, ut revertántur aquæ ad Ægýptios super currus et équites eórum. Cumque extendísset Moyses manum contra mare, revérsum est primo dilúculo ad priórem locum: fugientibúsque Ægýptiis occurrérunt aquæ, et invólvit eos Dóminus in médiis flúctibus. Reversæque sunt aquæ, et operuérunt currus, et équites cuncti exércitus Pharaónis, qui sequéntes ingréssi fúerant mare: nec unus quidem supérfuit ex eis. Fílii autem Israël perrexérunt per médium sicci maris, et aquæ eis erant quasi pro muro a dextris et a sinístris: liberavítque Dóminus in die illa Israël de manu Ægyptiórum. Et vidérunt Ægýptios mórtuos super litus maris, et manum magnam, quam exercúerat Dóminus contra eos: timuítque pópulus Dóminum, et credidérunt Dómino et Moysi, servo ejus. Tunc cécinit Moyses et fílii Israël carmen hoc Dómino, et dixérunt:
 _
 _
-!!Tractus
-!!Exodi 15:1 et 2.
+!Tractus
+! Exodi 15:1 et 2.
 Cantémus Dómino: glorióse enim honorificátus est: equum et ascensórem projécit in mare: adjútor et protéctor factus est mihi in salútem,
 V. Hic Deus meus, et honorificábo eum: Deus patris mei, et exaltábo eum.
 V. Dóminus cónterens bella: Dóminus nomen est illi.
@@ -124,8 +124,8 @@ Deus, cujus antíqua mirácula étiam nostris sǽculis coruscáre sentímus: dum
 $Per Dominum
 _
 _
-!!Prophetia Quinta
-!!Isa 54:17; 55:1-11
+!Prophetia Quinta
+!Isa 54:17; 55:1-11
 Hæc est heréditas servórum Dómini: et justítia eórum apud me, dicit Dóminus. Omnes sitiéntes, veníte ad aquas: et qui non habétis argéntum, properáte, émite et comédite: veníte, émite absque argénto et absque ulla commutatióne vinum et lac. Quare appénditis argéntum non in pánibus, et labórem vestrum non in saturitáte? Audíte audiéntes me, et comédite bonum, et delectábitur in crassitúdine ánima vestra. Inclináte aurem vestram, et veníte ad me: audíte, et vivet ánima vestra, et fériam vobíscum pactum sempitérnum, misericórdias David fidéles. Ecce, testem pópulis dedi eum, ducem ac præceptórem géntibus. Ecce, gentem, quam nesciébas, vocábis: et gentes, quæ te non cognovérunt, ad te current propter Dóminum, Deum tuum, et sanctum Israël, quia glorificávit te. Quærite Dóminum, dum inveníri potest: invocáte eum, dum prope est. Derelínquat ímpius viam suam et vir iníquus cogitatiónes suas, et revertátur ad Dóminum, et miserébitur ejus, et ad Deum nostrum: quóniam multus est ad ignoscéndum. Non enim cogitatiónes meæ cogitatiónes vestræ: neque viæ vestræ viæ meæ, dicit Dóminus. Quia sicut exaltántur cœli a terra, sic exaltátæ sunt viæ meæ a viis vestris, et cogitatiónes meæ a cogitatiónibus vestris. Et quómodo descéndit imber et nix de cœlo, et illuc ultra non revértitur, sed inébriat terram, et infúndit eam, et germináre eam facit, et dat semen serénti et panem comedénti: sic erit verbum meum, quod egrediátur de ore meo: non revertátur ad me vácuum, sed fáciet, quæcúmque volui, et prosperábitur in his, ad quæ misi illud: dicit Dóminus omnípotens.
 _
 _
@@ -136,8 +136,8 @@ Omnípotens sempitérne Deus, multíplica in honórem nóminis tui, quod patrum 
 $Per Dominum
 _
 _
-!!Prophetia Sexta
-!!Baruch 3:9-38
+!Prophetia Sexta
+!Baruch 3:9-38
 Audi, Israël, mandáta vitæ: áuribus pércipe, ut scias prudéntiam. Quid est, Israël, quod in terra inimicórum es? Inveterásti in terra aliéna, coinquinátus es cum mórtuis: deputátus es cum descendéntibus in inférnum. Dereliquísti fontem sapiéntiæ. Nam si in via Dei ambulásses, habitásses útique in pace sempitérna. Disce, ubi sit prudéntia, ubi sit virtus, ubi sit intelléctus: ut scias simul, ubi sit longitúrnitas vitæ et victus, ubi sit lumen oculórum et pax. Quis invénit locum ejus? et quis intrávit in thesáuros ejus? Ubi sunt príncipes géntium, et qui dominántur super béstias, quæ sunt super terram? qui in ávibus cœli ludunt, qui argéntum thesaurízant et aurum, in quo confídunt hómines, et non est finis acquisitiónis eórum? qui argéntum fábricant, et sollíciti sunt, nec est invéntio óperum illórum? Extermináti sunt, et ad ínferos descendérunt, et álii loco eórum surrexérunt. Júvenes vidérunt lumen, et habitavérunt super terram: viam autem disciplínæ ignoravérunt, neque intellexérunt sémitas ejus, neque fílii eórum suscepérunt eam, a fácie ipsórum longe facta est: non est audíta in terra Chánaan, neque visa est in Theman. Fílii quoque Agar, qui exquírunt prudéntiam, quæ de terra est, negotiatóres Merrhæ et Theman, et fabulatóres, et exquisitóres prudéntiæ et intellegéntias: viam autem sapiéntiæ nesciérunt, neque commemoráti sunt sémitas ejus. O Israël, quam magna est domus Dei et ingens locus possessiónis ejus! Magnus est et non habet finem: excélsus et imménsus. Ibi fuérunt gigántes nomináti illi, qui ab inítio fuérunt, statúra magna, sciéntes bellum. Non hos elegit Dóminus, neque viam disciplínæ invenérunt: proptérea periérunt. Et quóniam non habuérunt sapiéntiam, interiérunt propter suam insipiéntiam. Quis ascéndit in cœlum, et accépit eam et edúxit eam de núbibus? Quis transfretávit mare, et invénit illam? et áttulit illam super aurum eléctum? Non est, qui possit scire vias ejus neque qui exquírat sémitas ejus: sed qui scit univérsa, novit eam et adinvénit eam prudéntia sua: qui præparávit terram in ætérno témpore, et replévit eam pecúdibus et quadrupédibus: qui emíttit lumen, et vadit: et vocávit illud, et obædit illi in tremóre. Stellæ autem dedérunt lumen in custódiis suis, et lætátæ sunt: vocátæ sunt, et dixérunt: Adsumus: et luxérunt ei cum jucunditáte, qui fecit illas. Hic est Deus noster, et non æstimábitur álius advérsus eum. Hic adinvénit omnem viam disciplínæ, et trádidit illam Jacob púero suo et Israël dilécto suo. Post hæc in terris visus est, et cum homínibus conversátus est.
 _
 _
@@ -148,8 +148,8 @@ Deus, qui Ecclésiam tuam semper géntium vocatióne multíplicas: concéde prop
 $Per Dominum
 _
 _
-!!Prophetia Septima
-!!Ezech 37:1-14
+!Prophetia Septima
+!Ezech 37:1-14
 In diébus illis: Facta est super me manus Dómini, et edúxit me in spíritu Dómini: et dimísit me in médio campi, qui erat plenus óssibus: et circumdúxit me per ea in gyro: erant autem multa valde super fáciem campi síccaque veheménter. Et dixit ad me: Fili hóminis, putásne vivent ossa ista? Et dixi: Dómine Deus, tu nosti. Et dixit ad me: Vaticináre de óssibus istis: et dices eis: Ossa árida, audíte verbum Dómini. Hæc dicit Dóminus Deus óssibus his: Ecce, ego intromíttam in vos spíritum, et vivétis. Et dabo super vos nervos, et succréscere fáciam super vos carnes, et superexténdam in vobis cutem: et dabo vobis spíritum, et vivétis, et sciétis, quia ego Dóminus. Et prophetávi, sicut præcéperat mihi: factus est autem sónitus prophetánte me, et ecce commótio: et accessérunt ossa ad ossa, unumquódque ad junctúram suam. Et vidi, et ecce, super ea nervi et carnes ascendérunt: et exténta est in eis cutis désuper, et spíritum non habébant. Et dixit ad me: Vaticináre ad spíritum, vaticináre, fili hóminis, et dices ad spíritum: Hæc dicit Dóminus Deus: A quátuor ventis veni, spíritus, et insúffla super interféctos istos, et revivíscant. Et prophetávi, sicut præcéperat mihi: et ingréssus est in ea spíritus, et vixérunt: steterúntque super pedes suos exércitus grandis nimis valde. Et dixit ad me: Fili hóminis, ossa hæc univérsa, domus Israël est: ipsi dicunt: Aruérunt ossa nostra, et périit spes nostra, et abscíssi sumus. Proptérea vaticináre, et dices ad eos: Hæc dicit Dóminus Deus: Ecce, ego apériam túmulos vestros, et edúcam vos de sepúlcris vestris, pópulus meus: et indúcam vos in terram Israël. Et sciétis, quia ego Dóminus, cum aperúero sepúlcra vestra et edúxero vos de túmulis vestris, pópule meus: et dédero spíritum meum in vobis, et vixéritis, et requiéscere vos fáciam super humum vestram: dicit Dóminus omnípotens.
 _
 _
@@ -160,13 +160,13 @@ Deus, qui nos ad celebrándum paschále sacraméntum utriúsque Testaménti pág
 $Per Dominum
 _
 _
-!!Prophetia Octava
-!!Isa 4:1-6
+!Prophetia Octava
+!Isa 4:1-6
 Apprehéndent septem mulíeres virum unum in die illa, dicéntes: Panem nostrum comedémus et vestiméntis nostris operiémur: tantúmmodo invocétur nomen tuum super nos, aufer oppróbrium nostrum. In die illa erit germen Dómini in magnificéntia et glória, et fructus terræ súblimis, et exsultátio his, qui salváti fúerint de Israël. Et erit: Omnis, qui relíctus fúerit in Sion et resíduus in Jerúsalem, sanctus vocábitur, omnis, qui scriptus est in vita in Jerúsalem. Si ablúerit Dóminus sordes filiárum Sion, et sánguinem Jerúsalem láverit de médio ejus, in spíritu judícii et spíritu ardóris. Et creábit Dóminus super omnem locum montis Sion, et ubi invocátus est, nubem per diem, et fumum et splendórem ignis flammántis in nocte: super omnem enim glóriam protéctio. Et tabernáculum erit in umbráculum diéi ab æstu, et in securitátem et absconsiónem a túrbine et a plúvia.
 _
 _
-!!Tractus
-!!Isa 5:1 et 2
+!Tractus
+!Isa 5:1 et 2
 Vínea facta est dilécto in cornu, in loco úberi.
 V. Et macériam circúmdedit, et circumfódit: et plantávit víneam Sorec, et ædificávit turrim in médio ejus.
 V. Et tórcular fodit in ea: vínea enim Dómini Sábaoth domus Israël est.
@@ -178,8 +178,8 @@ Deus, qui in ómnibus Ecclésiæ tuæ fíliis, sanctórum Prophetárum voce mani
 $Per Dominum
 _
 _
-!!Prophetia Nona
-!!Exod 12:1-11
+!Prophetia Nona
+!Exod 12:1-11
 In diébus illis: Dixit Dóminus ad Móysen et Aaron in terra Ægýpti: Mensis iste vobis princípium ménsium: primus erit in ménsibus anni. Loquímini ad univérsum cœtum filiórum Israël, et dícite eis: Décima die mensis hujus tollat unusquísque agnum per famílias et domos suas. Sin autem minor est númerus, ut suffícere possit ad vescéndum agnum, assúmet vicínum suum, qui junctus est dómui suæ, juxta númerum animárum, quæ suffícere possunt ad esum agni. Erit autem agnus absque mácula, másculus, annículus: juxta quem ritum tollétis et hædum. Et servábitis eum usque ad quartam décimam diem mensis hujus: immolabítque eum univérsa multitúdo filiórum Israël ad vésperam. Et sument de sánguine ejus, ac ponent super utrúmque postem et in superlimináribus domórum, in quibus cómedent illum. Et edent carnes nocte illa assas igni, et ázymos panes cum lactúcis agréstibus. Non comedétis ex eo crudum quid nec coctum aqua, sed tantum assum igni: caput cum pédibus ejus et intestínis vorábitis. Nec remanébit quidquam ex eo usque mane. Si quid resíduum fúerit, igne comburétis. Sic autem comedétis illum: Renes vestros accingétis, et calceaménta habébitis in pédibus, tenéntes báculos in mánibus, et comedétis festinánter: est enim Phase (id est tránsitus) Dómini.
 _
 _
@@ -190,8 +190,8 @@ Omnípotens sempitérne Deus, qui in ómnium óperum tuórum dispensatióne mir�
 $Qui tecum
 _
 _
-!!Prophetia Decima
-!!Jonæ 3:1-10
+!Prophetia Decima
+!Jonæ 3:1-10
 In diébus illis: Factum est verbum Dómini ad Jonam Prophétam secúndo, dicens: Surge, et vade in Níniven civitátem magnam: et prædica in ea prædicatiónem, quam ego loquor ad te. Et surréxit Jonas, et ábiit in Níniven juxta verbum Dómini. Et Nínive erat cívitas magna itínere trium diérum. Et cœpit Jonas introíre in civitátem itínere diéi uníus: et clamávit et dixit: Adhuc quadragínta dies, et Nínive subvertétur. Et credidérunt viri Ninivítæ in Deum: et prædicavérunt jejúnium, et vestíti sunt saccis a majóre usque ad minórem. Et pervénit verbum ad regem Nínive: et surréxit de sólio suo, et abjécit vestiméntum suum a se, et indútus est sacco, et sedit in cínere. Et clamávit et dixit in Nínive ex ore regis et príncipum ejus, dicens: Hómines et juménta et boves et pécora non gustent quidquam: nec pascántur, et aquam non bibant. Et operiántur saccis hómines et juménta, et clament ad Dóminum in fortitúdine, et convertatur vir a via sua mala, et ab iniquitáte, quæ est in mánibus eórum. Quis scit, si convertátur et ignóscat Deus: et revertátur a furóre iræ suæ, et non períbimus? Et vidit Deus ópera eórum, quia convérsi sunt de via sua mala: et misértus est pópulo suo, Dóminus, Deus noster.
 _
 _
@@ -202,13 +202,13 @@ Deus, qui diversitátem géntium in confessióne tui nóminis adunásti: da nobi
 $Per Dominum
 _
 _
-!!Prophetia Undecima
-!!Deut 31:22-30.
+!Prophetia Undecima
+!Deut 31:22-30.
 In diébus illis: Scripsit Móyses canticum, et dócuit fílios Israël. Præcepítque Dóminus Josue, fílio Nun, et ait: Confortáre, et esto robústus: tu enim introdúces fílios Israël in terram, quam pollícitus sum, et ego ero tecum. Postquam ergo scripsit Móyses verba legis hujus in volúmine, atque complévit: præcépit Levítis, qui portábant arcam fœderis Dómini, dicens: Tóllite librum istum, et pónite eum in látere arcæ fœderis Dómini, Dei vestri: ut sit ibi contra te in testimónium. Ego enim scio contentiónem tuam et cérvicem tuam duríssimam. Adhuc vivénte me et ingrediénte vobíscum, semper contentióse egístis contra Dóminum: quanto magis, cum mórtuus fúero? Congregáte ad me omnes majóres natu per tribus vestras, atque doctóres, et loquar audiéntibus eis sermónes istos, et invocábo contra eos cœlum et terram. Novi enim, quod post mortem meam iníque agétis et declinábitis cito de via, quam præcépi vobis: et occúrrent vobis mala in extrémo témpore, quando fecéritis malum in conspéctu Dómini, ut irritétis eum per ópera mánuum vestrárum. Locútus est ergo Móyses, audiénte univérso cœtu Israël, verba cárminis hujus, et ad finem usque complévit.
 _
 _
-!!Tractus
-!!Deut 32:1-4
+!Tractus
+!Deut 32:1-4
 Atténde, cœlum, et loquar: et áudiat terra verba ex ore meo.
 V. Exspectétur sicut plúvia elóquium meum: et descéndant sicut ros verba mea.
 V. Sicut imber super gramen et sicut nix super fænum: quia nomen Dómini invocábo,
@@ -222,8 +222,8 @@ Deus, celsitúdo humílium et fortitúdo rectórum, qui per sanctum Móysen, pú
 $Per Dominum
 _
 _
-!!Prophetia Duodecima
-!!Dan 3:1-24.
+!Prophetia Duodecima
+!Dan 3:1-24.
 In diébus illis: Nabuchodónosor rex fecit státuam áuream, altitúdine cubitórum sexagínta, latitúdine cubitórum sex, et státuit eam in campo Dura provínciæ Babylónis. Itaque Nabuchodónosor rex misit ad congregándos sátrapas, magistrátus, et júdices, duces, et tyránnos, et præféctos, omnésque príncipes regiónum, ut convenírent ad dedicatiónem státuæ, quam eréxerat Nabuchodónosor rex. Tunc congregáti sunt sátrapæ, magistrátus, et júdices, duces, et tyránni, et optimátes, qui erant in potestátibus constitúti, et univérsi príncipes regiónum, ut convenírent ad dedicatiónem státuæ, quam eréxerat Nabuchodónosor rex. Stabant autem in conspéctu státuæ, quam posúerat Nabuchodónosor rex, et præco clamábat valénter: Vobis dícitur populis, tríbubus et linguis: In hora, qua audiéritis sónitum tubæ, et fístulæ, et cítharæ, sambúcæ, et psaltérii, et symphóniæ, et univérsi géneris musicórum, cadéntes adoráte státuam áuream, quam constítuit Nabuchodónosor rex. Si quis autem non prostrátus adoráverit, eádem hora mittétur in fornácem ignis ardéntis. Post hæc ígitur statim ut audiérunt omnes pópuli sónitum tubæ, fístulæ, et cítharæ, sambúcæ, et psaltérii, et symphóniæ, et omnis géneris musicórum, cadéntes omnes pópuli, tribus et linguæ adoravérunt státuam auream, quam constitúerat Nabuchodónosor rex. Statímque in ipso témpore accedéntes viri Chaldæi accusavérunt Judæos, dixerúntque Nabuchodónosor regi: Rex, in ætérnum vive: tu, rex, posuísti decrétum, ut omnis homo, qui audiérit sónitum tubæ, fístulæ, et cítharæ, sambúcæ, et psaltérii, et symphóniæ, et univérsi géneris musicórum, prostérnat se et adóret státuam áuream: si quis autem non prócidens adoráverit, mittátur in fornácem ignis ardéntis. Sunt ergo viri Judæi, quos constituísti super ópera regiónis Babylónis, Sidrach, Misach et Abdénago: viri isti contempsérunt, rex, decrétum tuum: deos tuos non colunt, et státuam áuream, quam erexísti, non adórant. Tunc Nabuchodónosor in furóre et in ira præcépit, ut adduceréntur Sidrach, Misach et Abdénago: qui conféstim addúcti sunt in conspéctu regis. Pronuntiánsque Nabuchodónosor rex, ait eis: Veréne, Sidrach, Misach et Abdénago, deos meos non cólitis, et státuam áuream, quam constítui, non adorátis? Nunc ergo si estis parati, quacúmque hora audieritis sonitum tubæ, fístulæ, cítharæ, sambúcæ, et psaltérii, et symphóniæ, omnísque géneris musicórum, prostérnite vos et adoráte státuam, quam feci: quod si non adoravéritis, eadem hora mittémini in fornácem ignis ardéntis; et quis est Deus, qui erípiet vos de manu mea? Respondéntes Sidrach, Misach et Abdénago, dixérunt regi Nabuchodónosor: Non opórtet nos de hac re respóndere tibi. Ecce enim, Deus noster, quem cólimus, potest erípere nos de camíno ignis ardéntis, et de mánibus tuis, o rex, liberáre. Quod si nolúerit, notum sit tibi; rex, quia deos tuos non cólimus et státuam áuream, quam erexísti, non adorámus. Tunc Nabuchodónosor replétus est furóre, et aspéctus faciéi illíus immutátus est super Sidrach, Misach et Abdénago, et præcépit, ut succenderétur fornax séptuplum, quam succéndi consuéverat. Et viris fortíssimis de exércitu suo jussit, ut, ligátis pédibus Sidrach, Misach et Abdénago, mítterent eos in fornácem ignis ardéntis. Et conféstim viri illi vincti, cum braccis suis et tiáris et calceaméntis et véstibus, missi sunt in médium fornácis ignis ardéntis: nam jússio regis urgébat: fornax autem succénsa erat nimis. Porro viros illos, qui míserant Sidrach, Misach et Abdénago, interfécit flamma ignis. Viri autem hi tres, id est, Sidrach, Misach et Abdénago, cecidérunt in médio camíno ignis ardéntis colligáti. Et ambulábant in médio flammæ laudántes Deum, et benedicéntes Dómino.
 _
 _
@@ -236,8 +236,8 @@ _
 !!Benedictio Fontis
 ! His expletis, si ecclesia habuerit Fontem baptismalem, Sacerdos benedicturus Fontem, accipit Pluviale violaceum, et præcedente Cruce, cum candelabris, et Cereo benedicto accenso, descendit cum Clero, et Ministris paratis ad Fontem: et interim cantatur sequens:
 _
-!!Tractus
-!!Ps 41:2-4.
+!Tractus
+!Ps 41:2-4.
 v. Sicut cervus desíderat ad fontes aquárum: iía desíderat ánima mea ad te, Deus.
 V. Sitívit ánima mea ad Deum vivum: quando véniam, et apparébo ante fáciem Dei?
 V. Fuérunt mihi lácrimæ meæ panes die ac nocte, dum dícitur mihi per síngulos dies: Ubi est Deus tuus?


### PR DESCRIPTION
This change was added in [Closes issue #3564](https://github.com/DivinumOfficium/divinum-officium/commit/050925e473c21aee9c386459415ae8005c850a5a) but I am not sure if this was intentional because it's not a pattern used in the rest of the repo. Usually, we have `!Tractus` and Verses also have only one `!`