### PR TITLE
Revert recent accidental changes (plus an Italian fix)

### DIFF
--- a/web/www/horas/English/Tempora/Epi2-0.txt
+++ b/web/www/horas/English/Tempora/Epi2-0.txt
@@ -5,7 +5,7 @@ Dominica II post Epiphaniam;;Semiduplex;;5
 God hath received * Israel his servant, as he spoke to our fathers, to Abraham and to his seed for ever.
 
 [Oratio]
-Všemohoucí, věčný Bože, jenž věci nebeské i pozemské řídíš, snažné prosby lidu svého milostivě vyslyš a mír svůj uděl našim časům. 
+Almighty and eternal God, as thou govern all things in heaven and on earth; in thy mercy hear the supplication of thy people, and grant thy peace in our times.
 $Per Dominum
 
 [Lectio1]
@@ -103,7 +103,7 @@ Lord, being asked, went to the marriage, to strengthen the marriage tie, and to 
 &teDeum
 
 [Ant 2]
-Byla svatba * v Káně Galilejské: a byl tam Ježíš i Maria, jeho matka.
+There was a marriage * in Cana of Galilee: and Jesus was there, with Mary, his mother.
 
 [Ant 3]
-Když docházelo víno, * přikázal Ježíš naplnit džbány vodou, která pak byla proměněna ve víno, alleluja.
+The wine failing, * Jesus commanded the water pots to be filled with water, which was changed into wine, alleluia.

--- a/web/www/horas/Italiano/Psalterium/Common/Prayers.txt
+++ b/web/www/horas/Italiano/Psalterium/Common/Prayers.txt
@@ -221,7 +221,7 @@ V. Dalle porte degli inferi.
 R. Libera, Signore, le loro anime.
 
 [Oratio Visita_]
-r. Visita, o Signore, te ne preghiamo, quest’abitazione e respingi lungi da essa tutte le insidie del nemico: i tuoi Santi Angeli abitino in essa, ci custodiscano in pace; e la tua benedizione sia sempre sopra di noi. 
+v. Visita, o Signore, te ne preghiamo, quest’abitazione e respingi lungi da essa tutte le insidie del nemico: i tuoi Santi Angeli abitino in essa, ci custodiscano in pace; e la tua benedizione sia sempre sopra di noi. 
 
 [respice]
 V. Rivolgi, o Signore, lo sguardo sui tuoi servi e sulle tue opere, e guida i loro figli.

--- a/web/www/horas/Latin/Sancti/12-25.txt
+++ b/web/www/horas/Latin/Sancti/12-25.txt
@@ -435,12 +435,6 @@ Exórtum est * in ténebris lumen rectis corde: miséricors, et miserátor, et j
 Apud Dóminum * misericórdia, et copiósa apud eum redémptio.;;129
 De fructu * ventris tui ponam super sedem tuam.;;131
 
-[Ant Vespera 3]
-In princípio * et ante sǽcula Deus erat Verbum: ipse natus est nobis Salvátor mundi.;;109
-Virgo Verbo concépit, * Virgo permánsit, Virgo péperit Regem ómnium regum.;;110
-Beátus venter, * qui te portávit, Christe, et beáta úbera quæ te lactavérunt Dóminum, et Salvatórem mundi, allelúia.;;111
-Illúxit nobis dies * redemptiónis novæ, reparatiónis antíquæ, felicitátis ætérnæ.;;131
-
 [Capitulum Vespera 3]
 @:Capitulum Laudes
 


### PR DESCRIPTION
- 4cbf012102a4e0b51acf76c01f25e0ad2e9195a4 added a second `Ant Vespera 3` section to `horas/Latin/Sancti/12-25.txt`. This shadows the section with the correct antiphons for the Roman Rite, so I'm reverting this change. I'm not sure what @Augustinus-Altovadensis was trying to accomplish. Perhaps it was meant to apply only to the Cistercian office. If it wasn't simply a mistake, he'll have to try again.
- dc500d9ec7d7ffffe3dabb65ceb1dde350413053 replaced three texts in `horas/English/Tempora/Epi2-0.txt` with Czech. I'm reverting this obvious mistake.
- There's also a fix for the Italian translation of Compline that I had forgotten to commit. This gives the oration Visita the same kind of initial capital in Italian that it has in Latin and other translations.