### PR TITLE
'mea; Si introíbunt' → 'mea: Si introíbunt'

### DIFF
--- a/web/www/horas/Latin/Psalterium/Invitatorium.txt
+++ b/web/www/horas/Latin/Psalterium/Invitatorium.txt
@@ -8,7 +8,7 @@ v. Quóniam ipsíus est mare, et ipse fecit illud, et áridam fundavérunt manus
 $ant
 v. Hódie, si vocem ejus audiéritis, nolíte obduráre corda vestra, ^ sicut in exacerbatióne secúndum diem tentatiónis in desérto: ubi tentavérunt me patres vestri, probavérunt et vidérunt ópera mea.
 $ant2
-v. Quadragínta annis próximus fui generatióni huic, et dixi; Semper hi errant corde, ipsi vero non cognovérunt vias meas: quibus jurávi in ira mea; Si introíbunt in réquiem meam.
+v. Quadragínta annis próximus fui generatióni huic, et dixi: Semper hi errant corde, ipsi vero non cognovérunt vias meas: quibus jurávi in ira mea: Si introíbunt in réquiem meam.
 $ant
 &Gloria
 $ant2


### PR DESCRIPTION
A semicolon doesn't precede a capital letter. It should be colon.