### PR TITLE
Fix formatting for the canticle of Isaiah (Remove unnecessary spaces from Psalm266.txt and Psalm267.txt)

### DIFF
--- a/web/www/horas/English/psalms/Psalm266.txt
+++ b/web/www/horas/English/psalms/Psalm266.txt
@@ -1,5 +1,5 @@
 (Canticum Isaiae * Isa 33:2-10)
- 33:2 O Lord, have mercy on us: for we have waited for thee: be thou our arm in the morning, and our salvation in the time of trouble.
+33:2 O Lord, have mercy on us: for we have waited for thee: be thou our arm in the morning, and our salvation in the time of trouble.
 33:3 At the voice of the angel the people fled, and at the lifting up thyself the nations are scattered.
 33:4 And your spoils shall be gathered together as the locusts are gathered, as when the ditches are full of them.
 33:5 The Lord is magnified, for he hath dwelt on high: he hath filled Sion with judgment and justice.

--- a/web/www/horas/English/psalms/Psalm267.txt
+++ b/web/www/horas/English/psalms/Psalm267.txt
@@ -1,5 +1,5 @@
 (Canticum Isaiae * Isa 33:13-18)
- 33:13 Hear, you that are far off, what I have done, and you that are near know my strength.
+33:13 Hear, you that are far off, what I have done, and you that are near know my strength.
 33:14 The sinners in Sion are afraid, trembling hath seized upon the hypocrites. Which of you can dwell with devouring fire? which of you shall dwell with everlasting burnings?
 33:15 He that walketh in justices, and speaketh truth, that casteth away avarice by oppression, and shaketh his hands from all bribes, that stoppeth his ears lest he hear blood, and shutteth his eyes that he may see no evil.
 33:16 He shall dwell on high, the fortifications of rocks shall be his highness: bread is given him, his waters are sure.


### PR DESCRIPTION
Psalm266.txt and Psalm267.txt (both of the txt files which contain the canticle of Isaiah) have a space at the start of the first verse which leads to a minor visual issue where the first verse isn't highlighted in red, as seen in the screenshots below:

![1](https://github.com/user-attachments/assets/e40a17d3-a066-46d0-96fc-509b91040e77)
![2](https://github.com/user-attachments/assets/769fa12c-bb2b-4275-9fd3-ddb93b88221a)

This pull requests removes those spaces. For reference, both screenshots are taken from the Sunday Matins of the 1963 Monastic office.

