### PR TITLE
Ordo: new features

### DIFF
--- a/web/cgi-bin/horas/kalendar.pl
+++ b/web/cgi-bin/horas/kalendar.pl
@@ -129,6 +129,7 @@ use constant MONTHLENGTH => ('', 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
 use constant DAYNAMES => qw/Dom. F.II F.III F.IV F.V F.VI Sabb./;
 
 # output html table with entries
+
 sub kalendar_table {
   my ($kyear, $kmonth, $mode) = @_;
   my $background = (our $whitebground) ? ' class="contrastbg"' : '';
@@ -141,8 +142,11 @@ sub kalendar_table {
     $output .= "<TR><TH>C.E.</TH><TH>D.L.</TH><TH></TH><TH>Dies</TH><TH></TH></TR>\n";
     $cols = 5 + $compare;
   } else {
-    $output .= "<TR><TH>Dies</TH><TH>de Tempore</TH><TH>Sanctorum</TH><TH>d.h.</TH></TR>\n";
-    $cols = 4;
+    $output .= "<TR><TH>Dies</TH><TH>de Tempore</TH><TH>Sanctorum</TH><TH>Vespera</TH><TH>d.h.</TH></TR>\n";
+    $cols = 5;
+
+    #    $output .= "<TR><TH>Dies</TH><TH>de Tempore</TH><TH>Sanctorum</TH><TH>d.h.</TH></TR>\n";
+    #    $cols = 4;
   }
 
   my $to = (MONTHLENGTH)[$kmonth];
@@ -172,10 +176,10 @@ sub kalendar_table {
       }
     }
 
-    $output .=
-        '<TR>'
-      . join('', map { '<TD' . (length($_) < 52 ? ' ALIGN="CENTER"' : '') . ">$_</TD>" } table_row($date1, $cday))
-      . "</TR>\n";
+    $output .= '<TR>'
+      . join('',
+      map { '<TD' . (length($_) < 20 || $_ =~ /\<A/ ? ' ALIGN="CENTER"' : '') . ">$_</TD>" } table_row($date1, $cday),
+      ) . "</TR>\n";
   }
   $output .= note('nigra19') if $mode eq 'kal';
   $output =~ s/{(.+?)}/ setfont('maroon', $1) /ge;

--- a/web/cgi-bin/horas/kalendar/kal.pl
+++ b/web/cgi-bin/horas/kalendar/kal.pl
@@ -99,7 +99,10 @@ sub findkalentry {
   $rankname =~ s/IV. classis/Memoria/ if $ver =~ /Monastic|Ordo Praedicatorum/;
 
   (
-    setfont(liturgical_color($srank[0]), $rank > 4 ? latin_uppercase($srank[0]) : $srank[0]),
+    setfont(
+      liturgical_color($srank[0]),
+      $rank > 4 && $srank[0] !~ /octava|vigilia/i ? latin_uppercase($srank[0]) : $srank[0],
+    ),
     setfont('1 maroon', ' ' . $rankname),
   );
 }

--- a/web/cgi-bin/horas/kalendar/ordo.pl
+++ b/web/cgi-bin/horas/kalendar/ordo.pl
@@ -6,7 +6,7 @@ sub ordo_entry {
   my ($date, $ver, $compare, $winneronly) = @_;
 
   our $version = $ver;
-  our ($day, $month, $year, $dayname, %scriptura, %commemoratio);
+  our ($day, $month, $year, $dayname, %scriptura, @commemoentries);
 
   precedence($date);
 
@@ -24,6 +24,15 @@ sub ordo_entry {
   ($c2, $h1, $h2) = ('', '', $h1) unless $h2;
   $c2 = setfont($smallblack, "$h1:") if $h1;
   $c2 .= "<I>" . setfont(liturgical_color($h2), " $h2") . "</I>" if $h2;
+
+  if ($c2 && @commemoentries > 1) {
+    for my $ind (1 .. @commemoentries - 1) {
+      my %com = %{setupstring('Latin', "$commemoentries[$ind].txt")};
+      my $comname = $com{Rank};
+      $comname =~ s/\;\;.*//;
+      $c2 .= " <I>&amp; " . setfont(liturgical_color($comname), " $comname") . "</I>" if $comname;
+    }
+  }
 
   $c2 =~ s/Hebdomadam/Hebd/i;
   $c2 =~ s/Quadragesima/Quadr/i;
@@ -54,17 +63,19 @@ sub ordo_entry {
     $c2 .= setfont($smallblack, ' m.t.v.');
   }
 
-  if ( $version !~ /196/
-    && $winner =~ /Sancti/
-    && exists($winner{Lectio1})
-    && $winner{Lectio1} !~ /\@Commune/i
-    && $winner{Lectio1} !~ /\!(Matt|Marc|Luc|Joannes)\s+[0-9]+\:[0-9]+\-[0-9]+/i)
-  {
-    $c2 .= setfont($smallfont, " *L1*");
-  }
+  our $hora;
+  my $temphora = $hora;
+  $hora = 'Vespera';
+  precedence($date);
+  $hora = $temphora;
+  my $cv = $dayname[2];
+  $cv =~ s/.*?(Vespera|A capitulo|$)/$1/;
 
-  $c2 ||= '_' if $compare;
-  ($c1, $c2);
+  if ($compare) {
+    $c2 ||= '_';
+    $cv ||= '_';
+  }
+  return ($c1, $c2, $cv);
 }
 
 # prepare row
@@ -73,14 +84,20 @@ sub table_row {
   our ($version1, $compare, $version2, $dayofweek);
 
   my $d = substr($date, 3, 2) + 0;
-  my ($c1, $c2) = ordo_entry($date, $version1, $compare);
+  my ($c1, $c2, $cv) = ordo_entry($date, $version1, $compare);
 
   if ($compare) {
-    my ($c21, $c22) = ordo_entry($date, $version2, $compare);
+    my ($c21, $c22, $cv2) = ordo_entry($date, $version2, $compare);
     $c1 .= "<br/>$c21";
     $c2 .= "<br/>$c22";
+    $cv .= "<br/>$cv2";
   }
-  (qq(<A HREF=# onclick="callbrevi('$date');">$d</A>), $c1, $c2, @{[(DAYNAMES)[$dayofweek]]});
+  (
+    qq(<A HREF=# onclick="callbrevi('$date');">$d</A>),
+    $c1, $c2,
+    qq(<FONT SIZE="-2">$cv</FONT>),
+    @{[(DAYNAMES)[$dayofweek]]},
+  );
 }
 
 # html_header_ordo


### PR DESCRIPTION
1. showing additional commemorations (where applicable; in the order given in Tabulae; for June 28 (DA version) Vigilia comes before infra 8vam S.J.B. due to technical issue otherwise)
2. new column "Vespera" given the Vespers information
3. Kalendarium: no capitalisation for infra Octavam and Vigilia