### PR TITLE
Trid/DA: Matins Versicles infra 8vam Ascensionis

### DIFF
--- a/web/cgi-bin/horas/specmatins.pl
+++ b/web/cgi-bin/horas/specmatins.pl
@@ -256,10 +256,15 @@ sub psalmi_matutinum {
     setbuild2("9 lectiones");
 
     unless (exists($winner{'Ant Matutinum'})) {
-      if (($name eq 'Pasch' || $name eq 'Asc') && $rank < 5) {    #??? ex
+      if ( ($name eq 'Pasch' || $name eq 'Asc')
+        && $version !~ /trident/i
+        && $rank < 5
+        && $winner{'Rank'} !~ /(?:in|post).*octava.*Ascensio/i)
+      {
         my $dname = ($winner{Rank} =~ /Dominica/i) ? 'Dominica' : 'Feria';
         @spec = split("\n", $spec{"Pasch Ant $dname"});
         foreach my $i (3, 4, 8, 9, 13, 14) { $psalmi[$i] = $spec[$i]; }
+        setbuild2("Pasch Ant $dname special versums for nocturns");
       } elsif ($winner =~ /tempora/i
         && $name =~ /^(?:Adv|Quad|Pasch)$/i)
       {


### PR DESCRIPTION
Even infra 8vam Ascensionis, Paschal Ferial Versicles are substituted in after Nocturns. For Tridentine, it also looks wrong throughout Paschal Tide as even Semiduplex receive Psalms and Antiphones etc. from Commune. 

Since the Rubrics in the Psalterium and for the Octave of the Ascension seem to be somehow in contradiction (Breviarum Romanum 1942; I guess universally for DA), could someone (maybe @MRoth1910 ) check, for instance, Matins of 

- Robert Bellarmine:  May 13, 2024 (Feria II infra Octavam Ascensionis) 

if not the Versicles should be of the Ascension rather than Ferial Paschal tide. (DA version) Curiosly, for Rubrics 1960, which does not have the Octave anymore, the Versicle is of the Ascension. 