### PR TITLE
"use utf8;" in script files

### DIFF
--- a/web/cgi-bin/horas/specials/capitulis.pl
+++ b/web/cgi-bin/horas/specials/capitulis.pl
@@ -1,5 +1,6 @@
 # use warnings;
 # use strict;
+use utf8;
 
 sub capitulum_major {
   my $lang = shift;

--- a/web/cgi-bin/horas/specials/hymni.pl
+++ b/web/cgi-bin/horas/specials/hymni.pl
@@ -1,5 +1,6 @@
 # use strict;
 # use warnings;
+use utf8;
 
 sub gethymn {
   my ($lang) = @_;

--- a/web/cgi-bin/horas/specials/orationes.pl
+++ b/web/cgi-bin/horas/specials/orationes.pl
@@ -1,5 +1,6 @@
 # use strict;
 # use warnings;
+use utf8;
 
 # *** checkcommemoratio \%office
 # return the text of [Commemoratio] [Commemoratio n] or an empty string

--- a/web/cgi-bin/horas/specials/preces.pl
+++ b/web/cgi-bin/horas/specials/preces.pl
@@ -1,5 +1,6 @@
 # use strict;
 # use warnings;
+use utf8;
 
 #*** preces($item)
 # returns 1 = yes or 0 = omit after deciding about the preces

--- a/web/cgi-bin/horas/specials/psalmi.pl
+++ b/web/cgi-bin/horas/specials/psalmi.pl
@@ -1,5 +1,6 @@
 # use strict;
 # use warnings;
+use utf8;
 
 sub psalmi {
   my $lang = shift;

--- a/web/cgi-bin/horas/specials/specprima.pl
+++ b/web/cgi-bin/horas/specials/specprima.pl
@@ -1,5 +1,6 @@
 # use warnings;
 # use strict;
+use utf8;
 
 sub lectio_brevis_prima {
 


### PR DESCRIPTION
close #4137

@mbab. apparently each sub `.pl`-script needs its own `use utf8;` for special characters to match in regex's