### PR TITLE
Jube domne Italian revision (plus a couple of minor errors)

### DIFF
--- a/web/www/horas/Francais/Psalterium/Prayers.txt
+++ b/web/www/horas/Francais/Psalterium/Prayers.txt
@@ -105,7 +105,7 @@ v. Je confesse à Dieu tout puissant, à la bienheureuse Marie toujours Vierge, 
 C'est pourquoi je supplie la bienheureuse Marie toujours Vierge, Saint Michel Archange, Saint Jean-Baptiste, les saints Apôtres Pierre et Paul, à notre bienheureux père Saint Benoît, tous les Saints, de prier pour moi le Seigneur notre Dieu.
 
 [Misereatur]
-v. Que le Dieu tout-puissant ait pitié de vous, et que, après vous avoir pardonné vos péchés, il vous conduise à la vie éternelle. Ainsi soit-il.
+v. Que le Dieu tout-puissant ait pitié de nous, et que, après nous avoir pardonné nos péchés, il nous conduise à la vie éternelle. Ainsi soit-il.
 
 [Indulgentiam]
 v. Que le Seigneur tout-puissant et tout miséricordieux + nous accorde l'indulgence, l'absolution et la rémission de nos péchés. Ainsi soit-il.

--- a/web/www/horas/Italiano/Martyrologium/07-16.txt
+++ b/web/www/horas/Italiano/Martyrologium/07-16.txt
@@ -1,7 +1,7 @@
 Festa della beata Vergine Maria del monte Carmélo.
 A Sebaste, in Arménia, i santi Martiri Atenógene Vescovo e dieci suoi discepoli, sotto l'Imperatore Diocleziano.
 A Tréviri san Valentino, Vescovo e Martire.
-A Cordova, nella Spagna, san Sisenàndo, Levita e Martire, il quale, per la fede di Cir sto, fu scannato dai Saracèni.
+A Cordova, nella Spagna, san Sisenàndo, Levita e Martire, il quale, per la fede di Cristo, fu scannato dai Saracèni.
 Nello stesso giorno il natale di san Fàusto Martire, il quale sotto l'Imperatore Dècio, essendo stato confitto in croce, visse su quella cinque giorni, e finalmente, trafitto da frecce, volò al cielo.
 A Saintes, in Frància, i santi Martiri Rainélde Vergine e i suoi Compagni, uccisi dai barbari per la fede di Cristo.
 A Bèrgamo san Donnióne Martire.

--- a/web/www/horas/Italiano/Psalterium/Prayers.txt
+++ b/web/www/horas/Italiano/Psalterium/Prayers.txt
@@ -310,6 +310,6 @@ Benedictio. Il Signore onnipotente ci conceda una notte tranquilla e una fine pe
 Benedictio. Ci benedica e custodisca l'onnipotente e misericordioso Signore, + il Padre, e il Figlio, e lo Spirito Santo.
 
 [Jube domne]
-V. Dègnati, o padre, di benedirmi.
+V. Dègnati, padre, di benedirmi.
 (sed rubrica 1960 dicitur)
-V. Comanda o Signore, la benedizione.
+V. Dègnati, Signore, di benedirmi.


### PR DESCRIPTION
I've made the _Jube, domne/Domine_ Italian translation consistent (cf. #4028 discussion).

Other:
- Fix a typo in Italian.
- Put French _misereatur_ translation in the same person as the Latin (a Frenchman complained to me about this).
