### PR TITLE
quick hack to prevent perl warnings in FileIO.pm

### DIFF
--- a/web/cgi-bin/horas/specials/orationes.pl
+++ b/web/cgi-bin/horas/specials/orationes.pl
@@ -378,6 +378,7 @@ sub oratio {
       my @centries = $cv == 1 ? @ccommemoentries : @commemoentries;
 
       foreach my $commemo (@centries) {
+        next unless $commemo;
         setbuild2("Comm-$cv: $commemo");
 
         my $key = 0;    # let's start with lowest rank


### PR DESCRIPTION
eg. Laudes 12/14/2024 1960

@FAJ-Munich `@commemoentries` contains empty strings, could fix this in proper place?

+AMDG+
