### PR TITLE
Revert "Consistency in Prayers.txt and solving #3781"

### DIFF
--- a/web/www/horas/Dansk/Psalterium/Prayers.txt
+++ b/web/www/horas/Dansk/Psalterium/Prayers.txt
@@ -1,6 +1,5 @@
 [Pater noster]
-v. Fader vor, du som er i himlene,  Helliget vorde dit navn.  Komme dit rige.  Ske din vilje som i himlen, således også på jorden. 
-Giv os i dag vort daglige brød.  Og forlad os vor skyld, som også vi forlader vore skyldnere.  Og led os ikke i fristelse:  Men fri os fra det onde.  Amen.
+v. Fader vor, du som er i himlene,  Helliget vorde dit navn.  Komme dit rige.  Ske din vilje som i himlen, således også på jorden. Giv os i dag vort daglige brød.  Og forlad os vor skyld, som også vi forlader vore skyldnere.  Og led os ikke i fristelse:  Men fri os fra det onde.  Amen.
 Fader vor, du som er i himlene!
 
 [Pater_noster1]
@@ -52,8 +51,7 @@ R. Og lad mit råb nå til dig.
 /:skip second 'O Lord, hear my prayer':/
 
 [Confiteor]
-v. Jeg bekender for Gud den almægtige, for den salige Maria, evig Jomfru, for den salige Ærkeengel Michael, den salige Johannes Døberen, de hellige Apostle Peter og Paulus, og alle Helgen, at jeg har syndet såre meget, i tanke, ord og gerning: /:han slår sig tre gange for brystet:/ ved min skyld, ved min skyld, ved min overmåde store skyld. 
-Derfor beder jeg den salige Maria, evig Jomfru, den salige Ærkeengel Michael, den salige Johannes Døberen, de hellige Apostle Peter og Paulus og alle Helgen, at bede for mig til Herren, vor Gud.
+v. Jeg bekender for Gud den almægtige, for den salige Maria, evig Jomfru, for den salige Ærkeengel Michael, den salige Johannes Døberen, de hellige Apostle Peter og Paulus, og alle Helgen, at jeg har syndet såre meget, i tanke, ord og gerning: /:han slår sig tre gange for brystet:/ ved min skyld, ved min skyld, ved min overmåde store skyld. Derfor beder jeg den salige Maria, evig Jomfru, den salige Ærkeengel Michael, den salige Johannes Døberen, de hellige Apostle Peter og Paulus og alle Helgen, at bede for mig til Herren, vor Gud.
 
 [ConfiteorOP]
 v.  I confess to almighty God, to blessed Mary ever Virgin, to blessed Dominic our father, to all the Saints and to you, brethren, that I have sinned exceedingly by thought, word, deed and omission, through my fault: I beseech you to pray for me.

--- a/web/www/horas/Deutsch/Psalterium/Prayers.txt
+++ b/web/www/horas/Deutsch/Psalterium/Prayers.txt
@@ -1,6 +1,5 @@
 [Pater noster]
-v. Vater unser, der Du bist im Himmel. Geheiligt werde dein Name. Zu uns komme Dein Reich. Dein Wille geschehe, wie im Himmel, also auch auf Erden.  
-Unser tägliches Brot gibt uns heute, und vergib uns unsere Schuld, wie auch wir vergeben unseren Schuldigern. Und führe uns nicht in Versuchung, sondern erlöse uns von dem Übel. Amen.
+v. Vater unser, der Du bist im Himmel. Geheiligt werde dein Name. Zu uns komme Dein Reich. Dein Wille geschehe, wie im Himmel, also auch auf Erden.  Unser tägliches Brot gibt uns heute, und vergib uns unsere Schuld, wie auch wir vergeben unseren Schuldigern. Und führe uns nicht in Versuchung, sondern erlöse uns von dem Übel. Amen.
 
 [Pater_noster1]
 v. Vater unser, der Du bist im Himmel. Geheiligt werde dein Name. Zu uns komme Dein Reich. Dein Wille geschehe, wie im Himmel, also auch auf Erden.  Unser tägliches Brot gibt uns heute, und vergib uns unsere Schuld, wie auch wir vergeben unseren Schuldigern.
@@ -8,8 +7,7 @@ V. Und führe uns nicht in Versuchung:
 R. Sondern erlöse uns von dem Übel.
 
 [Ave Maria]
-v. Gegrüßest seist du Maria, voll der Gnade: Der Herr ist mit dir. Du bist gebenedeit unter den Frauen, und gebenedeit ist die Frucht deines Leibes Jesus. 
-Heilige Maria, Mutter Gottes, bitte für uns Sünder jetzt und in der Stunde unseres Todes. Amen.
+v. Gegrüßest seist du Maria, voll der Gnade: Der Herr ist mit dir. Du bist gebenedeit unter den Frauen, und gebenedeit ist die Frucht deines Leibes Jesus. Heilige Maria, Mutter Gottes, bitte für uns Sünder jetzt und in der Stunde unseres Todes. Amen.
 
 [Credo]
 v. Ich glaube an Gott, den allmächtigen Vater, Schöpfer des Himmels und der Erde.
@@ -22,7 +20,9 @@ Ich glaube an den Heiligen Geist, die heilige katholische Kirche, Gemeinschaft d
 
 [Credo secreto]
 !Das « Credo » wird still gebetet bis « Auferstehung des Fleisches. »
