### PR TITLE
Brute Force solution to #525 + Missa version names

### DIFF
--- a/web/cgi-bin/DivinumOfficium/RunTimeOptions.pm
+++ b/web/cgi-bin/DivinumOfficium/RunTimeOptions.pm
@@ -32,12 +32,9 @@ sub unequivocal {
 }
 
 use constant LEGACY_VERSION_NAMES => {
-  'Tridentine 1570' => 'Tridentine - 1570',
-  'Tridentine 1910' => 'Tridentine - 1906',
-  'Rubrics 1960' => 'Rubrics 1960 - 1960',
-  'Reduced 1955' => 'Reduced - 1955',
+  'Tridentine - 1910' => 'Tridentine - 1906',
   'Monastic' => 'Monastic - 1963',
-  '1960 Newcalendar' => 'Rubrics 1960 - 2020 USA',
+  'Dominican' => 'Ordo Praedicatorum - 1962',
 };
 
 # exported

--- a/web/cgi-bin/horas/dialogcommon.pl
+++ b/web/cgi-bin/horas/dialogcommon.pl
@@ -289,7 +289,9 @@ sub setupstring($$%) {
       }
 
       # Fill in the missing things from the layer below.
-      ${$new_sections}{'__preamble'} .= "\n${$base_sections}{'__preamble'}";
+      unless (${$new_sections}{'__preamble'} eq ${$base_sections}{'__preamble'}) {
+        ${$new_sections}{'__preamble'} .= "\n${$base_sections}{'__preamble'}";
+      }
       ${$new_sections}{$_} ||= ${$base_sections}{$_} foreach (keys(%{$base_sections}));
 
       # Ensure consistency in ranking of Offices by always defaulting to Latin even if there is a Translation itself
@@ -333,13 +335,25 @@ sub setupstring($$%) {
     # out some subsequent substitutions.
     foreach my $key ((exists $sections{'Rule'}) ? 'Rule' : (), sort(keys(%sections))) {
       if ($key !~ /Commemoratio|LectioE/i || $missa) {
-        1 while $sections{$key} =~ s/$inclusionregex/
+        my $iiij = 0;
+        my $iiiT = $sections{$key};
+
+        while (
+          $sections{$key} =~ s/$inclusionregex/
           get_loadtime_inclusion(\%sections, $basedir, $lang,
           $1,             # Filename.
           $2 ? $2 : $key, # Keyword.
           $3,             # Substitutions.
           $fname)         # Caller's filename.
-          /ge;
+				/ge
+        ) {
+
+          if ($iiij++ > 6) {
+            $error .= "Error in resolving $fname : $key :: $lang ::: $iiiT<br>";
+            $sections{$key} = "Cannot resolve too deeply nested Hashes";
+            last;
+          }
+        }
       }
     }
   } else {

--- a/web/cgi-bin/missa/missa.pl
+++ b/web/cgi-bin/missa/missa.pl
@@ -165,13 +165,17 @@ PrintTag
 }
 
 # translate from new breviary version names
-$version =~ s/Monastic(.*)/Monastic/;
-$version =~ s/ - 196.$//;
-$version =~ s/ -//;
-$version =~ s/1888/1910/;
-$version =~ s/ 1954//;
-$version =~ s/Rubrics 1960 2020 USA/1960 Newcalendar/;
-$version =~ s/Ordo Praedicatorum/Dominican/;
+if ($version =~ /Monastic/i) {
+  if ($version =~ /Trid/i) {
+    $version = 'Tridentinum - 1570';
+  } elsif ($version =~ /Divino/i) {
+    $version = 'Divino Afflatu - 1954';
+  } else {
+    $version = 'Rubrics 1960 - 1960';
+  }
+}
+$version =~ s/(1888|1906)/1910/;
+$version =~ s/Ordo Praedicatorum.*/Dominican/;
 
 if ($pmode =~ /(main|missa)/i) {
 
@@ -205,6 +209,7 @@ PrintTag
 }
 
 #common end for programs
+if ($building && $buildscript) { print buildscript($buildscript); }
 if ($error) { print "<P ALIGN=CENTER><FONT COLOR=red>$error</FONT></P>\n"; }
 if ($debug) { print "<P ALIGN=center><FONT COLOR=blue>$debug</FONT></P>\n"; }
 $command =~ s/(pray|setup)//ig;

