### PR TITLE
Tridentine: Fixing Preces feriales 

### DIFF
--- a/web/www/horas/Dansk/Psalterium/Major Special.txt
+++ b/web/www/horas/Dansk/Psalterium/Major Special.txt
@@ -6,7 +6,8 @@ R. Og vis medlidenhed med dine tjenere!
 V. Lad din godhed komme over os, Herre,
 R. For vi har håbet på dig.
 V. Dine præster skal klæde sig i retfærdighed, 
-R. Og dine hellige skal juble.
+R. Og dine hellige skal juble. ~
+
 V. Lad os bede for vor mest velsignede Pave~
 r. N.
 R. Herren bevare ham og give ham liv og velsigne ham på~
@@ -15,7 +16,7 @@ V. Lad os bede for vor Biskop ~
 r. N.
 R. I din styrke, må han stå fast og fuld af omsorg for os, Herre,~
 i dit navns ophøjethed.
-/:I Rom udelades det foregående vers og dets svar. Andetsteds indsættes navnet på den lokale biskop ved bogstavet N. Hvis den hellige stol eller den lokale biskops stol er ledig, udelades de respektive V. og R., henholdsvis.:/
+/:I Rom udelades det foregående vers og dets svar. Andetsteds indsættes navnet på den lokale biskop ved bogstavet N. Hvis den hellige stol eller den lokale biskops stol er ledig, udelades de respektive V. og R., henholdsvis.:/ ~
 (sed rubrica tridentina omittitur)
 
 V. Gud, bevar Dronningen.
@@ -25,10 +26,10 @@ R. Vogt dem, og tag dig af dem til evig tid.
 V. Husk din menighed, 
 R. Som du ejede fra begyndelsen. 
 V. Må freden råde i din styrke.
-R. Og overflod i dine tårne.
+R. Og overflod i dine tårne. ~
 
 V. Lad os bede for vore velgørere.
-R. For dit navns skyld, Herre, skænk nådigst alle vore godgørere det evige liv. Amen.  
+R. For dit navns skyld, Herre, skænk nådigst alle vore godgørere det evige liv. Amen.  ~
 (sed rubrica tridentina omittitur)
 
 V. Lad os bede for de afdøde troende.
@@ -41,8 +42,8 @@ V. For de lidende og fangne.
 R. Udfri dem, Israels Gud, af alle deres trængsler!
 V. Send dem hjælp, Herre, fra helligdommen.
 R. Og beskyt dem fra Zion. 
-
 (sed rubrica tridentina dicuntur)
+_
 $Domine exaudi
 &psalm(129) 
 

--- a/web/www/horas/Deutsch/Psalterium/Major Special.txt
+++ b/web/www/horas/Deutsch/Psalterium/Major Special.txt
@@ -1509,7 +1509,7 @@ R. Und laß dich gnädig stimmen gegen deine Diener.
 V. Laß deine Huld, Herr, über uns doch kommen.
 R. Wie wir auf dich hoffen.
 V. Laß in Gerechtigkeit sich hüllen deine Priester.
-R. Und deine Heiligen lasse jubeln.
+R. Und deine Heiligen lasse jubeln. ~
 
 V. Lasset uns beten für unseren Heiligen Vater~
 r. N.
@@ -1517,7 +1517,7 @@ R. Es möge ihn der Herr erhalten und ihn trösten und auf Erden glücklich mach
 V. Lasset uns beten für unseren Oberhirten~
 r. N.
 R. Er stehe fest und sei ein Hirt, in deiner Stärke, o Herr, entsprechend der Erhabenheit deines Namens.
-/:In Rom wird der vorstehende Versikel mit Antwort ausgelassen, anderswo wird der Name des Diözesanbischofs eingefügt. Bei Vakanz des Apostolischen und/oder bischöflichen Stuhls werden die entsprechenden Versikel ausgelassen.:/
+/:In Rom wird der vorstehende Versikel mit Antwort ausgelassen, anderswo wird der Name des Diözesanbischofs eingefügt. Bei Vakanz des Apostolischen und/oder bischöflichen Stuhls werden die entsprechenden Versikel ausgelassen.:/ ~
 (sed rubrica tridentina omittitur)
 
 V. O Herr, erhalte heil den Landesherrscher.