-v. Ich glaube an Gott, den allmächtigen Vater, Schöpfer des Himmels und der Erde. Und an Jesus Christus, Seinen eingeborenen Sohn, unsern Herrn, der empfangen ist vom Heiligen Geist, geboren aus Maria, der Jungfrau, gelitten unter Pontius Pilatus, gekreuzigt, gestorben und begraben, abgestiegen zu der Hölle, am dritten Tage wieder auferstanden von den Toten, aufgefahren in den Himmel; Er sitzet zur Rechten Gottes, des allmächtigen Vaters; von dannen er kommen wird zu richten die Lebendigen und die Toten. Ich glaube an den Heiligen Geist, die heilige katholische Kirche, Gemeinschaft der Heiligen, Nachlaß der Sünden.
+v. Ich glaube an Gott, den allmächtigen Vater, Schöpfer des Himmels und der Erde.
+Und an Jesus Christus, Seinen eingeborenen Sohn, unsern Herrn, der empfangen ist vom Heiligen Geist, geboren aus Maria, der Jungfrau, gelitten unter Pontius Pilatus, gekreuzigt, gestorben und begraben, abgestiegen zu der Hölle, am dritten Tage wieder auferstanden von den Toten, aufgefahren in den Himmel; Er sitzet zur Rechten Gottes, des allmächtigen Vaters; von dannen er kommen wird zu richten die Lebendigen und die Toten.
+Ich glaube an den Heiligen Geist, die heilige katholische Kirche, Gemeinschaft der Heiligen, Nachlaß der Sünden.
 V. Auferstehung des Fleisches.
 R. Und das ewige Leben. Amen.
 
@@ -61,8 +61,7 @@ R. Und laß mein Rufen zu dir kommen.
 /:das zweite 'O Herr, erhöre mein Gebet' wird ausgelassen:/
 
 [Confiteor_]
-v. Ich bekenne Gott, dem Allmächtigen, der seligen, allzeit reinen Jungfrau Maria, dem heiligen Erzengel Michael, dem heiligen Johannes dem Täufer, den heiligen Aposteln Petrus und Paulus und allen Heiligen, daß ich viel gesündigt habe in Gedanken, Worten und Werken: /:man schlägt sich an die Brust:/ durch meine Schuld, durch meine Schuld, durch meine große Schuld. 
-Darum bitte ich die selige, allzeit reine Jungfrau Maria, den heiligen Erzengel Michael, den heiligen Johannes den Täufer, die heiligen Apostel Petrus und Paulus und alle Heiligen für mich zu beten bei Gott, unserem Herrn. 
+v. Ich bekenne Gott, dem Allmächtigen, der seligen, allzeit reinen Jungfrau Maria, dem heiligen Erzengel Michael, dem heiligen Johannes dem Täufer, den heiligen Aposteln Petrus und Paulus und allen Heiligen, daß ich viel gesündigt habe in Gedanken, Worten und Werken: /:man schlägt sich an die Brust:/ durch meine Schuld, durch meine Schuld, durch meine große Schuld. Darum bitte ich die selige, allzeit reine Jungfrau Maria, den heiligen Erzengel Michael, den heiligen Johannes den Täufer, die heiligen Apostel Petrus und Paulus und alle Heiligen für mich zu beten bei Gott, unserem Herrn. 
 
 [Confiteor] (rubrica Monastica)
 @:Confiteor_:s/Paulus und allen /Paulus, unserem heiligen Vater Benedikt und allen / s/Paulus und alle/Paulus, unseren heiligen Vater Benedikt und alle/

--- a/web/www/horas/English/Psalterium/Prayers.txt
+++ b/web/www/horas/English/Psalterium/Prayers.txt
@@ -1,6 +1,5 @@
 [Pater noster]
-v. Our Father, who art in heaven,  Hallowed be thy name.  Thy kingdom come.  Thy will be done on earth as it is in heaven. 
-Give us this day our daily bread.  And forgive us our trespasses, as we forgive those who trespass against us.  And lead us not into temptation:  But deliver us from evil.  Amen.
+v. Our Father, who art in heaven,  Hallowed be thy name.  Thy kingdom come.  Thy will be done on earth as it is in heaven. Give us this day our daily bread.  And forgive us our trespasses, as we forgive those who trespass against us.  And lead us not into temptation:  But deliver us from evil.  Amen.
 
 [Pater_noster1]
 v. Our Father, who art in heaven, Hallowed be thy name. Thy kingdom come. Thy will be done on earth as it is in heaven. Give us this day our daily bread. And forgive us our trespasses, as we forgive those who trespass against us. 
@@ -8,13 +7,10 @@ V. And lead us not into temptation:
 R. But deliver us from evil. 
 
 [Ave Maria]
-v. Hail Mary, full of grace, the Lord is with thee; blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus. 
-Holy Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.
+v. Hail Mary, full of grace, the Lord is with thee; blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.
 
 [Credo]
-v. I believe in God, the Father almighty, Creator of heaven and earth. 
-And in Jesus Christ, his only Son, our Lord; who was conceived by the Holy Ghost, born of the Virgin Mary, suffered under Pontius Pilate, was crucified, died and was buried: he descended into hell; the third day he arose again from the dead; he ascended into heaven; sitteth at the right hand of God the Father almighty: from thence he shall come to judge the living and the dead. 
-I believe in the Holy Ghost, the holy catholic Church, the communion of Saints, the forgiveness of sins, the resurrection of the body, and life everlasting. Amen.
+v. I believe in God, the Father almighty, Creator of heaven and earth. And in Jesus Christ, his only Son, our Lord; who was conceived by the Holy Ghost, born of the Virgin Mary, suffered under Pontius Pilate, was crucified, died and was buried: he descended into hell; the third day he arose again from the dead; he ascended into heaven; sitteth at the right hand of God the Father almighty: from thence he shall come to judge the living and the dead. I believe in the Holy Ghost, the holy catholic Church, the communion of Saints, the forgiveness of sins, the resurrection of the body, and life everlasting. Amen.
 
 [Pater secreto]
 /:"Our Father" is said silently until "And lead us not into temptation:".:/
@@ -61,8 +57,7 @@ R. And let my cry come unto thee.
 /:skip second 'O Lord, hear my prayer':/
 
 [Confiteor_]
