### PR TITLE
MONASTIC 1930: Hebd Quinquagesima et Quadragesima prima

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -1762,7 +1762,7 @@ sub setheadline {
       if ($version !~ /196/) {
         $rankname =
             ($rank < 2) ? 'Ferial'
-          : ($rank < 3) ? 'Feria major'
+          : ($rank < 3) ? ($version =~ /monastic.*divino/i ? 'Feria privilegiata III. ordinis' : 'Feria major')
           : ($rank < 5) ? 'Feria privilegiata II. ordinis'
           : 'Feria privilegiata';
       } else {

--- a/web/www/horas/Latin/Tempora/Quad1-1.txt
+++ b/web/www/horas/Latin/Tempora/Quad1-1.txt
@@ -1,7 +1,10 @@
 [Rank]
 Feria Secunda infra Hebdomadam I in Quadragesima;;Feria major;;2.1
 
-[Rank] (rubrica 1960)
+[Rank] (rubrica 1930)
+Feria Secunda infra Hebdomadam I in Quadragesima;;Feria major;;4.9
+
+[Rank] (rubrica 196)
 Feria Secunda infra Hebdomadam I in Quadragesima;;Feria major;;3.9
 
 [Rule]

--- a/web/www/horas/Latin/Tempora/Quad1-2.txt
+++ b/web/www/horas/Latin/Tempora/Quad1-2.txt
@@ -1,7 +1,10 @@
 [Rank]
 Feria Tertia infra Hebdomadam I in Quadragesima;;Feria major;;2.1
 
-[Rank] (rubrica 1960)
+[Rank] (rubrica 1930)
+Feria Tertia infra Hebdomadam I in Quadragesima;;Feria major;;4.9
+
+[Rank] (rubrica 196)
 Feria Tertia infra Hebdomadam I in Quadragesima;;Feria major;;3.9
 
 [Rule]

--- a/web/www/horas/Latin/Tempora/Quad1-3.txt
+++ b/web/www/horas/Latin/Tempora/Quad1-3.txt
@@ -1,7 +1,7 @@
 [Rank]
 Feria Quarta Quattuor Temporum Quadragesimæ;;Feria major;;2.1
 
-[Rank] (rubrica 1960)
+[Rank] (rubrica 196 aut rubrica 1930)
 Feria Quarta Quattuor Temporum Quadragesimæ;;Feria major;;4.9
 
 [Rule]

--- a/web/www/horas/Latin/Tempora/Quad1-4.txt
+++ b/web/www/horas/Latin/Tempora/Quad1-4.txt
@@ -1,7 +1,10 @@
 [Rank]
 Feria Quinta infra Hebdomadam I in Quadragesima;;Feria major;;2.1
 
-[Rank] (rubrica 1960)
+[Rank] (rubrica 1930)
+Feria Quinta infra Hebdomadam I in Quadragesima;;Feria major;;4.9
+
+[Rank] (rubrica 196)
 Feria Quinta infra Hebdomadam I in Quadragesima;;Feria major;;3.9
 
 [Rule]

--- a/web/www/horas/Latin/Tempora/Quad1-5.txt
+++ b/web/www/horas/Latin/Tempora/Quad1-5.txt
@@ -1,7 +1,7 @@
 [Rank]
 Feria Sexta Quattuor Temporum Quadragesimæ;;Feria major;;2.1
 
-[Rank] (rubrica 1960)
+[Rank] (rubrica 196 aut rubrica 1930)
 Feria Sexta Quattuor Temporum Quadragesimæ;;Feria major;;4.9
 
 [Rule]

--- a/web/www/horas/Latin/Tempora/Quad1-6.txt
+++ b/web/www/horas/Latin/Tempora/Quad1-6.txt
@@ -1,7 +1,7 @@
 [Rank]
 Sabbato Quattuor Temporum Quadragesimæ;;Feria major;;2.1
 
-[Rank] (rubrica 1960)
+[Rank] (rubrica 196 aut rubrica 1930)
 Sabbato Quattuor Temporum Quadragesimæ;;Feria major;;4.9
 
 [Rule]

--- a/web/www/horas/Latin/Tempora/Quadp3-3.txt
+++ b/web/www/horas/Latin/Tempora/Quadp3-3.txt
@@ -1,7 +1,7 @@
 [Rank]
-Feria IV Cinerum;;Feria privilegiata;;6
+Feria IV Cinerum;;Feria privilegiata;;6.9
 
-[Rank] (rubrica 1960)
+[Rank] (rubrica 196)
 Feria IV Cinerum;;Feria privilegiata;;7
 
 [Rule]
@@ -30,6 +30,8 @@ Cum enim cœ́perint alíquibus tentatiónibus ea ipsa scílicet illis súbtrahi
 
 [Responsory3]
 @Tempora/Quadp3-1:Responsory1
+(sed rubrica monastica)
+@Tempora/Quadp3-1:Responsory2
 
 [Ant 2]
 Cum jejunátis, * nolíte fíeri sicut hypócritæ, tristes.

--- a/web/www/horas/Latin/Tempora/Quadp3-4.txt
+++ b/web/www/horas/Latin/Tempora/Quadp3-4.txt
@@ -1,7 +1,10 @@
 [Rank]
 Feria V post Cineres;;Feria major;;2.1
 
-[Rank](rubrica 1960)
+[Rank] (rubrica 1930)
+Feria V post Cineres;;Feria major;;4.9
+
+[Rank] (rubrica 196)
 Feria V post Cineres;;Feria major;;3.9
 
 [Rule]

--- a/web/www/horas/Latin/Tempora/Quadp3-5.txt
+++ b/web/www/horas/Latin/Tempora/Quadp3-5.txt
@@ -1,7 +1,10 @@
 [Rank]
 Feria VI post Cineres;;Feria major;;2.1
 
-[Rank](rubrica 1960)
+[Rank] (rubrica 1930)
+Feria VI post Cineres;;Feria major;;4.9
+
+[Rank] (rubrica 196)
 Feria VI post Cineres;;Feria major;;3.9
 
 [Rule]

--- a/web/www/horas/Latin/Tempora/Quadp3-6.txt
+++ b/web/www/horas/Latin/Tempora/Quadp3-6.txt
@@ -1,7 +1,10 @@
 [Rank]
 Sabbato post Cineres;;Feria major;;2.1
 
-[Rank](rubrica 1960)
+[Rank] (rubrica 1930)
+Sabbato post Cineres;;Feria major;;4.9
+
+[Rank] (rubrica 196)
 Sabbato post Cineres;;Feria major;;3.9
 
 [Rule]
@@ -30,6 +33,8 @@ Verum ille non oblivíscitur oratiónem páuperum, neque avértit fáciem suam a
 
 [Responsory3]
 @Tempora/Quadp3-1:Responsory1
+(sed rubrica monastica)
+@Tempora/Quadp3-1:Responsory2
 
 [Versum 2]
 @Tempora/Quadp3-4:Versum 2

--- a/web/www/horas/Latin/TemporaM/Quad1-1.txt
+++ b/web/www/horas/Latin/TemporaM/Quad1-1.txt
@@ -1,5 +1,0 @@
-@Tempora/Quad1-1
-
-[Rank]
-Feria Secunda infra Hebdomadam I in Quadragesima;;Feria major;;3
-

--- a/web/www/horas/Latin/TemporaM/Quad1-2.txt
+++ b/web/www/horas/Latin/TemporaM/Quad1-2.txt
@@ -1,5 +1,0 @@
-@Tempora/Quad1-2
-
-[Rank]
-Feria Tertia infra Hebdomadam I in Quadragesima;;Feria major;;3
-

--- a/web/www/horas/Latin/TemporaM/Quad1-3.txt
+++ b/web/www/horas/Latin/TemporaM/Quad1-3.txt
@@ -1,5 +1,0 @@
-@Tempora/Quad1-3
-
-[Rank]
-Feria Quarta Quattuor Temporum Quadragesimæ;;Feria major;;4
-

--- a/web/www/horas/Latin/TemporaM/Quad1-4.txt
+++ b/web/www/horas/Latin/TemporaM/Quad1-4.txt
@@ -1,5 +1,0 @@
-@Tempora/Quad1-4
-
-[Rank]
-Feria Quinta infra Hebdomadam I in Quadragesima;;Feria major;;3
-

--- a/web/www/horas/Latin/TemporaM/Quad1-5.txt
+++ b/web/www/horas/Latin/TemporaM/Quad1-5.txt
@@ -1,5 +1,0 @@
-@Tempora/Quad1-5
-
-[Rank]
-Feria Sexta Quattuor Temporum Quadragesimæ;;Feria major;;4
-

--- a/web/www/horas/Latin/TemporaM/Quad1-6.txt
+++ b/web/www/horas/Latin/TemporaM/Quad1-6.txt
@@ -1,5 +1,0 @@
-@Tempora/Quad1-6
-
-[Rank]
-Sabbato Quattuor Temporum Quadragesimæ;;Feria major;;4
-

--- a/web/www/horas/Latin/TemporaM/Quadp3-1.txt
+++ b/web/www/horas/Latin/TemporaM/Quadp3-1.txt
@@ -1,1 +1,11 @@
 @Tempora/Quadp3-1
+
+[Rank] (rubrica divino)
+Feria II infra Hebdomadam Quinquagesimæ;;Feria major;;2.1
+
+[Lectio2]
+@Tempora/Quadp3-1::s/\n10 / ¶\n10 /
+
+[Responsory4]
+@Tempora/Quadp3-0:Responsory6
+

--- a/web/www/horas/Latin/TemporaM/Quadp3-2.txt
+++ b/web/www/horas/Latin/TemporaM/Quadp3-2.txt
@@ -1,1 +1,10 @@
 @Tempora/Quadp3-2
+
+[Rank] (rubrica divino)
+Feria III infra Hebdomadam Quinquagesimæ;;Feria major;;2.1
+
+[Lectio1]
+@Tempora/Quadp3-2::s/\n10 / ¶\n10 /
+
+[Responsory4]
+@TemporaM/Quadp3-0:Responsory8

--- a/web/www/horas/Latin/TemporaM/Quadp3-3.txt
+++ b/web/www/horas/Latin/TemporaM/Quadp3-3.txt
@@ -1,7 +1,0 @@
-@Tempora/Quadp3-3
-
-[Rank]
-Feria IV Cinerum;;Feria privilegiata;;7
-
-[Responsory3]
-@Tempora/Quadp3-1:Responsory2

--- a/web/www/horas/Latin/TemporaM/Quadp3-4.txt
+++ b/web/www/horas/Latin/TemporaM/Quadp3-4.txt
@@ -1,1 +1,0 @@
-@Tempora/Quadp3-4

--- a/web/www/horas/Latin/TemporaM/Quadp3-5.txt
+++ b/web/www/horas/Latin/TemporaM/Quadp3-5.txt
@@ -1,1 +1,0 @@
-@Tempora/Quadp3-5

--- a/web/www/horas/Latin/TemporaM/Quadp3-6.txt
+++ b/web/www/horas/Latin/TemporaM/Quadp3-6.txt
@@ -1,4 +1,0 @@
-@Tempora/Quadp3-6
-
-[Responsory3]
-@Tempora/Quadp3-1:Responsory2


### PR DESCRIPTION
In 1930:
1. Temporis post Septuagesimam on equal rank as Temporis Adventus (!), namely Feria privilegiata III. ordinis (de facto same as Feria major in Tridentine and Divino Roman)
2. Temporis Quadragesimae post diem Cinerum et Passionis ante Dominicam Palmarum all on the same rank "Feria privilegiata II. ordinis" (de facto same as Dominica minor)