### PR TITLE
Add Portuguese to Hymus in Tertia from Minor Special.txt 

### DIFF
--- a/web/www/horas/Portugues/Psalterium/Special/Minor Special.txt
+++ b/web/www/horas/Portugues/Psalterium/Special/Minor Special.txt
@@ -1,3 +1,20 @@
+[Hymnus Tertia]
+v. Dignai-vos, Santo Espírito,
+Vós que sois um com o Pai e o Filho,
+nesta hora habitar em nossos corações e
+encher-nos com vossa santidade
+_
+Que nossas bocas, sentidos, mentes,
+Professem vossa majestade,
+Inflamai em nós o fogo da caridade
+E que levemos vossa verdade ao mundo
+_
+* Ó Jesus, a vós seja a Glória,
+Vós, que tendes o cetro do mundo,
+Com o Pai e o Santo Espírito
+Pelos Séculos dos Séculos. 
+Amém.
+
 [Hymnus Sexta]
 v. Ó Deus, verdade e força
 que o mundo governais,


### PR DESCRIPTION
Translate to Portuguese the Hymnus Tertia from web/www/horas/Portugues/Psalterium/Special/Minor Special.txt

I use the portguese translation from the [Nunc-Sancte-Nobis.pdf](https://salvemaria.com.br/wp-content/uploads/2018/04/Nunc-Sancte-Nobis.pdf) from [salvemaria.com.br](https://salvemaria.com.br)