-v. I confess to almighty God, to blessed Mary ever Virgin, to blessed Michael the Archangel, to blessed John the Baptist, to the holy Apostles Peter and Paul, and to all the Saints, that I have sinned exceedingly in thought, word and deed: /:strikes his breast:/ through my fault, through my fault, through my most grievous fault. 
-Therefore I beseech blessed Mary ever Virgin, blessed Michael the Archangel, blessed John the Baptist, the holy Apostles Peter and Paul, and all the Saints, to pray for me to the Lord our God. 
+v. I confess to almighty God, to blessed Mary ever Virgin, to blessed Michael the Archangel, to blessed John the Baptist, to the holy Apostles Peter and Paul, and to all the Saints, that I have sinned exceedingly in thought, word and deed: /:strikes his breast:/ through my fault, through my fault, through my most grievous fault. Therefore I beseech blessed Mary ever Virgin, blessed Michael the Archangel, blessed John the Baptist, the holy Apostles Peter and Paul, and all the Saints, to pray for me to the Lord our God. 
 
 [Confiteor] (rubrica Ordo Praedicatorum)
 v.  I confess to almighty God, to blessed Mary ever Virgin, to blessed Dominic our father, to all the Saints and to you, brethren, that I have sinned exceedingly by thought, word, deed and omission, through my fault: I beseech you to pray for me.

--- a/web/www/horas/Espanol/Psalterium/Prayers.txt
+++ b/web/www/horas/Espanol/Psalterium/Prayers.txt
@@ -1,6 +1,5 @@
 [Pater noster]
-v. Padre nuestro, que estás en los cielos, santificado sea tu nombre, venga a nosotros tu reino, hágase tu voluntad así en la tierra como en el cielo. 
-El pan nuestro de cada día dánosle hoy; perdónanos nuestras deudas, así como nosotros perdonamos a nuestros deudores, y no nos dejes caer en la tentación, mas líbranos del mal. Amén.
+v. Padre nuestro, que estás en los cielos, santificado sea tu nombre, venga a nosotros tu reino, hágase tu voluntad así en la tierra como en el cielo. El pan nuestro de cada día dánosle hoy; perdónanos nuestras deudas, así como nosotros perdonamos a nuestros deudores, y no nos dejes caer en la tentación, mas líbranos del mal. Amén.
 
 [Pater_noster1]
 v. Padre nuestro, que estás en los cielos, santificado sea tu nombre, venga a nosotros tu reino, hágase tu voluntad así en la tierra como en el cielo. El pan nuestro de cada día dánosle hoy; perdónanos nuestras deudas, así como nosotros perdonamos a nuestros deudores:
@@ -8,8 +7,7 @@ V. No nos dejes caer en tentación:
 R. Mas líbranos del mal.
 
 [Ave Maria]
-v. Ave, María, llena de gracia, el Señor es contigo, bendita Tú eres entre todas las mujeres, y bendito es el fruto de tu vientre, Jesús. 
-Santa María, Madre de Dios, ruega por nosotros pecadores, ahora y en la hora de nuestra muerte. Amén.
+v. Ave, María, llena de gracia, el Señor es contigo, bendita Tú eres entre todas las mujeres, y bendito es el fruto de tu vientre, Jesús. Santa María, Madre de Dios, ruega por nosotros pecadores, ahora y en la hora de nuestra muerte. Amén.
 
 [Credo]
 v. Creo en Dios, Padre Todopoderoso, Creador del cielo y de la tierra. 
@@ -22,7 +20,9 @@ Creo en el Espíritu Santo, la santa Iglesia católica, la comunión de los sant
 
 [Credo secreto]
 /:El «Creo» en silencio hasta «La resurrección de la carne».:/
-v. Creo en Dios, Padre Todopoderoso, Creador del cielo y de la tierra. Creo en Jesucristo, su único Hijo, Nuestro Señor: que fue concebido por obra y gracia del Espíritu Santo, nació de Santa María Virgen; padeció bajo el poder de Poncio Pilato, fue crucificado, muerto y sepultado: descendió a los infiernos, al tercer día resucitó de entre los muertos, subió a los cielos y está sentado a la derecha de Dios, Padre todopoderoso. Desde allí ha de venir a juzgar a los vivos y a los muertos. Creo en el Espíritu Santo, la santa Iglesia católica, la comunión de los santos, el perdón de los pecados:
+v. Creo en Dios, Padre Todopoderoso, Creador del cielo y de la tierra. 
+Creo en Jesucristo, su único Hijo, Nuestro Señor: que fue concebido por obra y gracia del Espíritu Santo, nació de Santa María Virgen; padeció bajo el poder de Poncio Pilato, fue crucificado, muerto y sepultado: descendió a los infiernos, al tercer día resucitó de entre los muertos, subió a los cielos y está sentado a la derecha de Dios, Padre todopoderoso. Desde allí ha de venir a juzgar a los vivos y a los muertos. 
+Creo en el Espíritu Santo, la santa Iglesia católica, la comunión de los santos, el perdón de los pecados:
 V. La resurrección de la carne:
 R. Y la vida eterna. Amén.
 
@@ -61,8 +61,7 @@ R. Y llegue a ti nuestro clamor.
 /:El segundo «Señor, escucha» no se dice.:/
 
 [Confiteor]
-v. Yo, pecador, me confieso a Dios todopoderoso, a la bienaventurada siempre Virgen María, al bienaventurado San Miguel Arcángel, al bienaventurado San Juan Bautista, a los bienaventurados apóstoles Pedro y Pablo, a todos los santos (y a vosotros hermanos o a vos, Padre), que pequé gravemente con el pensamiento, palabra y obra /:se golpea el pecho tres veces:/, por mi culpa, por mi culpa, por mi grandísima culpa; 
-por tanto, ruego a la bienaventurada siempre Virgen María, al bienaventurado San Miguel Arcángel, al bienaventurado San Juan Bautista, a los santos Apóstoles Pedro y Pablo, a todos los santos (y vosotros hermanos o a vos, Padre), que roguéis por mí a Dios, nuestro Señor. 
+v. Yo, pecador, me confieso a Dios todopoderoso, a la bienaventurada siempre Virgen María, al bienaventurado San Miguel Arcángel, al bienaventurado San Juan Bautista, a los bienaventurados apóstoles Pedro y Pablo, a todos los santos (y a vosotros hermanos o a vos, Padre), que pequé gravemente con el pensamiento, palabra y obra /:se golpea el pecho tres veces:/, por mi culpa, por mi culpa, por mi grandísima culpa; por tanto, ruego a la bienaventurada siempre Virgen María, al bienaventurado San Miguel Arcángel, al bienaventurado San Juan Bautista, a los santos Apóstoles Pedro y Pablo, a todos los santos (y vosotros hermanos o a vos, Padre), que roguéis por mí a Dios, nuestro Señor. 
 
 [Misereatur]
 v. Dios todopoderoso tenga misericordia de nosotros, perdone nuestros pecados, y nos lleve a la vida eterna. Amén.

