### PR TITLE
code: fixes

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -1285,7 +1285,7 @@ sub precedence {
   our $datafolder;
 
   # set global date
-  our ($date1) = shift || strictparam('date');
+  our ($date1) = shift || strictparam('date') || strictparam('date1');
   if (!$date1 || $votive =~ /hodie/) { $date1 = gettoday(); }
   $date1 =~ s/\//\-/g;
   ($month, $day, $year) = split('-', $date1);

--- a/web/cgi-bin/horas/specmatins.pl
+++ b/web/cgi-bin/horas/specmatins.pl
@@ -1093,7 +1093,7 @@ sub lectio : ScriptFunc {
   my $item = translate('Lectio', $lang);
   $item .= " %s" unless ($item =~ /%s/);
   $w = "_\n" . setfont($largefont, sprintf($item, $num)) . "\n$w";
-  my @w = split("\n", $w);
+  my @w = split("\n+", $w);
   $w = "";
 
   my $initial = $nonumbers;


### PR DESCRIPTION
   - prevent spliting biblical readings in two paragraphs when using 'nonumber'
   - from options return to used date not today

+AMDG+