@@ -1527,10 +1527,10 @@ R. Und leite es und trag es auf den Schultern bis in ewige Zeiten.
 V. Gedenke deiner Gemeinde.
 R. Die du von jeher als Besitz gehabt hast.
 V. Es herrsche Glück in deinen Mauern.
-R. Und Wohlstand sei in deinen Häusern.
+R. Und Wohlstand sei in deinen Häusern. ~
 
 V. Lasset uns beten für die, die uns Gutes tun.
-R. Würdige dich, o Herr, allen, die uns Gutes tun um deines gütigen Wesens willen, als Lohn das ewige Leben zu gewähren.
+R. Würdige dich, o Herr, allen, die uns Gutes tun um deines gütigen Wesens willen, als Lohn das ewige Leben zu gewähren. ~
 (sed rubrica tridentina omittitur)
 
 V. Lasset uns beten für die verstorbenen Gläubigen.
@@ -1543,8 +1543,8 @@ V. Für die, die in Bedrängnis und in Knechtschaft sich befinden.
 R. Befreie sie, Gott Israels, von allen ihren Nöten.
 V. Sende ihnen Hilfe, o Herr, von deinem heiligen Throne.
 R. Und von Sion aus sei ihnen Schützer.
-
 (sed rubrica tridentina dicuntur)
+_
 $Domine exaudi
 &psalm(129) 
 

--- a/web/www/horas/English/Psalterium/Major Special.txt
+++ b/web/www/horas/English/Psalterium/Major Special.txt
@@ -1351,15 +1351,17 @@ R. And be gracious unto thy servants.
 V. Let thy mercy, O Lord, be upon us.
 R. As we have hoped in thee.
 V. Let thy priests be clothed with justice: 
-R. And may thy saints rejoice.
+R. And may thy saints rejoice. ~
+
 V. Let us pray for our most blessed Pope~
 r. N.
 R. The Lord preserve him and give him life, and make him blessed upon the earth: and deliver him not up to the will of his enemies. 
 V. Let us pray for our bishop ~
 r. N.
 R. May he stand firm and care for us in the strength of the Lord, in the might of thy name.
-/:In Rome, the preceding Versicle and its Response are omitted.  Elsewhere, the name of the local Ordinary is inserted at the letter N.  If the Holy See or the See of the local Bishop is vacant, the appropriate V. and R., either or both as the case may be, is omitted.:/
+/:In Rome, the preceding Versicle and its Response are omitted.  Elsewhere, the name of the local Ordinary is inserted at the letter N.  If the Holy See or the See of the local Bishop is vacant, the appropriate V. and R., either or both as the case may be, is omitted.:/ ~
 (sed rubrica tridentina omittitur)
+
 V. O Lord, save our leaders.
 R. And mercifully hear us when we call upon thee.
 V. O Lord, save thy people, and bless thine inheritance: 
@@ -1367,10 +1369,12 @@ R. Govern them and lift them up for ever.
 V. Remember thy congregation, 
 R. Which thou hast possessed from the beginning. 
 V. Let peace be in thy strength:
-R. And abundance in thy towers.
+R. And abundance in thy towers. ~
+
 V. Let us pray for our benefactors.
-R. O Lord, for thy name's sake, deign to reward with eternal life all who do us good. Amen.  
+R. O Lord, for thy name's sake, deign to reward with eternal life all who do us good. Amen. ~
 (sed rubrica tridentina omittitur)
+
 V. Let us pray for the faithful departed.
 R. Eternal rest grant unto them, O Lord, and let perpetual light shine upon them.
 V. May they rest in peace.
@@ -1382,8 +1386,10 @@ R. Deliver them, God of Israel, from all their tribulations.
 V. O Lord, send them help from thy sanctuary.
 R. And defend them out of Sion. 
 (sed rubrica tridentina dicuntur)
+_
 $Domine exaudi
 &psalm(129) 
+
 (deinde dicuntur)
 V. Turn us again, O Lord, God of Hosts.
 R. Show us thy face, and we shall be whole.

--- a/web/www/horas/Espanol/Psalterium/Major Special.txt
+++ b/web/www/horas/Espanol/Psalterium/Major Special.txt
@@ -1442,7 +1442,7 @@ R. Ten compasión de tus siervos.
 V. Que tu misericordia, Señor, venga sobre nosotros.
 R. Como lo esperamos de ti.
 V. Que tus sacerdotes se vistan de gala.