--- a/web/www/horas/Francais/Psalterium/Prayers.txt
+++ b/web/www/horas/Francais/Psalterium/Prayers.txt
@@ -1,20 +1,44 @@
 [Pater noster]
-v. Notre Père, qui êtes aux cieux, Que votre nom soit sanctifié, que votre règne arrive, Que votre volonté soit faite sur la terre comme au ciel. 
-Donnez-nous aujourd'hui notre pain de chaque jour. Pardonnez-nous nos offenses comme nous pardonnons à ceux qui nous ont offensés. Et ne nous laissez pas succomber à la tentation. Mais délivrez-nous du mal. Ainsi soit-il.
+v. Notre Père, qui êtes aux cieux,
+Que votre nom soit sanctifié, que votre règne arrive,
+Que votre volonté soit faite sur la terre comme au ciel.
+Donnez-nous aujourd'hui notre pain de chaque jour.
+Pardonnez-nous nos offenses comme nous pardonnons à ceux qui nous ont offensés.
+Et ne nous laissez pas succomber à la tentation.
+Mais délivrez-nous du mal.
+Ainsi soit-il.
 
 [Pater_noster1]
-v. Notre Père, qui êtes aux cieux, Que votre nom soit sanctifié, que votre règne arrive, Que votre volonté soit faite sur la terre comme au ciel. Donnez-nous aujourd'hui notre pain de chaque jour. Pardonnez-nous nos offenses comme nous pardonnons à ceux qui nous ont offensés :
+v. Notre Père, qui êtes aux cieux,
+Que votre nom soit sanctifié, que votre règne arrive,
+Que votre volonté soit faite sur la terre comme au ciel.
+Donnez-nous aujourd'hui notre pain de chaque jour.
+Pardonnez-nous nos offenses comme nous pardonnons à ceux qui nous ont offensés :
 V. Et ne nous laissez pas succomber à la tentation.
 R. Mais délivrez-nous du mal.
 
 [Ave Maria]
-v. Je vous salue, Marie, pleine de grâce, le Seigneur est avec vous ; Vous êtes bénie entre toutes les femmes, et Jésus, le fruit de vos entrailles, est béni. 
-Sainte Marie, Mère de Dieu, priez pour nous, pauvres pécheurs, maintenant et à l'heure de notre mort. Ainsi soit-il.
+v. Je vous salue, Marie, pleine de grâce, le Seigneur est avec vous ;
+Vous êtes bénie entre toutes les femmes, et Jésus, le fruit de vos entrailles, est béni.
+Sainte Marie, Mère de Dieu, priez pour nous, pauvres pécheurs, maintenant et à l'heure de notre mort.
+Ainsi soit-il.
 
 [Credo]
 v. Je crois en Dieu, le Père tout-puissant, Créateur du ciel et de la terre.
-Et en Jésus-Christ, son Fils unique, notre Seigneur, Qui a été conçu du Saint Esprit, est né de la Vierge Marie, A souffert sous Ponce Pilate, a été crucifié, est mort, a été enseveli, Est descendu aux enfers, le troisième jour est ressuscité des morts, Est monté aux cieux, Est assis à la droite de Dieu le Père tout-puissant, D'où il viendra juger les vivants et les morts. 
-Je crois au Saint Esprit, A la sainte Eglise Catholique, A la communion des Saints, A la rémission de péchés, A la resurrection de la chair, A la vie éternelle. Ainsi soit-il.
+Et en Jésus-Christ, son Fils unique, notre Seigneur,
+Qui a été conçu du Saint Esprit, est né de la Vierge Marie,
+A souffert sous Ponce Pilate, a été crucifié, est mort, a été enseveli,
+Est descendu aux enfers, le troisième jour est ressuscité des morts,
+Est monté aux cieux,
+Est assis à la droite de Dieu le Père tout-puissant,
+D'où il viendra juger les vivants et les morts.
+Je crois au Saint Esprit,
+A la sainte Eglise Catholique,
+A la communion des Saints,
+A la rémission de péchés,
+A la resurrection de la chair,
+A la vie éternelle.
+Ainsi soit-il.
 
 [Pater secreto]
 /:« Notre Père » en silence jusqu'à « Et ne nous laissez pas succomber à la tentation : »:/
@@ -27,10 +51,6 @@ R. Qui a fait le ciel et la terre.
 [Converte nos]
 V. Convertissez-nous, +++︎ ô Dieu, notre Sauveur.
 R. Et détournez de nous votre colère.
-
-[Dominus det]
-V. Que le Seigneur nous donne Sa paix.
-R. Et la vie éternelle. Ainsi soit-il.
 
 [Gloria]
 V. Gloire au Père, au Fils, * et au Saint-Esprit.
@@ -54,12 +74,27 @@ V. Seigneur, exaucez ma prière.
 R. Et que ma voix aille jusqu'à vous !
 /:on omet le deuxième "Seigneur, exaucez ma prière":/
 
-[Confiteor_]
-v. Je confesse à Dieu tout puissant, à la bienheureuse Marie toujours Vierge, à Saint Michel Archange, à Saint Jean-Baptiste, aux saints Apôtres Pierre et Paul, à tous les Saints que j'ai beaucoup péché, par pensées, par paroles et par actions : /:on se frappe le cœur :/ C'est ma faute, c'est ma faute, c'est ma très grande faute.
-C'est pourquoi je supplie la bienheureuse Marie toujours Vierge, Saint Michel Archange, Saint Jean-Baptiste, les saints Apôtres Pierre et Paul, tous les Saints, de prier pour moi le Seigneur notre Dieu.
+[Confiteor]
+v. Je confesse à Dieu tout puissant,
+à la bienheureuse Marie toujours Vierge,
+à Saint Michel Archange, à Saint Jean-Baptiste,
+aux saints Apôtres Pierre et Paul, à tous les Saints
+que j'ai beaucoup péché, par pensées, par paroles et par actions : /:on se frappe le cœur :/ C'est ma faute, c'est ma faute, c'est ma très grande faute.
+C'est pourquoi je supplie la bienheureuse Marie toujours Vierge,
+Saint Michel Archange, Saint Jean-Baptiste,
+les saints Apôtres Pierre et Paul, tous les Saints,
+de prier pour moi le Seigneur notre Dieu.
 
