### PR TITLE
Cist: C8 + C9 Vespers incl. Czech

### DIFF
--- a/web/cgi-bin/horas/specials/capitulis.pl
+++ b/web/cgi-bin/horas/specials/capitulis.pl
@@ -39,6 +39,13 @@ sub monastic_major_responsory {
 
   my ($resp, $c) = getproprium($key, $lang, $seasonalflag, 1);
 
+  # CIST: the Cistercian rite has Responsoria prolixa for every Festum Serm. on j. Vespers. 
+  if ($version =~ /cist/i && $vespera == 1) {
+    my $key_cist = "Responsory $hora 1";
+    ($resp, $c) = getproprium($key_cist, $lang, $seasonalflag, 1);
+    ($resp, $c) = getproprium($key, $lang, $seasonalflag, 1) if !$resp; 
+  }
+
   # Monastic Responsories at Major Hours are usually identical to Roman at Tertia and Sexta
   if (!$resp) {
     $key =~ s/Vespera/Breve Tertia/ if $version =~ /cist/i;

--- a/web/www/Tabulae/Kalendaria/CAV.txt
+++ b/web/www/Tabulae/Kalendaria/CAV.txt
@@ -75,5 +75,9 @@
 05-12=05-12=Ss. Nerei, Achillei et Domitillae Virgini atque Pancratii Martyrum=2=
 05-26=05-26=S. Philippi Nerii, Confessoris=2=S. Eleutherii, Papæ et Martyris=1=
 05-31=05-31=S. Petronillæ, Virginis=1=
+*June*
+06-01=06-01Av=Dedicatio Ecclesiæ Abbatiæ Altovadensis=6=
 *September*
 09-28=09-28=S. Wenceslai, Ducis, Martyris et Patroni Principalis Regni Bohemiæ=5=
+*November*
+11-09=11-09=In dedicatione Basilicæ SS. Salvatoris=5=S. Theodori=1=

--- a/web/www/horas/Bohemice/Commune/C8.txt
+++ b/web/www/horas/Bohemice/Commune/C8.txt
@@ -1,0 +1,278 @@
+[Officium]
+Officium Dedicationis Ecclesiae
+
+[Ant Vespera]
+Domu tvému, Pane, * náleží svatost po všechny dny.;;109
+Dům můj, * bude domem modlitby.;;110
+Toto je dům Páně * pevně ustanoven, s dobrými základy na pevné skále.;;111
+Dobré základy má * dům Páně na pevné skále.;;112
+Drahé kameny * jsou všechny tvé zdi, a věže Jerusaléma jsou vystavěny z drahokamů.;;147
+
+[Hymnus Vespera]
+v. Město Jerusalém svatý, 
+Zvaný míru zjevení, 
+Jež postaveno je v nebi 
+Z mnoha živých kamenů, 
+A Anděli korunován 
+Jak nevěsta zdobeno.
+_
+Právě přichází až z nebe, 
+Pro svatební komnatu, 
+Připraveno, aby sňatkem 
+S Pánem bylo spojeno, 
+Ulice a stěny její 
+Z nejčistšího zlata jsou.
+_
+Brány skvějí se perlami, 
+Vchody všechny dokořán, 
+A na základě svých zásluh 
+Uvedeni budou tam
+Všichni, kdož pro Krista jméno 
+Zde na světě trpějí.
+_
+Bitím a všemi útlaky 
+Vyleštěné kameny, 
+Zaujímají svá místa, 
+Které ruka umělce
+Určila jim na vše věky 
+V posvátných těch budovách.
+_
+Sláva, čest a pocta Bohu 
+Ze všech vždy Nejvyššímu, 
+Spolu Otci, Synovi i
+Duchu Utěšiteli.
+Jim náleží chvála a moc
+Po všechny věčné věky.
+Amen.
+
+[Versum 1]
+V. Toto je dům Páně, poctivě vystavěný.
+R. S dobrými základy na pevné skále.
+
+[Ant 1]
+The Most High hath hallowed His Tabernacle. * For this is the House of God, whereon His Name shall be called, whereof it is written My Name shall be there, saith the Lord.
+
+[Oratio]
+Bože, jenž nám každý rok znovu přinášíš den posvěcení tohoto tvého svatého chrámu, a svatými tajemstvími nás vždy zachováváš v bezpečí; vyslyš prosby svého lidu a dej, aby kdokoliv, kdo vkročí do tohoto chrámu, aby prosil o tvá dobrodiní, se radoval z tvého vyslyšení.
+$Per Dominum
+
+[Oratio1]
+Bože, jenž neviditelně obsahuješ úplně všechno, a přece pro spásu lidského rodu viditelně ukazuješ znamení své moci; osvěť tento chrám mocí svého přebývání a dej, aby všichni, kdož sem s prosbami přijdou, v jakémkoliv pokoření k tobě budou volat, obdrželi dobrodiní tvé útěchy.
+$Per Dominum
+
+[Invit]
+Holiness becometh the house of God. * In her let us worship her Bridegroom, even Christ.
+
+[Ant Matutinum]
+Lift up your gates, O ye princes, * and be ye lift up, ye everlasting doors.;;23
+The Lord shall be my God, * and this stone shall be called God's house.;;45
+Moses built an altar * to the Lord God.;;47
+This is none other but the house of God, and this is the gate of heaven.;;83
+Jacob beheld a ladder set up on the earth, and the top of it reached to heaven, and the angels of God descending on it. And he said: Surely this place is holy.;;86
+Jacob set up the stone for a pillar, and poured oil upon the top of it.;;87
+He that dwelleth in the help of the Most High * shall abide under the shadow of the God of heaven.;;90
+The Temple of the Lord is holy. * The same is God's workmanship and God's building.;;95
+Blessed be the glory of the Lord * from His holy place. Alleluia.;;98
+
+[Nocturn 2 Versum]
+V. Můj dům. 
+R. Bude se nazývat domem modlitby. 
+
+[Lectio1]
+Lesson from the book of Paralipomenon
+!2 Chr 7:1-5
+1 And when Solomon had made an end of his prayer, fire came down from heaven, and consumed the holocausts and the victims: and the majesty of the Lord filled the house.
+2 Neither could the priests enter into the temple of the Lord, because the majesty of the Lord had filled the temple of the Lord.
+3 Moreover all the children of Israel saw the fire coming down, and the glory of the Lord upon the house: and falling down with their faces to the ground, upon the stone pavement, they adored and praised the Lord: because he is good, because his mercy endureth for ever.
+4 And the king and all the people sacrificed victims before the Lord.
+5 And king Solomon offered a sacrifice of twenty-two thousand oxen, and one hundred and twenty thousand rams: and the king and all the people dedicated the house of God.
+
+[Responsory1]
+R. When the Temple was dedicated the people sang praise;
+* And sweet in their mouths was the sound.
+V. The Lord's house is established in the top of the mountains; and all nations shall flow unto it.
+R. And sweet in their mouths was the sound.
+
+[Lectio2]
+!2 Chr 7:6-9
+6 And the priests stood in their offices: and the Levites with the instruments of music of the Lord, which king David made to praise the Lord: because his mercy endureth for ever, singing the hymns of David by their ministry: and the priests sounded with trumpets before them, and all Israel stood.
+7 Solomon also sanctified the middle of the court before the temple of the Lord: for he offered there the holocausts, and the fat of the peace offerings: because the brazen altar, which he had made, could not hold the holocausts and the sacrifices and the fat:
+8 And Solomon kept the solemnity at that time seven days, and all Israel with him, a very great congregation, from the entrance of Emath to the torrent of Egypt.
+9 And he made on the eighth day a solemn assembly, because he had kept the dedication of the altar seven days, and had celebrated the solemnity seven days.
+
+[Responsory2]
+R. The Lord's house is established in the top of the mountains, and exalted above the hills;
+* And all nations shall flow unto it, and shall say: Glory be to thee, O Lord!
+V. They shall doubtless come again with rejoicing, bringing their sheaves with them.
+R. And all nations shall flow unto it, and shall say: Glory be to thee, O Lord!
+
+[Lectio3]
+!2 Chr 7:11-16
+11 And Solomon finished the house of the Lord, and the king's house, and all that he had designed in his heart to do, in the house of the Lord, and in his own house, and he prospered.
+12 And the Lord appeared to him by night, and said: I have heard thy prayer, and I have chosen this place to myself for a house of sacrifice.
+13 If I shut up heaven, and there fall no rain, or if I give orders, and command the locust to devour the land, or if I send pestilence among my people:
+14 And my people, upon whom my name is called, being converted, shall make supplication to me, and seek out my face, and do penance for their most wicked ways: then will I hear from heaven, and will forgive their sins and will heal their land.
+15 My eyes also shall be open, and my ears attentive to the prayer of him that shall pray in this place.
+16 For I have chosen, and have sanctified this place, that my name may be there for ever, and my eyes and my heart may remain there perpetually.
+
+[Responsory3]
+R. O Lord, bless this house which I have built unto thy name. whosoever shall come unto this place and pray, then
+* Hear thou from the excellent throne of thy glory.
+V. O Lord, if thy people turn and pray toward thy sanctuary.
+R. Hear thou from the excellent throne of thy glory.
+&Gloria
+R. Hear Thou from the excellent throne of thy glory.
+
+[Lectio4]
+From the Sermons of St. Augustine, Bishop (of Hippo.)
+!252nd for the Season.
+Dearly beloved brethren, as often as we keep the Dedication-Feast of some Altar or Church, if we think faithfully and carefully, and live holily and righteously, that which is done in temples made with hands, is done in our soul by a spiritual building. He at the Dedication of the Temple. lied not who said: The temple of God is holy; which temple ye are (i Cor. iii. 17,) and again: Know ye not that your body is the temple of the Holy Ghost, Which is in you, (vi. 19.) And therefore, dearly beloved brethren, since by the grace of God, without any foregoing deserts of our own, we have been made meet to become the Temple of God, let us work as hard as we can, with His help, that our Lord may not find in His Temple, that is, in us, anything to offend the eyes of His Majesty.
+
+[Responsory4]
+R. If they pray toward this place,
+* Forgive the sin of thy people, O God, and teach them the good way wherein they should walk, and manifest forth thy glory in this place.
+V. Give ear, O Shepherd of Israel, thou that leadest Joseph like a flock, thou that sittest upon the cherubim.
+R. Forgive the sin of thy people, O God, and teach them the good way wherein they should walk, and manifest forth thy glory in this place.
+
+[Lectio5]
+Let the Tabernacle of our heart be swept clean of vices and filled with virtues. Let it be locked to the devil, and thrown open to Christ. Yea, let us so work, that we may be able to open the door of the kingdom of heaven with the key of good works. For even as evil works are so many bolts and bars to close against us the entrance into life, so beyond doubt are good works the key thereto. And therefore, dearly beloved brethren, let each one look into his own conscience, and when he findeth the wounds of guilt there, let him first strive by prayers, fasting, or alms deeds to purge his conscience, and so let him dare to take the Eucharist.
+
+[Responsory5]
+R. How dreadful is this place!
+* Surely this is none other but the house of God, and this is the gate of heaven.
+V. This is the house of God, stoutly builded, well founded upon a sure rock.
+R. Surely this is none other but the house of God, and this is the gate of heaven.
+
+[Lectio6]
+For if he acknowledge his iniquity, and withdraw himself from the Altar of God, he will soon attain unto the mercy of the pardon of God, for, as he that exalted himself shall be abased, so shall he that humbleth himself be exalted. (Luke xiv. n.) He who, as I have said, acknowledging his iniquity, withdraweth himself through lowliness from the Altar of the Church, till he have mended his life, need have but little fear that he will be excommunicated from the eternal marriage supper in heaven.
+
+[Responsory6]
+R. Jacob rose up early in the morning, and set up the stone for a pillar, and poured oil upon the top of it, and vowed a vow unto the Lord.
+* Surely this place is holy, and I knew it not.
+V. And Jacob awaked out of his sleep, and he said
+R. Surely this place is holy, and I knew it not.
+&Gloria
+R. Surely this place is holy, and I knew it not.
+
+[Lectio7]
+From the Holy Gospel according to Luke
+!Luke 19:1-10
+At that time: Jesus entered and passed through Jericho. And, behold, there was a man named Zacchaeus, which was the chief among the publicans, and he was rich. And so on.
+_
+Homily by St. Ambrose, Bishop (of Milan.)
+!Bk. viii. on Luke.
+Zacchaeus was little of stature, that is, he was not raised aloft among men by nobility of birth, and, like the most of the world, he possessed few merits. When he heard that the Lord and Saviour, Who had come unto His Own, and Whom His Own had not received, (John i. 11,) was coming, he desired to see Him. But the sight of Jesus is not easy; to any on the earth it is impossible. And since Zacchaeus had neither the Prophets, nor yet the Law, as a gracious help to his nature, he climbed up into a sycamore tree, raising his feet above the vanity of the Jews, and straightening the crooked branches of his former life, and therefore he received Jesus to lodge within his house.
+
+[Responsory7]
+R. My house shall be called the house of prayer, saith the Lord. Therein, he that asketh, receiveth; he that seeketh, findeth;
+* And to him that knocketh, it shall be opened.
+V. Ask, and ye shall receive; seek, and ye shall find.
+R. And to him that knocketh, it shall be opened.
+
+[Lectio8]
+He did well to climb up into a tree, that a good tree might bring forth good fruits, (Matth. vii. 17,) and that the slip of the wild olive, grafted, contrary to nature, into the good olive, might bring forth the fruits of the law. (Rom. xi. 17, 24.) For the root is holy, however unprofitable the branches. Their barren beauty hath now been overshadowed by the belief of the Gentiles in the Resurrection, as by a material upgrowth. Zacchaeus, then, was in the sycamore tree, and the blind man by the way-side, (xviii. 35.) For the one, Jesus stood waiting to show mercy, and asked him before He healed him, what he would that He should do for him; being unbidden of the other, He bade Himself to be his Guest, knowing how rich was the reward of receiving Him. Nevertheless, albeit He had heard no words of invitation, yet had He seen how his heart went.
+
+[Responsory8]
+R. All thy walls are of stones most precious.
+* The towers of Jerusalem shall be built up with jewels.
+V. The gates of Jerusalem shall be built up with the sapphire stone, and the emerald, and all her walls round about with stones most precious.
+R. The towers of Jerusalem shall be built up with jewels.
+&Gloria
+R. The towers of Jerusalem shall be built up with jewels.
+
+[Lectio9]
+But lest we should seem haughtily to pass by the poor blind man, and to hurry on to the rich one, let us stand waiting for him, as the Lord stood and waited; let us ask of him, as Christ asked of him. Let us ask, because we are ignorant; Christ asked, because He knew. Let us ask, that we may know whence he received his cure; Christ asked, that all of us may know from one example where through we are to earn a sight of the Lord. Christ asked, that we might believe that none, save they that confess Him, can be saved.
+&teDeum
+
+[Capitulum Laudes]
+!Zjevení 21:2
+v. Viděl jsem svaté město, nový Jerusalém, sestupující z nebe, ozdobený jako nevěsta pro svého ženicha.
+$Deo gratias
+
+[Hymnus Laudes]
+v. Jak úhelný a základní 
+Kámen Kristus poslán byl, 
+Aby on ve zdech všech domů  
+Spojoval své kameny, 
+A Sion svatý jej přijal 
+Neb v něm věříc zůstává.
+_
+Celé ono svaté, Bohem, 
+Též milované město,  
+Plné je písní a chvály, 
+I zpěvu radostného,
+Boha v Trojici jednoho 
+S nadšením vším velebí.
+_
+V tento chrám, nejvyšší Bože, 
+prosíme tě, přijdi již,
+A s laskavou dobrotou svou 
+Přijmi přání prosících,  
+A přehojné požehnání 
+Vylej nám zde v plnosti.
+_
+Zde nechť si zaslouží všichni 
+Vyslyšení proseb svých, 
+A když obdrží, co chtěli,  
+Se Svatými navěky,
+Do Ráje jsou uvedeni,
+A spočinou v pokoji.
+_
+Sláva, čest a pocta Bohu 
+Ze všech vždy Nejvyššímu, 
+Spolu Otci, Synovi i
+Duchu Utěšiteli.
+Jim náleží chvála a moc
+Po všechny věčné věky.
+Amen.
+
+[Ant 2]
+Zachee, * rychle slez ze stromu, neboť je třeba, abych dnes zůstal ve tvém domě; a on ihned slezl, a přijal jej s radostí do svého domu; Dnes Bůh připravil spásu tomuto domu, alleluja.
+
+[Lectio Prima]
+!Zjevení 21:4-4
+v. Pak setře Bůh každou slzu z jejich očí; a smrti již více nebude, ani pláče, ani nářku, ani bolesti již více nebude, neboť odejdou již předtím. A řekl ten, který seděl na trůnu: „Hle, vše učiním nové.“ 
+
+[Responsory Breve Tertia]
+R.br. Domu tvému, Pane, * náleží svatost.
+R. Domu tvému, Pane, * náleží svatost.
+V. Po všechny dny.
+R. Náleží svatost
+&Gloria
+R. Domu tvému, Pane, * náleží svatost.
+
+[Versum Tertia]
+V. Toto místo je svaté, na němž se modlil kněz.
+R. Za přestoupení a hříchy lidu.
+
+[Capitulum Sexta]
+!Zjevení 21:3
+v. Pak jsem uslyšel veliký hlas od trůnu, který pravil: „Hle stánek Boží s lidmi, a Bůh s nimi přebývá; a oni jsou jeho lidem, i sám Bůh s nimi jim bude Bohem.“  
+$Deo gratias
+
+[Responsory Breve Sexta]
+R.br. This place is holy, * wherein the Priest prayeth.
+R. This place is holy, * wherein the Priest prayeth
+V. For the pardon of the transgressions and offences of the people.
+R. The Priest prayeth.
+&Gloria
+R. This place is holy, * wherein the Priest prayeth.
+
+[Responsory Breve Nona]
+R.br. Toto je dům Páně, * poctivě vystavěný.
+R. Toto je dům Páně, * poctivě vystavěný.
+V. S dobrými základy na pevné skále.
+R. Poctivě vystavěný.
+&Gloria
+R. Toto je dům Páně, * poctivě vystavěný.
+
+[Versum Nona]
+V. Dobře ustavený je dům Páně.
+R. Na pevné skále.
+
+[Versum 3]
+V. Domu tvému, Pane, náleží svatost.
+R. Po všechny dny.
+
+[Ant 3]
+Ó, jak strašné je * toto místo, opravdu to může být jen dům Boží a brána nebeská.

--- a/web/www/horas/Bohemice/Commune/C9.txt
+++ b/web/www/horas/Bohemice/Commune/C9.txt
@@ -1,0 +1,227 @@
+[Officium]
+Officium Defunctorum
+
+[Ant Vespera]
+I will walk before the Lord * in the land of the living.;;114
+Woe is me! O Lord, * that my sojourn is long;;119
+The Lord shall keep thee from all evil, * the Lord shall keep thy soul.;;120
+If Thou, Lord, shouldest mark iniquities, * O Lord, who shall stand.;;129
+O Lord, forsake not * the works of thine own hands.;;137
+
+[Versum 1]
+V. I heard a voice from heaven, saying unto me:
+R. Blessed are the dead which die in the Lord.
+
+[Ant 1]
+All that the Father giveth Me shall come to Me; * and him that cometh to Me I will in no wise cast out.
+
+[Ant 1] (rubrica cisterciensis)
+Slyšel jsem * hlas z nebe, který pravil: Blažení mrtví, kteří umírají v Pánu.
+
+[Oratio_Fid]
+$Oremus
+v. O God, who art thyself at once the Maker and the Redeemer of all thy faithful ones, grant unto the souls of thy servants and handmaids remission of all their sins, making of our entreaties unto our great Father a mean whereby they may have that forgiveness which they have ever hoped for.
+$Qui vivis
+
+[Oratio1]
+v. Lord, we pray thee to absolve the soul of thy servant or, thine handmaid N. (here express the name) who hath died unto the world, that he (or, she) may live unto thee. And whereinsoever while he (or, she) walked among men he (or, she) hath transgressed through the weakness of the flesh, do Thou in the exceeding tenderness of thy mercy forgive and put away.
+$Per Dominum
+
+[Oratio2]
+v. O Lord God, who art the great pardoner, grant rest and refreshment, peace and blessing, light and glory, unto the souls of thy men-servants and thy maid-servants, (or, the soul of thy servant, or, of thine handmaid,) whose year's-mind we are keeping.
+$Per Dominum
+
+[Invit]
+Unto the Eternal King all live. * O come, let us worship Him.
+
+[Ant Matutinum]
+Make my way straight before thy face, * O Lord my God.;;5
+Return, O Lord, deliver my soul * O save me for thy mercy's sake.;;6
+Lest he tear my soul like a lion, * while there is none to deliver, or to save.;;7
+He maketh me to lie down * in green pastures.;;22
+Lord, remember not the sins of my youth, * nor my transgressions.;;24
+I believe that I shall yet see the goodness of the Lord * in the land of the living.;;26
+Be pleased, O Lord, to deliver me * O Lord, look upon me to help me.;;39
+Lord, heal my soul; * for I have sinned against thee.;;40
+My soul thirsteth for the living God; * when shall I come and appear before God?;;41
+
+[Nocturn 1 Versum]
+V. From the gates of hell.
+R. Deliver their souls, O Lord.
+
+[Nocturn 2 Versum]
+V. May the Lord set them with princes;
+R. Even with the princes of his people.
+
+[Nocturn 3 Versum]
+V. O deliver not unto beasts the souls of them that praise thee!
+R. And forget not the souls of thy poor for ever.
+
+[Lectio1]
+!Job 7:16-21
+16 Spare me, for my days are nothing.
+17 What is a man that thou shouldst magnify him? or why dost thou set thy heart upon him?
+18 Thou visitest him early in the morning, and thou provest him suddenly.
+19 How long wilt thou not spare me, nor suffer me to swallow down my spittle?
+20 I have sinned: what shall I do to thee, O keeper of men? why hast thou set me opposite to thee, and I am become burdensome to myself?
+21 Why dost thou not remove my sin, and why dost thou not take away my iniquity? Behold now I shall sleep in the dust: and if thou seek me in the morning, I shall not be.
+
+[Responsory1]
+R. I believe that my Redeemer liveth, and that I shall stand up from the earth at the latter day,
+* And in my flesh shall I see God my Saviour.
+V. Whom I shall see for myself, and mine eyes shall behold, and not another.
+R. And in my flesh shall I see God my Saviour.
+
+[Lectio2]
+!Job 10:1-7
+1 My soul is weary of my life, I will let go my speech against myself, I will speak in the bitterness of my soul.
+2 I will say to God: Do not condemn me: tell me why thou judgest me so.
+3 Doth it seem good to thee that thou shouldst calumniate me, and oppress me, the work of thy own hands, and help the counsel of the wicked?
+4 Hast thou eyes of flesh: or, shalt thou see as man seeth?
+5 Are thy days as the days of man, and are thy years as the times of men:
+6 That thou shouldst inquire after my iniquity, and search after my sin?
+7 And shouldst know that I have done no wicked thing, whereas there is no man that can deliver out of thy hand.
+
+[Responsory2]
+R. Thou Who didst call up Lazarus from the grave after that he had begun to stink
+* Do Thou, O Lord, grant them rest and a place of forgiveness.
+V. Thou Who shalt come to judge the quick and dead, and the world by fire
+R. Do Thou, O Lord, grant them rest and a place of forgiveness.
+
+[Lectio3]
+!Job 10:8-12
+8 thy hands have made me, and fashioned me wholly round about, and dost thou thus cast me down headlong on a sudden?
+9 Remember, I beseech thee, that thou hast made me as the clay, and thou wilt bring me into dust again.
+10 Hast thou not milked me as milk, and curdled me like cheese?
+11 Thou hast clothed me with skin and flesh: thou hast put me together with bones and sinews:
+12 Thou hast granted me life and mercy, and thy visitation hath preserved my spirit.
+
+[Responsory3]
+R. Lord, when Thou comest to judge the earth, where shall I hide myself from the face of thy wrath?
+* For I have sinned greatly in my life.
+V. I dread my sins, I blush before thee I see the great tribunal set! In fear and terror I implore thee, Forgive when soul and Judge are met!
+R. For I have sinned greatly in my life.
+$Requiem
+R. For I have sinned greatly in my life.
+
+[Lectio4]
+!Job 13:22-28
+22 Answer me.
+23 How many are my iniquities and sins? make me know my crimes and offences.
+24 Why hidest thou thy face, and thinkest me thy enemy?
+25 Against a leaf, that is carried away with the wind, thou showest thy power, and thou pursuest a dry straw.
+26 For thou writest bitter things against me, and wilt consume me for the sins of my youth.
+27 Thou hast put my feet in the stocks, and hast observed all my paths, and hast considered the steps of my feet:
+28 Who am to be consumed as rottenness, and as a garment that is moth-eaten.
+
+[Responsory4]
+R. Remember, O God, that my life is wind.
+* The eye of him that hath seen me shall see me no more.
+V. Out of the depths have I cried unto thee, O Lord! Lord, hear my voice.
+R. The eye of him that hath seen me shall see me no more.
+
+[Lectio5]
+!Job 14:1-6
+1 Man born of a woman, living for a short time, is filled with many miseries.
+2 Who cometh forth like a flower, and is destroyed, and fleeth as a shadow, and never continueth in the same state.
+3 And dost thou think it meet to open thy eyes upon such an one, and to bring him into judgment with thee?
+4 Who can make him clean that is conceived of unclean seed? is it not thou who only art?
+5 The days of man are short, and the number of his months is with thee: thou hast appointed his bounds which cannot be passed.
+6 Depart a little from him, that he may rest, until his wished for day come, as that of the hireling
+
+[Responsory5]
+R. Woe is me, O Lord! for I have sinned greatly in my life. I am smitten what shall I do? Whither shall I flee but unto thee, O my God?
+* Have mercy upon me, when Thou comest at the latter day.
+V. My soul is sore vexed, but Thou, O Lord, help me.
+R. Have mercy upon me, when Thou comest at the latter day.
+
+[Lectio6]
+!Job 14:13-16
+13 Who will grant me this, that thou mayst protect me in hell, and hide me till thy wrath pass, and appoint me a time when thou wilt remember me?
+14 Shall man that is dead, thinkest thou, live again? all the days in which I am now in warfare, I expect until my change come.
+15 Thou shalt call me, and I will answer thee: to the work of thy hands thou shalt reach out thy right hand.
+16 Thou indeed hast numbered my steps, but spare my sins.
+
+[Responsory6]
+R. Hold not my sins in remembrance, O Lord,
+* When thou comest to judge the world by fire.
+V. Make my way straight before thy face, O Lord my God.
+R. When thou comest to judge the world by fire.
+$Requiem
+R. When thou comest to judge the world by fire.
+
+[Lectio7]
+!Job 17:1-3; 17:11-15
+1 My spirit shall be wasted, my days shall be shortened, and only the grave remaineth for me.
+2 I have not sinned, and my eye abideth in bitterness.
+3 Deliver me O Lord, and set me beside thee, and let any man's hand fight against me.
+11 My days have passed away, my thoughts are dissipated, tormenting my heart.
+12 They have turned night into day, and after darkness I hope for light again.
+13 If I wait hell is my house, and I have made my bed in darkness.
+14 If I have said to rottenness: thou art my father; to worms, my mother and my sister.
+15 Where is now then my expectation, and who considereth my patience?
+
+[Responsory7]
+R. Forasmuch as I sin daily, and repent not, the fear of death troubleth me.
+* O God, have mercy upon me, and save me, for in hell there is no redemption.
+V. Save me, O God, by thy name, and judge me in thy strength.
+R. O God, have mercy upon me, and save me, for in hell there is no redemption.
+
+[Lectio8]
+!Job 19:20-27
+20 The flesh being consumed. My bone hath cleaved to my skin, and nothing but lips are left about my teeth.
+21 Have pity on me, have pity on me, at least you my friends, because the hand of the Lord hath touched me.
+22 Why do you persecute me as God, and glut yourselves with my flesh?
+23 Who will grant me that my words may be written? Who will grant me that they may be marked down in a book?
+24 With an iron pen and in a plate of lead, or else be graven with an instrument in flint stone.
+25 For I know that my Redeemer liveth, and in the last day I shall rise out of the earth.
+26 And I shall be clothed again with my skin, and in my flesh I will see my God.
+27 Whom I myself shall see, and my eyes shall behold, and not another: this my hope is laid up in my bosom.
+
+[Responsory8]
+R. O Lord, judge me not according to my works; for I have done nothing that can be counted in respect of thee. I beseech thy majesty therefore, that thou wouldest
+* Blot out my transgressions, O God.
+V. Lord, wash me thoroughly from mine iniquity and cleanse me from my sin.
+R. Blot out my transgressions, O God.
+
+[Lectio9]
+!Job 10:18-22
+18 Why didst thou bring me forth out of the womb: O that I had been consumed that eye might not see me!
+19 I should have been as if I had not been, carried from the womb to the grave.
+20 Shall not the fewness of my days be ended shortly? suffer me, therefore, that I may lament my sorrow a little:
+21 Before I go, and return no more, to a land that is dark and covered with the mist of death:
+22 A land of misery and darkness, where the shadow of death, and no order, but everlasting horror dwelleth.
+
+[Responsory9]
+R. Deliver me, O Lord, from eternal death in that awful day;
+* when the heavens and the earth shall be shaken, and Thou shalt come to judge the world by fire.
+V. Quaking and dread take hold upon me, when I look for the coming of the trial and the wrath to come.
+R. When the heavens and the earth shall be shaken.
+V. That day is a day of wrath, of wasteness and desolation, a great day and exceeding bitter.
+R. When Thou shalt come to judge the world by fire.
+$Requiem
+R. Deliver me, O Lord, from eternal death in that awful day, when the heavens and the earth shall be shaken, and Thou shalt come to judge the world by fire.
+
+[Conclusio]
+V. O Lord, grant them eternal rest.
+R. And let the everlasting light shine upon them.
+V. May they rest in peace.
+R. Amen.
+
+[Ant Laudes_]
+Jásají Hospodinu * zdrcené kosti.;;50
+Vyslyš, Pane, * modlitbu mou: k tobě každý člověk přijde.;;64
+Mě přijala * tvá pravice, Hospodine.;;62
+Od bran pekelných vysvoboď, Hospodine, mou duši.;;222
+Všechno, co dýchá, * ať chválí Hospodina.;;150
+
+[Ant 2]
+I am the resurrection and the life: * he that believeth in me, though he were dead, yet shall he live; and whosoever liveth and believeth in me shall never die.
+
+[Responsory91]
+R. Deliver me from the ways of hell, O Lord, Who didst break the gates of brass in sunder, and didst descend into hell, and give them light,
+* That they that sat in affliction and darkness might behold thee.
+V. Crying and saying, Thou hast come, O our Redeemer
+R. That they that sat in affliction and darkness might behold thee.
+$Requiem
+R. That they that sat in affliction and darkness might behold thee.

--- a/web/www/horas/Bohemice/CommuneM/C8.txt
+++ b/web/www/horas/Bohemice/CommuneM/C8.txt
@@ -1,0 +1,68 @@
+[Ant Vespera] (tempore paschali et rubrica cisterciensis)
+Alleluja, * alleluja, alleluja.
+
+[Ant 1] (rubrica cisterciensis)
+Věčný pokoj * od věčného Otce, tomuto domu věčný pokoj, Slovo Otcovo, buď pokoj tomuto domu, ať laskavý utěšitel udělí pokoj tomuto domu.
+
+[Responsorium] (rubrica cisterciensis)
+<font color="red">Responsorium.</font> Hrozné je toto místo, avšak není to nic jiného než dům Boží a brána nebeská. * Vpravdě je totiž Hospodin na tomto místě, ale já jsem to nevěděl.
+V. Jakmile procitnul Jákob ze sna, řekl: 
+* Vpravdě je totiž Hospodin na tomto místě, ale já jsem to nevěděl.
+
+[AntMatutinumM]
+I will come into thy house; I will worship towards thy holy temple.;;5
+The Lord is in his holy temple, the Lord’s throne is in heaven.;;10
+Adore ye the Lord in his holy court.;;28
+Blessed are they that dwell in thy house, O Lord: they shall praise thee for ever and ever.;;83
+
+[Nocturn 1 Versum] (rubrica cisterciensis)
+V. Základy má dům Páně.
+R. Nad vycholky hor.
+
+[Nocturn 2 Versum] (rubrica cisterciensis)
+@Commune/C8:Versum 3
+
+[Nocturn 3 Versum] (rubrica cisterciensis)
+V. Blažení, kdo přebývají ve tvém domě, Pane.
+R. Na věky věkův tě budou chválit.
+
+
+[Responsory4]
+R. How terrible is this place! This is no other but the house of God, and the gate of heaven.
+* Indeed the Lord is in this place, and I knew it not.
+V. Jacob saw in his sleep a ladder standing upon the earth, and the top thereof touching heaven: the angels also of God ascending and descending by it.
+R. Indeed the Lord is in this place, and I knew it not.
+
+[Lectio5]
+@Commune/C8:Lectio4:s/And therefore.*//
+
+[Lectio6]
+@Commune/C8:Lectio4:3 s/.*(And therefore)/$1/ s/$/~/
+@Commune/C8:Lectio5:s/For even.*//
+
+[Lectio7]
+@Commune/C8:Lectio5:s/.*(For even)/$1/
+
+[Responsory8]
+R. How lovely are thy tabernacles, O Lord of hosts! My soul longeth and fainteth
+* For the courts of the Lord.
+V. They that dwell in thy house, O Lord they shall praise thee for ever and ever.
+R. For the courts of the Lord.
+
+[Lectio10]
+@Commune/C8:Lectio8:s/Zacchaeus, .*//s
+
+[Lectio11]
+@Commune/C8:Lectio8:s/.* Zacchaeus, /Zacchaeus, /s
+
+[Responsory11]
+R. Blessed art thou in the holy temple of thy glory that has been built
+* To the praise and glory of your name O Lord.
+V. Bless this house that I have built.
+R. To the praise and glory of your name O Lord.
+
+[Responsory12]
+R. I saw the holy city, the new Jerusalem, coming down out of heaven from God, prepared as a bride adorned for her husband.
+*And I heard a great voice from the throne, saying: Behold the tabernacle of God with men, and he will dwell with them.
+V. And they shall be his people; and God himself with them shall be their God.
+R. And I heard a great voice from the throne, saying: Behold the tabernacle of God with men, and he will dwell with them.

--- a/web/www/horas/Latin/Commune/C9.txt
+++ b/web/www/horas/Latin/Commune/C9.txt
@@ -5,6 +5,7 @@ Officium Defunctorum
 Psalmi Dominica
 Antiphonas horas
 Capitulum Versum 2 ad Laudes et Vesperas
+(sed rubrica cisterciensis omittitur)
 Omit Incipit Hymnus Capitulum Lectio Preces Capitulum Commemoratio Suffragium
 Special Conclusio
 Limit Benedictiones Oratio
@@ -26,6 +27,9 @@ R. Beáti mórtui qui in Dómino moriúntur.
 [Ant 1]
 Omne * quod dat mihi Pater, ad me véniet; et eum qui venit ad me, non eíciam foras.
 
+[Ant 1] (rubrica cisterciensis)
+Audívi * vocem de cœlo dicéntem: Beáti mórtui qui in Dómino moriúntur.
+
 [Oratio 1]
 @:Oratio_a_porta
 @:Oratio_Fid
@@ -35,6 +39,12 @@ $Pater noster Et
 _
 &psalm(145)
 (sed rubrica 1955 aut rubrica 1960 aut rubrica monastica aut die Omnium Defunctorum omittitur)
+$A porta inferi
+
+[Oratio_a_porta] (rubrica cisterciensis)
+$Pater totum secreto
+_
+&psalm(145)
 $A porta inferi
 
 [Oratio_Fid]

--- a/web/www/horas/Latin/CommuneM/C8.txt
+++ b/web/www/horas/Latin/CommuneM/C8.txt
@@ -8,11 +8,62 @@ Divinum auxilium
 [Ant Vespera]
 @Commune/C8::s/112/147/
 
+[Ant Vespera] (rubrica cisterciensis)
+@Commune/C8::1-3
+@Commune/C8::5 s/112/147/
+@Commune/C8::4
+
+[Ant Vespera] (tempore paschali et rubrica cisterciensis)
+Allelúia, * allelúia, allelúia.;;109
+;;110
+;;111
+;;147
+
+[Responsorium] (rubrica cisterciensis)
+<font color="red">Responsorium.</font> Terríbilis est locus iste: non est hic áliud nisi domus Dei et porta caeli: * Vere étenim Dóminus est in loco isto, et ego nesciébam.
+V. Cumque evigilásset Jacob a somno, ait: 
+* Vere étenim Dóminus est in loco isto, et ego nesciébam.
+
+[Versum 1] (rubrica cisterciensis)
+@Commune/C8:Nocturn 2 Versum
+
+[Versum 2] (rubrica cisterciensis)
+@:Versum 1
+
+[Versum 3] (rubrica cisterciensis)
+@:Versum 1
+
+[Ant 1] (rubrica cisterciensis)
+Pax æterna * ab ætérno Patre, huic domui pax perénnis, Verbum Patris sit pax huic dómui, pacem pius consolátor huic præstet dómui.
+
+[Ant Laudes] (tempore paschali et rubrica cisterciensis)
+Allelúia, * allelúia, allelúia.
+
+[Ant Sexta] (rubrica cisterciensis)
+@Commune/C8:Ant Vespera:5
+
+[Responsory Breve Sexta] (rubrica cisterciensis)
+@:Responsory Breve Nona
+
+[Ant Nona] (rubrica cisterciensis)
+@Commune/C8:Ant Vespera:4
+
 [AntMatutinumM]
 Introíbo * in domum tuam, Dómine, † et adorábo ad templum sanctum tuum.;;5
 Dóminus * in templo sancto suo, † Dóminus in cælo sedes ejus.;;10
 Adoráte * Dóminum in aula sancta ejus.;;28
 Beáti, * qui hábitant in domo tua, Dómine; † in sǽcula sæculórum laudábunt te.;;83
+
+[Nocturn 1 Versum] (rubrica cisterciensis)
+V. Fundáta est domus Dómini.
+R. Supra vérticem móntium.
+
+[Nocturn 2 Versum] (rubrica cisterciensis)
+@Commune/C8:Versum 3
+
+[Nocturn 3 Versum] (rubrica cisterciensis)
+V. Beáti, qui hábitant in domo tua, Dómine.
+R. In sæcula sæculórum laudábunt te.
 
 [Ant Matutinum]
 @:AntMatutinumM:1-2
@@ -114,3 +165,5 @@ _
 
 [Responsory SextaM]
 @Commune/C8:Versum Tertia
+(sed rubrica cisterciensis)
+@Commune/C8:Versum 3

--- a/web/www/horas/Latin/CommuneM/C9.txt
+++ b/web/www/horas/Latin/CommuneM/C9.txt
@@ -4,3 +4,9 @@
 @Commune/C9
 Matutinum romanum
 Omit MLitany
+
+[Ant Vespera] (rubrica cisterciensis)
+@Commune/C9::s/Hei/Heu/
+
+[Ant Laudes] (rubrica cisterciensis)
+@Commune/C9::s/;;62/;;62;66/ s/;;150/;;148;149;150/

--- a/web/www/horas/Latin/Sancti/06-01Av.txt
+++ b/web/www/horas/Latin/Sancti/06-01Av.txt
@@ -1,0 +1,10 @@
+[Rank]
+In Dedicatione Ecclesiæ Abbatialis in Altovado;;Serm. maj.;;6;;ex C8
+
+[Rule]
+ex C8;
+12 lectiones
+Psalmi Dominica
+
+[Responsory Vespera 1]
+@CommuneM/C8:Responsorium


### PR DESCRIPTION
**Cistercian version:** C8 and C9 Vespers added including Czech translation
**specials/capitulis.pl:** for Cistercian version, the _Responsorium prolixum_ added as `Responsory Vespers 1`, which is usually reserved only for Nativity. As a _Responsorium prolixum_ is part of first Vespers of every Festum Sermonis (like first Class in Roman Calendar), we need them quite a lot...