-R. Y que tus fieles vitoreen.
+R. Y que tus fieles vitoreen. ~
 
 V. Oremos por nuestro Santo Padre, el Papa~
 r. N.
@@ -1450,7 +1450,7 @@ R. El Señor lo guarde y lo conserve en vida para que sea dichoso en la tierra y
 V. Oremos por nuestro Obispo~
 r. N.
 R. Que apaciente con tu poder, Señor, para gloria de tu nombre.
-/:Los dos versos que anteceden con su Responsorio se omiten en Roma; en los demás lugares en vez de la letra N. exprésese por todos el nombre del Obispo diocesano. Estando vacante la Sede Apostólica o Episcopal, omítase el Verso correspondiente, con su Responsorio.:/
+/:Los dos versos que anteceden con su Responsorio se omiten en Roma; en los demás lugares en vez de la letra N. exprésese por todos el nombre del Obispo diocesano. Estando vacante la Sede Apostólica o Episcopal, omítase el Verso correspondiente, con su Responsorio.:/ ~
 (sed rubrica tridentina omittitur)
 
 V. Señor, salva al Rey.  
@@ -1460,10 +1460,10 @@ R. Sé su Pastor y llévalos siempre.
 V. Acuérdate de tu Iglesia.  
 R. Que adquiriste desde antiguo.
 V. Haya paz dentro de tus muros.
-R. Seguridad en tus palacios.
+R. Seguridad en tus palacios. ~
 
 V. Oremos por nuestros bienhechores.
-R. Por amor de tu nombre, Señor, recompensa a todos nuestros bienhechores con la vida eterna. Amén.
+R. Por amor de tu nombre, Señor, recompensa a todos nuestros bienhechores con la vida eterna. Amén. ~
 (sed rubrica tridentina omittitur)
 
 V. Oremos por los fieles difuntos.
@@ -1476,8 +1476,8 @@ V. Por los oprimidos y los prisioneros.
 R. Líbralos, ¡Oh Dios de Israel!, de todos sus sufrimientos.  
 V. Envíales tu auxilio desde el santuario.	
 R. Defiéndelos desde Sión.	
-
 (sed rubrica tridentina dicuntur)
+_
 $Domine exaudi
 &psalm(129) 
 

--- a/web/www/horas/Francais/Psalterium/Major Special.txt
+++ b/web/www/horas/Francais/Psalterium/Major Special.txt
@@ -1476,7 +1476,7 @@ R. Et laissez-Vous fléchir par les prières de Vos serviteurs.
 V. Répandez, Seigneur, Votre miséricorde sur nous.
 R. Car nous avons espéré en Vous.
 V. Revétez Vos prêtres de justice.
-R. Et comblez vos fidèles de joie.
+R. Et comblez vos fidèles de joie. ~
 
 V. Prions pour notre très Saint Père le Pape~
 r. N.
@@ -1484,7 +1484,7 @@ R. Que le Seigneur le garde, qu'Il lui prête vie, et le rende heureux sur la te
 V. Prions aussi pour notre Evêque ~
 r. N.
 R. Donnez-lui la fermeté et faites-le paître son troupeau dans Votre force, Seigneur, dans la majesté de Votre nom.
-/:A Rome le verset précédent est omis ; partout ailleurs, le nom de l'Ordinaire du lieu est inséré à la lettre N. Si le Saint-Siège ou le Siège de l'évêque du lieu est vacant, les V. et R. appropriés, l'un, l'autre ou les deux selon les circonstances, sont omis.:/
+/:A Rome le verset précédent est omis ; partout ailleurs, le nom de l'Ordinaire du lieu est inséré à la lettre N. Si le Saint-Siège ou le Siège de l'évêque du lieu est vacant, les V. et R. appropriés, l'un, l'autre ou les deux selon les circonstances, sont omis.:/ ~
 (sed rubrica tridentina omittitur)
 
 V. Seigneur sauvez le roi.
@@ -1494,10 +1494,10 @@ R. Régnez sur eux et soutenez-les à jamais.
 V. Souvenez-Vous de ceux que Vous avez assemblés.
 R. Et qui sont Vôtres depuis toujours.
 V. Que la paix règne dans tes murailles.
-R. Et la sécurité dans tes forteresses.
+R. Et la sécurité dans tes forteresses. ~
 
 V. Prions pour nos bienfaiteurs.