-[Confiteor] (rubrica Monastica)
-@:Confiteor_:s/Paul, à/Paul, à notre bienheureux père Saint Benoît, et à/ s/Paul, tous/Paul, à notre bienheureux père Saint Benoît, tous/
+[Confiteor](rubrica Monastica)
+v. Je confesse à Dieu tout puissant,
+à la bienheureuse Marie toujours Vierge,
+à Saint Michel Archange, à Saint Jean-Baptiste,
+aux saints Apôtres Pierre et Paul, à notre bienheureux père Saint Benoît, et à tous les Saints
+que j'ai beaucoup péché, par pensées, par paroles et par actions : /:on se frappe le cœur :/ C'est ma faute, c'est ma faute, c'est ma très grande faute.
+C'est pourquoi je supplie la bienheureuse Marie toujours Vierge,
+Saint Michel Archange, Saint Jean-Baptiste,
+les saints Apôtres Pierre et Paul, à notre bienheureux père Saint Benoît, tous les Saints,
+de prier pour moi le Seigneur notre Dieu.
 
 [Misereatur]
 v. Que le Dieu tout-puissant ait pitié de vous, et que, après vous avoir pardonné vos péchés, il vous conduise à la vie éternelle. Ainsi soit-il.

--- a/web/www/horas/Italiano/Psalterium/Prayers.txt
+++ b/web/www/horas/Italiano/Psalterium/Prayers.txt
@@ -1,6 +1,5 @@
 [Pater noster]
-v. Padre nostro che sei nei cieli, sia santificato il tuo nome; venga il tuo regno, sia fatta la tua volontà, come in cielo così in terra. 
-Dacci oggi il nostro pane quotidiano, rimetti a noi i nostri debiti, come noi li rimettiamo ai nostri debitori e non ci indurre in tentazione, ma liberaci dal male. Amen.
+v. Padre nostro che sei nei cieli, sia santificato il tuo nome; venga il tuo regno, sia fatta la tua volontà, come in cielo così in terra. Dacci oggi il nostro pane quotidiano, rimetti a noi i nostri debiti, come noi li rimettiamo ai nostri debitori e non ci indurre in tentazione, ma liberaci dal male. Amen.
 
 [Pater_noster1]
 v. Padre nostro che sei nei cieli, sia santificato il tuo nome; venga il tuo regno, sia fatta la tua volontà, come in cielo così in terra. Dacci oggi il nostro pane quotidiano, rimetti a noi i nostri debiti, come noi li rimettiamo ai nostri debitori:
@@ -8,13 +7,10 @@ V. E non ci indurre in tentazione:
 R. Ma liberaci dal male.
 
 [Ave Maria]
-v. Ave, o Maria, piena di grazia, il Signore è con te. Tu sei benedetta tra le donne e benedetto è il frutto del tuo seno, Gesù. 
-Santa Maria, Madre di Dio, prega per noi peccatori, adesso e nell'ora della nostra morte. Amen.
+v. Ave, o Maria, piena di grazia, il Signore è con te. Tu sei benedetta tra le donne e benedetto è il frutto del tuo seno, Gesù. Santa Maria, Madre di Dio, prega per noi peccatori, adesso e nell'ora della nostra morte. Amen.
 
 [Credo]
-v. Io Credo in Dio, Padre onnipotente, creatore del cielo e della terra; 
-e in Gesù Cristo, suo unico Figlio, nostro Signore, il quale fu concepito di Spirito Santo, nacque da Maria Vergine, patì sotto Ponzio Pilato, fu crocifisso, morì e fu sepolto; discese agli inferi; il terzo giorno risuscitò da morte; salì al cielo, siede alla destra di Dio Padre onnipotente; di là verrà a giudicare i vivi e i morti. 
-Credo nello Spirito Santo, la santa Chiesa cattolica, la comunione dei santi, la remissione dei peccati, la risurrezione della carne, la vita eterna. Amen.
+v. Io Credo in Dio, Padre onnipotente, creatore del cielo e della terra; e in Gesù Cristo, suo unico Figlio, nostro Signore, il quale fu concepito di Spirito Santo, nacque da Maria Vergine, patì sotto Ponzio Pilato, fu crocifisso, morì e fu sepolto; discese agli inferi; il terzo giorno risuscitò da morte; salì al cielo, siede alla destra di Dio Padre onnipotente; di là verrà a giudicare i vivi e i morti. Credo nello Spirito Santo, la santa Chiesa cattolica, la comunione dei santi, la remissione dei peccati, la risurrezione della carne, la vita eterna. Amen.
 
 [Pater secreto]
 /:Si dice il «Padre nostro» sottovoce fino a «E non ci indurre in tentazione».:/

--- a/web/www/horas/Latin/Psalterium/Prayers.txt
+++ b/web/www/horas/Latin/Psalterium/Prayers.txt
@@ -1,20 +1,44 @@
 [Pater noster]
-v. Pater noster, qui es in cælis, sanctificétur nomen tuum: advéniat regnum tuum: fiat volúntas tua, sicut in cælo et in terra. 
-Panem nostrum cotidiánum da nobis hódie: et dimítte nobis débita nostra, sicut et nos dimíttimus debitóribus nostris: et ne nos indúcas in tentatiónem: sed líbera nos a malo. Amen.
+v. Pater noster, qui es in cælis, 
+sanctificétur nomen tuum: advéniat regnum tuum: 
+fiat volúntas tua, sicut in cælo et in terra. 
+Panem nostrum cotidiánum da nobis hódie: 
+et dimítte nobis débita nostra, sicut et nos dimíttimus debitóribus nostris: 
+et ne nos indúcas in tentatiónem: 
+sed líbera nos a malo. 
+Amen.
 
 [Pater_noster1]
