### PR TITLE
Restore preces feriales translations for Italian and Hungarian by correcting section names

### DIFF
--- a/web/www/horas/Italiano/Psalterium/Major Special.txt
+++ b/web/www/horas/Italiano/Psalterium/Major Special.txt
@@ -1617,7 +1617,7 @@ V. L'onnipotente e misericordioso Signore ci esaudisca.
 R. Amen.
 $Fidelium animae
 
-[Preces feriales_]
+[Preces feriales Laudes_]
 V. Io dissi: Signore abbi pietà di me.
 R. Sana l'anima mia, perché ho peccato contro di te.
 V. Volgiti a noi, o Signore, e fino a quando [sarai sdegnato]?

--- a/web/www/horas/Magyar/Psalterium/Major Special.txt
+++ b/web/www/horas/Magyar/Psalterium/Major Special.txt
@@ -1276,7 +1276,7 @@ R. Obumbrabit tibi
 &Gloria
 R. Scapulis suis obumbrabit tibi
 
-[Preces feriales_]
+[Preces feriales Laudes_]
 V. Így szóltam: Uram, irgalmazz nekem.
 R. Gyógyítsd meg lelkemet, mert vétkeztem ellened.
 V. Fordulj vissza felém, Uram, meddig még?


### PR DESCRIPTION
In [Italian](https://www.divinumofficium.com/cgi-bin/horas/Pofficium.pl?date1=03-20-2024&command=prayVespera&version=Rubrics%201960%20-%201960&testmode=regular&lang2=Italiano&votive=), Preces feriales appear in English. This PR changes the section name in `Major Special.txt` from `Preces feriales_` to `Preces feriales Laudes_` in the files for Italiano and Magyar in order to match the section name in the Latin file. I think this is the correct fix, but I haven't tested it extensively. in particular, I haven't tried to use all the variations of preces feriales that appear in the Latin file.