--- a/web/cgi-bin/missa/propers.pl
+++ b/web/cgi-bin/missa/propers.pl
@@ -88,7 +88,7 @@ sub specials {
 
       if (
            ($rule =~ /omit.*\b$label\b/i)
-        || (($version =~ /1570/) && ($item =~ / Leo/))    # omit Leonine prayers issue #367
+        || (($version =~ /1570/) && ($item =~ / Leo/i))    # omit Leonine prayers issue #367
       ) {
         # Skip omitted section
         $tind++ while ($tind < @t && $t[$tind] !~ $section_regex);
@@ -410,7 +410,7 @@ sub getcc {
 }
 
 sub world_mission_sunday {
-  $version =~ /DA|1955|196/
+  $version =~ /Divino|1955|196/
     && $winner{Rank} =~ /Dominica/i
     && monthday($day, $month, $year, 1, 0) eq '104-0';
 }
@@ -707,7 +707,7 @@ sub loadspecial {
 sub delconclusio {
   $ctotalnum++;
   if ($version =~ /(1955|196)/ && $rank >= 5 && $ctotalnum > 2) { return ""; }
-  if ($version =~ /(196|196)/ && $ctotalnum > 3) { return ""; }    # Fixme
+  if ($version =~ /196/ && $ctotalnum > 3) { return ""; }    # Fixme
   my $ostr = shift;
   my @ostr = split("\n", $ostr);
   $ostr = '';

--- a/web/www/Tabulae/data.txt
+++ b/web/www/Tabulae/data.txt
@@ -10,13 +10,8 @@ Monastic - <!--Tridentinum -->1617,M1617,M1617,M1617
 Monastic - <!--Divino -->1930,M1930,M1930,M1930
 Monastic - 1963,M1963,M1963,XXXX
 Ordo Praedicatorum - 1962,OP1962,1960,XXXX
-# - missa still uses old names
-Tridentine 1570,1570,1570,1570
-Tridentine 1910,1906,1906,1910
-Divino Afflatu,1954,DA,DA
-Reduced 1955,1955,1960,DA
-Rubrics 1960,1960,1960,1960
+# - some missa still use old names
+Tridentine - 1910,1906,1906,1910
 1965-1967,1960,1960,1960
-1960 Newcalendar,NC,Newcal,Newcal
 Monastic,M1963,M1963,XXXX
 Dominican,1967OP,1960,XXXX

--- a/web/www/missa/missa.dialog
+++ b/web/www/missa/missa.dialog
@@ -15,18 +15,21 @@ Text width percent~>$textwidth~>Entry~>12;;
 Don't use fancy characters~>$nofancychars~>Checkbutton;;
 
 [general]
-Version~>$version~>Optionmenu~>{Tridentine 1570,Tridentine 1910,Divino Afflatu,Reduced 1955,Rubrics 1960,1965-1967,1960 Newcalendar,Dominican};;
+Version~>$version~>Optionmenu~>versions;;
 Language 2~>$lang2~>Optionmenu~>languages;;
 Votive~>$votive~>Optionmenu~>votives;;
 
 [generalc]
-Version 1~>$version1~>Optionmenu~>{Tridentinum,Divino Afflatu,Reductions 1955,Rubrics 1960};;
-Version 2~>$version2~>Optionmenu~>{Tridentinum,Divino Afflatu,Reductions 1955,Rubrics 1960};;
+Version 1~>$version1~>Optionmenu~>versions;;
+Version 2~>$version2~>Optionmenu~>versions;;
 Language 1~>$lang1~>Optionmenu~>languages;;
 Language 2~>$lang2~>Optionmenu~>languages;;
 
 [languages]
 Latin,Čeština/Cesky,Deutsch,English,Español/Espanol,Français/French,Italiano,Magyar,Nederlands,Polski,Português/Portugues,Українська/Ukrainian
+
+[versions]
+Tridentine - 1570,Tridentine - 1910,Divino Afflatu - 1954,Reduced - 1955,Rubrics 1960 - 1960,Rubrics 1960 - 2020 USA,1965-1967,Dominican
 
 [communes]
 C1,Commune Apostolorum, 


### PR DESCRIPTION
1. breaking nested loops after six iterations 

@APMarcello3  @mbab @fiapps  : This should resolve the CPU overload; however, maybe the limit of 6 nestings is too narrow? Please test if any working references are broken by this limit.

2. Renaming the Missa version names hopefully resolving some other issue within the Cache for the `setupstring` function.