-v. Pater noster, qui es in cælis, sanctificétur nomen tuum: advéniat regnum tuum: fiat volúntas tua, sicut in cælo et in terra. Panem nostrum cotidiánum da nobis hódie: et dimítte nobis débita nostra, sicut et nos dimíttimus debitóribus nostris:
+v. Pater noster, qui es in cælis, 
+sanctificétur nomen tuum: advéniat regnum tuum: 
+fiat volúntas tua, sicut in cælo et in terra.  
+Panem nostrum cotidiánum da nobis hódie: 
+et dimítte nobis débita nostra, sicut et nos dimíttimus debitóribus nostris:
 V. Et ne nos indúcas in tentatiónem:
 R. Sed líbera nos a malo.
 
 [Ave Maria]
-v. Ave María, grátia plena; Dóminus tecum: benedícta tu in muliéribus, et benedíctus fructus ventris tui Jesus. 
-Sancta María, Mater Dei, ora pro nobis peccatóribus, nunc et in hora mortis nostræ. Amen.
+v. Ave María, grátia plena; Dóminus tecum: 
+benedícta tu in muliéribus, et benedíctus fructus ventris tui Jesus. 
+Sancta María, Mater Dei, ora pro nobis peccatóribus, nunc et in hora mortis nostræ. 
+Amen.
 
 [Credo]
-v. Credo in Deum, Patrem omnipoténtem, Creatórem cæli et terræ. 
-Et in Jesum Christum, Fílium ejus únicum, Dóminum nostrum: qui concéptus est de Spíritu Sancto, natus ex María Vírgine, passus sub Póntio Piláto, crucifíxus, mórtuus, et sepúltus: descéndit ad ínferos; tértia die resurréxit a mórtuis; ascéndit ad cælos; sedet ad déxteram Dei Patris omnipoténtis: inde ventúrus est judicáre vivos et mórtuos.
-Credo in Spíritum Sanctum, sanctam Ecclésiam cathólicam, Sanctórum communiónem, remissiónem peccatórum, carnis resurrectiónem, vitam ætérnam. Amen.
+v. Credo in Deum, Patrem omnipoténtem, Creatórem cæli et terræ.
+Et in Jesum Christum, Fílium ejus únicum, Dóminum nostrum: 
+qui concéptus est de Spíritu Sancto, natus ex María Vírgine, 
+passus sub Póntio Piláto, crucifíxus, mórtuus, et sepúltus: 
+descéndit ad ínferos; tértia die resurréxit a mórtuis; 
+ascéndit ad cælos; 
+sedet ad déxteram Dei Patris omnipoténtis: 
+inde ventúrus est judicáre vivos et mórtuos.
+Credo in Spíritum Sanctum, 
+sanctam Ecclésiam cathólicam, 
+Sanctórum communiónem, 
+remissiónem peccatórum, 
+carnis resurrectiónem, 
+vitam ætérnam. 
+Amen.
 
 [Pater secreto]
 /:« Pater Noster » dicitur secreto usque ad « Et ne nos indúcas in tentatiónem: »:/
@@ -70,8 +94,15 @@ R. Et clamor meus ad te véniat.
 /:secunda 'Domine, exaudi' omittitur:/
 
 [Confiteor_]
-v. Confíteor Deo omnipoténti, beátæ Maríæ semper Vírgini, beáto Michaéli Archángelo, beáto Joánni Baptístæ, sanctis Apóstolis Petro et Paulo, et ómnibus Sanctis, quia peccávi nimis, cogitatióne, verbo et ópere: /:percutit sibi pectus:/ mea culpa, mea culpa, mea máxima culpa. 
-Ídeo precor beátam Maríam semper Vírginem, beátum Michaélem Archángelum, beátum Joánnem aptístam, sanctos Apóstolos Petrum et Paulum, et omnes Sanctos, oráre pro me ad Dóminum Deum nostrum.
+v. Confíteor Deo omnipoténti, 
+beátæ Maríæ semper Vírgini, 
+beáto Michaéli Archángelo, beáto Joánni Baptístæ, 
+sanctis Apóstolis Petro et Paulo, et ómnibus Sanctis,  
+quia peccávi nimis, cogitatióne, verbo et ópere: /:percutit sibi pectus:/ mea culpa, mea culpa, mea máxima culpa. 
+Ídeo precor beátam Maríam semper Vírginem, 
+beátum Michaélem Archángelum, beátum Joánnem Baptístam, 
+sanctos Apóstolos Petrum et Paulum, et omnes Sanctos, 
+oráre pro me ad Dóminum Deum nostrum.
 
 [Confiteor]
 @:Confiteor_

--- a/web/www/horas/Magyar/Psalterium/Prayers.txt
+++ b/web/www/horas/Magyar/Psalterium/Prayers.txt
@@ -1,6 +1,5 @@
 [Pater noster]
-v. Mi Atyánk, aki a mennyekben vagy, szenteltessék meg a te neved; jöjjön el a te országod; legyen meg a te akaratod, amint a mennyben, úgy a földön is. 
-Mindennapi kenyerünket add meg nekünk ma; és bocsásd meg vétkeinket, miképpen mi is megbocsátunk az ellenünk vétkezőknek; és ne vígy minket kísértésbe, de szabadíts meg a gonosztól. Ámen.
+v. Mi Atyánk, aki a mennyekben vagy, szenteltessék meg a te neved; jöjjön el a te országod; legyen meg a te akaratod, amint a mennyben, úgy a földön is. Mindennapi kenyerünket add meg nekünk ma; és bocsásd meg vétkeinket, miképpen mi is megbocsátunk az ellenünk vétkezőknek; és ne vígy minket kísértésbe, de szabadíts meg a gonosztól. Ámen.
 
 [Pater_noster1]
 v. Mi Atyánk, aki a mennyekben vagy, szenteltessék meg a te neved; jöjjön el a te országod; legyen meg a te akaratod, amint a mennyben, úgy a földön is. Mindennapi kenyerünket add meg nekünk ma; és bocsásd meg vétkeinket, miképpen mi is megbocsátunk az ellenünk vétkezőknek.