-R. Seigneur, accordez la vie éternelle à ceux qui nous font du bien, pour la gloire de Votre Nom. Ainsi soit-il.
+R. Seigneur, accordez la vie éternelle à ceux qui nous font du bien, pour la gloire de Votre Nom. Ainsi soit-il. ~
 (sed rubrica tridentina omittitur)
 
 V. Prions pour les fidèles défunts.
@@ -1510,8 +1510,8 @@ V. Prions pour les affligés et les captifs.
 R. Délivrez-les, Dieu d'Israël, de toutes leurs tribulations.
 V. Envoyez-leur, Seigneur, du secours de Votre sanctuaire.
 R. Et de Sion, protégez-les.
-
 (sed rubrica tridentina dicuntur)
+_
 $Domine exaudi
 &psalm(129) 
 

--- a/web/www/horas/Italiano/Psalterium/Major Special.txt
+++ b/web/www/horas/Italiano/Psalterium/Major Special.txt
@@ -1625,7 +1625,7 @@ R. Placati coi tuoi servi.
 V. Discenda sopra di noi, o Signore, la tua misericordia.
 R. Come noi abbiamo sperato in te.
 V. I tuoi Sacerdoti si rivestano di giustizia.
-R. E i tuoi santi esultino.
+R. E i tuoi santi esultino. ~
 
 V. Preghiamo per il beatissimo nostro Papa~
 r. N.
@@ -1633,7 +1633,7 @@ R. Il Signore lo conservi, gli dia vigore, e lo renda felice sulla terra, e non 
 V. Preghiamo anche per il nostro Vescovo~
 r. N.
 R. Stia saldo e coltivi [il suo gregge] colla tua fortezza, o Signore, nella sublimità del tuo nome.
-/:A Roma si omette il precedente Versetto col suo Responsorio; altrove invece alla lettera N. si esprima da tutti il nome del Vescovo della Diocesi. Durante la vacanza della Sede Apostolica od Episcopale, l'uno o l'altro o ambidue i rispettivi Versetti col proprio Responsorio si tralasciano.:/
+/:A Roma si omette il precedente Versetto col suo Responsorio; altrove invece alla lettera N. si esprima da tutti il nome del Vescovo della Diocesi. Durante la vacanza della Sede Apostolica od Episcopale, l'uno o l'altro o ambidue i rispettivi Versetti col proprio Responsorio si tralasciano.:/ ~
 (sed rubrica tridentina omittitur)
 
 V. Signore, fa salvo il Re.
@@ -1643,10 +1643,10 @@ R. E guidali e innalzali fino alla vita eterna.
 V. Ricordati del tuo Popolo.
 R. Che hai posseduto fin da principio.
 V. Regni la pace nelle tue mura.
-R. E l'abbondanza nelle tue torri.
+R. E l'abbondanza nelle tue torri. ~
 
 V. Preghiamo per i nostri benefattori.
-R. Degnati, o Signore, di ricambiare con la vita eterna tutti coloro, che ci fanno del bene per la gloria del tuo nome. Amen.
+R. Degnati, o Signore, di ricambiare con la vita eterna tutti coloro, che ci fanno del bene per la gloria del tuo nome. Amen. ~
 (sed rubrica tridentina omittitur)
 
 V. Preghiamo per i fedeli defunti.
@@ -1659,8 +1659,8 @@ V. Per gli afflitti e i prigionieri.
 R. Liberali, o Dio d'Israele, da tutte le loro tribolazioni.
 V. Manda loro, Signore, soccorso dal tuo santuario.
 R. E da Sion difendili.
-
 (sed rubrica tridentina dicuntur)
+_
 $Domine exaudi
 &psalm(129)
 

--- a/web/www/horas/Latin/Psalterium/Major Special.txt
+++ b/web/www/horas/Latin/Psalterium/Major Special.txt
@@ -1821,15 +1821,17 @@ R. Et deprecábilis esto super servos tuos.
 V. Fiat misericórdia tua, Dómine, super nos.
 R. Quemádmodum sperávimus in te.
 V. Sacerdótes tui induántur justítiam.
-R. Et sancti tui exsúltent.
+R. Et sancti tui exsúltent. ~
+
 V. Orémus pro beatíssimo Papa nostro~
 r. N.
 R. Dóminus consérvet eum, et vivíficet eum, et beátum fáciat eum in terra, et non tradat eum in ánimam inimicórum ejus.
 V. Orémus et pro Antístite nostro ~
 r. N.
 R. Stet et pascat in fortitúdine tua, Dómine, in sublimitáte nóminis tui.
