### PR TITLE
Usage

### DIFF
--- a/web/www/horas/English/Tempora/101-0.txt
+++ b/web/www/horas/English/Tempora/101-0.txt
@@ -5,7 +5,7 @@ The Lord open your hearts * in His law and commandments, and may the Lord our Go
 Lesson from the first book of Machabees
 !1 Mac 1:1-7
 1 Now it came to pass, after that Alexander the son of Philip the Macedonian, who first reigned in Greece, coming out of the land of Cethim, had overthrown Darius king of the Persians and Medes:
-2 He fought many battles, and took the strong holds of all, and slew the kings of the earth:
+2 He fought many battles, and took the strongholds of all, and slew the kings of the earth:
 3 And he went through even to the ends of the earth, and took the spoils of many nations: and the earth was quiet before him.
 4 And he gathered a power, and a very strong army: and his heart was exalted and lifted up.
 5 And he subdued countries of nations, and princes: and they became tributaries to him.

--- a/web/www/horas/English/Tempora/103-3.txt
+++ b/web/www/horas/English/Tempora/103-3.txt
@@ -10,7 +10,7 @@ Lesson from the first book of Machabees
 [Lectio2]
 !1 Mac 12:44-47
 44 And he said to Jonathan: Why hast thou troubled all the people, whereas we have no war?
-45 Now therefore send them back to their own houses: and choose thee a few men that may be with thee, and come with me to Ptolemais, and I will deliver it to thee, and the rest of the strong holds, and the army, and all that have any charge, and I will return and go away: for this is the cause of my coming.
+45 Now therefore send them back to their own houses: and choose thee a few men that may be with thee, and come with me to Ptolemais, and I will deliver it to thee, and the rest of the strongholds, and the army, and all that have any charge, and I will return and go away: for this is the cause of my coming.
 46 And Jonathan believed him, and did as he said: and sent away his army, and they departed into the land of Juda:
 47 But he kept with him three thousand men: of whom he sent two thousand into Galilee, and one thousand went with him.
 

--- a/web/www/horas/English/Tempora/105-5.txt
+++ b/web/www/horas/English/Tempora/105-5.txt
@@ -19,4 +19,4 @@ Lesson from the second book of Machabees
 28 But as soon as the sun was risen both sides joined battle: the one part having with their valour the Lord for a surety of victory and success: but the other side making their rage their leader in battle. 
 29 But when they were in the heat of the engagement there appeared to the enemies from heaven five men upon horses, comely with golden bridles, conducting the Jews: 30 Two of whom took Machabeus between them, and covered him on every side with their arms, and kept him safe: but cast darts and fireballs against the enemy, so that they fell down, being both confounded with blindness, and filled with trouble.
 31 And there were slain twenty thousand five hundred, and six hundred horsemen. 
-32 But Timotheus fled into Gazara a strong hold, where Chereas was governor
+32 But Timotheus fled into Gazara a stronghold, where Chereas was governor

--- a/web/www/horas/English/Tempora/115-2.txt
+++ b/web/www/horas/English/Tempora/115-2.txt
@@ -16,4 +16,4 @@ Lesson from the book of Habacuc
 !Hab 1:8-10
 8 Their horses are lighter than leopards, and swifter than evening wolves; and their horsemen shall be spread abroad: for their horsemen shall come from afar, they shall fly as an eagle that maketh haste to eat.
 9 They shall all come to the prey, their face is like a burning wind: and they shall gather together captives as the sand.
-10 And their prince shall triumph over kings, and princes shall be his laughingstock: and he shall laugh at every strong hold, and shall cast up a mount, and shall take it.
+10 And their prince shall triumph over kings, and princes shall be his laughingstock: and he shall laugh at every stronghold, and shall cast up a mount, and shall take it.


### PR DESCRIPTION
Research shows that "stronghold" in the sense of a fortress has always been one word (even if hyphenated).