@@ -8,8 +7,7 @@ V. És ne vígy minket kísértésbe,
 R. De szabadíts meg a gonosztól.
 
 [Ave Maria]
-v. Üdvözlégy Mária, malaszttal teljes; az Úr van teveled. Áldott vagy te az asszonyok között, és áldott a te méhednek gyümölcse, Jézus. 
-Asszonyunk, Szűz Mária, Istennek Szent Anyja, imádkozzál érettünk, bűnösökért, most és halálunk óráján. Ámen.
+v. Üdvözlégy Mária, malaszttal teljes; az Úr van teveled. Áldott vagy te az asszonyok között, és áldott a te méhednek gyümölcse, Jézus. Asszonyunk, Szűz Mária, Istennek Szent Anyja, imádkozzál érettünk, bűnösökért, most és halálunk óráján. Ámen.
 
 [Credo]
 v. Hiszek egy Istenben, mindenható Atyában, mennynek és földnek Teremtőjében.
@@ -47,8 +45,7 @@ R. És kiáltásom jusson elődbe.
 /:hagyd ki a második 'Uram, hallgasd meg könyörgésemet':/
 
 [Confiteor]
-v. Gyónom a mindenható Istennek, a Boldogságos, mindenkor Szűz Máriának, Szent Mihály főangyalnak, Keresztelő Szent Jánosnak, Szent Péter és Pál apostoloknak, és minden szenteknek: hogy fölöttébb vétkeztem gondolattal, szóval és cselekedettel. /:mellét megüti:/ Én vétkem, én vétkem, én igen nagy vétkem. 
-Kérem azért a Boldogságos, mindenkor Szűz Máriát, Szent Mihály főangyalt, Keresztelő Szent Jánost, Szent Péter és Pál apostolokat, és minden szenteket, imádkozzanak érettem a mi Urunkhoz, Istenünkhöz.
+v. Gyónom a mindenható Istennek, a Boldogságos, mindenkor Szűz Máriának, Szent Mihály főangyalnak, Keresztelő Szent Jánosnak, Szent Péter és Pál apostoloknak, és minden szenteknek: hogy fölöttébb vétkeztem gondolattal, szóval és cselekedettel. /:mellét megüti:/ Én vétkem, én vétkem, én igen nagy vétkem. Kérem azért a Boldogságos, mindenkor Szűz Máriát, Szent Mihály főangyalt, Keresztelő Szent Jánost, Szent Péter és Pál apostolokat, és minden szenteket, imádkozzanak érettem a mi Urunkhoz, Istenünkhöz.
 
 [Misereatur]
 v. Irgalmazzon nekünk a mindenható Isten, bocsássa meg vétkeinket és vezessen el minket az örök életre. Ámen.

--- a/web/www/horas/Polski/Psalterium/Prayers.txt
+++ b/web/www/horas/Polski/Psalterium/Prayers.txt
@@ -1,6 +1,5 @@
 [Pater noster]
-v. Ojcze nasz, któryś jest w niebie, święć się imię Twoje: przyjdź królestwo Twoje: bądź wola Twoja, jako w niebie tak i na ziemi. 
-Chleba naszego powszedniego daj nam dzisiaj: i odpuść nam nasze winy, jako i my odpuszczamy naszym winowajcom: i nie wódź nas na pokuszenie: ale nas zbaw ode złego. Amen.
+v. Ojcze nasz, któryś jest w niebie, święć się imię Twoje: przyjdź królestwo Twoje: bądź wola Twoja, jako w niebie tak i na ziemi. Chleba naszego powszedniego daj nam dzisiaj: i odpuść nam nasze winy, jako i my odpuszczamy naszym winowajcom: i nie wódź nas na pokuszenie: ale nas zbaw ode złego. Amen.
 
 [Pater_noster1]
 v. Ojcze nasz, któryś jest w niebie, święć się imię Twoje: przyjdź królestwo Twoje: bądź wola Twoja, jako w niebie tak i na ziemi. Chleba naszego powszedniego daj nam dzisiaj: i odpuść nam nasze winy, jako i my odpuszczamy naszym winowajcom:
@@ -8,8 +7,7 @@ V. I nie wódź nas na pokuszenie:
 R. Ale nas zbaw ode złego.
 
 [Ave Maria]
-v. Zdrowaś Maryjo, łaskiś pełna; Pan z Tobą: błogosławionaś ty między niewiastami, i błogosławiony owoc żywota twojego, Jezus. 
-Święta Maryjo, Matko Boża, módl się za nami grzesznymi, teraz i w godzinę śmierci naszej. Amen.
+v. Zdrowaś Maryjo, łaskiś pełna; Pan z Tobą: błogosławionaś ty między niewiastami, i błogosławiony owoc żywota twojego, Jezus. Święta Maryjo, Matko Boża, módl się za nami grzesznymi, teraz i w godzinę śmierci naszej. Amen.
 
 [Credo]
 v. Wierzę w Boga, Ojca wszechmogącego, Stworzyciela nieba i ziemi.
@@ -63,8 +61,7 @@ R. A wołanie moje niech do Ciebie przyjdzie.
 /:opuścić drugie „Panie, wysłuchaj”:/
 
 [Confiteor_]