-/:Romæ præcedens Versus cum suo Responsorio omittitur; alibi vero ad litteram N. ab omnibus nomen diœcesani Episcopi exprimatur, Vacante Apostolica vel Episcopali Sede, alteruter vel uterque respectivus Versus cum suo Responsorio præteritur.:/
+/:Romæ præcedens Versus cum suo Responsorio omittitur; alibi vero ad litteram N. ab omnibus nomen diœcesani Episcopi exprimatur, Vacante Apostolica vel Episcopali Sede, alteruter vel uterque respectivus Versus cum suo Responsorio præteritur.:/ ~
 (sed rubrica tridentina omittitur)
+
 V. Dómine, salvum fac regem.
 R. Et exáudi nos in die, qua invocavérimus te.
 V. Salvum fac pópulum tuum, Dómine, et bénedic hereditáti tuæ.
@@ -1837,10 +1839,12 @@ R. Et rege eos, et extólle illos usque in ætérnum.
 V. Meménto Congregatiónis tuæ.
 R. Quam possedísti ab inítio.
 V. Fiat pax in virtúte tua.
-R. Et abundántia in túrribus tuis.
+R. Et abundántia in túrribus tuis. ~
+
 V. Orémus pro benefactóribus nostris.
-R. Retribúere dignáre, Dómine, ómnibus, nobis bona faciéntibus propter nomen tuum, vitam ætérnam.  Amen.
+R. Retribúere dignáre, Dómine, ómnibus, nobis bona faciéntibus propter nomen tuum, vitam ætérnam.  Amen. ~
 (sed rubrica tridentina omittitur)
+
 V. Orémus pro fidélibus defúnctis.
 R. Réquiem ætérnam dona eis, Dómine, et lux perpétua lúceat eis.
 V. Requiéscant in pace.
@@ -1852,8 +1856,10 @@ R. Líbera eos, Deus Israël, ex ómnibus tribulatiónibus suis.
 V. Mitte eis, Dómine, auxílium de sancto.
 R. Et de Sion tuére eos.
 (sed rubrica tridentina dicuntur)
+_
 $Domine exaudi
-&psalm(129) 
+&psalm(129)
+
 (deinde dicuntur)
 V. Dómine, Deus virtútum, convérte nos.
 R. Et osténde fáciem tuam, et salvi érimus.

--- a/web/www/horas/Magyar/Psalterium/Major Special.txt
+++ b/web/www/horas/Magyar/Psalterium/Major Special.txt
@@ -1284,7 +1284,7 @@ R. Légy kegyes a te szolgádhoz.
 V. Legyen irgalmad felettünk, Uram.
 R. Ahogy mi Tebenned bizakodunk.
 V. Papjaid öltözzenek igazságba.
-R. És szentjeid örvendezzenek.
+R. És szentjeid örvendezzenek. ~
 
 V. Imádkozzunk boldog hírű pápánkért~
 r. N.-ért.
@@ -1292,7 +1292,7 @@ R. Az Úr őrizze meg és éltesse őt, tegye boldoggá a földön, és ne adja 
 V. Imádkozzunk szolgádért, püspökünkért~
 r. N.-ért.
 R. Tartson ki hűségben, és irányítson minket a te erőddel és a te Neved felségében.
-/:In Rome, the preceding Versicle and its Response are omitted.  Elsewhere, the name of the local Ordinary is inserted at the letter N.  If the Holy See or the See of the local Bishop is vacant, the appropriate V. and R., either or both as the case may be, is omitted.:/
+/:In Rome, the preceding Versicle and its Response are omitted.  Elsewhere, the name of the local Ordinary is inserted at the letter N.  If the Holy See or the See of the local Bishop is vacant, the appropriate V. and R., either or both as the case may be, is omitted.:/ ~
 (sed rubrica tridentina omittitur)
 
 V. Uram, őrizd meg vezetőinket.
@@ -1302,10 +1302,10 @@ R. Kormányozd és emeld fel őket mindörökké.
 V. Emlékezz meg, Uram, a te gyülekezetedről.
 R. Akik kezdettől fogva a tieid voltak.
 V. Legyen békesség a te akaratod szerint.
