### PR TITLE
French typos

### DIFF
--- a/web/www/horas/Francais/Psalterium/Common/Prayers.txt
+++ b/web/www/horas/Francais/Psalterium/Common/Prayers.txt
@@ -134,7 +134,7 @@ Les Chérubins et les Séraphins * Vous proclament sans cesse :
 Les Cieux et la terre sont remplis * de la majesté de Votre gloire.
 Le chœur glorieux * des Apôtres,
 Le phalange vénérable * des Prophètes,
-L'armée des Martyrs éclatante de blancheur * célèbre Vos louanges ;
+L'armée des Martyrs éclatante de blancheur * célèbrent Vos louanges ;
 La sainte Eglise confesse * Votre nom par toute la terre,
 Ô Père * d'infinie majesté !
 Et elle vénère Votre Fils * véritable et unique.

--- a/web/www/horas/Francais/Tempora/113-2.txt
+++ b/web/www/horas/Francais/Tempora/113-2.txt
@@ -1,19 +1,19 @@
 [Lectio1]
 Lecture du livre de Daniel
 !Dan 3:14-15
-14	Nabuchodonosor prit la parole et leur dit: « Est-ce à des-sein, Sidrac, Misac et Abdénago, que vous ne servez pas mon dieu et que vous n'adorez pas la statue d'or que j'ai dres-sée !
-15	Maintenant si vous êtes prêts, au moment où vous entendrez le son de la trompette, du chalumeau, de la cithare, de la sambuque, du psaltérion, de la cornemuse et de toutes les sortes d'Instru-ments, à vous prosterner pour adorer la statue que j'ai faite... Mais si vous ne l'adorez pas, vous serez jetés à l'instant même au milieu de la fournaise de feu ardent, et quel est le dieu qui vous déli-vrera de ma main ? »
+14	Nabuchodonosor prit la parole et leur dit: « Est-ce à dessein, Sidrac, Misac et Abdénago, que vous ne servez pas mon dieu et que vous n'adorez pas la statue d'or que j'ai dressée !
+15	Maintenant si vous êtes prêts, au moment où vous entendrez le son de la trompette, du chalumeau, de la cithare, de la sambuque, du psaltérion, de la cornemuse et de toutes les sortes d'instruments, à vous prosterner pour adorer la statue que j'ai faite. Mais si vous ne l'adorez pas, vous serez jetés à l'instant même au milieu de la fournaise de feu ardent, et quel est le dieu qui vous délivrera de ma main ? »
 
 [Lectio2]
 !Dan 3:16-19
-16	Sidrac, Misac et Abdénago répondirent au roi et dirent: « Nabuchodonosor, sur ce point nous n'a-vons pas besoin de t'adresser une réponse
+16	Sidrac, Misac et Abdénago répondirent au roi et dirent: « Nabuchodonosor, sur ce point nous n'avons pas besoin de t'adresser une réponse
 17	si vraiment notre Dieu que nous servons peut nous délivrer, il nous délivrera de la fournaise de feu ardent et de ta main, ô roi.
 18	Sinon, qu'il soit connu de toi, ô roi, que nous ne servirons pas tes dieux et que nous ne nous prosternerons pas devant la statue d'or que tu as dressée. »
-19	Alors Nabuchodonosor fut rempli de fureur, et l'aspect de son visage fut chan-gé envers Sidrac, Misac, et Abdénago. Reprenant la parole, il ordonna de chauf-fer la fournaise sept fois plus qu'on n'avait jugé convenable de le faire.
+19	Alors Nabuchodonosor fut rempli de fureur, et l'aspect de son visage fut changé envers Sidrac, Misac, et Abdénago. Reprenant la parole, il ordonna de chauffer la fournaise sept fois plus qu'on n'avait jugé convenable de le faire.
 
 [Lectio3]
 !Dan 3:21-24
 21	Alors ces hommes, avec leurs tuniques, leurs robes, leurs mantaux et leurs autres vêtements, furent liés et jetés dans la fournaise de feu ardent.
-22	Comme l'ordre du roi était pressant et la four-naise extraordinairement chauffée, la flamme de feu tua ces hommes qui y avaient jeté Sidrac, Misac et Abdénago.
-23	Et ces trois hommes, Sidrac, Misse et Abdénago tombèrent au milieu de la fournaise ardente, tout liés. Ce qui suit, je ne l'ai pas trouvé dans les livres hébreux.
+22	Comme l'ordre du roi était pressant et la fournaise extraordinairement chauffée, la flamme de feu tua ces hommes qui y avaient jeté Sidrac, Misac et Abdénago.
+23	Et ces trois hommes, Sidrac, Misac et Abdénago tombèrent au milieu de la fournaise ardente, tout liés. Ce qui suit, je ne l'ai pas trouvé dans les livres hébreux.
 24	Et ils marchaient au milieu de la flamme, louant Dieu et bénissant le Seigneur.


### PR DESCRIPTION
This corrects some typos reported to me by a French-speaking user. The only change that might be controversial is making a verb in the Te Deum translation plural because there's a compound subject. I include his report below the horizontal rule.

---
```
Lectio 1 de Daniéle Prophéta.     Remove hyphens
         14.   des-sein                  dessein
               dres-sée                  dressée
         15.   d’Instru-ments            d’instruments (no capital lettre I, no hyphen)
               que j’ai faite….          que j’ai faite.
               déli-vrera                délivrera

Lectio 2  Dan 3:16-19
         16.    n’a-vons                 n’avons
         19.    chan-gé                  changé
                chauf-fer                chauffer

Lectio 2  Dan 3:21-24
         22.   four-naise                fournaise
         23.   Misse                     Missac
```

Te Deum - In the following passage (after Sanctus), there are three successive subjects to the verb célébrer. It should therefore be conjugated at the third person plural (present indicative), not singular, as is the case here. The correction conforms with other translations of the Te Deum:

```
         Le chœur glorieux des Apôtres,
         La phalange vénérable des Prophètes,
         L’armée des Martyrs éclatante de blancheur célèbre Vos louanges.
                                                    célèbrent Vos louanges
```