-v. Spowiadam się Bogu wszechmogącemu, Najświętszej Maryi zawsze Dziewicy, świętemu Michałowi Archaniołowi, świętemu Janowi Chrzcicielowi, świętym Apostołom Piotrowi i Pawłowi, i wszystkim Świętym, że bardzo zgrzeszyłem, myślą, mową i uczynkiem: /:bijąc się w piersi:/ moja wina, moja wina, moja bardzo wielka wina. 
-Przeto błagam Najświętszą Maryję zawsze Dziewicę, świętego Michała Archanioła, świętego Jana Chrzciciela, świętych Apostołów Piotra i Pawła, i wszystkich świętych, o modlitwę za mnie do Pana Boga naszego.
+v. Spowiadam się Bogu wszechmogącemu, Najświętszej Maryi zawsze Dziewicy, świętemu Michałowi Archaniołowi, świętemu Janowi Chrzcicielowi, świętym Apostołom Piotrowi i Pawłowi, i wszystkim Świętym, że bardzo zgrzeszyłem, myślą, mową i uczynkiem: /:bijąc się w piersi:/ moja wina, moja wina, moja bardzo wielka wina. Przeto błagam Najświętszą Maryję zawsze Dziewicę, świętego Michała Archanioła, świętego Jana Chrzciciela, świętych Apostołów Piotra i Pawła, i wszystkich świętych, o modlitwę za mnie do Pana Boga naszego.
 
 [Confiteor] (rubrica Monastica)
 @:Confiteor_:s/Pawłowi/Pawłowi, Świętemu Ojcu naszemu Benedyktowi/ s/Pawła/Pawła, Świętego Ojca naszego Benedykta/

--- a/web/www/horas/Portugues/Psalterium/Prayers.txt
+++ b/web/www/horas/Portugues/Psalterium/Prayers.txt
@@ -1,6 +1,13 @@
 [Pater noster]
-v. Pai Nosso, que estais nos céus, santificado seja o vosso Nome, venha a nós o vosso Reino; seja feita a vossa vontade assim na terra como no Céu.
-O pão nosso de cada dia nos dai hoje; Perdoai-nos as nossas dívidas, assim como nós perdoamos aos nossos devedores; e não nos deixeis cair em tentação; mas livrai-nos do mal. Amém.
+v. Pai Nosso, que estais nos céus, ~ 
+santificado seja o vosso Nome, ~
+venha a nós o vosso Reino; ~
+seja feita a vossa vontade assim na terra como no Céu.
+O pão nosso de cada dia nos dai hoje; ~
+Perdoai-nos as nossas dívidas, assim como nós perdoamos aos nossos devedores; ~
+e não nos deixeis cair em tentação; ~
+mas livrai-nos do mal. ~
+Amém.
 
 [Ave Maria]
 v. Ave, Maria, Cheia de graça, o Senhor é convosco; bendita sois Vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus.
@@ -8,8 +15,14 @@ Santa Maria, Mãe de Deus, rogai por nós, pecadores, agora e na hora da nossa m
 
 [Credo]
 v. Creio em Deus, Pai todo-poderoso, Criador do Céu e da Terra;
-e em Jesus Cristo, seu único Filho, Nosso Senhor, que foi concebido pelo poder do Espírito Santo; nasceu da Virgem Maria; padeceu sob Pôncio Pilatos, foi crucificado, morto e sepultado; desceu à mansão dos mortos; ressuscitou ao terceiro dia; subiu aos Céus, onde está sentado à direita de DeusPai todo-poderoso, de onde  há-de vir a julgar os vivos e os mortos. 
-Creio no Espírito Santo, na santa Igreja Católica; na comunhão dos Santos; na remissão dos pecados; na ressurreição da carne; na vida eterna. Amém.
+ e em Jesus Cristo, seu único Filho, Nosso Senhor, que foi concebido~
+ pelo poder do Espírito Santo; nasceu da Virgem Maria; padeceu~
+ sob Pôncio Pilatos, foi crucificado, morto e sepultado; desceu~
+ à mansão dos mortos; ressuscitou ao terceiro dia; subiu aos Céus,~
+ onde está sentado à direita de DeusPai todo-poderoso, de onde ~
+ há-de vir a julgar os vivos e os mortos. Creio no Espírito Santo,~
+ na santa Igreja Católica; na comunhão dos Santos; na remissão~
+ dos pecados; na ressurreição da carne; na vida eterna. Amém.
 
 [Adjutorium nostrum]
 V. O nosso auxílio está + no nome do Senhor,
@@ -39,15 +52,22 @@ R. E que meu clamor chegue até Vós.
 !passar segunda Senhor, ouvi a minha oração.
 
 [Confiteor]
-v. Eu me confesso a Deus, todo poderoso, à bem-aventurada sempre Virgem Maria,ao bem-aventurado S. Miguel Arcanjo, ao bem-aventurado S. João Baptista,aos Santos Apóstolos S. Pedro e S. Paulo, e a todos os santos:que pequei muitas vezes por pensamentos, palavras e obras:Por minha culpa, por minha culpa, por minha tão grande culpa.
-Portanto rogo à bem-aventurada sempre Virgem Maria, ao bem-aventurado S. Miguel Arcanjo,ao bem-aventurado S. João Baptista, aos Santos Apóstolos S. Pedro e S. Paulo, e a todos os Santos,que rogueis a Deus, nosso Senhor, por mim. 
+v. Eu me confesso a Deus, todo poderoso, à bem-aventurada sempre Virgem Maria,~
+ao bem-aventurado S. Miguel Arcanjo, ao bem-aventurado S. João Baptista,~
+aos Santos Apóstolos S. Pedro e S. Paulo, e a todos os santos:~
+que pequei muitas vezes por pensamentos, palavras e obras:~
+Por minha culpa, por minha culpa, por minha tão grande culpa.~
+Portanto rogo à bem-aventurada sempre Virgem Maria, ao bem-aventurado S. Miguel Arcanjo,~
+ao bem-aventurado S. João Baptista, aos Santos Apóstolos S. Pedro e S. Paulo, e a todos os Santos,~
+que rogueis a Deus, nosso Senhor, por mim. 
 
 [Misereatur]
 v. Compadeça-se de vós o Senhor omnipotente; vos perdoe os pecados e guie até à vida eterna.
 Amém.
 
 [Indulgentiam]
-v. Que o Senhor + cruz omnipotente e misericordioso nos conceda o perdão,a absolvição e a remissão dos nossos pecados.
+v. Que o Senhor + cruz omnipotente e misericordioso nos conceda o perdão,~
+a absolvição e a remissão dos nossos pecados.
 Amém.
 
 [Domine labia]


### PR DESCRIPTION
Reverts DivinumOfficium/divinum-officium#3782 because it adds needless line breaks and introduces typos into the Compline texts (cf. Baptistam -> aptistam)