-R. És bőség a te erősségeidben.
+R. És bőség a te erősségeidben. ~
 
 V. Imádkozzunk jótevőinkért.
-R. Az Úr fizesse vissza minden jó cselekedetüket, a Te nevedért mindörökre. Ámen.
+R. Az Úr fizesse vissza minden jó cselekedetüket, a Te nevedért mindörökre. Ámen. ~
 (sed rubrica tridentina omittitur)
 
 V. Imádkozzunk az elhunyt hívekért.
@@ -1318,8 +1318,8 @@ V. Imádkozzunk az elnyomottakért és bebörtönzöttekért.
 R. Mentsd meg őket, Izrael Istene, minden nyomorúságukban.
 V. Küldj nekik segítséget szentélyedből.
 R. És Sionból irányítsd őket.
-
 (sed rubrica tridentina dicuntur)
+_
 $Domine exaudi
 &psalm(129) 
 

--- a/web/www/horas/Polski/Psalterium/Major Special.txt
+++ b/web/www/horas/Polski/Psalterium/Major Special.txt
@@ -1367,7 +1367,7 @@ R. I dasz się przebłagać sługom swoim.
 V. Niech miłosierdzie twoje trwa nad nami, Panie.
 R. Bo w Tobie pokładamy nadzieję.
 V. Niech kapłani Twoi przyobleką sprawiedliwość.
-R. A święci Twoi się uradują.
+R. A święci Twoi się uradują. ~
 
 V. Módlmy się za najświętszego Papieża naszego~
 r. N.
@@ -1375,7 +1375,7 @@ R. Niech Pan go zachowa, i ożywia go, i niech czyni go błogosławionym na ziem
 V. Módlmy się też za Biskupa naszego ~
 r. N.
 R. Niech stoi stanowczo i strzeże stada siłą Twoją, Panie, we wspaniałości Twojego imienia.
-/:W Rzymie opuszcza się powyższy werset z jego odpowiedzią; w innych miejscach za literę N. podstawia się imię biskupa diecezjalnego, a w przypadku nieobsadzonej Stolicy Apostolskiej lub biskupiej, opuszcza się odpowiedni werset z jego odpowiedzią.:/
+/:W Rzymie opuszcza się powyższy werset z jego odpowiedzią; w innych miejscach za literę N. podstawia się imię biskupa diecezjalnego, a w przypadku nieobsadzonej Stolicy Apostolskiej lub biskupiej, opuszcza się odpowiedni werset z jego odpowiedzią.:/ ~
 (sed rubrica tridentina omittitur)
 
 V. Panie, zbaw króla.
@@ -1385,10 +1385,10 @@ R. I króluj mu, i rządź je, i wywyższaj je aż na wieki.
 V. Pamiętaj o Zgromadzeniu Twoim.
 R. Które od początku do Ciebie należy.
 V. Czyń pokój w murach Twoich.
-R. I dostatek w basztach Twoich.
+R. I dostatek w basztach Twoich. ~
 
 V. Módlmy się za dobroczyńców naszych.
-R. Panie, racz dla imienia Twego obdarzyć wszystkich, którzy nam dobrze czynili, życiem wiecznym.  Amen.
+R. Panie, racz dla imienia Twego obdarzyć wszystkich, którzy nam dobrze czynili, życiem wiecznym.  Amen. ~
 (sed rubrica tridentina omittitur)
 
 V. Módlmy się za wiernych zmarłych.
@@ -1401,8 +1401,8 @@ V. Za udręczonych i uwięzionych.
 R. Wyzwól ich, Boże Izraela, od wszystkich ich utrapień.
 V. Ześlij im, Panie, pomoc ze świątyni Twojej.
 R. I opiekuj się nimi z Syjonu.
-
 (sed rubrica tridentina dicuntur)
+_
 $Domine exaudi
 &psalm(129) 
 


### PR DESCRIPTION
The newlines in the database files are crucial to tell the code what exactly gets omitted in Tridentine version. To achieve joined layout, we have to work with the "tilde" `~` instead, keeping the empty lines.
__

Revert "Update Major Special.txt"

This reverts commit 1d510fc512005222f39756dc48baa1d3bfde88d7.

Revert "Update Major Special.txt"

This reverts commit 9e884402a106664d9b427271cfc8caabf5f1340a.