### PR TITLE
Cist: C10+C11 & Christmas Propers till Vigilia Epiphaniæ

### DIFF
--- a/web/cgi-bin/DivinumOfficium/SetupString.pl
+++ b/web/cgi-bin/DivinumOfficium/SetupString.pl
@@ -209,6 +209,8 @@ sub get_dayname_for_condition {
       && ($day == 2 || ($day == 3 && $dayofweek == 1) || ($day == 1 && day_of_week(11, 1, $year) != 6 && $vesp_or_comp))
     );
   return 'Nicolai' if $month == 12 && $day == 6;
+  return 'Nat28' if $month == 12 && $day == 28;
+  return 'Nat29' if $month == 12 && $day == 29;
   return '';
 }
 

--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -993,7 +993,8 @@ sub concurrence {
         && $cwrank[0] !~ /Dominica|feria|in.*octava/i)
 
       # on Christmas Eve and New Year's Eve, nothing of a preceding Sunday
-      || ($cwinner =~ /12-25|01-01/)
+      || ($cwinner =~ /12-25|01-01/ && $version !~ /cist/i)
+      # Cist: we need Comm. of S. Silvester on 01-01
 
       # in 1st Vespers of Duplex II. cl. also commemoration of any Duplex
       || ( $crank >= 5

--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -993,8 +993,10 @@ sub concurrence {
         && $cwrank[0] !~ /Dominica|feria|in.*octava/i)
 
       # on Christmas Eve and New Year's Eve, nothing of a preceding Sunday
-      || ($cwinner =~ /12-25|01-01/ && $version !~ /cist/i)
-      # Cist: we need Comm. of S. Silvester on 01-01
+      || ($cwinner =~ /12-25|01-01/ && $version !~ /cist/i) 
+      
+      # Cist: we need Comm. of S. Silvester on 31-12
+      || ($cwinner =~ /12-25/ && $version =~ /cist/i)
 
       # in 1st Vespers of Duplex II. cl. also commemoration of any Duplex
       || ( $crank >= 5
@@ -1764,7 +1766,7 @@ sub rankname {
         $rankname =~ s/Semiduplex //;
       }
     }
-  } elsif ($commune =~ /C10/) {    # Can;t use winner due 9/13/2025 DA
+  } elsif ($commune =~ /C10/) {    # Can't use winner due 9/13/2025 DA
     $rankname = $ranktable[1];     # Simplex - BMV Sabbato
   } elsif ($version =~ /196/ && $winner =~ /Pasc[07]-[1-6]/) {
     $rankname = "$t{'Dies Octavæ'} I. $t{classis}";    # Paschal & Pentecost Octave post 1960

--- a/web/cgi-bin/horas/specials.pl
+++ b/web/cgi-bin/horas/specials.pl
@@ -93,7 +93,7 @@ sub specials {
     ) {
       $skipflag = 1;
 
-      if ($item =~ /incipit/i && $version !~ /1955|196/) {
+      if ($item =~ /incipit/i && $version !~ /1955|196|cist/i) {
         $comment = 2;
         setbuild1($ite, 'limit');
       } else {
@@ -102,7 +102,7 @@ sub specials {
       }
       setcomment($label, 'Preces', $comment, $lang) if ($rule !~ /Omit.*? $ite mute/i);
 
-      if ($item =~ /incipit/i && $version !~ /1955|196/ && $winner !~ /C12/) {
+      if ($item =~ /incipit/i && $version !~ /1955|196/ && $winner !~ /C12/ && !($version =~ /cist/i && $winner =~ /C9/)) {
         if ($hora eq 'Laudes') {
           push(@s, '/:' . translate('Si Laudes', $lang) . ':/');
         } else {

--- a/web/cgi-bin/horas/specials.pl
+++ b/web/cgi-bin/horas/specials.pl
@@ -93,7 +93,7 @@ sub specials {
     ) {
       $skipflag = 1;
 
-      if ($item =~ /incipit/i && $version !~ /Cist|1955|196/) {
+      if ($item =~ /incipit/i && $version !~ /Cist|1955|196/i) {
         $comment = 2;
         setbuild1($ite, 'limit');
       } else {
@@ -102,7 +102,7 @@ sub specials {
       }
       setcomment($label, 'Preces', $comment, $lang) if ($rule !~ /Omit.*? $ite mute/i);
 
-      if ($item =~ /incipit/i && $version !~ /Cist|1955|196/ && $winner !~ /C12/) {
+      if ($item =~ /incipit/i && $version !~ /1955|196/ && $winner !~ /C12/ && !($version =~ /cist/i && $winner =~ /C9/)) {
         if ($hora eq 'Laudes') {
           push(@s, '/:' . translate('Si Laudes', $lang) . ':/');
         } else {

--- a/web/www/Tabulae/Kalendaria/CAV.txt
+++ b/web/www/Tabulae/Kalendaria/CAV.txt
@@ -77,6 +77,8 @@
 05-31=05-31=S. Petronillæ, Virginis=1=
 *June*
 06-01=06-01Av=Dedicatio Ecclesiæ Abbatiæ Altovadensis=6=
+*July*
+07-17=07-16=Beatæ Mariæ Virginis de Monte Carmelo=5=S. Alexii, Confessoris=1=
 *September*
 09-28=09-28=S. Wenceslai, Ducis, Martyris et Patroni Principalis Regni Bohemiæ=5=
 *November*

--- a/web/www/horas/Bohemice/Commune/C1.txt
+++ b/web/www/horas/Bohemice/Commune/C1.txt
@@ -41,7 +41,7 @@ až na konci časů přijde,
 nás učinil účastnými
 na radosti bez ustání.
 _
-* Buď Bohu Otci sláva, čest
+Buď Bohu Otci sláva, čest
 i Synu, který z mrtvých vstal,
 i Duchu Utěšiteli
 bud chvála všechen věků věk.

--- a/web/www/horas/Bohemice/Commune/C1.txt
+++ b/web/www/horas/Bohemice/Commune/C1.txt
@@ -52,8 +52,8 @@ V. Do celé země vyšel zvuk jejich učení.
 R. A do všech končin okrsku zemského jejich slova.
 
 [Versum 1] (rubrica cisterciensis)
-Nesmírně poctěni jsou tví přátelé, Bože.
-Nesmírně pevné je jejich vládnutí.
+V. Nesmírně poctěni jsou tví přátelé, Bože.
+R. Nesmírně pevné je jejich vládnutí.
 
 [Ant 1]
 Budou vás totiž vydávat * veleradám, a ve svých shromážděních vás budou bičovat; a předvádět vás před krále a místodržící kvůli mě na svědectví jim i Pohanům.

--- a/web/www/horas/Bohemice/Commune/C10.txt
+++ b/web/www/horas/Bohemice/Commune/C10.txt
@@ -4,8 +4,16 @@ Officium Beatae Mariae Virginis in Sabbato
 [Ant 1_]
 Blažená Matko a nedotčená Panno! * Slavná Královno světa! Přimlouvej se za nás u Pána!
 
+[Ant 1_Pasch]
+Královno nebes, * raduj se, alleluja: Neboť ten, jejž sis zasloužila nosit, alleluja, Vstal z mrtvých, jak řekl, alleluja. Přimlouvej se za nás u Boha, alleluja.
+
 [Invit]
 Zdrávas Maria, milostiplná: * Pán s tebou.
+
+[Ant Laudes] (rubrica tridentina aut rubrica cisterciensis)
+@Commune/C11
+(sed tempore paschali)
+Alleluja, * alleluja, alleluja.
 
 [Versum 2]
 V. Požehnaná jsi mezi ženami.

--- a/web/www/horas/Bohemice/Commune/C11.txt
+++ b/web/www/horas/Bohemice/Commune/C11.txt
@@ -2,6 +2,13 @@
 Jeho levice * je pod mou hlavou, a jeho pravice mě objímá.;;112
 Krásnou * ses stala a sladkou ve svých potěšeních, svatá Boží Rodičko.;;147
 
+[Ant Vespera] (rubrica cisterciensis)
+Když Král * seděl u svého stolu, můj nard vydával sladkou vůni.;;109
+Jeho levice * je pod mou hlavou, a jeho pravice mě objímá.;;112
+Jsem černá, * ale krásná, dcery Jerusalémské, proto si mě Král zamiloval, a uvedl mě do své ložnice.;;121
+Již zima přešla, * déšť přišel a zase odešel; vstaň, má přítelkyně, a pojď.;;126
+Krásnou * ses stala a sladkou ve svých potěšeních, svatá Boží Rodičko.;;147
+
 [Hymnus Vespera]
 !První sloku tohoto hymnu zpíváme vkleče
 v. Zdrávas, hvězdo moří,
@@ -103,7 +110,7 @@ $Deo gratias.
 v. Ó přeslavná Paní světa, 
 Povýšená nad nebesa,
 Jenž tebe stvořil, Maria, 
-Svatýmis prsy krmila.
+Svatými's prsy krmila.
 _
 Což Eva bídná ztratila,
 To svým Plodem nahradila,
@@ -131,7 +138,17 @@ v. Na náměstích jsem voněla jako skořice a vonný balzám, jako nejjemněj�
 [Capitulum Sexta]
 !Syr 24:15-16
 v. A tak jsem na Siónu obdržela sídlo. Usadil mě v městě, které miloval jako mě, v Jerusalémě vykonávám svou moc. V lidu plném slávy jsem zapustila kořeny, v Pánově údělu je jeho dědictví, a v plnosti svatých se zdržuji.
-$Deo gratias.
+$Deo gratias
+
+[Capitulum Sexta] (rubrica cisterciensis)
+!Cant. 6:9.
+v. Uzřely ji dcery sionské, a velebí ji coby nejkrásnější; a královny ji vychválily.
+$Deo gratias
+
+[Capitulum Nona] (rubrica cisterciensis)
+!Cant. 6:10.
+v. Kdopak to je? Vychází jak jitřenka na východě, krásná jak luna, jasná jak slunce, hrozná jak seřazené šiky vojska.
+$Deo gratias
 
 [Ant 3]
 Blahoslavenou mě budou zvát * všechna pokolení, neboť na pokornou služebnici shlédl Bůh.

--- a/web/www/horas/Bohemice/Commune/C11.txt
+++ b/web/www/horas/Bohemice/Commune/C11.txt
@@ -3,11 +3,11 @@ Jeho levice * je pod mou hlavou, a jeho pravice mě objímá.;;112
 Krásnou * ses stala a sladkou ve svých potěšeních, svatá Boží Rodičko.;;147
 
 [Ant Vespera] (rubrica cisterciensis)
-Když Král * seděl u svého stolu, můj nard vydával sladkou vůni.;;109
-Jeho levice * je pod mou hlavou, a jeho pravice mě objímá.;;112
+Když Král * seděl u svého stolu, můj nard vydával svou vůni.;;109
+Vylitá mast * je tvé jméno, proto si tě mladé dívky velice zamilovaly.;;112
 Jsem černá, * ale krásná, dcery Jerusalémské, proto si mě Král zamiloval, a uvedl mě do své ložnice.;;121
-Již zima přešla, * déšť přišel a zase odešel; vstaň, má přítelkyně, a pojď.;;126
-Krásnou * ses stala a sladkou ve svých potěšeních, svatá Boží Rodičko.;;147
+Požehnaná jsi * mezi ženami, a požehnaný plod života tvého.;;126
+Krásná jsi a zdobná, * dcero Jerusalémská, hrozná jako seřazená šik vojska.;;147
 
 [Hymnus Vespera]
 !První sloku tohoto hymnu zpíváme vkleče
@@ -100,6 +100,9 @@ After thy delivery thou still remainest a virgin; * undefiled Mother of God, pra
 [Versum 0]
 V. Oroduj za nás, svatá Boží Rodičko.
 R. Abychom hodni byli učinění zaslíbení Kristových.
+
+[Ant Laudes] (rubrica cisterciensis)
+@:Ant Vespera:s/;;.*//g
 
 [Capitulum Laudes]
 !Sir 24:14

--- a/web/www/horas/Bohemice/Commune/C2.txt
+++ b/web/www/horas/Bohemice/Commune/C2.txt
@@ -42,9 +42,6 @@ R. A ustanovil jej nad dílem svých rukou.
 [Ant 1]
 Tento Svatý * pro zákon Boží bojoval až do smrti, a řečí bezbožníků se pranic nebál; stál totiž na pevné zemi.
 
-[Ant 1] (rubrica cisterciensis)
-Blaze muži, * který trpí pokušení, neboť až bude vyzkoušen, přijme korunu života, kterou zaslíbil Bůh těm, kteří jej milují.
-
 [Oratio]
 Shlédni na naši slabost, všemohoucí Bože, a protože břímě našich skutků nás tíží, nechť nás chrání slavná přímluva svatého N., tvého Mučedníka a Biskupa.
 $Per Dominum

--- a/web/www/horas/Bohemice/Commune/C9.txt
+++ b/web/www/horas/Bohemice/Commune/C9.txt
@@ -17,19 +17,19 @@ Vše, * co mi dává Otec, ke mně přijde; a toho, kdo za mnou přijde, nevyže
 
 [Oratio_Fid]
 $Oremus
-v. O God, who art thyself at once the Maker and the Redeemer of all thy faithful ones, grant unto the souls of thy servants and handmaids remission of all their sins, making of our entreaties unto our great Father a mean whereby they may have that forgiveness which they have ever hoped for.
+v. Bože, Stvořiteli a Vykupiteli všech věřících, duším svých služebníků a služebnic uděl odpuštění všech hříchů; aby slitování, které sobě vždy žádaly, zbožnými prosbami i dosáhli.
 $Qui vivis
 
 [Oratio1]
-v. Lord, we pray thee to absolve the soul of thy servant or, thine handmaid N. (here express the name) who hath died unto the world, that he (or, she) may live unto thee. And whereinsoever while he (or, she) walked among men he (or, she) hath transgressed through the weakness of the flesh, do Thou in the exceeding tenderness of thy mercy forgive and put away.
+v. Vysvoboď, prosíme, Pane, duši svého služebníka N., aby zemřelý světu žil pro tebe; a to, co pro křehkost těla v lidském jednání spáchal, ty slitováním své přemilosrdné laskavosti očisti.
 $Per Dominum
 
 [Oratio2]
-v. O Lord God, who art the great pardoner, grant rest and refreshment, peace and blessing, light and glory, unto the souls of thy men-servants and thy maid-servants, (or, the soul of thy servant, or, of thine handmaid,) whose year's-mind we are keeping.
+v. Bože, Hospodine odpuštění; dej duším svých služebníků a služebnic, jejichž výroční den uložení do hrobu si připomínáme, stolec občerstvení, blaženost spočinutí a světelnou jasnost.
 $Per Dominum
 
 [Invit]
-Unto the Eternal King all live. * O come, let us worship Him.
+Králi, pro nějž všichni žijí, * Pojďme se poklonit.
 
 [Ant Matutinum]
 Spravuj, * Hospodine, můj Bože, před svou tváří mou cestu.;;5

--- a/web/www/horas/Bohemice/CommuneM/C10.txt
+++ b/web/www/horas/Bohemice/CommuneM/C10.txt
@@ -1,6 +1,18 @@
+[Responsory Vespera] (rubrica cisterciensis)
+R.br. Po porodu jsi zůstala * neporušenou Pannou.
+R. Po porodu jsi zůstala * neporušenou Pannou.
+V. Boží Rodičko, přimlouvej se za nás.
+R. Meporušenou Pannou.
+
+[Responsory Vespera] (tempore adventus et rubrica cisterciensis)
+R.br. Anděl Páně * Zvěstoval Panně Marii.
+R. Anděl Páně * Zvěstoval Panně Marii.
+V. A ona počala z Ducha Svatého.
+R. Zvěstoval Panně Marii.
+
 [MM Capitulum]
 !Eccli 24:26-28
-v. Transíte ad me, omnes qui concupíscitis me, et a generatiónibus meis implémini: spíritus enim meus super mel dulcis, et heréditas mea super mel et favum: memória mea in generatióne sæculórum.
+v. Přistupte ke mně všichni, kdo po mně toužíte, a nasyťte se mými plody. Vždyť můj duch je nad med sladší, mé dědictví je nad plástev medu; má paměť potrvá po všechna pokolení.
 $Deo gratias
 _
 V. Krásnou ses stala, a sladkou.

--- a/web/www/horas/Bohemice/CommuneM/C2.txt
+++ b/web/www/horas/Bohemice/CommuneM/C2.txt
@@ -2,6 +2,9 @@
 V. Spravedlivý rozkvete jako lilie.
 R. A pokvete navěky před Hospodinem.
 
+[Ant 1] (rubrica cisterciensis)
+Blaze muži, * který trpí pokušení, neboť až bude vyzkoušen, přijme korunu života, kterou zaslíbil Bůh těm, kteří jej milují.
+
 [Ant 2] (rubrica cisterciensis)
 @Commune/C2:Ant 3:s/mě\./mě, praví Pán./
 

--- a/web/www/horas/Bohemice/Sancti/01-01.txt
+++ b/web/www/horas/Bohemice/Sancti/01-01.txt
@@ -27,7 +27,7 @@ v. Zjevila se milost Boha, našeho Spasitele, všem lidem, který nás naučila 
 $Deo gratias
 
 [Ant 1]
-Pro svou velikou * lásku, kterou nás miloval Bůh, poslal svého Syna v podobě hříšného těla, alleluja.
+Pro svou nesmírnou * lásku, kterou nás miloval Bůh, poslal svého Syna v podobě hříšného těla, alleluja.
 
 [Ant 1] (rubrica cisterciensis)
 Kdo je ze země, * mluví jako ze země; kdo však přichází z nebe, je nade vším: a co viděl a slyšel, o tom i svědčí, ale jeho svědectví nikdo nepřijímá; kdo však přijme jeho svědectví, dá tím na vědomí, že Bůh je pravdomluvný.
@@ -156,7 +156,7 @@ Among all that are born of women the Lord Jesus Christ stood alone in holiness. 
 &teDeum
 
 [Ant 2]
-This day is set forth a wonderful mystery, * a new thing hath been created in the earth: God is made man. That which He was, He remaineth; and that which He was not, He taketh; suffering therein neither confusion nor division.
+Podivuhodné tajemství * nám bylo dnes ukázáno: obnoveny jsou přirozenosti, Bůh se stal člověkem: tím, co byl, také zůstal, a čím nebyl, to na sebe vzal, a nestrpěl smísení <i>božské a lidské podstaty</i>, ani rozdělení.
 
 [Ant 3]
 Veliké * tajemství dědičnosti; chrámem Božím stalo se lůno, které nepoznalo muže a nebyl od ní poskvrněn tím, že přijal tělo, všechny Národy přišly a pravily: Sláva tobě, Pane!

--- a/web/www/horas/Bohemice/Sancti/01-01.txt
+++ b/web/www/horas/Bohemice/Sancti/01-01.txt
@@ -21,16 +21,19 @@ V keři, který uzřel Mojžíš * ohněm nestrávený, poznáváme tvé neporu�
 Vykvetl kořen Jesse, * vyšla hvězda z Jakuba. Panna porodila Spasitele, a my tě chválíme, Bože náš.;;126
 Hle, Maria * nám zrodila Spasitele. Když jej Jan uviděl, zvolal a řekl: „Hle, Beránek Boží, hle ten, který na sebe vzal hříchy světa, alleluja.“;;147
 
-[Capitulum Vespera]
+[Capitulum Laudes]
 !Titus 2:11-12
 v. Zjevila se milost Boha, našeho Spasitele, všem lidem, který nás naučila zavrhnout bezbožnost a světské touhy, a střízlivě, spravedlivě a zbožně žít v tomto světě.
 $Deo gratias
 
 [Ant 1]
-God, for His great love * wherewith He loved us, sent His Own Son in the likeness of sinful flesh. Alleluia.
+Pro svou velikou * lásku, kterou nás miloval Bůh, poslal svého Syna v podobě hříšného těla, alleluja.
+
+[Ant 1] (rubrica cisterciensis)
+Kdo je ze země, * mluví jako ze země; kdo však přichází z nebe, je nade vším: a co viděl a slyšel, o tom i svědčí, ale jeho svědectví nikdo nepřijímá; kdo však přijme jeho svědectví, dá tím na vědomí, že Bůh je pravdomluvný.
 
 [Oratio]
-Bože, jenž jsi plodné panenství blahoslavené Panny Marie požehnal a tak lidstvu udělil milost věčně spásy, dej, prosíme, aby­chom se přesvědčovali, že se za nás přimlouvá ta, jejímž prostřednictvím jsme obdrželi původce života, našeho Pána, Ježíše Krista, tvého Syna.
+Bože, jenž jsi plodné panenství blahoslavené Panny Marie požehnal a tak lidstvu udělil milost věčně spásy, dej, prosíme, abychom se přesvědčovali, že se za nás přimlouvá ta, jejímž prostřednictvím jsme obdrželi původce života, našeho Pána, Ježíše Krista, tvého Syna.
 $Qui tecum
 
 [Ant Matutinum]

--- a/web/www/horas/Bohemice/Sancti/01-02.txt
+++ b/web/www/horas/Bohemice/Sancti/01-02.txt
@@ -1,0 +1,6 @@
+[Rank]
+Oktáv sv. Štěpána Prvomučedníka
+
+[Oratio]
+Všemohoucí věčný Bože, jenž jsi prvotiny Mučedníků zasvětil krví blaženého Levity Štěpána; uděl, prosíme, aby se nám stal přímluvcem ten, který se i za své pronásledovatele přimlouval u našeho Pána Ježíše Krista, tvého Syna;
+$Qui tecum

--- a/web/www/horas/Bohemice/Sancti/12-25.txt
+++ b/web/www/horas/Bohemice/Sancti/12-25.txt
@@ -8,7 +8,14 @@ Naplnily se * dny Marii, aby porodila svého prvorozeného Syna.;;111
 Know ye that the kingdom * of God is at hand? Amen, I say unto you, it will not tarry.;;112
 Lift up your heads; * behold, your redemption draweth nigh.;;116
 
-[Capitulum Vespera]
+[Ant Vespera] (rubrica cisterciensis)
+Předtím, než spolu začali žít, * ukázalo se, že Maria počala z Ducha svatého, alleluja.;;109
+Josefe, synu Davidův, * neboj se přijmout Marii za svou manželku: dítě, které se z ní narodí, je z Ducha svatého, alleluja.;;110
+Naplnily se * dny Marii, aby porodila svého prvorozeného Syna.;;111
+Radujme se všichni věřící, * náš Spasitel se narodil do světa: dnes vyšlo potomstvo vznešeného rodu, avšak panenská čistota byla zachována.;;112
+Hle, již přišla * plnost času, v němž poslal Bůh svého Syna na zemi, narozeného z Panny, postaveného pod zákon, aby vykoupil podřízené zákonu.;;116
+
+[Capitulum Vespera 1]
 !Titus 3:4-5
 v. Zjevila se dobrota a liství našeho Spasitele, Boha; nikoliv pro spravedlivé činy, které jsme my vykonali, ale pro své milosrdenství nás <i>Bůh</i> spasil.
 $Deo gratias
@@ -53,12 +60,31 @@ Amen.
 [HymnusM Vespera]
 @:Hymnus Vespera
 
+[Versum 1] (rubrica cisterciensis)
+V. Požehnaný jenž přichází ve jménu Páně.
+R. Bůh Hospodin, a rozzářil se nad námi.
+
+[Ant 1] (rubrica cisterciensis)
+Když byla * zasnoubena Matka Ježíšova Maria s Josefem, ještě než spolu začali žít, ukázalo se, že počala; ovšem dítě, které se z ní narodilo, je z Ducha svatého, alleluja.
+
 [Oratio]
 Uděl nám, prosíme, všemohoucí Bože, aby nové Zrození tvého Jednorozeného v těle vysvobodilo nás, které odvěké otroctví drží pod jhem hříchu.
 $Per eumdem
 
 [Invit]
 Kristus se nám narodil, * Pojďte, klanějme se mu.
+
+[Nocturn 1 Versum]
+V. Jako ženich.
+R. Pán vystupuje ze své svatební komnaty.
+
+[Nocturn 2 Versum]
+V. Krásný vzhledem nade všechny lidské syny.
+R. Milost se rozlila na tvých rtech.
+
+[Nocturn 3 Versum]
+V. On sám mě vzýval, alleluja.
+R. Ty jsi můj otec, alleluja.
 
 [Lectio1]
 !Isa 9:1-6
@@ -118,7 +144,14 @@ R. Koho jste viděli, pastýři? povězte, zvěstujte nám, kdo se objevil na ze
 Spasitel náš, moji nejmilejší, se dnes narodil: Radujme se! Ani se nesluší poddávat se smutku dnes, v den, kdy se zrodil život. Tento život, když zvítězil nad strachem smrtelnosti, přinesl nám radost z přislíbené věčnosti. Nikdo není vyloučen z účasti na této radosti. Všichni máme společný důvod se radovat: náš Pán, ničitel hříchu a smrti, když nenašel nikoho, kdo by byl svoboden od hříchu, přišel, aby nás všechny vysvobodil.	Zajásej svatý, neboť se blížíš k palmě mučednictví. Zaraduj se hříšní­ku, neboť jsi pozván k odpuštění. Jásej Pohane, neboť jsi povolán k životu. Boží Syn totiž, když se naplnil čas určený nedozírnou hlubinou božského úradku, přijal lidskou přirozenost, aby ji smířil s jejím tvůrcem, aby totiž ďábel, tvůrce smrti, byl přemožen toutéž smrtí, kterou nás on sám přemáhá.
 
 [Lectio5]
-V tomto boji, do nějž kvůli nám Pán vstoupil, se bude bojovat podle velikého a podivuhodného práva rovnosti, kdy všemohoucí Pán bojuje s nejlítějším nepřítelem nikoliv ve své vznešenosti, nýbrž ponížen v naši ubohost. Postavil se mu tedy v obou formách, účasten sice naší smrtelnosti, avšak zcela bez hříchu. Tomuto zrození je tedy zcela cizí to, co čteme o ostatních: „Nikdo na zemi není čistý a bez hříchu, ani nemluvně staré jeden den.“ Nic tedy v tomto jedinečném zrození nepřešlo z žádostivosti těla, nic nezůstalo ze zákona hříchu.	
+V tomto boji, do nějž kvůli nám Pán vstoupil, se bude bojovat podle velikého a podivuhodného práva rovnosti, kdy všemohoucí Pán bojuje s nejlítějším nepřítelem nikoliv ve své vznešenosti, nýbrž ponížen v naši ubohost. Postavil se mu tedy v obou formách, účasten sice naší smrtelnosti, avšak zcela bez hříchu. Tomuto zrození je tedy zcela cizí to, co čteme o ostatních: „Nikdo na zemi není čistý a bez hříchu, ani nemluvně staré jeden den.“ Nic tedy v tomto jedinečném zrození nepřešlo z žádostivosti těla, nic nezůstalo ze zákona hříchu.
+
+[Ant Laudes] (rubrica cisterciensis)
+Zrodila matka * Krále, jehož jméno je věčné, a mateřské radosti spojila s panenskou ctí: a nebylo před ní podobné nalezeno, ani její následovnice, alleluja.
+Světlo vzešlo * nad námi, neboť dnes se narodil Spasitel, alleluja.
+Dnes Panna věrná, * třebaže zrodila vtělené Slovo, Pannou zůstala i po porodu, a my všichni ji chválíme slovy „Požehnaná jsi mezi ženami.“
+Radujme se všichni věřící, * náš Spasitel se narodil ve světě; dnes vzešlo potomstvo vznešeného rodu, avšak zachována byla panenská čistota. 
+Dnes * nám neporušená Panna zrodila Boha oděného v křehké tělo, jejž mohla kojit; všichni se mu klanějme, neboť přišel nás spasit.
 
 [Capitulum Laudes]
 !Heb 1:1-2
@@ -167,6 +200,10 @@ i Otci, Duchu milosti
 po všechny věky věčnosti.
 Amen.
 
+[Versum 2]
+V. Chlapec se nám narodil.
+R. Syn nám byl dán.
+
 [Ant 2]
 Sláva * na výsostech Bohu, a na zemi pokoj lidem dobré vůle, alleluja, alleluja.
 
@@ -174,10 +211,28 @@ Sláva * na výsostech Bohu, a na zemi pokoj lidem dobré vůle, alleluja, allel
 !Židům 1:11-12
 v. Oni zahynou, ty však vytrváš; a všichni zpuchří jako oděv; a jako plášť je vyměníš, a oni budou vyměněni; ty sám jsi však vždy stejný, a tvé roky nepominou.
 
+[Responsory Breve Tertia] (rubrica cisterciensis)
+R.br. Slovo se stalo tělem, * A přebývalo mezi námi.
+R. Slovo se stalo tělem, * A přebývalo mezi námi.
+V. A uviděli jsme jeho slávu, slávu, kterou má Jednorozený <i>Syn</i> od Otce.
+R. A přebývalo mezi námi.
+
 [Capitulum Sexta]
 !Židům 1:10
 v. A; Ty jsi, Pane, na začátku stvořil zemi; a dílem tvých rukou jsou nebesa. 
 $Deo gratias
+
+[Responsory Breve Sexta] (rubrica cisterciensis)
+R.br. Požehnaný, jenž přichází,  * Ve jménu Páně.
+R. Požehnaný, jenž přichází,  * Ve jménu Páně.
+V. Bůh Hospodin, a rozzářil se nad námi.
+R. Ve jménu Páně.
+
+[Ant Vespera 3] (rubrica cisterciensis)
+Na počátku * a před věky Bůh byl Slovo: právě on se nám narodil jako Spasitel světa.;;109
+Panna Slovo počala, * Pannou zůstala, jako Pana porodila Krále všech králů.;;110
+Blažené lůno, * které tě nosilo, Kriste, a blažené prsy, které tě kojily, Hospodina, a Spasitele světa, alleluja.;;111
+Zazářil nám den * nového vykoupení, napravení pradávné viny, <i>den</i> věčného štěstí.;;131
 
 [Ant 3]
 Dnes * se narodil Kristus; dnes se ukázal Spasitel; dnes na zemi zpívají Andělé, radují se Archandělé; dnes jásají spravedliví, a říkají: „Sláva na výsostech Bohu, alleluja.“

--- a/web/www/horas/Bohemice/Sancti/12-25.txt
+++ b/web/www/horas/Bohemice/Sancti/12-25.txt
@@ -236,3 +236,28 @@ Zazářil nám den * nového vykoupení, napravení pradávné viny, <i>den</i> 
 
 [Ant 3]
 Dnes * se narodil Kristus; dnes se ukázal Spasitel; dnes na zemi zpívají Andělé, radují se Archandělé; dnes jásají spravedliví, a říkají: „Sláva na výsostech Bohu, alleluja.“
+
+[Octava 3] (rubrica cisterciensis)
+!Připomínka Oktávu Narození Páně
+Ant. Nepoznala panenská Matka muže, porodila však bez bolesti Spasitele světa, a samotného Krále Andělů sama Panna kojila ňadry naplněnými z nebes.
+_
+V. Chlapec se nám narodil.
+R. Syn nám byl dán.
+_
+$Oremus
+v. Uděl nám, prosíme, všemohoucí Bože, aby nové Zrození tvého Jednorozeného v těle vysvobodilo nás, které odvěké otroctví drží pod jhem hříchu.
+$Per eumdem
+
+[Octava 2] (rubrica cisterciensis)
+!Připomínka Oktávu Narození Páně
+Ant. Slovo se stalo tělem, a přebývalo mezi námi; a uzřeli jsme jeho slávu, slávu, kterou má Jednorozený <i>Syn</i> od Otce, plný milosti a pravdy, alleluja, alleluja, alleluja.
+_
+V. Chlapec se nám narodil.
+R. Syn nám byl dán.
+_
+$Oremus
+v. Uděl nám, prosíme, všemohoucí Bože, aby nové Zrození tvého Jednorozeného v těle vysvobodilo nás, které odvěké otroctví drží pod jhem hříchu.
+$Per eumdem
+
+[Octava 1]
+@:Octava 3

--- a/web/www/horas/Bohemice/Sancti/12-26.txt
+++ b/web/www/horas/Bohemice/Sancti/12-26.txt
@@ -1,0 +1,227 @@
+[Rank]
+Sv. Štěpána Prvomučedníka
+
+[Ant 1]
+Štěpán pak, * naplněn milostí i mocí, konal veliká znamení mezi lidem.
+
+[Oratio]
+Dej nám, prosíme, Pane, napodobovat, co uctíváme; abychom se naučili milovat své nepřátele, neboť slavíme Narození pro nebe toho, jenž se i za své pronásledovatele dokázal modlit k našemu Pánu Ježíši Kristu, tvému Synu:
+$Qui tecum
+
+[Commemoratio] (rubrica cisterciensis)
+!Připomínka všech Svatých Mučedníků
+@CommuneM/C3:Oratio proper
+v. Bože, jenž nás rozradostňuješ každoroční slavností všech svatých Mučedníků; uděl laskavě, abychom, když se radujeme z jejich zásluh, byli podníceni jejich příklady.
+$Per Dominum
+
+[Invit]
+He That once a little Child, Shivering in the manger lay, Set on Stephen's blessed head, A crown that fadeth not away; * O come, let us worship Him!
+
+[Lectio1]
+Lesson from the Acts of Apostles
+!Acts 6:1-6
+1 And in those days, the number of the disciples increasing, there arose a murmuring of the Greeks against the Hebrews, for that their widows were neglected in the daily ministration.
+2 Then the twelve calling together the multitude of the disciples, said: It is not reason that we should leave the word of God, and serve tables.
+3 Wherefore, brethren, look ye out among you seven men of good reputation, full of the Holy Ghost and wisdom, whom we may appoint over this business.
+4 But we will give ourselves continually to prayer, and to the ministry of the word.
+5 And the saying was liked by all the multitude. And they chose Stephen, a man full of faith, and of the Holy Ghost, and Philip, and Prochorus, and Nicanor, and Timon, and Parmenas, and Nicolas, a proselyte of Antioch.
+6 These they set before the apostles; and they praying, imposed hands upon them.
+
+[Responsory1]
+R. And Stephen, full of grace and power
+* Did great wonders and miracles among the people.
+V. There arose certain of the synagogue, disputing with Stephen; and they were not able to resist the wisdom, and the Spirit which spoke.
+R. Did great wonders and miracles among the people.
+
+[Lectio2]
+!Acts 6:7-10;7:54
+7 And the word of the Lord increased; and the number of the disciples was multiplied in Jerusalem exceedingly: a great multitude also of the priests obeyed the faith.
+8 And Stephen, full of grace and fortitude, did great wonders and signs among the people.
+9 Now there arose some of that which is called the synagogue of the Libertines, and of the Cyrenians, and of the Alexandrians, and of them that were of Cilicia and Asia, disputing with Stephen.
+10 And they were not able to resist the wisdom and the spirit that spoke.
+54 Now hearing these things, they were cut to the heart, and they gnashed with their teeth at him.
+
+[Responsory2]
+R. All that sat in the council, looking steadfastly on Stephen, saw
+* His face as it had been the face of an angel standing among them.
+V. Full of grace and power, he did great wonders and miracles among the people.
+R. His face as it had been the face of an angel standing among them.
+
+[Lectio3]
+!Acts 7:55-59
+55 But he, being full of the Holy Ghost, looking up steadfastly to heaven, saw the glory of God, and Jesus standing on the right hand of God. And he said: Behold, I see the heavens opened, and the Son of man standing on the right hand of God.
+56 And they crying out with a loud voice, stopped their ears, and with one accord ran violently upon him.
+57 And casting him forth without the city, they stoned him; and the witnesses laid down their garments at the feet of a young man, whose name was Saul.
+58 And they stoned Stephen, invoking, and saying: Lord Jesus, receive my spirit.
+59 And falling on his knees, he cried with a loud voice, saying: Lord, lay not this sin to their charge. And when he had said this, he fell asleep in the Lord.
+
+[Responsory3]
+R. The blessed Stephen looked up steadfastly into heaven, and saw the glory of God, and said
+* Behold, I see the heavens opened, and the Son of Man standing at the right hand of the power of God.
+V. But Stephen, being full of the Holy Ghost, looked up steadfastly into heaven, and saw the glory of God, and said
+R. Behold, I see the heavens opened, and the Son of man standing at the right hand of the power of God.
+&Gloria
+R. Behold, I see the heavens opened, and the Son of Man standing at the right hand of the power of God.
+
+[Lectio4]
+From the Sermons of St. Fulgentius, Bishop (of Ruspe.)
+!On St. Stephen
+Yesterday we were celebrating the birth in time of our Eternal King; today we celebrate the victory, through suffering, of one of His soldiers. Yesterday our King was pleased to come forth from His royal palace of the Virgin's womb, clothed in a robe of flesh, to visit the world; today His soldier, laying aside the tabernacle of the body, entereth in triumph into the heavenly palaces. The One, preserving unchanged that glory of the Godhead which He had before the world was, girded Himself with the form of a servant, and entered the arena of this world to fight sin; the other taketh off the garments of this corruptible body, and entereth into the heavenly mansions, where he will reign for ever. The One cometh down, veiled in flesh; the other goeth up, clothed in a robe of glory, red with blood.
+
+[Responsory4]
+R. They stoned Stephen, calling upon God and saying:
+* Lord Jesus Christ, receive my spirit; and lay not this sin to their charge.
+V. And he kneeled down, and cried with a loud voice, saying
+R. Lord Jesus Christ, receive my spirit; and lay not this sin to their charge.
+
+[Lectio5]
+The One cometh down amid the jubilation of angels; the other goeth up amid the stoning of the Jews. Yesterday the holy angels were singing, Glory to God in the highest; today there is joy among them, for they receive Stephen into their company. Yesterday the Lord came forth from the Virgin's womb; today His soldier is delivered from the prison of the body. Yesterday Christ was for our sakes wrapped in swaddling bands; today He girdeth Stephen with a robe of immortality. Yesterday the new-born Christ lay in a narrow manger; today Stephen entereth victorious into the boundless heavens. The Lord came down alone that He might raise many up; our King humbled Himself that He might set His soldiers in high places.
+
+[Responsory5]
+R. They ran upon him with one accord, and cast him out of the city, calling upon God, and saying:
+* Lord Jesus, receive my spirit.
+V. And the witnesses laid down their clothes at a young man's feet, whose name was Saul; and they stoned Stephen, calling upon God, and saying
+R. Lord Jesus, receive my spirit.
+
+[Lectio6]
+Why brethren, it behoveth us to consider with what arms Stephen was able, amid all the cruelty of the Jews, to remain more than conqueror, and worthily to attain to so blessed a triumph. Stephen, in that struggle which brought him to the crown whereof his name is a prophecy, had for armour the love of God and man, and by it he remained victorious on all hands. The love of God strengthened him against the cruelty of the Jews; and the love of his neighbour made him pray even for his murderers. Through love he rebuked the wandering, that they might be corrected; through love he prayed for them that stoned him, that they might not be punished. By the might of his love he overcame Saul his cruel persecutor; and earned for a comrade in heaven, the very man who had done him to death upon earth.
+
+[Responsory6]
+R. The ungodly fell upon the righteous, to put him to death.
+* But he received the stones with joy, that he might earn a crown of glory.
+V. They stopped their ears, and ran upon him with one accord.
+R. But he received the stones with joy, that he might earn a crown of glory.
+&Gloria
+R. But he received the stones with joy, that he might earn a crown of glory.
+
+[Lectio7]
+From the Holy Gospel according to Matthew
+!Matt 23:34-39
+At that time, Jesus said to the scribes and pharisee: I send to you prophets, and wise men, and scribes: and some of them you will put to death and crucify. And so on,
+_
+Homily by St. Jerome, Priest (at Bethlehem.)
+!Book IV, Commentary on Matth. XXIII
+We have already remarked that the Lord's words, Fill ye up the measure of your fathers, (32,) refer in the first place to Himself, Whom the Jews afterwards put to death. In a secondary sense it may likewise be applied to His disciples, of whom He saith, Behold, I send unto you Prophets, and wise men, and Scribes. Here observe that, according to the Apostle writing to the Corinthians, (1 Cor. xii. 4,) there are diversities of gifts among Christ's followers. Some are Prophets of that which is to come; some are wise men, who know the due season for rebuke and exhortation; some are Scribes learned in the law. And of these they stoned Stephen, slew Paul with the sword, crucified Peter, and scourged the Disciples mentioned in the Acts of the Apostles. (v, 40; xvi, 23.)
+
+[Responsory7]
+R. Stephen, the servant of God, who was stoned by the Jews, saw the heavens opened he saw and entered in.
+* Blessed is he, unto whom the heavens were opened.
+V. While his poor body was crushed by the hurtling shower of stones, God's brightness broke upon him out of the heavenly palaces.
+R. Blessed is he unto whom the heavens were opened.
+
+[Lectio8]
+It is a subject of dispute among commentators who is meant by Zacharias the son of Barachias. We read of several persons of the name of Zacharias. But here, in order to prevent any mistake, it is particularly said, Whom ye slew between the temple and the altar. I have read various opinions in various places upon this question, and I will give each. First, some hold that Zacharias the son of Barachias is the eleventh of the twelve Minor Prophets; and this opinion is supported by the father's name. But the Bible nowhere telleth us that this Prophet was slain between the temple and the altar; and it is hardly possible that he can have been, for in his time it could scarcely be said that even the ruins of the temple were in existence. Secondly, others maintain that this Zacharias was Zacharias, the father of John the Baptist. This interpretation is derived from the dreams of the Apocryphal Gospels, wherein it is asserted that he was martyred for preaching Christ's coming.
+
+[Responsory8]
+R. The gates of heaven were opened to Christ's blessed martyr Stephen, and he is the first of all the martyrs.
+* Wherefore he reigneth crowned in heaven.
+V. For he was the first to make an offering of his death to that Saviour Who vouchsafed to suffer death for us.
+R. Wherefore he reigneth crowned in heaven.
+&Gloria
+R. Wherefore he reigneth crowned in heaven.
+
+[Lectio9]
+A third school will have it that this Zacharias, the son of Barachias, was that Zacharias of whom we read, in Chron. xxiv. 22, that he was slain by Joash, king of Judah, between the temple and the altar. Against this it is to be remarked, that that Zacharias was not the son of Barachias, but of Jehoiada the priest; whence it is written, Joash remembered not the kindness which Jehoiada his father had done to him. The question therefore ariseth, if this opinion be true, why, the name and manner of death both agreeing with this explanation, Zacharias is called the son, not of Jehoiada, but of Barachias. In Hebrew, Barachias signifieth the Blessed of the Lord, and Jehoiada proves his Righteousness. In the Gospel used by the Nazarenes the name of Jehoiada is used instead of Barachias.
+&teDeum
+
+[Ant Laudes]
+They stoned Stephen, * calling upon God, and saying: Lay not this sin to their charge.
+The stones of the brook * were sweet to him; all the souls of the righteous follow him.
+O my God, my soul followeth hard after thee, * for my flesh hath been stoned for thy sake.
+Stephen saw the heavens opened; * he saw and entered in; blessed is he unto whom the heavens were opened.
+Behold, I see * the heavens opened, and Jesus standing on the right hand of the power of God.
+
+[Ant Laudes] (rubrica cisterciensis)
+Když však * Štěpán, naplněn Duchem svatým, hleděl do nebe, uviděl slávu Boží, a Ježíše, stojícího po pravici Otce.
+Kamenovali * Židé Štěpána, když on zvolal: Pane Ježíši, přijmi mého ducha.
+Přilnula má duše k tobě, * vždyť mé tělo je kamenováno pro tebe, můj Bože.
+Štěpán uviděl * nebesa otevřená, viděl je a vstoupil: blažen je člověk, jemuž se nebesa otevřela.
+Padl na kolena, * a velikým hlasem Štěpán zvolal: Pane Ježíši, nepříčítej jim tento hřích.
+
+[Capitulum Laudes]
+!Skutky 6:8
+v. A Štěpán, * naplněn milostí i silou, konal veliká znamení mezi lidem.
+$Deo gratias
+
+[Versum 2]
+V. Bohabojní muži pohřbili Štěpána.
+R. A drželi nad ním veliký smutek.
+
+[Versum 2] (rubrica cisterciensis)
+@CommuneM/C2
+
+[Ant 2] (rubrica cisterciensis)
+Otevřely se * nebeské brány Kristovu Mučedníku Štěpánovi, jenž se v počtu Mučedníků nachází jako první, a proto se jako vítěz raduje v nebe korunován, alleluja.
+
+[Octava 2]
+!Připomínka Oktávu sv. Štěpána
+Ant. Štěpán pak, * naplněn milostí i mocí, konal veliká znamení mezi lidem.
+_
+V. Bohabojní muži pohřbili Štěpána.
+R. A drželi nad ním veliký smutek.
+_
+$Oremus
+Dej nám, prosíme, Pane, napodobovat, co uctíváme; abychom se naučili milovat své nepřátele, neboť slavíme Narození pro nebe toho, jenž se i za své pronásledovatele dokázal modlit k našemu Pánu Ježíši Kristu, tvému Synu:
+$Qui tecum
+
+[Octava 2] (rubrica cisterciensis)
+!Připomínka Oktávu sv. Štěpána
+Ant. Když však * Štěpán, naplněn Duchem svatým, hleděl do nebe, uviděl slávu Boží, a Ježíše, stojícího po pravici Otce.
+_
+@CommuneM/C2:Versum 2
+(sed die Nat29)
+@Commune/C2:Versum 1
+_
+$Oremus
+Dej nám, prosíme, Pane, napodobovat, co uctíváme; abychom se naučili milovat své nepřátele, neboť slavíme Narození pro nebe toho, jenž se i za své pronásledovatele dokázal modlit k našemu Pánu Ježíši Kristu, tvému Synu:
+$Qui tecum
+
+[Lectio Prima]
+!Skutky 7:59
+v. Klesl pak na kolena a hlasitě zvolal: „Pane, nepřičítej jim tento hřích.“ A po těchto slovech zesnul v Pánu.
+
+[Capitulum Sexta]
+!Skutky 6:9-10
+v. Povstali pak někteří ze Synagogy, jež se nazývala Synagogou Propuštěnců, též Kyrénští, Alexandrijští, a těch, kteří byli z Kilikie a Asie, a disputovali se Štěpánem; avšak nedokázali odolat jeho moudrosti a Duchu, který mluvil.
+$Deo gratias
+
+[Capitulum Nona] (rubrica cisterciensis)
+!Skutky 7
+v. Když však Štěpán, naplněn Duchem svatým, hleděl do nebe, uviděl slávu Boží, a Ježíše, stojícího po pravici Boží.
+$Deo gratias
+
+[Versum 3]
+V. Štěpán viděl nebesa otevřená.
+R. Viděl a vstoupil. Blažený člověk, jemuž se nebesa otevřela.
+
+[Versum 3] (rubrica cisterciensis)
+@CommuneM/C2
+
+[Ant 3]
+Bohabojní muži pohřbili Štěpána * a drželi nad ním veliký smutek.
+
+[Ant 3] (rubrica cisterciensis)
+Když pohlédl do nebe, * uzřel blažený Štěpán slávu Boží, a řekl: "Hle, vidím nebesa otevřená, a Syna člověka stojícího po pravici Boží."
+
+[Octava 3]
+!Připomínka Oktávu sv. Štěpána
+Ant. Bohabojní muži pohřbili Štěpána * a drželi nad ním veliký smutek.
+_
+V. Štěpán viděl nebesa otevřená.
+R. Viděl a vstoupil. Blažený člověk, jemuž se nebesa otevřela.
+_
+$Oremus.
+Dej nám, prosíme, Pane, napodobovat, co uctíváme; abychom se naučili milovat své nepřátele, neboť slavíme Narození pro nebe toho, jenž se i za své pronásledovatele dokázal modlit k našemu Pánu Ježíši Kristu, tvému Synu:
+$Qui tecum
+
+[Octava 3] (rubrica cisterciensis)
+!Připomínka Oktávu sv. Štěpána
+Ant. Štěpán uviděl * nebesa otevřená, viděl je a vstoupil: blažen je člověk, jemuž se nebesa otevřela.
+_
+@CommuneM/C2:Versum 2
+(sed die Nat28)
+@Commune/C2:Versum 1
+_
+$Oremus.
+Dej nám, prosíme, Pane, napodobovat, co uctíváme; abychom se naučili milovat své nepřátele, neboť slavíme Narození pro nebe toho, jenž se i za své pronásledovatele dokázal modlit k našemu Pánu Ježíši Kristu, tvému Synu:
+$Qui tecum

--- a/web/www/horas/Bohemice/Sancti/12-27.txt
+++ b/web/www/horas/Bohemice/Sancti/12-27.txt
@@ -1,0 +1,211 @@
+[Rank]
+sv. Jana, Apoštola a Evangelisty
+
+[Versum 1]
+V. Opravdu hoden cti je blažený Apoštol Jan.
+R. Jenž při poslední večeři ležel na hrudi Páně.
+
+[Versum 1] (rubrica cisterciensis)
+@CommuneM/C1
+
+[Ant 1]
+Toto je Jan, * který ležel na hrudi Páně při večeři; blažený Apoštol, jemuž byla odhalena nebeská tajemství.
+
+[Oratio]
+Církev svou, Pane, laskavě osvěť; aby osvětlena naukami svatého Jana, tvého Apoštola a Evangelisty, došla až k darům věčným.
+$Per Dominum
+
+[Lectio1]
+Lesson from the first letter of St. John the Apostle
+!1 John 1:1-5
+1 That which was from the beginning, which we have heard, which we have seen with our eyes, which we have looked upon, and our hands have handled, of the word of life:
+2 For the life was manifested; and we have seen and do bear witness, and declare unto you the life eternal, which was with the Father, and hath appeared to us:
+3 That which we have seen and have heard, we declare unto you, that you also may have fellowship with us, and our fellowship may be with the Father, and with his Son Jesus Christ.
+4 And these things we write to you, that you may rejoice, and your joy may be full.
+5 And this is the declaration which we have heard from him, and declare unto you: That God is light, and in him there is no darkness.
+
+[Responsory1]
+R. Right worthy of honour is the blessed Apostle John, who leaned on the Lord's bosom at the Last Supper.
+* To Him did Christ upon the Cross commit His mother, virgin to virgin.
+V. The Lord chose him for his clean maidenhood, and loved him more than all the rest.
+R. To him did Christ upon the Cross commit His mother, virgin to virgin.
+
+[Lectio2]
+!1 John 1:6-10
+6 If we say that we have fellowship with him, and walk in darkness, we lie, and do not the truth.
+7 But if we walk in the light, as he also is in the light, we have fellowship one with another, and the blood of Jesus Christ his Son cleanseth us from all sin.
+8 If we say that we have no sin, we deceive ourselves, and the truth is not in us.
+9 If we confess our sins, he is faithful and just, to forgive us our sins, and to cleanse us from all iniquity.
+10 If we say that we have not sinned, we make him a liar, and his word is not in us.
+
+[Responsory2]
+R. This is the disciple which testifieth of these things, and wrote these things.
+* And we know that his testimony is true.
+V. He drank in the rivers of the Gospel from the Lord's Breast as from an holy fountain.
+R. And we know that his testimony is true.
+
+[Lectio3]
+!1 John 2:1-5
+1 My little children, these things I write to you, that you may not sin. But if any man sin, we have an advocate with the Father, Jesus Christ the just:
+2 And he is the propitiation for our sins: and not for ours only, but also for those of the whole world.
+3 And by this we know that we have known him, if we keep his commandments.
+4 He who saith that he knoweth him, and keepeth not his commandments, is a liar, and the truth is not in him.
+5 But he that keepeth his word, in him in very deed the charity of God is perfected.
+
+[Responsory3]
+R. This is that most blessed Evangelist and Apostle John.
+* Who was found worthy that the Lord should honour him more than all the rest, by a special privilege of love.
+V. This is the disciple whom Jesus loved, which also leaned on the Lord's Breast at supper.
+R. Who was found worthy that the Lord should honour him more than all the rest, by a special privilege of love.
+&Gloria
+R. Who was found worthy that the Lord should honour him more than all the rest, by a special privilege of love.
+
+[Lectio4]
+From the Book on Ecclesiastical writers, written by St. Jerome, Priest (at Bethlehem.) 
+!Ch. 9
+The Apostle John whom Jesus loved was a son of Zebedee, and brother of the Apostle James, who was beheaded by Herod soon after our Lord suffered. He was the last of the Evangelists to write his Gospel, which he published at the request of the Bishops of Asia, against Cerinthus and other heretics, and particularly against the then spreading doctrine of the Ebionites, who asserted that Christ had had no existence before Mary. It was therefore needful for the Evangelist to declare His Eternal and Divine Generation.
+
+[Responsory4]
+R. Him that overcometh will I make a pillar in My temple, saith the Lord,
+* And I will write My name upon him, and the name of the city, which is New Jerusalem.
+V. To him that overcometh will I give to eat of the tree of life, which is in the midst of the Paradise of My God.
+R. And I will write My name upon him, and the name of the city, which is New Jerusalem.
+
+[Lectio5]
+In the fourteenth year after Nero, Domitian stirred up the second persecution, and John was exiled to the island of Patmos, where he wrote his Apocalypse, which hath been explained by Justin the Martyr and Irenaeus. When Domitian was killed, the Senate annulled all his acts, on account of his savage cruelty, and the Apostle returned to Ephesus, during the reign of Nerva. He remained at Ephesus until the time of Trajan, and founded and governed all the Churches of Asia. There, in an extreme old age, he died, in the sixty-eighth year after the Lord's passion, and was buried near the city.
+
+[Responsory5]
+R. Jesus loved him, because his singular gift of purity made him more worthy of love.
+* He chose him for a virgin unto Himself, and he remaineth a virgin for ever.
+V. At the end, when He was dying upon the Cross, to him did He commit His mother, maiden to maiden.
+R. He chose him for a virgin unto Himself, and he remaineth a virgin for ever.
+
+[Lectio6]
+From the Commentary upon the Epistle to the Galatians, by the same author
+!Book 3, Ch. 6
+The Blessed Evangelist John lived at Ephesus down to an extreme old age, and, at length, when he was with difficulty carried to the Church, and was not able to exhort the congregation at length, he was used simply to say at each meeting, My little children, love one another. At last the disciples and brethren were weary with hearing these words continually, and asked him, Master, wherefore ever sayest thou this only? Whereto he replied to them, (worthy of John,) It is the commandment of the Lord, and if this only be done, it is enough.
+
+[Responsory6]
+R. In the midst of the congregation did the Lord open his mouth.
+* And filled him with the spirit of wisdom and understanding.
+V. He made him rich with joy and gladness.
+R. And filled him with the spirit of wisdom and understanding.
+&Gloria
+R. And filled him with the spirit of wisdom and understanding.
+
+[Lectio7]
+From the Holy Gospel according to John
+!John 21:19-24
+In that time Jesus said to Peter: Follow me. Peter turning about, saw that disciple whom Jesus loved following. And so on.
+_
+Homily on this passage by St. Augustine, Bishop (of Hippo)
+!124 on the Tract on John
+The Church knoweth of two different lives, which God hath revealed and blessed: one is the life of faith, the other the life of knowledge; one the life of this pilgrimage, the other the life of the eternal mansions; one the life of work, the other the life of rest; one the life of the journey, the other the life of home; one the life of action, the other the life of contemplation. The one escheweth evil and doeth good; the other hath no evil to eschew, and only an exceeding good to enjoy. The one striveth with the enemy, the other hath no enemies, and reigneth.
+
+[Responsory7]
+R. In that day will I take thee, O My servant, and will make thee as a signet before Me.
+* For I have chosen thee, saith the Lord.
+V. Be thou faithful unto death, and I will give thee a crown of life.
+R. For I have chosen thee, saith the Lord.
+
+[Lectio8]
+The one succoureth the needy; the other is where there are no needy to succour. The one forgiveth them that trespass against it, that its own trespasses may be forgiven; the other neither hath trespasses to forgive nor to be forgiven. The one is chastened with evil, lest it be exalted above measure by good; the other enjoyeth such a fulness of grace that it feeleth no evil, and cleaveth so firmly unto the Highest Good, that it hath no temptation to pride.
+
+[Responsory8]
+R. This is that John which leaned on the Lord's Breast at supper
+* Even that blessed Apostle unto whom were made known the secret things of heaven.
+V. He drank in the rivers of the Gospel from the Lord's Breast, as from an holy fountain.
+R. Even that blessed Apostle unto whom were made known the secret things of heaven.
+&Gloria
+R. Even that blessed Apostle unto whom were made known the secret things of heaven.
+
+[Lectio9]
+Therefore the one is good, but still sorrowful; the other is better and perfectly blessed. And of these two lives there are types, of the one in the Apostle Peter, of the other in John. The one laboureth here even unto the end, and findeth its end hereafter; the other stretcheth out into the hereafter, and in eternity findeth no end. Therefore is it said unto the one, Follow Me; but of the other, If I will that he tarry till I come, what is that to thee? Follow thou Me. What is the meaning of these words? who can know? who can understand? what is it? is it Follow thou Me, imitating Me in the bearing of earthly sorrow; let him tarry till I come again, bringing the everlasting reward?
+&teDeum
+
+[Ant Laudes]
+Right worthy of honour * is the blessed Apostle John, who leaned on the Lord's bosom at the Last Supper.
+This is the disciple * which testifieth of these things, and we know that his testimony is true.
+This is My disciple * if I will that he tarry till I come?
+There be some standing here, * which shall not taste of death, till they see the Son of man in His kingdom.
+Behold My servant, * whom I have chosen, I have put My spirit upon him.
+
+[Ant Laudes] (rubrica cisterciensis)
+Hle, můj služebník * vyvolený, jejž jsem si vyvolil, a seslal na něj svého Ducha.
+On je ten učedník, * který vydává svědectví o těchto věcech; a víme, že jeho svědectví je pravdivé.
+Seslal Pán * svou ruku, a dotkl se mých úst, a naplnil je.
+Někteří z těch, kteří zde stojí, * nepoznají smrt, dokud neuvidí Syna člověka v jeho království.
+Ovšem Apoštol Jan, * panic Bohem vyvolený, byl tím, jemuž Pán jako panici svěřil svou panenskou Matku.
+
+[Capitulum Laudes]
+!Sir 15:1-2
+v. Kdo se bojí Boha, koná dobro: a komu leží na srdci spravedlnost, zachovává ji~
+a ona mu vyjde vstříc jako ctihodná matka.
+$Deo gratias
+
+[Versum 2]
+V. To je ten učedník, který vydal svědectví o těchto věcech.
+R. A my víme, že jeho svědectví je pravdivé.
+
+[Versum 2] (rubrica cisterciensis)
+@CommuneM/C1
+
+[Ant 2] (rubrica cisterciensis)
+Uprostřed * shromáždění otevřel Pán jeho ústa, a naplnil jej duchem moudrosti a poznání, alleluja.
+
+[Octava 2]
+!Připomínka Oktávu sv. Jana
+Ant. Toto je Jan, * který ležel na hrudi Páně při večeři; blažený Apoštol, jemuž byla odhalena nebeská tajemství.
+_
+V. To je ten učedník, který vydal svědectví o těchto věcech.
+R. A my víme, že jeho svědectví je pravdivé.
+_
+$Oremus
+v. Církev svou, Pane, laskavě osvěť; aby osvětlena naukami svatého Jana, tvého Apoštola a Evangelisty, došla až k darům věčným.
+$Per Dominum
+
+[Octava 2] (rubrica cisterciensis)
+!Připomínka Oktávu sv. Jana
+Ant. On je ten učedník, * který vydává svědectví o těchto věcech; a víme, že jeho svědectví je pravdivé.
+_
+@CommuneM/C1:Versum 2
+_
+$Oremus
+v. Církev svou, Pane, laskavě osvěť; aby osvětlena naukami svatého Jana, tvého Apoštola a Evangelisty, došla až k darům věčným.
+$Per Dominum
+
+[Lectio Prima]
+!Sir 15:5
+v. Uprostřed Shromáždění otevřel svá ústa, a Pán jej naplnil duchem moudrosti a poznání, a oblékl jej ve štólu slávy.
+
+[Capitulum Sexta]
+!Sir 15:3
+v. Za pokrm mu dal chléb života a poznání, a vodu spásné moudrosti dal mu pít Pán, náš Bůh. 
+$Deo gratias
+
+[Ant 3]
+A saying * went abroad among the brethren, that that disciple should not die; and Jesus did not say that he should not die, but so will I have him remain till I come.
+
+[Ant 3] (rubrica cisterciensis)
+Jan byl Apoštol * a Evangelista, panic, jehož si Pán vyvolil, a někteří jej velmi milovali.
+
+[Octava 3]
+!Připomínka Oktávu sv. Jana
+Ant. A saying went abroad * among the brethren, that that disciple should not die; and Jesus did not say that he should not die, but so will I have him remain till I come.
+_
+V. Opravdu hoden cti je blažený Apoštol Jan.
+R. Jenž při poslední večeři ležel na hrudi Páně.
+_
+$Oremus
+v. Církev svou, Pane, laskavě osvěť; aby osvětlena naukami svatého Jana, tvého Apoštola a Evangelisty, došla až k darům věčným.
+$Per Dominum
+
+[Octava 3] (rubrica cisterciensis)
+!Připomínka Oktávu sv. Jana
+Ant. Ovšem Apoštol Jan, * panic Bohem vyvolený, byl tím, jemuž Pán jako panici svěřil svou panenskou Matku.
+_
+@CommuneM/C1:Versum 2
+_
+$Oremus
+v. Církev svou, Pane, laskavě osvěť; aby osvětlena naukami svatého Jana, tvého Apoštola a Evangelisty, došla až k darům věčným.
+$Per Dominum

--- a/web/www/horas/Bohemice/Sancti/12-28.txt
+++ b/web/www/horas/Bohemice/Sancti/12-28.txt
@@ -1,0 +1,253 @@
+[Rank]
+Svatých Neviňátek, Mučedníků
+
+[Versum 1]
+V. Rozlícený Herodes pobil mnoho dětí.
+R. V judském Betlémě, městě Davidově.
+
+[Ant 1]
+To jsou ti, * kteří nedošli poskvrnění se ženami; jsou totiž panicové,~
+a následují Beránka, kamkoliv jde.
+
+[Versum 1] (rubrica cisterciensis)
+@CommuneM/C3
+
+[Oratio]
+Bože, jehož chválu dnešního dne Neviňátka jako mučedníci, nikoliv řečí, ale smrtí vyznala, veškeré zlo hříchů v nás umrtvi, aby víru v tebe, kterou vyznává náš jazyk, také život mravy hlásal.
+$Per Dominum
+
+[Hymnus Matutinum]
+v. Zděšený tyran slyší zvěst,
+že Vladař vládců tu již jest,
+že má vést Izraelův dům,
+zasednout na Davidův trůn.
+_
+Omráčen zprávou, strhne křik:
+Mám už jít, je tu následník.
+Biřici, pospěš pro kopí,
+ať kolébky krev zatopí.
+_
+K čemu ten hrozný zločin je,
+jak Herodovi prospěje?
+Zdráv mezi všemi mrtvými
+unikne Kristus jediný.
+_
+Buď sláva tobě, Ježíši,
+zrozený z Panny nejčistší,
+i Otci, Duchu milosti
+po všechny věky věčnosti.
+Amen.
+
+[Ant Matutinum 11]
+These are they * which came out of great tribulation, and have washed their robes in the blood of the Lamb.
+
+[Lectio1]
+Lesson from the book of Jeremias
+!Jer 31:15-17
+15 Thus saith the Lord: A voice was heard on high of lamentation, of mourning, and weeping, of Rachel weeping for her children, and refusing to be comforted for them, because they are not.
+16 Thus saith the Lord: Let thy voice cease from weeping, and thy eyes from tears: for there is a reward for thy work, saith the Lord: and they shall return out of the land of the enemy.
+17 And here is hope for thy last end, saith the Lord: and the children shall return to their own borders.
+
+[Responsory1]
+R. A hundred forty four thousand, which were redeemed from the earth; these are they which were not defiled with women.
+* For they remained virgins; therefore are they kings before God, and the Lamb of God is with them.
+V. These are they which came out of great tribulation, and have washed their robes in the Blood of the Lamb.
+R. For they remained virgins; therefore are they kings before God, and the Lamb of God is with them.
+
+[Lectio2]
+!Jer 31:18-20
+18 Hearing I heard Ephraim when he went into captivity: thou hast chastised me, and I was instructed, as a young bullock unaccustomed to the yoke. Convert me, and I shall be converted, for thou art the Lord my God.
+19 For after thou didst convert me, I did penance: and after thou didst shew unto me, I struck my thigh: I am confounded and ashamed, because I have borne the reproach of my youth.
+20 Surely Ephraim is an honourable son to me, surely he is a tender child: for since I spoke of him, I will still remember him.
+
+[Responsory2]
+R. I heard under the altar the voices of them that were slain, saying:
+* How long dost Thou not avenge our blood? And it was said unto them from God: Rest yet for a little season, until the number of your brethren be fulfilled.
+V. I saw under the altar of God the souls of them that were slain for the Word of God, and for the testimony which they held, and they cried with a loud voice, saying:
+R. How long dost Thou not avenge our blood? And it was said unto them from God: Rest yet for a little season, until the number of your brethren be fulfilled.
+
+[Lectio3]
+!Jer 31:21-23
+21 Set thee up a watchtower, make to thee bitterness: direct thy heart into the right way, wherein thou hast walked: return, O virgin of Israel, return to these thy cities.
+22 How long wilt thou be dissolute in deliciousness, O wandering daughter? for the Lord hath created a new thing upon the earth: A woman shall compass a man.
+23 Thus saith the Lord of hosts, the God of Israel: As yet shall they say this word in the land of Juda, and in the cities thereof, when I shall bring back their captivity: The Lord bless thee, the beauty of justice, the holy mountain.
+
+[Responsory3]
+R. They worshipped Him That liveth for ever and ever.
+* And cast their crowns before the throne of the Lord their God.
+V. And they fell down upon their faces before the throne, and blessed Him That liveth for ever and ever.
+R. And cast their crowns before the throne of the Lord their God.
+&Gloria
+R. And cast their crowns before the throne of the Lord their God.
+
+[Lectio4]
+From the Sermons of St. Augustine, Bishop (of Hippo)
+!10th on the Saints
+Dearly beloved brethren, today we keep the birthday of those children, who, as we are informed by the Gospel, were massacred by the savage King Herod. Therefore let earth rejoice with exceeding joy, for she is the mother of these heavenly soldiers, and of this numerous host. The love of the vile Herod could never have crowned these blessed ones as hath his hatred. For the Church testifieth by this holy solemnity, that whereas iniquity did specially abound against these little saints, so much the more were heavenly blessings poured out upon them.
+
+[Responsory4]
+R. The blood of thy saints have they shed like water round about Jerusalem.
+* And there was none to bury them.
+V. The dead bodies of thy servants have they given to be meat unto the fowls of the air, the flesh of thy saints unto the beasts of the earth.
+R. And there was none to bury them.
+
+[Lectio5]
+Blessed art thou, O Bethlehem in the land of Judah, which hast suffered the cruelty of King Herod in the slaughter of thy children; who art found worthy to offer at once to God a whole white-robed army of guileless martyrs! Surely, it is well to keep their birthday, even that blessed birthday which gave them from earth to heaven, more blessed than the day that brought them out of their mother's womb. Scarcely had they entered on the life that now is, when they obtained that glorious life which is to come.
+
+[Responsory5]
+R. These holy ones suffered for thy sake, O Lord take vengeance for them.
+* For day by day they cry unto thee.
+V. Avenge, O Lord, the blood of thy saints which is shed.
+R. For day by day they cry unto thee.
+
+[Lectio6]
+We praise the death of other martyrs because it was the crowning act of an undaunted and persistent testimony; but these were crowned at once. He That maketh an end to this present life, gave to them at its very gates that eternal blessedness which we hope for at its close. They whom the wickedness of Herod tore from their mothers' breasts are rightfully called the flowers of martyrdom; hardly had these buds of the Church shown their heads above the soil, in the winter of unbelief, when the frost of persecution nipped them.
+
+[Responsory6]
+R. These are they which have not defiled their garments.
+* They shall walk with Me in white, for they are worthy.
+V. These are they which were not defiled with women for they are virgins.
+R. They shall walk with Me in white, for they are worthy.
+&Gloria
+R. They shall walk with Me in white, for they are worthy.
+
+[Lectio7]
+From the Holy Gospel according to Matthew
+!Matt 2:13-18
+At that time, an angel of the Lord appeared in sleep to Joseph, saying: Arise, and take the child and his mother, and fly into Egypt: and be there until I shall tell thee. And so on.
+_
+Homily by St. Jerome, Priest (at Bethlehem)
+!Book I Comment, on Matth. II
+He took the young Child, and His mother, and fled into Egypt, by night and in darkness; and the darkness of that night was a figure of the darkness of ignorance in which they left the unbelievers from whom they fled. But when they returned into Judaea, we learn not from the Gospel that it was by night, or in darkness; which is an image of that light which will lighten the Jews, when, at the end of the world, they shall receive back the faith, which now lighteneth the Gentiles, even as Judaea received Christ returning from Egypt.
+
+[Responsory7]
+R. The saints sung a new song before the throne of God and the Lamb.
+* And their voices were echoed on earth.
+V. These were redeemed from among men, being the first-fruits unto God, and to the Lamb, and in their mouth was found no guile.
+R. And their voices were echoed on earth.
+
+[Lectio8]
+That it might be fulfilled which was spoken of the Lord by the Prophet, saying Out of Egypt have I called My Son. Those who go about to deny the authority of the Hebrew Scriptures, ask where any such passage is to be found in the Septuagint. But, although they find it not there, I tell them that the fact of its being written in the Prophet Hosea (xi. i) can be proved by the texts which I have lately published.
+
+[Responsory8]
+R. I saw under the Altar of God the souls of them that were slain for the word of God, which they held, and they cried with a loud voice
+* Avenge, O Lord, the blood of thy saints, which is shed.
+V. Under the throne of God all the saints cry aloud
+R. Avenge, O Lord, the blood of thy saints, which is shed.
+
+[Lectio9]
+Then was fulfilled that which was spoken by Jeremias the Prophet, saying; In Rama was there a voice heard, weeping and great mourning; Rachel weeping for her children. The child of Rachel was Benjamin, and Bethlehem is not a town belonging to his tribe. We must therefore seek another reason why Rachel should weep for the children of Judah, to whom Bethlehem belongeth, as for her own. The plain answer is that she is buried at Ephrath close to Bethlehem, and she is called Mother on account of the resting-place of her earthly tabernacle being there. It is possible also that she is called Mother because the tribes of Judah and Benjamin were joined together, and Herod slew not only all the children that were in Bethlehem, but also in all the coasts thereof.
+
+[Responsory9]
+R. What are these which are arrayed in white robes? and whence came they? And he said to me:
+* These are they which came out of great tribulation, and have washed their robes, and made them white in the Blood of the Lamb.
+V. I saw under the Altar of God the souls of them which were slain for the word of God, and for the testimony which they held.
+R. These are they which came out of great tribulation, and have washed their robes, and made them white in the Blood of the Lamb.
+&Gloria
+R. These are they which came out of great tribulation, and have washed their robes, and made them white in the Blood of the Lamb.
+
+[Ant Laudes]
+Herodes pln hněvu * zabil mnoho chlapců v judském Betlémě, městě Davidově.
+Herod slew many children * from two years old, and under, for the Lord's sake.
+Their angels * do always behold the face of the Father.
+In Rama was there a voice * heard, weeping and mourning, Rachel weeping for her children.
+Under the throne of God * all the saints cry aloud: Avenge our blood, O our God!
+
+[Ant Laudes] (rubrica cisterciensis)
+Herodes pln hněvu * zabil mnoho chlapců v judském Betlémě, městě Davidově.
+Jejich Andělé * neustále patří na tvář Otcovu.
+Byl slyšet hlas v Ramě, * nářek a pláč, Ráchel oplakává své syny.
+Pod trůnem Božím * Svatí volali: Pomsti naši krev, náš Bože.
+Svatí zpívali * novou píseň před trůnem Božím, i Beránkovým, a též země zněla jejich hlasy.
+
+[Capitulum Laudes]
+!Zjevení 14:1
+v. Viděl jsem Beránka státi na hoře Sion, a spolu s ním tam bylo sto čtyřicet čtyři tisíc, kteří měli jeho jméno a jméno Otcovo napsané na čele.
+$Deo gratias
+
+[Hymnus Laudes]
+v. Vám, květy mučedníků, čest!
+Nepřítel Kristův vás dal smést
+na samém prahu života
+jak vichrem růží poupata.
+_
+Kristova první oběti,
+jehňátka hnaná k zabití,
+hned před oltářem nyní jste
+a s vavříny si hrajete.
+_
+Buď sláva tobě, Ježíši,
+zrozený z Panny nejčistší,
+i Otci, Duchu milosti
+po všechny věky věčnosti.
+Amen.
+
+[Octava 2]
+!Připomínka Oktávu Svatých Neviňátek
+Ant. To jsou ti, * kteří nedošli poskvrnění se ženami; jsou totiž panicové, a následují Beránka, kamkoliv on jde.
+_
+V. Rozlícený Herodes pobil mnoho dětí.
+R. V judském Betlémě, městě Davidově.
+_
+$Oremus
+Bože, jehož chválu dnešního dne Neviňátka jako mučedníci, nikoliv řečí, ale smrtí vyznala, veškeré zlo hříchů v nás umrtvi, aby víru v tebe, kterou vyznává náš jazyk, také život mravy hlásal.
+$Per Dominum
+
+[Octava 2] (rubrica cisterciensis)
+!Připomínka Oktávu Svatých Neviňátek
+Ant. Herodes pln hněvu * zabil mnoho chlapců v judském Betlémě, městě Davidově.
+_
+@CommuneM/C3:Versum 2
+_
+$Oremus
+Bože, jehož chválu dnešního dne Neviňátka jako mučedníci, nikoliv řečí, ale smrtí vyznala, veškeré zlo hříchů v nás umrtvi, aby víru v tebe, kterou vyznává náš jazyk, také život mravy hlásal.
+$Per Dominum
+
+[Lectio Prima]
+!Zjevení 14:4-5
+v. Tito jsou vykoupeni jako první z lidí pro Boha a Beránka, a v jejich ústech nebyla shledána lež; bez poskvrny totiž jsou před trůnem Božím.
+
+[Capitulum Sexta]
+!Zjevení 14:4
+v. To jsou ti, kteří nedošli poskvrnění se ženami; jsou totiž panicové, a následují Beránka, kamkoliv on jde.
+$Deo gratias
+
+[Ant Vespera 3C]
+Od dvou let * a níže zabil Herodes mnoho chlapců kvůli Pánu.
+Nechte maličké * ke mně přijíti, takovým lidem totiž patří království nebeské.
+Vyprali své oděvy * a vybělili je v krvi Beránkově.
+Tito jsou vykoupeni * jako první z lidí pro Boha a Beránka, a v jejich ústech nebyla nalezena lež.
+
+[Versum 3]
+V. Pod trůnem Božím volají všichni Svatí.
+R. Pomsti naši krev, náš Bože.
+
+[Versum 3] (rubrica cisterciensis)
+@CommuneM/C3
+
+[Ant 3]
+Nevinné * děti byly zabity namísto Krista, kojenci byli pobiti nespravedlivým králem; následují samotného Beránka bez poskvrny, a vždy říkají: Sláva tobě, Pane.
+
+[Ant 3] (rubrica cisterciensis)
+Budou se mnou kráčet v bílém, * neboť jsou hodni, a nevymažu jejich jména z knihy života.
+
+[Octava 3]
+!Připomínka Oktávu Svatých Neviňátek
+Ant. To jsou ti, * kteří nedošli poskvrnění se ženami; jsou totiž panicové, a následují Beránka, kamkoliv on jde.
+_
+V. Rozlícený Herodes pobil mnoho dětí.
+R. V judském Betlémě, městě Davidově.
+_
+$Oremus
+Bože, jehož chválu dnešního dne Neviňátka jako mučedníci, nikoliv řečí, ale smrtí vyznala, veškeré zlo hříchů v nás umrtvi, aby víru v tebe, kterou vyznává náš jazyk, také život mravy hlásal.
+$Per Dominum
+
+[Octava 3] (rubrica cisterciensis)
+!Připomínka Oktávu Svatých Neviňátek
+Ant. Nechte maličké * ke mně přijíti, takovým lidem totiž patří království nebeské.
+_
+@CommuneM/C3:Versum 2
+_
+$Oremus
+Bože, jehož chválu dnešního dne Neviňátka jako mučedníci, nikoliv řečí, ale smrtí vyznala, veškeré zlo hříchů v nás umrtvi, aby víru v tebe, kterou vyznává náš jazyk, také život mravy hlásal.
+$Per Dominum

--- a/web/www/horas/Bohemice/Sancti/12-29.txt
+++ b/web/www/horas/Bohemice/Sancti/12-29.txt
@@ -1,0 +1,31 @@
+[Rank]
+sv. Tomáše <i>Becketa</i> z Canterbury, Biskupa a Mučedníka
+
+[Oratio]
+Bož̌e, pro jehož Církev slavný Biskup Tomáš padl pod meči bezbožných, uděl, prosíme, aby všichni, kdož vzývají jeho pomoc, dosáhli spásného vyslyšení své prosby.
+$Per Dominum
+
+[Lectio4]
+Thomas was born in London, (in the year of our Lord 11 17,) and succeeded Theobald in the Archbishopric of Canterbury (in 1162). He had previously filled with great distinction the office of Lord Chancellor, and showed an indomitable firmness in his duty as Primate. When Henry II., King of England, in an assembly of the Bishops and great men of his realm, endeavoured to pass laws detrimental to the advantage and dignity of the Church, he opposed himself so steadily to the king's wishes, that, neither promises, nor threats availing to shake him, he was about to be cast into prison, had he not made good his escape in time. The whole of his kinsfolk without regard to age or sex, his friends, and his advisers, were then banished the kingdom, and those who were able, were bound by an oath to make their way to the presence of Thomas, in the hope that though careless of his own sufferings, he might yield at the sight of their misery. But neither flesh and blood, nor the pleadings of natural affection could make him swerve from the line of his pastoral duty.
+
+[Lectio5]
+Lie betook himself to Pope Alexander III., by whom he was graciously received, and who committed him to the care of the Cistercians at Pontigni. As soon as this came to the knowledge of King Henry, he sent threatening letters to the monks, in order to drive Thomas from this shelter. The saint was unwilling that the Cistercian Order should suffer on his account, and therefore voluntarily withdrew from Pontigni, and accepted the invitation of Lewis VII., King of France, to go to his court. He remained here, until his banishment was recalled at the intercession of the Pope and of the King of France, and he returned to England amid great public joy. He was quietly continuing the work of a faithful shepherd of souls, when certain calumniators denounced him to the king as a plotter against the crown and the public peace. Henry, deceived by these libels, cried out that it was hard that one priest should never let him have quiet in his kingdom.
+
+[Lectio6]
+Come wicked servants of the king, hearing his words, and thinking to do him pleasure, betook themselves to Canterbury to rid him of the Archbishop. They entered the cathedral in the evening as Thomas was proceeding to assist at Evensong. The clergy in attendance on him, conscious of the attempt about to be made, wished to bolt the doors. But the saint caused them to be again opened, saying, The Church of God is not to be made a castle of, and for the cause of God's Church I am willing to die. He then said to his murderers, I charge you in the name of the Almighty God to hurt none of my people. With these words he fell on his knees, and commended himself to God, to the Blessed Virgin Mary, to St Denis, and to the other holy Patrons of the Church of Canterbury. He presently offered his sacred head for the stroke of death, and received it from the swords of those wicked men with the same constancy with which he had withstood the commands of the unrighteous king. The murderers pulled out his brains and strewed them all about the floor of the Church. He testified on the 29th day of December, in the (53rd) year of (his own age and of) our Lord 11 70, and, being afterwards honoured with many miracles, was canonised by Pope Alexander IIL (in 1173).
+
+[Lectio7]
+From the Holy Gospel according to John
+!John 10:11-16
+In that time Jesus said to the pharisees: I am the good shepherd. The good shepherd giveth his life for his sheep. And so on.
+_
+Homily by St. John Chrysostom, Patriarch (of Constantinople.)
+!59th on John.
+Dearly beloved brethren, the Bishops of the Church hold a great office, an office that needeth much that wisdom and strength whereof Christ hath given us an example. We must learn of Him to lay down our lives for the sheep and never to leave them; and to fight bravely against the wolf. This is the difference between the true shepherd and the hireling. The one leaveth the sheep and seeketh his own safety, but the other recketh not of his own safety, so as he may watch over the sheep. Christ then having given us the pattern of a good shepherd, warneth us against two enemies; first, the thief that cometh not but to kill and to steal, and, secondly, the hireling that standeth by, and defendeth not them that are committed to his charge.
+
+[Lectio8]
+Ezechiel hath said of old time, (xxxiv. 2): Woe be to the shepherds of Israel! do they not feed themselves? Should not the shepherds feed the flocks? But they did the contrary, a great wickedness and the root of many evils. Therefore, he saith, they brought not back that which was gone astray neither did they search for that which was lost neither did they bind up that which was broken, nor strengthen that which was sick; for they fed themselves, and not the flock. And Paul hath the same in other words, where he saith, (Phil. ii. 21): All seek their own, not the things which are Jesus Christ's.
+
+[Lectio9]
+Christ showeth Himself very different from either the thief or the hireling; whereas the thief cometh to destroy, He came that they might have life, and that they might have it more abundantly. The hireling fleeth, but He layeth down His life for the sheep, that the sheep perish not. When then the Jews went about to kill Him, He ceased not to teach He gave not up them that believed in Him, but stood steadfast and died. Wherefore He hath good title often to say, I am the Good Shepherd. It was but a little while, and He showed us how He could lay down His life for the sheep. And if it appeareth not as yet how they have life, and have it more abundantly, (but it shall appear, in the world which is to come,) we may well be persuaded of the truth of the second promise, who have seen the fulfilment of the first.
+&teDeum

--- a/web/www/horas/Bohemice/Sancti/12-29C.txt
+++ b/web/www/horas/Bohemice/Sancti/12-29C.txt
@@ -1,0 +1,9 @@
+[Rank]
+sv. Tomáše <i>Becketa</i> z Canterbury, Biskupa a Mučedníka;;MM. min.;;3;;ex C2
+
+[Rule]
+ex C2;
+
+[Oratio]
+Bož̌e, pro jehož Církev slavný Biskup Tomáš padl pod meči bezbožných, uděl, prosíme, aby všichni, kdož vzývají jeho pomoc, dosáhli spásného vyslyšení své prosby.
+$Per Dominum

--- a/web/www/horas/Bohemice/Sancti/12-31.txt
+++ b/web/www/horas/Bohemice/Sancti/12-31.txt
@@ -1,0 +1,6 @@
+[Rank]
+sv. Silvestra, Papeže a Vyznavače;;MM. min.;;3;;ex C4
+
+[Oratio]
+@Commune/C4::s/N./Silvestra/
+

--- a/web/www/horas/Bohemice/SanctiM/12-25.txt
+++ b/web/www/horas/Bohemice/SanctiM/12-25.txt
@@ -1,0 +1,14 @@
+[Responsory Vespera 1] (rubrica cisterciensis)
+<FONT COLOR=RED>Responsorium</FONT> Ó Judo a Jerusaléme, nebojte se, zítra vyjdete, a Hospodin bude s vámi.
+V. Vůbec se nebojte, uzříte pomoc Páně na sebou.
+R. Zítra vyjdete, a Hospodin bude s vámi.
+
+[Nocturn 2 Versum] (rubrica cisterciensis)
+V. Slovo se stalo tělem. 
+R. A přebývalo mezi námi.
+
+[Responsory4] (rubrica cisterciensis)
+<FONT COLOR=RED>Responsorium</FONT> Pro svou velikou lásku, kterou nás miloval Bůh Otec, poslal svého Syna 
+* V podobě hříšného těla, aby všechny zachránil.
+V. Hle, již nastala plnost času, v němž poslal Bůh svého Syna na zem, <i>Syna</i> narozeného z Panny, podřízeného zákonu.
+R. V podobě hříšného těla, aby všechny zachránil.

--- a/web/www/horas/Bohemice/SanctiM/12-28.txt
+++ b/web/www/horas/Bohemice/SanctiM/12-28.txt
@@ -1,0 +1,2 @@
+[Ant 1] (rubrica cisterciensis)
+O jak * slavné je království, v němž se spolu s Kristem radují Neviňátka, oděna v bílé štóly následují Beránka, kamkoliv jde.

--- a/web/www/horas/Bohemice/Tempora/Adv4-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Adv4-0.txt
@@ -1,0 +1,37 @@
+[Rank]
+Čtvrtá neděle Adventní;;
+
+[Oratio]
+Povzbuď, prosíme, Pane, svou moc a přijď, a velikou silou nám přispěj, aby pomocí Tvé milosti to, co hříchy naše pozdržují, Tvé shovívavé slitování uspíšilo.
+$Qui vivis
+
+[Responsory5]
+R. Hle, již nadchází plnost času v němž seslal Bůh svého Syna na zemi, narozeného s Panny, učiněného pod zákonem;
+* Aby ty, kteří byli podřízeni zákonu, vykoupil.
+V. Pro svou nesmírnou lásku, jíž si nás zamiloval Bůh, seslal svého Syna v podobě hříšného těla.
+R. Aby ty, kteří byli podřízeni zákonu, vykoupil.
+
+[Capitulum Laudes]
+!1 Kor 4:1-2
+v. Bratři: Ať se každý na nás dívá jako na Kristovy služebníky a správce Božích tajemství. A když tedy někdo něco spravuje, požaduje se ovšem od něho, aby na něj bylo spolehnutí.
+$Deo gratias
+
+[Ant Laudes]
+Zatrubte troubami * na Sionu, neboť blízko jest den Páně; hle, již přichází, aby nás zachránil, alleluja, alleluja.
+Hle, přijde * vytoužený všemi národy; a dům Páně bude naplněn slávou, alleluja.
+Křivé bude * narovnáno, a hrbolacé cesty vyrovnány; přijď, Pane, a neprodlévej, alleluja.
+Pán přijde, * vyjděte mu naproti se slovy: Veliké je jeho panství, a jeho vlády nebude konce; Bůh, Silný, Panovník, Vládce pokoje, alleluja, alleluja.
+Všemocné tvé Slovo, * Pane, sestoupí z královského trůnu, alleluja.
+
+[Capitulum Sexta]
+!1 Kor 4:3
+v. Mně na tom pramálo záleží, abych byl posuzován od vás nebo od nějakého jiného lidského soudu. Ale ani já sám sebe neposuzuji.
+$Deo gratias
+
+[Capitulum Nona]
+!1 Kor 4:5
+v. Proto nic nesuďte předčasně, než přijde Pán. On také vynese na světlo věci, které jsou dosud ukryty v temnotách, a učiní, že bude zřejmé, jaké měl kdo úmysly. A teprve tehdy může každý dostat od Boha chválu.
+$Deo gratias
+
+[Ant 2]
+Zdrávas Maria, * milostiplná; Pán s tebou; požehnaná jsi mezi ženami, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Nat1-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Nat1-0.txt
@@ -1,0 +1,78 @@
+[Versum 1]
+V. Slovo se stalo tělem, alleluja.
+R. A přebývalo mezi námi, alleluja.
+
+[Ant 1]
+Zatímco ticho * objímalo vše, a noc ve svém běhu prošla do středu své pouti, tvé všemohoucí Slovo, Pane, sesoupilo z královských trůnů.
+
+[Versum 1] (rubrica cisterciensis)
+V. Ve známost uvedl Hospodin.
+R. Svou Spásu.
+
+[Oratio]
+Všemohoucí, věčný Bože, řiď činy naše podle svého zalíbení, abychom si zasloužili ve jménu tvého milovaného Syna oplývat dobrými skutky.
+$Qui tecum
+
+[Responsory3](rubrica 1960)
+@Sancti/12-25:Responsory4
+&Gloria
+R. Blessed is that Virgin whose womb was made meet to bear our Lord Christ.
+
+[Lectio4]
+From the Sermons of Pope St. Leo (the Great.)
+!9th on Christmas.
+Dearly beloved brethren, the greatness of God's work, in its breadth and height, passeth the power of man's utterance; and, therefore, when we must needs not keep silence, we find it hard to know what to say. The words of the Prophet: Who shall declare His generation? (Isa. liii. 8) look not only to the Divine, but also to the human birth of Jesus Christ, the Son of God. Faith believeth, but words cannot explain, how the two natures were joined in one Person, and therein we find that we shall never lack matter of praise in Him, Whose abundance ever outrunneth the power of our expression.
+
+[Lectio5]
+Therefore let us rejoice, that this mystery of mercy is greater than we can ever speak; and let us feel that it is good for us to fail if we try to express the height and depth of redeeming love. He cometh nearest to the knowledge of the truth, who, the farther he advanceth, seeth all the more clearly that he can never overtake that whereafter he searcheth. For he that imagineth therein that he hath ever attained unto the goal, hath not found that which he seeketh, but hath altogether missed.
+
+[Lectio6]
+But lest we should be confounded at the weakness of our mortality, we have help in the words of the Prophets and Evangelists; and they are able so to inflame and teach us that we may see the Birth of the Lord, wherein the Word was made Flesh, not so much as a thing past, as a thing present. The proclamation of the angel to the shepherds who watched their flocks by night, ringeth in our ears also; and for this end are we appointed to rule the Lord's flock, that we may ever keep in our heart the word revealed from heaven, and say unto you, as we do this day Behold, I bring you good tidings of great joy, which shall be to all people; for unto you is born this day, in the city of David, a Saviour, Which is Christ the Lord!
+
+[Lectio7]
+From the Holy Gospel according to Luke
+!Luke 2:33-40
+In that time, his father and mother were wondering at those things which were spoken concerning him. And so on.
+_
+Homily by St. Ambrose, Bishop (of Milan.)
+!Bk. ii on Luke ii
+We see that God's abounding grace is poured forth on all by the birth of the Lord, and that the gift of prophecy is not denied to the righteous, but to the unbelieving. Simeon prophesieth that our Lord Jesus Christ is set for the fall and rising again of many in Israel, setting forth that the just and the unjust reap different fruits from the coming of the Saviour; so will it be with us; according to our individual works will the True and Just Judge apportion to us punishment or reward.
+
+[Lectio8]
+See, a sword shall pierce through thine own soul also. We have no record or tradition that Mary left this world by suffering a violent death, and the material sword can pierce the body only, and not the soul. Wherefore here we see the wisdom of Mary in that she was not ignorant of the heavenly mysteries. For, the word of God is quick, and powerful, and sharper than any two-edged sword, piercing even to the dividing asunder of soul and spirit, and of the joints and marrow, and is a discerner of the thoughts and intents of the heart for all things are naked and opened unto the eyes of the Son of God, from Whom also the secret things of our conscience are not hidden.
+
+[Responsory8]
+R. How is the King of heaven attended? He that containeth the world is laid in a stable;
+* Lying in a manger, reigning in heaven.
+V. Unto us is born, this day, in the city of David, a Saviour, Which is Christ the Lord.
+R. Lying in a manger, reigning in heaven.
+&Gloria
+R. Lying in a manger, reigning in heaven.
+
+[Lectio9]
+There had been a triple prophecy; the prophecy of Simeon had followed the prophecy of the virgin, and the prophecy of the wife; those, namely, of Mary and Elizabeth. And now ought the widow also to prophesy, that no sex nor state might be wanting. And Anna is brought before us with such a title from her widowhood and her life, that we may well believe that she received the grace to announce the Advent of the Redeemer. In our exhortation addressed to widows we have already treated of her gifts at length, and, as we have much matter before us, we will not now again enter on the subject.
+&teDeum
+
+[Ant Laudes] (rubrica cisterciensis)
+Zrodila matka * Krále, jehož jméno je věčné, a mateřské radosti spojila s panenskou ctí: a nebylo před ní podobné nalezeno, ani její následovnice, alleluja.
+Anděl * řekl pastýřům: „Zvěstuji vám velikou radost: dnes se vám narodil Spasitel světa, alleluja.“
+Shromáždilo se * s Andělem množství nebeských zástupů, které chválily <i>Boha</i> těmito slovy: „Sláva na výsostech Bohu, a na zemi pokoj lidem dobré vůle, alleluja.“
+Pastýři * si řekli mezi sebou: „Pojďme do Betléma, abychom uzřeli toto Slovo, které se stalo <i>tělem</i>, jež nám Pán ukázal, alleluja.“
+A přišli * ve spěchu: a nalezli Marii i Josefa, a nemluvňátko položené v jeslích, alleluja.
+
+[Capitulum Laudes]
+!Gal 4:1-2
+v. Bratři; Pokud je dědic nedospělý, v ničem se neliší od otroka, ačkoli je pánem všeho. Podléhá však poručníkům a správcům až do doby stanovené otcem.
+$Deo gratias
+
+[Lectio Prima]
+!Gal 4:7
+v. Již tedy není služebník, ale syn. A když synem, pak i dědicem skrze Boha.
+
+[Capitulum Sexta]
+!Gal 4:4-5
+v. Avšak když přišla plnost času, poslal Bůh svého Syna, zrozeného ze ženy, podřízeného zákonu, aby vysvobodil ty, kteří byli podřízeni zákonu, abychom byli přijati za syny.
+$Deo gratias
+
+[Ant 3]
+Chlapec Ježíš * prospíval věkem i moudrostí před Bohem i před lidmi.

--- a/web/www/horas/Bohemice/Tempora/Nat26.txt
+++ b/web/www/horas/Bohemice/Tempora/Nat26.txt
@@ -1,0 +1,8 @@
+[Rank]
+2. dne v Oktávu Narození Páně
+
+[Ant 1] (rubrica cisterciensis)
+Nepoznala panenská Matka muže, porodila však bez bolesti Spasitele světa, a samotného Krále Andělů sama Panna kojila ňadry naplněnými z nebes.
+
+[Ant 2] (rubrica cisterciensis)
+Slovo se stalo tělem, a přebývalo mezi námi; a uzřeli jsme jeho slávu, slávu, kterou má Jednorozený <i>Syn</i> od Otce, plný milosti a pravdy, alleluja, alleluja, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Nat27.txt
+++ b/web/www/horas/Bohemice/Tempora/Nat27.txt
@@ -1,0 +1,2 @@
+[Rank]
+3. dne v Oktávu Narození Páně;;Semiduplex;;2.1;;ex SanctiCist/12-25

--- a/web/www/horas/Bohemice/Tempora/Nat28.txt
+++ b/web/www/horas/Bohemice/Tempora/Nat28.txt
@@ -1,0 +1,2 @@
+[Rank]
+4. dne v Oktávu Narození Páně;;Semiduplex;;2.1;;ex SanctiCist/12-25

--- a/web/www/horas/Bohemice/Tempora/Nat29.txt
+++ b/web/www/horas/Bohemice/Tempora/Nat29.txt
@@ -1,0 +1,2 @@
+[Rank]
+5. dne v Oktávu Narození Páně;;Semiduplex;;2.1;;ex SanctiCist/12-25

--- a/web/www/horas/Bohemice/Tempora/Nat30.txt
+++ b/web/www/horas/Bohemice/Tempora/Nat30.txt
@@ -1,0 +1,7 @@
+[Rank]
+Oktávu Narození Páně;;Semiduplex;;2.1;;ex SanctiCist/12-25
+
+[Rank] (rubrica 1960)
+Die sexta post Nativitatem;;Duplex II classis;;5;;ex Sancti/12-25
+
+

--- a/web/www/horas/Bohemice/Tempora/Nat31.txt
+++ b/web/www/horas/Bohemice/Tempora/Nat31.txt
@@ -1,0 +1,3 @@
+[Rank]
+7. dne v Oktávu Narození Páně;;Semiduplex;;2.1;;ex SanctiCist/12-25
+

--- a/web/www/horas/Latin/Commune/C1.txt
+++ b/web/www/horas/Latin/Commune/C1.txt
@@ -53,6 +53,9 @@ Sicut fuit, sit júgiter
 Sæclum per omne glória.
 Amen.
 
+[Hymnus Vespera] (rubrica cisterciensis)
+@:HymnusM Vespera
+
 [HymnusM Vespera]
 Exsúltet cælum láudibus,
 Resúltet terra gáudiis:

--- a/web/www/horas/Latin/Commune/C10.txt
+++ b/web/www/horas/Latin/Commune/C10.txt
@@ -10,7 +10,7 @@ Special Benedictio
 Special Lectio 3
 Doxology=Nat
 Antiphonas horas
-(rubrica tridentina) Psalmi Dominica
+(rubrica tridentina nisi rubrica cisterciensis) Psalmi Dominica
 
 [Hymnus Vespera]
 @Commune/C11
@@ -31,6 +31,10 @@ Regína cæli, * lætáre, allelúja; quia quem meruísti portáre, allelúja; r
 
 [Oratio]
 @Commune/C11
+(sed tempore Adventus et rubrica cisterciensis)
+@Commune/C12:Oratio 2
+(sed tempore nativitatis aut epiphaniæ aut post partum et rubrica cisterciensis)
+@Commune/C12:Oratio Tertia
 
 [Invit]
 Ave María, grátia plena, * Dóminus tecum.
@@ -61,6 +65,8 @@ Per Vírginem matrem concédat nobis Dóminus salútem et pacem.
 
 [Ant Laudes] (rubrica tridentina aut rubrica cisterciensis)
 @Commune/C11
+(sed tempore paschali)
+Allelúia, * allelúia, allelúia.
 
 [Capitulum Laudes]
 @Commune/C11
@@ -77,7 +83,6 @@ R. Et benedíctus fructus ventris tui.
 
 [Ant 2_]
 Beáta Dei Génetrix, María, * Virgo perpétua, templum Dómini, sacrárium Spíritus Sancti, sola sine exémplo placuísti Dómino nostro Jesu Christo: ora pro pópulo, intérveni pro clero, intercéde pro devóto femíneo sexu.
-
 
 [Ant 2]
 @:Ant 2_

--- a/web/www/horas/Latin/Commune/C10.txt
+++ b/web/www/horas/Latin/Commune/C10.txt
@@ -59,7 +59,7 @@ Per Vírginem matrem concédat nobis Dóminus salútem et pacem.
 [Versum 0]
 @Commune/C11
 
-[Ant Laudes] (rubrica tridentina)
+[Ant Laudes] (rubrica tridentina aut rubrica cisterciensis)
 @Commune/C11
 
 [Capitulum Laudes]

--- a/web/www/horas/Latin/Commune/C11.txt
+++ b/web/www/horas/Latin/Commune/C11.txt
@@ -15,6 +15,13 @@ Doxology=Nat
 @Commune/C7::3 s/121/126/
 @:Ant VesperaBMV:2
 
+[Ant Vespera] (rubrica cisterciensis)
+Dum esset Rex * in accúbitu suo, nardus mea dedit odórem suum.;;109
+Unguéntum effúsum * nomen tuum, ídeo adolescéntulæ dilexérunt te nimis.;;112
+Nigra sum, * sed formósa, fíliæ Jerúsalem: ídeo diléxit me Rex, et introdúxit me in cubículum suum.;;121
+Benedícta tu * in muliéribus, et benedíctus fructus ventris tui.;;126
+Pulchra es, et decóra, * fília Jerúsalem, terríbilis ut castrórum ácies ordináta.;;147
+
 [Ant VesperaBMV]
 Læva ejus * sub cápite meo, et déxtera illíus amplexábitur me.;;112
 Speciósa * facta es et suávis in delíciis tuis, sancta Dei Génetrix.;;147
@@ -250,6 +257,9 @@ R. Ut digni efficiámur promissiónibus Christi.
 @Commune/C7:Ant Vespera:3 s/;;.*//
 @:Ant VesperaBMV:2 s/;;.*//
 
+[Ant Laudes] (rubrica cisterciensis)
+@:Ant Vespera:s/;;.*//g
+
 [Capitulum Laudes]
 !Sir 24:14
 v. Ab inítio et ante sǽcula creáta sum, et usque ad futúrum sǽculum non désinam, et in habitatióne sancta coram ipso ministrávi.
@@ -310,8 +320,18 @@ v. In platéis sicut cinnamómum et bálsamum aromatízans odórem dedi: quasi m
 v. Et sic in Sion firmáta sum, et in civitáte sanctificáta simíliter requiévi, et in Jerúsalem potéstas mea. Et radicávi in pópulo honorificáto, et in parte Dei mei heréditas illíus, et in plenitúdine sanctórum deténtio mea.
 $Deo gratias.
 
+[Capitulum Sexta] (rubrica cisterciensis)
+!Cant. 6:9.
+v. Vidérunt eam fíliæ Sion, et beátíssimam prædicavérunt: * et regínæ laudavérunt eam.
+$Deo gratias
+
 [Capitulum Nona]
 @:Lectio Prima
+$Deo gratias
+
+[Capitulum Nona] (rubrica cisterciensis)
+!Cant. 6:10.
+v. Quæ est ista, quæ progréditur quasi auróra consúrgens, § pulchra ut luna, elécta ut sol, * terríbilis ut castrórum ácies ordináta?
 $Deo gratias
 
 [Versum Nona]

--- a/web/www/horas/Latin/Commune/C2.txt
+++ b/web/www/horas/Latin/Commune/C2.txt
@@ -51,9 +51,6 @@ R. Et constituísti eum super ópera mánuum tuárum.
 [Ant 1]
 Iste Sanctus * pro lege Dei sui certávit usque ad mortem, et a verbis impiórum non tímuit: fundátus enim erat supra firmam petram.
 
-[Ant 1] (rubrica cisterciensis)
-Beátus vir, * qui suffert tentatiónem: quia cum probátus fúerit, accípiet corónam vitæ, quam repromísit Deus his, qui díligunt eum.
-
 [Oratio]
 Infirmitátem nostram réspice, omnípotens Deus: et quia pondus própriæ actiónis gravat, beáti N. Mártyris tui atque Pontíficis intercéssio gloriósa nos prótegat.
 $Per Dominum

--- a/web/www/horas/Latin/CommuneM/C10.txt
+++ b/web/www/horas/Latin/CommuneM/C10.txt
@@ -3,6 +3,21 @@
 [Responsory Vespera]
 @CommuneM/C11
 
+[Responsory Vespera] (rubrica cisterciensis)
+R.br. Post partum Virgo, * Invioláta permansísti.
+R. Post partum Virgo, * Invioláta permansísti.
+V. Dei Génitrix intercéde pro nobis.
+R. Invioláta permansísti.
+
+[Versum 1] (rubrica cisterciensis)
+@Commune/C11
+
+[Versum 2] (rubrica cisterciensis)
+@:Versum 1
+
+[Ant 1] (rubrica cisterciensis)
+@Commune/C11:Ant 3
+
 [Responsory3]
 @Commune/C12
 
@@ -20,29 +35,48 @@ R. In delíciis tuis, sancta Dei Génetrix.
 [Responsory Laudes]
 @:Responsory Vespera
 
+[Responsory Laudes] (rubrica cisterciensis)
+@CommuneM/C11
+
+[Ant 2] (rubrica cisterciensis)
+@Commune/C11::s/, allel[uú][ij]a//i
+
 [Lectio21]
 !from tempora
 
 [Ant Prima]
 @Commune/C7:Ant Vespera:1
+(sed rubrica cisterciensis)
+@Commune/C11:Ant Vespera:2
 
 [Ant Tertia]
 @Commune/C11:Ant VesperaBMV:1
+(sed rubrica cisterciensis)
+@Commune/C11:Ant Vespera:3
 
 [Responsory TertiaM]
 @Commune/C6:Versum 1
 
 [Ant Sexta]
 @Commune/C6:Ant Matutinum:7
+(sed rubrica cisterciensis)
+@Commune/C11:Ant Vespera:4
 
 [Responsory SextaM]
 @Commune/C6:Nocturn 2 Versum
 
 [Ant Nona]
 @Commune/C11:Ant VesperaBMV:2
+(sed rubrica cisterciensis)
+@Commune/C11:Ant Vespera:5
+
+[Capitulum Nona] (rubrica cisterciensis)
+@CommuneM/C11
 
 [Responsory NonaM]
 @Commune/C6:Nocturn 3 Versum
+(sed rubrica cisterciensis)
+@CommuneM/C6:Nocturn 3 Versum
 
 [Lectio M011]
 Ex Epístola sancti Ambrósii Epíscopi ad Sirícium Papam

--- a/web/www/horas/Latin/CommuneM/C10.txt
+++ b/web/www/horas/Latin/CommuneM/C10.txt
@@ -9,6 +9,12 @@ R. Post partum Virgo, * Invioláta permansísti.
 V. Dei Génitrix intercéde pro nobis.
 R. Invioláta permansísti.
 
+[Responsory Vespera] (tempore Adventus et rubrica cisterciensis)
+R.br. Angelus Dómini * Nuntiávit Maríæ.
+R. Angelus Dómini * Nuntiávit Maríæ.
+V. Et concépit de Spíritu Sancto.
+R. Nuntiávit Maríæ.
+
 [Versum 1] (rubrica cisterciensis)
 @Commune/C11
 
@@ -17,6 +23,8 @@ R. Invioláta permansísti.
 
 [Ant 1] (rubrica cisterciensis)
 @Commune/C11:Ant 3
+(sed tempore paschali)
+@:Ant 1_Pasch
 
 [Responsory3]
 @Commune/C12
@@ -40,6 +48,8 @@ R. In delíciis tuis, sancta Dei Génetrix.
 
 [Ant 2] (rubrica cisterciensis)
 @Commune/C11::s/, allel[uú][ij]a//i
+(sed tempore paschali)
+@Commune/C10:Ant 1_Pasch
 
 [Lectio21]
 !from tempora
@@ -48,11 +58,15 @@ R. In delíciis tuis, sancta Dei Génetrix.
 @Commune/C7:Ant Vespera:1
 (sed rubrica cisterciensis)
 @Commune/C11:Ant Vespera:2
+(sed tempore paschali et rubrica cisterciensis)
+@Psalterium/Psalmi/Psalmi minor:Pasch:2
 
 [Ant Tertia]
 @Commune/C11:Ant VesperaBMV:1
 (sed rubrica cisterciensis)
 @Commune/C11:Ant Vespera:3
+(sed tempore paschali et rubrica cisterciensis)
+@Psalterium/Psalmi/Psalmi minor:Pasch:3
 
 [Responsory TertiaM]
 @Commune/C6:Versum 1
@@ -61,6 +75,8 @@ R. In delíciis tuis, sancta Dei Génetrix.
 @Commune/C6:Ant Matutinum:7
 (sed rubrica cisterciensis)
 @Commune/C11:Ant Vespera:4
+(sed tempore paschali et rubrica cisterciensis)
+@Psalterium/Psalmi/Psalmi minor:Pasch:4
 
 [Responsory SextaM]
 @Commune/C6:Nocturn 2 Versum
@@ -69,6 +85,8 @@ R. In delíciis tuis, sancta Dei Génetrix.
 @Commune/C11:Ant VesperaBMV:2
 (sed rubrica cisterciensis)
 @Commune/C11:Ant Vespera:5
+(sed tempore paschali et rubrica cisterciensis)
+@Psalterium/Psalmi/Psalmi minor:Pasch:5
 
 [Capitulum Nona] (rubrica cisterciensis)
 @CommuneM/C11

--- a/web/www/horas/Latin/CommuneM/C11.txt
+++ b/web/www/horas/Latin/CommuneM/C11.txt
@@ -11,7 +11,16 @@ R. Ave María, grátia plena, * Dóminus tecum.
 [Responsory Vespera]
 @:Responsory Vespera_
 (sed rubrica cisterciensis)
-@:Responsory Vespera_: s/^(V\..*)\,.*$/$1./m
+@Commune/C6:Responsory Breve Tertia
+
+[Versum 1] (rubrica cisterciensis)
+@Commune/C11
+
+[Versum 2] (rubrica cisterciensis)
+@:Versum 1
+
+[Versum 3] (rubrica cisterciensis)
+@:Versum 1
 
 [AntMatutinumM]
 Favus distíllans * lábia tua, Sponsa, mel et lac sub lingua tua: † et odor vestimentórum tuórum sicut odor thuris.;;47
@@ -110,6 +119,8 @@ _
 
 [Responsory Laudes]
 @:Responsory Vespera
+(sed rubrica cisterciensis)
+@:Responsory Vespera_: s/^(V\..*)\,.*$/$1./m
 
 [Hymnus Laudes]
 @Commune/C10:HymnusM Laudes

--- a/web/www/horas/Latin/CommuneM/C2.txt
+++ b/web/www/horas/Latin/CommuneM/C2.txt
@@ -14,6 +14,9 @@ R. Et florébit in ætérnum ante Dóminum.
 [Versum 3] (rubrica cisterciensis)
 @:Versum 1
 
+[Ant 1] (rubrica cisterciensis)
+Beátus vir, * qui suffert tentatiónem: quia cum probátus fúerit, accípiet corónam vitæ, quam repromísit Deus his, qui díligunt eum.
+
 [Ant 2] (rubrica cisterciensis)
 @Commune/C2:Ant 3:s/me\./me, dicit Dóminus./
 

--- a/web/www/horas/Latin/Sancti/01-01.txt
+++ b/web/www/horas/Latin/Sancti/01-01.txt
@@ -25,6 +25,9 @@ Ecce María génuit * nobis Salvatórem, quem Joánnes videns, exclamávit, dice
 [Versum 1]
 @Tempora/Nat1-0
 
+[Versum 1] (rubrica cisterciensis)
+@Sancti/12-25:Versum 2
+
 [Ant 1]
 Propter nímiam * caritátem suam, qua diléxit nos Deus, Fílium suum misit in similitúdinem carnis peccáti, allelúja.
 

--- a/web/www/horas/Latin/Sancti/01-01.txt
+++ b/web/www/horas/Latin/Sancti/01-01.txt
@@ -19,11 +19,17 @@ Rubum, quem víderat Móyses * incombústum, conservátam agnóvimus tuam laudá
 Germinávit radix Jesse, * orta est stella ex Jacob: Virgo péperit Salvatórem; te laudámus, Deus noster.;;126
 Ecce María génuit * nobis Salvatórem, quem Joánnes videns, exclamávit, dicens: Ecce Agnus Dei, ecce qui tollit peccáta mundi, allelúja.;;147
 
+[Responsory Vespera 1] (rubrica cisterciensis)
+@SanctiM/12-25:Responsory4
+
 [Versum 1]
 @Tempora/Nat1-0
 
 [Ant 1]
 Propter nímiam * caritátem suam, qua diléxit nos Deus, Fílium suum misit in similitúdinem carnis peccáti, allelúja.
+
+[Ant 1] (rubrica cisterciensis)
+Qui de terra est, * de terra lóquitur; qui de cœlo venit, super omnes est: et quod vidit, et audívit, hoc testátur, et testimónium ejus nemo áccipit; qui autem accéperit ejus testimónium, signávit quia Deus verax est.
 
 [Oratio]
 Deus, qui salútis ætérnæ, beátæ Maríæ virginitáte fecúnda, humáno géneri prǽmia præstitísti: tríbue, quǽsumus; ut ipsam pro nobis intercédere sentiámus, per quam merúimus auctórem vitæ suscípere, Dóminum nostrum Jesum Christum Fílium tuum:

--- a/web/www/horas/Latin/Sancti/01-04.txt
+++ b/web/www/horas/Latin/Sancti/01-04.txt
@@ -19,6 +19,9 @@ Feria Te Deum
 Psalm5 Vespera3=115
 Lectio1 TempNat
 
+[Ant 1] (rubrica cisterciensis)
+@SanctiM/12-28
+
 [Responsory1] (rubrica tridentina)
 @Sancti/12-28
 

--- a/web/www/horas/Latin/Sancti/01-05cc.txt
+++ b/web/www/horas/Latin/Sancti/01-05cc.txt
@@ -11,3 +11,6 @@ Telésphori
 @Commune/C2:Oratio1 Gregem
 (sed rubrica tridentina aut rubrica 1930)
 @Commune/C2:Oratio1
+
+[Ant 1] (rubrica cisterciensis)
+@Commune/C2

--- a/web/www/horas/Latin/Sancti/02-23r.txt
+++ b/web/www/horas/Latin/Sancti/02-23r.txt
@@ -2,6 +2,8 @@
 S. Petri Damiani Episcopi Confessoris et Ecclesiæ Doctoris;;Duplex;;3;;vide C4a
 (sed rubrica 1930 aut rubrica 1963)
 S. Petri Damiani Episcopi, Confessoris et Ecclesiæ Doctoris O. N.;;Duplex;;3;;vide C4a
+(sed rubrica cisterciensis)
+S. Petri Damiani, Episcopi, Confessoris et Ecclesiæ Doctoris;;iij. Lect. et M.;;1.2;;vide C4a
 
 [Rule]
 vide C4a;

--- a/web/www/horas/Latin/Sancti/02-24.txt
+++ b/web/www/horas/Latin/Sancti/02-24.txt
@@ -4,6 +4,9 @@ S. Matthiæ Apostoli;;Duplex II classis;;5.1;;ex C1
 [Rank] (rubrica 196)
 S. Matthiæ Apostoli;;Duplex II classis;;5;;ex C1
 
+[Rank] (rubrica cisterciensis)
+S. Matthiæ Apostoli;;MM. maj.;;4.1;;ex C1
+
 [Rule]
 ex C1;
 Antiphonas horas

--- a/web/www/horas/Latin/Sancti/12-25.txt
+++ b/web/www/horas/Latin/Sancti/12-25.txt
@@ -460,3 +460,28 @@ _
 $Oremus
 v. Concéde, quǽsumus, omnípotens Deus: ut nos Unigéniti tui nova per carnem Natívitas líberet; quos sub peccáti jugo vetústa sérvitus tenet.
 $Per eumdem
+
+[Octava 3] (rubrica cisterciensis)
+!Commemoratio Octavæ Nativitatis
+Ant. Nésciens Mater Virgo virum, péperit sine dolóre Salvatórem sæculórum, ipsum Regem Angelórum sola Virgo lactábat úbere de cœlo pleno.
+_
+V. Puer natus est nobis.
+R. Fílius datus est nobis.
+_
+$Oremus
+v. Concéde, quǽsumus, omnípotens Deus: ut nos Unigéniti tui nova per carnem Natívitas líberet; quos sub peccáti jugo vetústa sérvitus tenet.
+$Per eumdem
+
+[Octava 2] (rubrica cisterciensis)
+!Commemoratio Octavæ Nativitatis
+Ant. Verbum caro factum est, et habitávit in nobis: et vídimus glóriam ejus, glóriam quasi Unigéniti a Patre plenum grátiæ, et veritátis, allelúia, allelúia, allelúia.
+_
+V. Puer natus est nobis.
+R. Fílius datus est nobis.
+_
+$Oremus
+v. Concéde, quǽsumus, omnípotens Deus: ut nos Unigéniti tui nova per carnem Natívitas líberet; quos sub peccáti jugo vetústa sérvitus tenet.
+$Per eumdem
+
+[Octava 1]
+@:Octava 3

--- a/web/www/horas/Latin/Sancti/12-25.txt
+++ b/web/www/horas/Latin/Sancti/12-25.txt
@@ -18,6 +18,13 @@ Compléti sunt * dies Maríæ, ut páreret Fílium suum primogénitum.;;111
 Scitóte * quia prope est regnum Dei: amen dico vobis, quia non tardábit.;;112
 Leváte cápita vestra: * ecce appropínquat redémptio vestra.;;116
 
+[Ant Vespera] (rubrica cisterciensis)
+Antequam convenírent * invénta est María habens in útero de Spíritu sancto, allelúia.;;109
+Joseph fili David * noli timére accípere Maríam cónjugem tuam: quod enim in ea natum est, de Spíritu sancto est, allelúia.;;110
+Compléti sunt * dies Maríæ, ut páreret Fílium suum primogénitum.;;111
+Gaudeámus omnes fidéles, * Salvátor noster natus est in mundo: hódie procéssit proles magnífici gérminis, et persevérat pudos virginitátis.;;112
+Ecce jam venit * plenitúdo témporis, in quo misit Deus fílium suum in terras, natum de Vírgine, factum sub lege, ut eos qui sub lege erant redímeter.;;116
+
 [Capitulum Vespera 1]
 !Titus 3:4-5
 v. Appáruit benígnitas, et humánitas Salvatóris nostri Dei: non ex opéribus justítiæ, quæ fécimus nos, sed secúndum suam misericórdiam salvos nos fecit.
@@ -101,8 +108,15 @@ Amen.
 V. Crástina die delébitur iníquitas terræ.
 R. Et regnábit super nos Salvátor mundi.
 
+[Versum 1] (rubrica cisterciensis)
+V. Benedíctus qui venit in nómine Dómini.
+R. Deus Dóminus, et illúxit nobis.
+
 [Ant 1]
 Cum ortus fúerit * sol de cælo, vidébitis Regem regum procedéntem a Patre, tamquam sponsum de thálamo suo.
+
+[Ant 1] (rubrica cisterciensis)
+Cum esset * desponsáta Mater Jesu María Joseph, ántequam convenírent, invénta est in útero habens: quod enim in ea natum est, de Spíritu sancto est, allelúia.
 
 [Oratio]
 Concéde, quǽsumus, omnípotens Deus: ut nos Unigéniti tui nova per carnem Natívitas líberet; quos sub peccáti jugo vetústa sérvitus tenet.
@@ -275,6 +289,13 @@ Angelus ad pastóres * ait: Annúntio vobis gáudium magnum: quia natus est vobi
 Facta est cum Angelo * multitúdo cæléstis exércitus laudántium Deum, et dicéntium: Glória in excélsis Deo, et in terra pax homínibus bonæ voluntátis, allelúja.
 Párvulus fílius * hódie natus est nobis: et vocábitur Deus, Fortis, allelúja, allelúja.
 
+[Ant Laudes] (rubrica cisterciensis)
+Génuit puérpera * Regem, cui nomen ætérnum, et gáudia matris habens cum virginitátis honóre: nec primam símilem visa est, nec habére sequéntem, allelúja.
+Lux orta est * super nos: quia hódie natus est Salvátor, allelúia.
+Virgo hódie fidélis, * etsi Verbum génuit incarnátum, Virgo mansit et post partum, quam laudántes omnes dícimus: Benedícta tu in muliéribus.
+Gaudeámus omnes fidéles, * Salvátor noster natus est in mundo: hódie procéssit proles magnífici gérminis, et persevérat pudor virginitátis.
+Hódie * intácta Virgo Deum nobis génuit téneris indútum membris, quem lactáre méruit: omnes ipsum adorémus, qui venit salváre nos.
+
 [Capitulum Laudes]
 !Heb 1:1-2
 v. Multifáriam, multísque modis olim Deus loquens pátribus in prophétis: novíssime diébus istis locútus est nobis in Fílio, quem constítuit herédem universórum, per quem fecit et sǽcula.
@@ -329,6 +350,10 @@ Amen.
 V. Notum fecit Dóminus, allelúja.
 R. Salutáre suum, allelúja.
 
+[Versum 2] (rubrica cisterciensis)
+V. Puer natus est nobis.
+R. Fílius datus est nobis.
+
 [Ant 2]
 Glória in excélsis Deo, * et in terra pax homínibus bonæ voluntátis, allelúja, allelúja.
 
@@ -355,6 +380,12 @@ R. Allelúja, allelúja.
 &Gloria
 R. Verbum caro factum est, * Allelúja, allelúja.
 
+[Responsory Breve Tertia] (rubrica cisterciensis)
+R.br. Verbum caro factum est, * Et habitávit in nobis.
+R. Verbum caro factum est, * Et habitávit in nobis.
+V. Et vídimus glóriam ejus, glóriam quasi Unigéniti a Patre.
+R. Et habitávit in nobis.
+
 [Versum Tertia]
 @:Nocturn 3 Versum
 
@@ -370,6 +401,12 @@ V. Salutáre suum.
 R. Allelúja, allelúja.
 &Gloria
 R. Notum fecit Dóminus, * Allelúja, allelúja.
+
+[Responsory Breve Sexta] (rubrica cisterciensis)
+R.br. Benedíctus qui venit  * In nómine Dómini.
+R. Benedíctus qui venit  * In nómine Dómini.
+V. Deus Dóminus, et illúxit nobis.
+R. In nómine Dómini.
 
 [Versum Sexta]
 V. Vidérunt omnes fines terræ, allelúja.
@@ -397,6 +434,12 @@ Redemptiónem * misit Dóminus pópulo suo: mandávit in ætérnum testaméntum 
 Exórtum est * in ténebris lumen rectis corde: miséricors, et miserátor, et justus Dóminus.;;111
 Apud Dóminum * misericórdia, et copiósa apud eum redémptio.;;129
 De fructu * ventris tui ponam super sedem tuam.;;131
+
+[Ant Vespera 3]
+In princípio * et ante sǽcula Deus erat Verbum: ipse natus est nobis Salvátor mundi.;;109
+Virgo Verbo concépit, * Virgo permánsit, Virgo péperit Regem ómnium regum.;;110
+Beátus venter, * qui te portávit, Christe, et beáta úbera quæ te lactavérunt Dóminum, et Salvatórem mundi, allelúia.;;111
+Illúxit nobis dies * redemptiónis novæ, reparatiónis antíquæ, felicitátis ætérnæ.;;131
 
 [Capitulum Vespera 3]
 @:Capitulum Laudes

--- a/web/www/horas/Latin/Sancti/12-26.txt
+++ b/web/www/horas/Latin/Sancti/12-26.txt
@@ -14,12 +14,24 @@ no Psalm5
 [Versum 1]
 @Commune/C2
 
+[Versum 1] (rubrica cisterciensis)
+@CommuneM/C2
+
 [Ant 1]
 Stéphanus autem * plenus grátia et fortitúdine, faciébat signa magna in pópulo.
 
 [Oratio]
 Da nobis, quǽsumus, Dómine, imitári quod cólimus: ut discámus et inimícos dilígere; quia ejus natalícia celebrámus, qui novit étiam pro persecutóribus exoráre Dóminum nostrum Jesum Christum Fílium tuum:
 $Qui tecum
+
+[Commemoratio] (rubrica cisterciensis)
+!Commemoratio omnium SS. Martyrum
+@CommuneM/C3:Oratio proper
+v. Deus, qui nos annua ómnium sanctórum Mártyrum tuórum commemoratióne lætíficas: § concéde propítius; * ut, quorum gaudémus méritis, § accendámur examplis.
+$Per Dominum
+
+[Commemoratio 3] (rubrica cisterciensis)
+@:Commemoratio
 
 [Octava 1]
 @:Octava 3
@@ -144,6 +156,13 @@ Adhǽsit ánima mea * post te, quia caro mea lapidáta est pro te, Deus meus.
 Stéphanus vidit * cælos apértos, vidit, et introívit: beátus homo, cui cæli patébant.
 Ecce vídeo * cælos apértos, et Jesum stántem a dextris virtútis Dei.
 
+[Ant Laudes] (rubrica cisterciensis)
+Cum autem * esset Stéphanus plenus Spíritu sancto, inténdens in cœlum, vidit glóriam Dei, et Jesum stantem ad déxteram Patris.
+Lapidábant * Judæi Stéphanum invocántem, et dicéntem: Dómine Jesu, áccipe spíritum meum.
+Adhǽsit ánima mea post te, * quia caro mea lapidáta est pro te, Deus meus.
+Stéphanus vidit * cœlos apértos, vidit, et introívit: beátus homo, cui cœli patébant.
+Pósitis autem génibus, * clamávit voce magna dicens Stéphanus: Dómine Jesu, ne státuas illis hoc peccátum.
+
 [Capitulum Laudes]
 !Act. 6:8
 v. Stéphanus autem plenus grátia et fortitúdine, faciébat prodígia et signa magna in pópulo.
@@ -153,8 +172,14 @@ $Deo gratias
 V. Sepeliérunt Stéphanum viri timoráti.
 R. Et fecérunt planctum magnum super eum.
 
+[Versum 2] (rubrica cisterciensis)
+@CommuneM/C2
+
 [Ant 2]
 @:Ant 1
+
+[Ant 2] (rubrica cisterciensis)
+Patefáctæ sunt * jánuæ cœli Christi Mártyri Stéphano, qui in número Mártyrum invéntus est primus, et ídeo triúmphat in cœlis coronátus, allelúia.
 
 [Octava 2]
 !Commemoratio Octavæ S. Stephani
@@ -162,6 +187,18 @@ Ant. Stéphanus autem plenus grátia et fortitúdine, faciébat signa magna in p
 _
 V. Sepeliérunt Stéphanum viri timoráti.
 R. Et fecérunt planctum magnum super eum.
+_
+$Oremus
+v. Da nobis, quǽsumus, Dómine, imitári quod cólimus: ut discámus et inimícos dilígere; quia ejus natalícia celebrámus, qui novit étiam pro persecutóribus exoráre Dóminum nostrum Jesum Christum Fílium tuum:
+$Qui tecum
+
+[Octava 2] (rubrica cisterciensis)
+!Commemoratio Octavæ S. Stephani
+Ant. Cum autem * esset Stéphanus plenus Spíritu sancto, inténdens in cœlum, vidit glóriam Dei, et Jesum stantem ad déxteram Patris.
+_
+@CommuneM/C2:Versum 2
+(sed die Nat29)
+@Commune/C2:Versum 1
 _
 $Oremus
 v. Da nobis, quǽsumus, Dómine, imitári quod cólimus: ut discámus et inimícos dilígere; quia ejus natalícia celebrámus, qui novit étiam pro persecutóribus exoráre Dóminum nostrum Jesum Christum Fílium tuum:
@@ -180,6 +217,11 @@ $Deo gratias
 @:Lectio Prima
 $Deo gratias
 
+[Capitulum Nona] (rubrica cisterciensis)
+!Act. 7
+v. Cum autem esset plenus Spíritu sancto, inténdens in cœlum, vidit glóriam Dei, et Jesum stantem ad dextris Dei. 
+$Deo gratias
+
 [Ant Vespera 3]
 @Sancti/12-25
 
@@ -187,8 +229,14 @@ $Deo gratias
 V. Stéphanus vidit cælos apértos.
 R. Vidit, et introívit: beátus homo, cui cæli patébant.
 
+[Versum 3] (rubrica cisterciensis)
+@CommuneM/C2
+
 [Ant 3]
 Sepeliérunt Stéphanum * viri timoráti, et fecérunt planctum magnum super eum.
+
+[Ant 3] (rubrica cisterciensis)
+Intuens in cœlum * beátus Stéphanus vidit glóriam Dei, et ait: Ecce vídeo cœlos apértos, et Fílium hóminis stantem a dextris Dei.
 
 [Octava 3]
 !Commemoratio Octavæ S. Stephani
@@ -200,3 +248,16 @@ _
 $Oremus
 v. Da nobis, quǽsumus, Dómine, imitári quod cólimus: ut discámus et inimícos dilígere; quia ejus natalícia celebrámus, qui novit étiam pro persecutóribus exoráre Dóminum nostrum Jesum Christum Fílium tuum:
 $Qui tecum
+
+[Octava 3] (rubrica cisterciensis)
+!Commemoratio Octavæ S. Stephani
+Ant. Stéphanus vidit * cœlos apértos, vidit, et introívit: beátus homo, cui cœli patébant.
+_
+@CommuneM/C2:Versum 2
+(sed die Nat28)
+@Commune/C2:Versum 1
+_
+$Oremus
+v. Da nobis, quǽsumus, Dómine, imitári quod cólimus: ut discámus et inimícos dilígere; quia ejus natalícia celebrámus, qui novit étiam pro persecutóribus exoráre Dóminum nostrum Jesum Christum Fílium tuum:
+$Qui tecum
+

--- a/web/www/horas/Latin/Sancti/12-27.txt
+++ b/web/www/horas/Latin/Sancti/12-27.txt
@@ -14,6 +14,9 @@ Antiphonas horas
 V. Valde honorándus est beátus Joánnes.
 R. Qui supra pectus Dómini in cena recúbuit.
 
+[Versum 1] (rubrica cisterciensis)
+@CommuneM/C1
+
 [Ant 1]
 Iste est Joánnes, * qui supra pectus Dómini in cena recúbuit: beátus Apóstolus, cui reveláta sunt secréta cæléstia.
 
@@ -142,6 +145,13 @@ Hic est discípulus meus: * sic eum volo manére, donec véniam.
 Sunt de hic stántibus, * qui non gustábunt mortem, donec vídeant Fílium hóminis in regno suo.
 Ecce puer meus, * eléctus, quem elégi, pósui super eum Spíritum meum.
 
+[Ant Laudes] (rubrica cisterciensis)
+Ecce puer meus * eléctus, quem elégi, pósui super eum Spíritum meum.
+Hic est discípulus ille * qui testimónium pérhibet de his: et scimus quia verum est testimónium ejus.
+Misit Dóminus * manum suam, et tétigit os meum, et replévit illud.
+Sunt de hic stántibus, * qui non gustábunt mortem, donec vídeant Fílium hóminis in regno suo.
+Joánnes autem Apóstolus * virgo Dei eléctus, cui Vírginem Matrem Dóminus vírgini commendávit.
+
 [Capitulum Laudes]
 !Sir 15:1-2
 v. Qui timet Deum, fáciet bona: et qui cóntinens est justítiæ, apprehéndet illam, et obviábit illi quasi mater honorificáta.
@@ -151,8 +161,14 @@ $Deo gratias
 V. Hic est discípulus ille, qui testimónium pérhibet de his.
 R. Et scimus quia verum est testimónium ejus.
 
+[Versum 2] (rubrica cisterciensis)
+@CommuneM/C1
+
 [Ant 2]
 @:Ant 1
+
+[Ant 2] (rubrica cisterciensis)
+In médio * Ecclésiæ apéruit Dóminus os ejus, et implévit eum spíritu sapiéntiæ et intelléctus, allelúia.
 
 [Octava 2]
 !Commemoratio Octavæ S. Joannis
@@ -160,6 +176,16 @@ Ant. Iste est Joánnes, qui supra pectus Dómini in cena recúbuit: beátus Apó
 _
 V. Hic est discípulus ille, qui testimónium pérhibet de his.
 R. Et scimus quia verum est testimónium ejus.
+_
+$Oremus
+v. Ecclésiam tuam, Dómine, benígnus illústra: ut beáti Joánnis Apóstoli tui et Evangelístæ, illumináta doctrínis, ad dona pervéniat sempitérna.
+$Per Dominum
+
+[Octava 2] (rubrica cisterciensis)
+!Commemoratio Octavæ S. Joannis
+Ant. Hic est discípulus ille * qui testimónium pérhibet de his: et scimus quia verum est testimónium ejus.
+_
+@CommuneM/C1:Versum 2
 _
 $Oremus
 v. Ecclésiam tuam, Dómine, benígnus illústra: ut beáti Joánnis Apóstoli tui et Evangelístæ, illumináta doctrínis, ad dona pervéniat sempitérna.
@@ -187,12 +213,25 @@ $Deo gratias
 [Ant 3]
 Exiit * sermo inter fratres, quod discípulus ille non móritur; et non dixit Jesus, Non móritur: sed, Sic eum volo manére, donec véniam.
 
+[Ant 3] (rubrica cisterciensis)
+Joánnes Apóstolus * et Evangelísta, virgo est eléctus a Dómino, atque inter céteros magis diléctus, allelúia.
+
 [Octava 3]
 !Commemoratio Octavæ S. Joannis
 Ant. Exiit sermo inter fratres, quod discípulus ille non móritur; et non dixit Jesus, Non móritur: sed, Sic eum volo manére, donec véniam.
 _
 V. Valde honorándus est beátus Joánnes.
 R. Qui supra pectus Dómini in cena recúbuit.
+_
+$Oremus
+v. Ecclésiam tuam, Dómine, benígnus illústra: ut beáti Joánnis Apóstoli tui et Evangelístæ, illumináta doctrínis, ad dona pervéniat sempitérna.
+$Per Dominum
+
+[Octava 3] (rubrica cisterciensis)
+!Commemoratio Octavæ S. Joannis
+Ant. Joánnes autem Apóstolus * virgo Dei eléctus, cui Vírginem Matrem Dóminus vírgini commendávit.
+_
+@CommuneM/C1:Versum 2
 _
 $Oremus
 v. Ecclésiam tuam, Dómine, benígnus illústra: ut beáti Joánnis Apóstoli tui et Evangelístæ, illumináta doctrínis, ad dona pervéniat sempitérna.

--- a/web/www/horas/Latin/Sancti/12-28.txt
+++ b/web/www/horas/Latin/Sancti/12-28.txt
@@ -26,6 +26,9 @@ no Psalm5
 V. Heródes irátus occídit multos púeros.
 R. In Béthlehem Judæ civitáte David.
 
+[Versum 1] (rubrica cisterciensis)
+@CommuneM/C3
+
 [Ant 1]
 Hi sunt, * qui cum muliéribus non sunt coinquináti: vírgines enim sunt, et sequúntur Agnum quocúmque íerit.
 
@@ -176,6 +179,13 @@ Angeli eórum * semper vident fáciem Patris.
 Vox in Rama * audíta est, plorátus et ululátus, Rachel plorans fílios suos.
 Sub throno Dei * omnes Sancti clamant: Víndica sánguinem nostrum, Deus noster.
 
+[Ant Laudes] (rubrica cisterciensis)
+Heródes irátus * occídit multos púeros in Béthlehem Judæ civitáte David.
+Angeli eórum * semper vident fáciem Patris.
+Vox in Rama audíta est, * plorátus et ululátus, Rachel plorans fílios suos.
+Sub throno Dei * Sancti clamábant: Víndica sánguinem nostrum, Deus noster.
+Cantábant Sancti * cánticum novum ante sedem Dei, et Agni, et resonábat terra in voces illórum.
+
 [Capitulum Laudes]
 !Apo 14:1
 v. Vidi supra montem Sion Agnum stántem, et cum eo centum quadragínta quátuor míllia habéntes nomen ejus, et nomen Patris ejus scriptum in fróntibus suis.
@@ -218,6 +228,16 @@ $Oremus
 v. Deus, cujus hodiérna die præcónium Innocéntes Mártyres non loquéndo, sed moriéndo conféssi sunt: ómnia in nobis vitiórum mala mortífica; ut fidem tuam, quam lingua nostra lóquitur, étiam móribus vita fateátur.
 $Per Dominum
 
+[Octava 2] (rubrica cisterciensis)
+!Commemoratio Octavæ SS. Innocentium
+Ant. Heródes irátus * occídit multos púeros in Béthlehem Judæ civitáte David.
+_
+@CommuneM/C3:Versum 2
+_
+$Oremus
+v. Deus, cujus hodiérna die præcónium Innocéntes Mártyres non loquéndo, sed moriéndo conféssi sunt: ómnia in nobis vitiórum mala mortífica; ut fidem tuam, quam lingua nostra lóquitur, étiam móribus vita fateátur.
+$Per Dominum
+
 [Lectio Prima]
 !Apo 14:4-5
 v. Hi empti sunt ex homínibus primítiæ Deo et Agno, et in ore ipsórum non est invéntum mendácium: sine mácula enim sunt ante thronum Dei.
@@ -234,19 +254,41 @@ $Deo gratias
 [Ant Vespera 3]
 @Sancti/12-25
 
+[Ant Vespera 3C]
+A bimátu * et infra occídit multos púeros Heródes propter Dóminum.
+Sínite párvulos * ad me veníre, tálium est enim regnum cœlórum.
+Lavérunt stolas suas * et cándidas eas fecérunt in sánguine Agni.
+Hi empti sunt * ex homínibus primítiæ Deo et Agno; et in ore eórum non est invéntum mendácium.
+
 [Versum 3]
 V. Sub throno Dei omnes Sancti clamant.
 R. Víndica sánguinem nostrum, Deus noster.
 
+[Versum 3] (rubrica cisterciensis)
+@CommuneM/C3
+
 [Ant 3]
 Innocéntes pro Christo * infántes occísi sunt, ab iníquo rege lacténtes interfécti sunt: ipsum sequúntur Agnum sine mácula, et dicunt semper: Glória tibi, Dómine.
 
+[Ant 3] (rubrica cisterciensis)
+Ambulábunt mecum in albis, * quóniam digni sunt, et non delébo nómina eórum de libro vitæ.
+
 [Octava 3]
-!Commemoratio Octavæ Ss. Innocentium
+!Commemoratio Octavæ SS. Innocentium
 Ant. Innocéntes pro Christo infántes occísi sunt, ab iníquo rege lacténtes interfécti sunt: ipsum sequúntur Agnum sine mácula, et dicunt semper: Glória tibi, Dómine.
 _
 V. Sub throno Dei omnes Sancti clamant.
 R. Víndica sánguinem nostrum, Deus noster.
+_
+$Oremus
+v. Deus, cujus hodiérna die præcónium Innocéntes Mártyres non loquéndo, sed moriéndo conféssi sunt: ómnia in nobis vitiórum mala mortífica; ut fidem tuam, quam lingua nostra lóquitur, étiam móribus vita fateátur.
+$Per Dominum
+
+[Octava 3] (rubrica cisterciensis)
+!Commemoratio Octavæ SS. Innocentium
+Ant. Sínite párvulos * ad me veníre, tálium est enim regnum cœlórum.
+_
+@CommuneM/C3:Versum 2
 _
 $Oremus
 v. Deus, cujus hodiérna die præcónium Innocéntes Mártyres non loquéndo, sed moriéndo conféssi sunt: ómnia in nobis vitiórum mala mortífica; ut fidem tuam, quam lingua nostra lóquitur, étiam móribus vita fateátur.

--- a/web/www/horas/Latin/Sancti/12-29.txt
+++ b/web/www/horas/Latin/Sancti/12-29.txt
@@ -45,3 +45,5 @@ Verum ab utróque se dissidére osténdit Christus: ab illis quidem, qui in ali�
 
 [Ant Vespera 3]
 @Sancti/12-25
+(sed rubrica cisterciensis)
+@Commune/C2:Ant Vespera

--- a/web/www/horas/Latin/Sancti/12-29C.txt
+++ b/web/www/horas/Latin/Sancti/12-29C.txt
@@ -1,0 +1,9 @@
+[Rank]
+sv. Tomáše <i>Becketa</i> z Canterbury, Biskupa a Mučedníka;;MM. min.;;3;;ex C2
+
+[Rule]
+ex C2;
+
+[Oratio]
+Bož̌e, pro jehož Církev slavný Biskup Tomáš padl pod meči bezbožných, uděl, prosíme, aby všichni, kdož vzývají jeho pomoc, dosáhli spásného vyslyšení své prosby.
+$Per Dominum

--- a/web/www/horas/Latin/Sancti/12-31.txt
+++ b/web/www/horas/Latin/Sancti/12-31.txt
@@ -12,6 +12,8 @@ Lectio1 OctNat
 
 [Ant Vespera]
 @Sancti/12-25:Ant Vespera 3
+(sed rubrica cisterciensis)
+@Commune/C4
 
 [Oratio]
 Da, quǽsumus, omnípotens Deus: ut beáti Silvéstri Confessóris tui atque Pontíficis veneránda solémnitas, et devotiónem nobis áugeat et salútem.

--- a/web/www/horas/Latin/Sancti/12-31.txt
+++ b/web/www/horas/Latin/Sancti/12-31.txt
@@ -46,3 +46,6 @@ Silvéster Románus, patre Rufíno, sæviénte persecutióne, in Sorácte monte 
 @Commune/C4:Lectio9 in 2 loco
 (sed rubrica tridentina)
 @Commune/C5
+
+[Ant 3] (rubrica cisterciensis)
+@Commune/C4:Ant 3 summi Pontificis

--- a/web/www/horas/Latin/SanctiM/01-01.txt
+++ b/web/www/horas/Latin/SanctiM/01-01.txt
@@ -6,6 +6,7 @@ Die Octavæ Nativitatis Domini;;Duplex I classis;;7;;ex SanctiM/12-25
 [Rule]
 12 lectiones
 no Commemoratio
+(sed rubrica cisterciensis omittitur)
 Lectio1 TempNat
 
 [Versum 1]

--- a/web/www/horas/Latin/SanctiM/12-25.txt
+++ b/web/www/horas/Latin/SanctiM/12-25.txt
@@ -11,6 +11,11 @@ R. Hódie sciétis * Quia véniet Dóminus.
 &Gloria
 R. Hódie sciétis * Quia véniet Dóminus.
 
+[Responsory Vespera 1] (rubrica cisterciensis)
+<FONT COLOR=RED>Responsorium</FONT> O Juda et Jerúsalem, nolíte timére: * Cras egrediémini, et Dóminus erit vobíscum.
+V. Constántes estóte, vidébitis auxílium Dómini super vos.
+R. Cras egrediémini, et Dóminus erit vobíscum.
+
 [Responsory Vespera]
 @:Responsory Breve Tertia
 
@@ -18,6 +23,13 @@ R. Hódie sciétis * Quia véniet Dóminus.
 Elevámini, * portæ æternáles, † et introíbit Rex glóriæ.;;23
 In princípio * et ante sǽcula Deus erat Verbum: † ipse natus est nobis Salvátor mundi.;;96
 Nato * Dómino Angelórum chorus canébat, dicens: Salus Deo nostro, allelúja.;;98
+
+[Nocturn 2 Versum] (rubrica cisterciensis)
+V. Verbum caro factum est.
+R. Et habitávit in nobis.
+
+[Nocturn 3 Versum] (rubrica cisterciensis)
+@Sancti/12-25::s/, allel[uú][ij]a//gi
 
 [Ant Matutinum 3N]
 Párvulus * fílius hódie natus est nobis: † et vocábitur Deus, Fortis, allelúja, allelúja.
@@ -48,6 +60,12 @@ R. Descéndit de cælis Deus verus a Patre génitus, † introívit in úterum V
 * Et exívit per portem clausam † Deus et homo, Lux et vita, cónditor mundi.
 V. Tamquam sponsus † Dóminus procédens de thálamo suo.
 R. Et exívit per portem clausam † Deus et homo, Lux et vita, cónditor mundi.
+
+[Responsory4] (rubrica cisterciensis)
+<FONT COLOR=RED>Responsorium</FONT> Propter nímiam charitátem suam, qua diléxit nos Deus Pater, Fílium suum misit 
+* In similitúdinem carnis peccáti, ut omnes salváret.
+V. Ecce jam venit plenitúdo témporis, in quo misit Deus Fílium suum in terras, natum de Vírgine, factum sub lege.
+R. In similitúdinem carnis peccáti, ut omnes salváret.
 
 [Lectio5]
 @Sancti/12-25:Lectio4:s/Exsúltet .*//s
@@ -114,12 +132,19 @@ R. Hoc erat in princípio apud Deum.
 
 [Responsory TertiaM]
 @Sancti/12-25:Versum Nona
+(sed rubrica cisterciensis)
+@Sancti/12-25:Nocturn 1 Versum
 
 [Responsory SextaM]
 @Sancti/12-25:Versum 2
+(sed rubrica cisterciensis)
+@:Nocturn 2 Versum
 
 [Responsory NonaM]
 @Sancti/12-25:Versum Sexta
+(sed rubrica cisterciensis)
+@:Nocturn 3 Versum
 
 [Ant Vespera 3]
 @Sancti/12-25::s/.*;;131//
+(sed rubrica cisterciensis omittitur)

--- a/web/www/horas/Latin/SanctiM/12-26.txt
+++ b/web/www/horas/Latin/SanctiM/12-26.txt
@@ -85,3 +85,5 @@ R. Facta est persecútio magna advérsus Ecclésiam, quæ erat Jerosólymis.
 
 [Ant Vespera 3]
 @Sancti/12-25::s/129/131/
+(sed rubrica cisterciensis)
+@Sancti/12-26:Ant Laudes

--- a/web/www/horas/Latin/SanctiM/12-27.txt
+++ b/web/www/horas/Latin/SanctiM/12-27.txt
@@ -86,3 +86,5 @@ R. Quid ad te, tu me séquere.
 
 [Ant Vespera 3]
 @Sancti/12-25::s/129.*/129/s
+(sed rubrica cisterciensis)
+@Sancti/12-27:Ant Laudes

--- a/web/www/horas/Latin/SanctiM/12-28.txt
+++ b/web/www/horas/Latin/SanctiM/12-28.txt
@@ -3,6 +3,9 @@
 [Rule]
 12 lectiones
 
+[Ant 1] (rubrica cisterciensis)
+O quam * gloriósum est regnum, in quo cum Christo gaudent Innocéntes, amícti stolis albis sequúntur Agnum quocúmque íerit.
+
 [AntMatutinumM]
 Isti * sunt, qui venérunt ex magna tribulatióne, † et lavérunt stolas suas in sánguine Agni.;;33
 Si coram * homínibus torménta passi sunt, † spes electórum est immortális in ætérnum.;;60
@@ -99,3 +102,5 @@ R. Deus noster.
 
 [Ant Vespera 3]
 @Sancti/12-25::s/129/131/
+(sed rubrica cisterciensis)
+@Sancti/12-28:Ant Vespera 3C

--- a/web/www/horas/Latin/SanctiM/12-31o.txt
+++ b/web/www/horas/Latin/SanctiM/12-31o.txt
@@ -3,6 +3,9 @@
 [Rank]
 S. Silvestri Papæ et Confessoris;;Duplex;;3;;vide C4
 
+[Rank] (rubrica cisterciensis)
+S. Silvestri Papæ et Confessoris;;Duplex;;3.1;;vide C4
+
 [Rule]
 vide C4;
 12 lectiones 

--- a/web/www/horas/Latin/Tempora/Nat1-0.txt
+++ b/web/www/horas/Latin/Tempora/Nat1-0.txt
@@ -20,6 +20,10 @@ Lectio1 OctNat
 V. Verbum caro factum est, allelúja.
 R. Et habitávit in nobis, allelúja.
 
+[Versum 1] (rubrica cisterciensis)
+V. Notum fecit Dóminus.
+R. Salutáre suum.
+
 [Ant 1]
 Dum médium siléntium * tenérent ómnia, et nox in suo cursu médium iter perágeret, omnípotens Sermo tuus, Dómine, a regálibus sédibus venit, allelúja.
 
@@ -87,6 +91,13 @@ R. Jacet in præsépio, et in cælis regnat.
 [Lectio9]
 Prophetávit ítaque Simeon, prophetáverat virgo, prophetáverat copuláta conjugio; prophétare debuit étiam vidua, ne qua aut proféssio deésset, aut sexus. Et ideo Anna et stipendiis viduitátis, et móribus talis inducitur, ut digna plane fuísse credátur, quæ Redemptórem ómnium venisse nuntiáret. Cujus merita cum álibi descripsérimus, cum viduas hortarémur, hoc loco, quóniam ad alia properamus, non putámus iteránda.
 &teDeum
+
+[Ant Laudes] (rubrica cisterciensis)
+Génuit puérpera * Regem, cui nomen ætérnum, et gáudia matris habens cum virginitátis honóre: nec primam símilem visa est, nec habére sequéntem, allelúja.
+Angelus * ad pastóres ait: Annúntio vobis gáudium magnum: quia natus est vobis hódie Salvátor mundi, allelúia.
+Facta est * cum Angelo multitúdo cœléstis exércitus laudántium, et dicéntium: Glória in excélsis Deo, et in terra pax homínibus bonæ voluntátis, allelúia.
+Pastóres * loquébantur ad ínvicem: Transeámus usque Béthlehem, et videámus hoc Verbum quod factum est, quod Dóminus osténdit nobis, allelúia
+Et venérunt * festinántes: et invenérunt Maríam, et Joseph, et infántem pósitum in præsépio, allelúia.
 
 [Capitulum Laudes]
 !Gal 4:1-2

--- a/web/www/horas/Latin/Tempora/Nat26.txt
+++ b/web/www/horas/Latin/Tempora/Nat26.txt
@@ -16,3 +16,9 @@ ex Sancti/12-25;
 
 [Ant 1]
 @Sancti/12-25:Ant 3
+
+[Ant 1] (rubrica cisterciensis)
+Nésciens Mater Virgo virum, péperit sine dolóre Salvatórem sæculórum, ipsum Regem Angelórum sola Virgo lactábat úbere de cœlo pleno.
+
+[Ant 2] (rubrica cisterciensis)
+Verbum caro factum est, et habitávit in nobis: et vídimus glóriam ejus, glóriam quasi Unigéniti a Patre plenum grátiæ, et veritátis, allelúia, allelúia, allelúia.

--- a/web/www/horas/Latin/Tempora/Nat27.txt
+++ b/web/www/horas/Latin/Tempora/Nat27.txt
@@ -17,6 +17,12 @@ ex Sancti/12-25;
 [Ant 1]
 @Sancti/12-25:Ant 3
 
+[Ant 1] (rubrica cisterciensis)
+@Tempora/Nat26
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Nat26
+
 [Commemoratio 2] (rubrica tridentina nisi rubrica altovadensis)
 @Sancti/12-26:Octava
 

--- a/web/www/horas/Latin/Tempora/Nat28.txt
+++ b/web/www/horas/Latin/Tempora/Nat28.txt
@@ -17,6 +17,12 @@ ex Sancti/12-25;
 [Ant 1]
 @Sancti/12-25:Ant 3
 
+[Ant 1] (rubrica cisterciensis)
+@Tempora/Nat26
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Nat26
+
 [Commemoratio 2] (rubrica tridentina nisi rubrica altovadensis)
 @Sancti/12-26:Octava
 @Sancti/12-27:Octava

--- a/web/www/horas/Latin/Tempora/Nat29.txt
+++ b/web/www/horas/Latin/Tempora/Nat29.txt
@@ -17,6 +17,22 @@ ex Sancti/12-25;
 [Ant 1]
 @Sancti/12-25:Ant 3
 
+[Ant 1] (rubrica cisterciensis)
+@Tempora/Nat26
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Nat26
+
+[Commemoratio 2] (rubrica tridentina nisi rubrica altovadensis)
+@Sancti/12-26:Octava
+@Sancti/12-27:Octava
+@Sancti/12-28:Octava
+
+[Commemoratio 3] (rubrica tridentina nisi rubrica altovadensis)
+@Sancti/12-26:Octava
+@Sancti/12-27:Octava
+@Sancti/12-28:Octava
+
 [Lectio1]
 Incipit Epístola beáti Pauli Apóstoli ad Romános
 !Rom 1:1-7

--- a/web/www/horas/Latin/Tempora/Nat30.txt
+++ b/web/www/horas/Latin/Tempora/Nat30.txt
@@ -4,8 +4,13 @@ Die VI infra Octavam Nativitatis;;Semiduplex;;2.1;;ex Sancti/12-25
 [Rank] (rubrica 196)
 Die sexta post Nativitatem;;Duplex II classis;;5;;ex Sancti/12-25
 
+[Rank] (rubrica cisterciensis)
+Die sexta post Nativitatem;;Duplex II classis;;2.9;;ex Tempora/Nat1-0
+
 [Rule]
 ex Sancti/12-25;
+(sed rubrica cisterciensis)
+ex Tempora/Nat1-0
 9 lectiones
 
 [Ant Vespera]
@@ -14,8 +19,17 @@ ex Sancti/12-25;
 [Versum 1]
 @Sancti/12-25:Versum 3
 
+[Versum 1] (rubrica cisterciensis)
+@Tempora/Nat1-0
+
 [Ant 1]
 @Sancti/12-25:Ant 3
+
+[Ant 1] (rubrica cisterciensis)
+@Tempora/Nat1-0
+
+[Ant 2] (rubrica cisterciensis)
+@:Ant 1
 
 [Lectio1]
 De Epístola ad Romános
@@ -90,3 +104,9 @@ Non medíocre fídei tibi hoc videátur exémplum, quod vilis sit persóna past�
 [Lectio9]
 Nec contemnénda putes quasi vília verba pastórum. A pastóribus enim María fidem cólligit, a pastóribus pópulus ad Dei reveréntiam congregátur. Miráti étiam sunt omnes qui audiérunt, de iis, quæ dicebántur a pastóribus ad ipsos. Mária autem conservábat ómnia verba hæc, cónferens in corde suo. Discámus sanctæ Vírginis in ómnibus castitátem, quæ non minus ore pudíca quam córpore, arguménta fídei conferébat in corde.
 &teDeum
+
+[Responsory SextaM] (rubrica cisterciensis)
+@SanctiM/12-25:Nocturn 2 Versum
+
+[Responsory NonaM] (rubrica cisterciensis)
+@SanctiM/12-25:Nocturn 3 Versum

--- a/web/www/horas/Latin/Tempora/Nat31.txt
+++ b/web/www/horas/Latin/Tempora/Nat31.txt
@@ -7,7 +7,7 @@ Die septima post Nativitatem;;Duplex II classis;;5;;ex Sancti/12-25
 [Rule]
 ex Sancti/12-25;
 9 lectiones
-no secunda vesperas
+No secunda vespera
 
 [Ant Vespera]
 @Sancti/12-25:Ant Vespera 3

--- a/web/www/horas/Latin/Tempora/Nat31.txt
+++ b/web/www/horas/Latin/Tempora/Nat31.txt
@@ -18,6 +18,12 @@ No secunda vespera
 [Ant 1]
 @Sancti/12-25:Ant 3
 
+[Ant 1] (rubrica cisterciensis)
+@Tempora/Nat26
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Nat26
+
 [Lectio1]
 De Epístola ad Romános
 !Rom 3:19-22

--- a/web/www/horas/Latin/TemporaM/Nat1-0.txt
+++ b/web/www/horas/Latin/TemporaM/Nat1-0.txt
@@ -12,6 +12,9 @@ Antiphonas horas
 [Versum 1]
 @Sancti/12-25:Versum Sexta
 
+[Versum 1] (rubrica cisterciensis)
+@Tempora/Nat1-0
+
 [Lectio1]
 @Tempora/Nat29
 

--- a/web/www/horas/Latin/TemporaM/Nat1-0a.txt
+++ b/web/www/horas/Latin/TemporaM/Nat1-0a.txt
@@ -7,3 +7,6 @@ This file is to be used when the Sunday falls on Dec 29.
 @Sancti/12-25:Octava
 @Sancti/12-26:Octava
 @Sancti/12-27:Octava
+
+[Commemoratio 1] (rubrica altovadensis)
+@Sancti/12-25:Octava

--- a/web/www/horas/Latin/TemporaM/Nat29.txt
+++ b/web/www/horas/Latin/TemporaM/Nat29.txt
@@ -8,6 +8,16 @@ Die V infra Octavam Nativitatis;;Duplex II classis;;5;;ex Sancti/12-25
 Psalmi Dominica
 Antiphonas horas
 
+[Commemoratio 2] (rubrica tridentina nisi rubrica altovadensis)
+@Sancti/12-26:Octava
+@Sancti/12-27:Octava
+@Sancti/12-28:Octava
+
+[Commemoratio 3] (rubrica tridentina nisi rubrica altovadensis)
+@Sancti/12-26:Octava
+@Sancti/12-27:Octava
+@Sancti/12-28:Octava
+
 [Ant Matutinum]
 @TemporaM/Nat1-0tt
 

--- a/web/www/horas/Latin/TemporaM/Nat30.txt
+++ b/web/www/horas/Latin/TemporaM/Nat30.txt
@@ -10,6 +10,24 @@ Antiphonas horas
 [Ant Vespera]
 @Sancti/12-25:Ant Vespera 3:s/.*;;129/;;131/
 
+[Commemoratio 2] (rubrica altovadensis)
+@Sancti/12-25:Octava
+
+[Commemoratio 3] (rubrica altovadensis)
+@Sancti/12-25:Octava
+
+[Commemoratio 2] (rubrica tridentina nisi rubrica altovadensis)
+@Sancti/12-25:Octava
+@Sancti/12-26:Octava
+@Sancti/12-27:Octava
+@Sancti/12-28:Octava
+
+[Commemoratio 3] (rubrica tridentina nisi rubrica altovadensis)
+@Sancti/12-25:Octava
+@Sancti/12-26:Octava
+@Sancti/12-27:Octava
+@Sancti/12-28:Octava
+
 [Ant Matutinum]
 @TemporaM/Nat1-0tt
 

--- a/web/www/horas/Latin/TemporaM/Nat31.txt
+++ b/web/www/horas/Latin/TemporaM/Nat31.txt
@@ -9,7 +9,7 @@ Antiphonas horas
 
 [Rule] (rubrica tridentina)
 ex SanctiM/12-25
-no secunda versperas
+No secunda vespera
 
 [Ant Matutinum] (rubrica 1963)
 @TemporaM/Nat1-0tt


### PR DESCRIPTION
C10 + C11 updated for Cistercian Rite
Christmas Propers were also updated for Cist. Rite (without Matins)
Discussion #4313: limited the deletion of Pater+Ave to C9. Otherwise it deletes the initial prayers also in the Sacred Triduum, which is not correct.
Bugfixes 