### PR TITLE
Cist. Updated Tempora till Dom. V. post Pascha + Czech

### DIFF
--- a/web/cgi-bin/horas/specials/capitulis.pl
+++ b/web/cgi-bin/horas/specials/capitulis.pl
@@ -33,6 +33,7 @@ sub monastic_major_responsory {
   our ($hora, $winner, $vespera, $seasonalflag, $version);
 
   my $key = "Responsory $hora";
+  my $key_cist = "";
 
   # special case only once
   $key .= ' 1' if $winner =~ /12-25/ && $vespera == 1;    #($winner =~ /(?:12-25|Quadp[123]-0)/ && $vespera == 1);
@@ -41,8 +42,9 @@ sub monastic_major_responsory {
 
   # CIST: the Cistercian rite has Responsoria prolixa for every Festum Serm. on j. Vespers.
   if ($version =~ /cist/i && $vespera == 1) {
-    my $key_cist = "Responsory $hora 1";
+    $key_cist = "Responsory $hora 1";
     ($resp, $c) = getproprium($key_cist, $lang, $seasonalflag, 1);
+    $key_cist = "" unless ($resp);
     ($resp, $c) = getproprium($key, $lang, $seasonalflag, 1) if !$resp;
   }
 
@@ -73,7 +75,7 @@ sub monastic_major_responsory {
 
   if ($resp) {
     my @resp = split("\n", $resp);
-    postprocess_short_resp(@resp, $lang);
+    postprocess_short_resp(@resp, $lang) unless $key_cist =~ /Responsory Vespera 1/;
     $resp = join("\n", @resp);
     $resp =~ s/\&gloria.*//gsi if $version =~ /cist/i;
   }

--- a/web/cgi-bin/horas/specials/psalmi.pl
+++ b/web/cgi-bin/horas/specials/psalmi.pl
@@ -414,7 +414,8 @@ sub psalmi_major {
   {
     @p = @psalmi;
   } elsif (($rule =~ /Psalmi Dominica/i || ($commune{Rule} && $commune{Rule} =~ /Psalmi Dominica/i))
-    && ($antiphones[0] !~ /\;\;\s*[0-9]+/))
+    && ($antiphones[0] !~ /\;\;\s*[0-9]+/)
+    && ($rule !~ /Psalmi Feria/i))
   {
     $prefix = translate("Psalmi, antiphonae", $lang) . ' ';
     my $h = $hora;

--- a/web/www/horas/Bohemice/Psalterium/Psalmi/Psalmi major.txt
+++ b/web/www/horas/Bohemice/Psalterium/Psalmi/Psalmi major.txt
@@ -47,6 +47,10 @@ Dejte velebení * našemu Bohu;;226(1-32)
 ;;226(33-65)
 Činely * sladce znějícími chvalte Boha.;;148;149;150
 
+[Cistercian Laudes] (tempore paschali)
+Alleluja, * alleluja, alleluja.;;50
+@:Monastic Laudes:2-5 s/.*;;/;;/gm
+
 [Monastic Vespera]
 Řekl Pán * mému pánu: Seď po mé pravici.;;109
 Věrná * jsou všechna jeho přikázání: potvrzená na věky věkův.;;110

--- a/web/www/horas/Bohemice/Sancti/03-19.txt
+++ b/web/www/horas/Bohemice/Sancti/03-19.txt
@@ -327,16 +327,16 @@ R. Ve tvé spáse.
 &Gloria
 R. Veliká je jeho sláva * ve tvé spáse.
 _
-V. Spravedlivý vyroste jako lilie.
+V. Spravedlivý poroste jako lilie.
 R. A kvést bude navěky před Hospodinem.
 
 [Responsory Nona]
-R.br. Spravedlivý vyroste * Jako lilie.
-R. Spravedlivý vyroste * Jako lilie.
+R.br. Spravedlivý poroste * Jako lilie.
+R. Spravedlivý poroste * Jako lilie.
 V. A kvést bude navěky před Hospodinem.
 R. Jako lilie.
 &Gloria
-R. Spravedlivý vyroste * Jako lilie.
+R. Spravedlivý poroste * Jako lilie.
 _
 V. Zasazeni v domě Hospodinově.
 R. V nádvořích domu našeho Boha.

--- a/web/www/horas/Bohemice/Sancti/04-25.txt
+++ b/web/www/horas/Bohemice/Sancti/04-25.txt
@@ -1,0 +1,36 @@
+[Rank]
+sv. Marka, Evangelisty;;Duplex II classis;;5.1;;ex C1ap
+
+[Rank1960]
+sv. Marka, Evangelisty;;Duplex II classis;;5;;ex C1ap
+
+[Rule]
+ex C1;
+9 lectiones
+Laudes Litania
+Psalmi Dominica
+Antiphonas horas
+Psalm5 Vespera=138
+
+[Oratio]
+Bože, jenž jsi svatého Marka, svého Evangelistu, pozvedl milostí hlásání tvého Evangelia; uděl, prosíme, abychom z jeho vzdělanosti vždy prospívali, a jeho modlitbou byli chráněni.
+$Per Dominum
+
+[Lectio4]
+From the Book upon Church Writers, composed by St. Jerome, Priest at Bethlehem.
+_
+Mark was the disciple and interpreter of Peter, and it was from what he had~
+heard Peter tell, that, at the request of the brethren at Rome, he wrote the~
+shortest of the Gospels. When Peter had heard it, he approved it, and gave it to~
+the Church to be read, by his authority. Mark betook himself to Egypt, with the~
+Gospel which he had compiled, and was the first man who preached Christ at~
+Alexandria. There he founded a Church with such teaching and austerity of life,~
+that all who followed Christ were constrained to imitate him.
+
+[Lectio5]
+Last of all, Philo, that most learned Jew, observing that the first Church of~
+Alexandria still kept the law of Moses, wrote a book concerning their manners,~
+as if in praise of his own nation, wherein he saith that under the teaching of~
+Mark, the Christians of Alexandria had all things in common, just as Luke~
+telleth us was the case with all them that believed at Jerusalem. Mark died in~
+the eighth year of Nero, and was buried at Alexandria. Anianus succeeded him.

--- a/web/www/horas/Bohemice/SanctiM/04-25.txt
+++ b/web/www/horas/Bohemice/SanctiM/04-25.txt
@@ -1,0 +1,12 @@
+[Rank]
+sv. Marka, Evangelisty
+
+[Lectio9]
+@Commune/C1a:Lectio7:s/ And no.*//s
+
+[Lectio10]
+@Commune/C1a:Lectio7:s/.*And/And/s s/$/~/
+@Commune/C1a:Lectio8:s/ Well.*//s
+
+[Lectio11]
+@Commune/C1a:Lectio8:s/.*Well/Well/s

--- a/web/www/horas/Bohemice/Tempora/Pasc0-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc0-0.txt
@@ -1,0 +1,121 @@
+[Rank]
+Dominica Resurrectionis;;Duplex I classis cum Octava Privilegiata I;;7
+
+[Rule]
+1 nocturn;
+Omit Hymnus Preces Suffragium Commemoratio;
+Minores sine Antiphona;
+Capitulum Versum 2;
+Psalmi Dominica;
+Prima=53
+
+[Ant 1]
+Ovšem v sobotu večer, * když už svítalo na první den v týdnu, přišla Maria Magdaléna a druhá Maria, aby viděly hrob, alleluja.
+
+[Oratio]
+Bože, jenž jsi nám dnešního dne skrze svého Jednorozeného po přemožení smrti otevřel bránu věčnosti, prosby naše, které nám předem vnukáš, rovněž svou pomocí provázej. 
+$Per eumdem
+
+[Special Vespera 1]
+#Sabbato Sancto special Paschal Vespera
+_
+$Pater noster
+$Ave Maria 
+_
+Ant. Alleluja, alleluja, alleluja.
+(sed rubrica cisterciensis)
+Ant. Alleluja, * alleluja, alleluja.
+&psalm(116)
+Ant. Alleluja, alleluja, alleluja.
+_
+Ant. Ovšem v sobotu večer, když už svítalo na první den v týdnu, přišla Maria Magdaléna a druhá Maria, aby viděly hrob, alleluja.
+(sed rubrica cisterciensis)
+Ant. Ovšem v sobotu večer.
+&psalm(232)
+Ant. Ovšem v sobotu večer, když už svítalo na první den v týdnu, přišla Maria Magdaléna a druhá Maria, aby viděly hrob, alleluja.
+
+&Dominus_vobiscum
+v. Ducha své lásky, Pane, nám vlej: abychom my, jež jsi nasytil Velikonočními Svátostmi, učinil sjednocené s tvou laskavostí.
+$Per Dominum eiusdem
+&Dominus_vobiscum
+
+V. Dobrořečme Pánu, alleluja, alleluja.
+R. Bohu díky, alleluja, alleluja.
+(nisi rubrica cisterciensis) $Fidelium animae
+$Pater noster
+
+[Invit]
+The Lord is risen, indeed, * Alleluia.
+
+[Ant Matutinum]
+I am who I am * and my counsel is not with the ungodly, my will is in the law of God, alleluia.;;1
+I asked my Father, * alleluia, and he gave me nations, alleluia, as inheritance, alleluia.;;2
+I have slept * and have taken my rest: and I have risen up, because the Lord hath protected me, alleluia, alleluia.;;3
+V. The Lord is risen from the sepulcher, alleluia.
+R. He, who hangeth on the tree, alleluia.
+
+[Lectio1]
+Continuation of the Holy Gospel according to Mark
+!Mark 16:1-7
+And when the sabbath was past, Mary Magdalen, and Mary the mother of James, and Salome, bought sweet spices, that coming, they might anoint Jesus. And what follows.
+_
+Homily of St. Gregory, Pope
+!21st Homily on the Gospels
+Dearly beloved brethren, ye have heard the deed of the holy women which had followed the Lord; how that they brought sweet spices to His sepulchre, and, now that He was dead, having loved Him while He was yet alive, they followed Him with careful tenderness still. But the deed of these holy women doth point to somewhat which must needs be done in the holy Church. And it behoveth us well to give ear to what they did, that we may afterward consider with ourselves what we must do likewise after their example. We also, who believe in Him That was dead, do come to His sepulchre bearing sweet spices, when we seek the Lord with the savour of good living, and the fragrant report of good works. Those women, when they brought their spices, saw a vision of Angels, and, in sooth, those souls whose godly desires do move them to seek the Lord with the savour of good lives, do see the countrymen of our Fatherland which is above.
+
+[Responsory1]
+R. The Angel of the Lord descended from heaven, and came and rolled back the stone, and sat upon it, and said unto the women:
+* Fear not ye; for I know that ye seek Him That was crucified: He is risen already. Come, see the place where the Lord was laid, alleluia.
+V. And entering into the sepulchre, they saw a young man sitting on the right side, clothed in a long white garment, and they were affrighted; and he saith unto them:
+R. Fear not ye: for I know that ye seek Him That was crucified: He is risen already; come, see the place where the Lord was laid, alleluia.
+&Gloria
+R. The Angel of the Lord descended from heaven, and came and rolled back the stone and sat upon it, and said unto the women: Fear not ye: for I know that ye seek Him That was crucified: He is risen already: Come, see the place where the Lord was laid, alleluia.
+
+[Lectio2]
+It behoveth us to mark what this meaneth, that they saw the Angel sitting on the right side. For what signifieth the left, but this life which now is? or the right, but life everlasting? Whence also it is written in the Song of Songs (ii. 6): His left hand is under my head, and His right hand doth embrace me. Since, therefore, our Redeemer had passed from the corruption of this life which now is, the Angel which told that His undying life was come, sat, as became him, on the right side. They saw him clothed in a white garment, for he was herald of the joy of this our great solemnity, and the glistering whiteness of his raiment told of the brightness of this holy Festival of ours. Of ours, said I? or of his? But if we will speak the truth, we must acknowledge that it is both his and ours. The Again-rising of our Redeemer is a Festival of gladness for us, for us it biddeth know that we shall not die for ever; and for Angels also it is a festival of gladness, for it biddeth them know that we are called to fulfill their number in heaven.
+
+[Responsory2]
+R. When the Sabbath was passed, Mary Magdalene, and Mary the mother of James, and Salome, had bought sweet spices,
+* That they might come and anoint Jesus, alleluia, alleluia.
+V. And very early in the morning, the first day of the week, they came unto the sepulchre, at the rising of the sun.
+R. That they might come and anoint Jesus, alleluia, alleluia.
+&Gloria
+R. That they might come and anoint Jesus, alleluia, alleluia.
+
+[Lectio3]
+See this glad Festival then, which is both his and ours, the Angel appeared in white raiment. For as the Lord, rising again from the dead, leadeth us unto the mansions above, He repaireth the breaches of the heavenly Fatherland. But what meaneth this, that the Angel said unto the women which came to the sepulchre: Fear not? Is it not as though he had said openly: Let them fear which love not the coming of the heavenly countrymen; let them be afraid who are so laden by fleshly lusts, that they have lost all hope ever to be joined to their company. But as for you, why fear ye, who, when ye see us, see but your fellow countrymen? Hence also Matthew, writing of the guise of the Angel, saith (xxviii. 3): His countenance was like lightning, and His raiment white as snow. The lightning speaketh of fear and great dread, the snow of the soft brilliancy of rejoicing.
+&teDeum
+
+[Prelude Matutinum] (rubrica 1955 aut rubrica 1960)
+!When the celebration of the solemn Paschal Vigil takes the place of the night office of Easter Sunday, Lauds of the same Easter Sunday are sung during the solemn Mass of the vigil, immediately after Communion, with Matins being omitted. The office of Easter Sunday then begins with Prime.
+_
+!Those who do not assist at the solemn Paschal Vigil, however, are bound to say Matins and Lauds of Easter Sunday.
+
+[Ant Laudes]
+For an angel of the Lord * descended from heaven and coming rolled back the stone and sat upon it, alleluia, alleluia.
+There was a great earthquake; * For an angel of the Lord descended from heaven, alleluia.
+And his countenance * was as lightning and his raiment as snow, alleluia, alleluia.
+And for fear of him * the guards were struck with terror and became as dead men, alleluia.
+And the angel answering * said to the women: Fear not you: for I know that you seek Jesus, alleluia.
+
+[Ant Laudes] (rubrica cisterciensis)
+Alleluja, * alleluja, alleluja.
+
+[Versum 2]
+Ant. Toto je den, * který učinil Pán; jásejme a radujme se v něm.
+
+[Ant 2]
+A brzo ráno * prvního dne v týdnu přišli k hrobu, a slunce již vyšlo, alleluja.
+
+[Ant 3]
+I pohlédli * a viděli odvalený kámen; byl totiž velmi veliký, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+Kristus, když vstal * z mrtvých, již neumírá, smrt nad ním již nemá žádnou moc, když tedy žije, žije Bohu, alleluja, alleluja.
+
+[Ant 41]
+Ovšem v sobotu večer, * když už svítalo na první den v týdnu, přišla Maria Magdaléna a druhá Maria, aby viděly hrob, alleluja.
+
+[Ant 43]
+Alleluia, Alleluia, Alleluia, Alleluia.
+Toto je den, * který učinil Pán; jásejme a radujme se v něm.

--- a/web/www/horas/Bohemice/Tempora/Pasc0-1.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc0-1.txt
@@ -1,0 +1,57 @@
+[Rank]
+Die II infra octavam Paschae;;Duplex I classis;;7;;ex Pasc0-0
+
+[Rule]
+ex Pasc0-0;
+1 nocturn;
+Omit Hymnus Preces Suffragium Commemoratio;
+Minores sine Antiphona;
+Capitulum Versum 2;
+Psalmi Dominica;
+
+[Oratio]
+Bože, jenž jsi velikonoční slavností udělil světu uzdravení; svůj lid, prosíme, nepřestávej obdarovávat nebeským darem, aby si i zasloužil obdržet dokonalou svobodu, i prospíval do života věčného.
+$Per Dominum.
+
+[Lectio1]
+Continuation of the Holy Gospel according to Luke
+!Luke 24:13-35
+And behold, two of them went, the same day, to a town which was sixty furlongs from Jerusalem, named Emmaus. And so forth.
+_
+Homily by Pope St. Gregory (the Great)
+!23rd on the Gospels
+Dearly beloved brethren, ye hear, how that while two of His disciples walked together in the way, not believing in His Resurrection, but talking, together concerning Him, the Lord manifested Himself unto them, but yet held their eyes that they should not know Him. This holding of the eyes of their body, wrought by the Lord, was a figure of the spiritual veil which was yet upon the eyes of their heart. For in their heart they loved and yet doubted: even as the Lord drew near to them outwardly, but showed not Who He was. To them that talked together of Him, He revealed His immediate presence; but hid, from them that doubted, the knowledge of His Person.
+
+[Responsory1]
+R. Mary Magdalene and the other Mary went very early to the sepulchre.
+* That Jesus whom ye seek, is not here: for He is risen, as He said: He goeth before you into Galilee; there shall ye see Him, alleluia, alleluia.
+V. And very early in the morning, the first day of the week, they came unto the sepulchre, at the rising of the sun; and, entering into the sepulchre, they saw a young man sitting upon the right side, who saith unto them:
+R. That Jesus Whom ye seek is not here: for He is risen, as He said: He goeth before you into Galilee: there shall ye see Him, alleluia, alleluia.
+
+[Lectio2]
+He spoke to them; He rebuked the hardness of their heart; He expounded unto them in all the Scriptures the things concerning Himself: and, nevertheless, seeing that He was yet a stranger to faith in their hearts, He made as though He would~
+have gone further. These words He made as though would here seem to mean He feigned, but He Who is simple Truth doth nothing with feigning: He only showed Himself to them in bodily manners, as He was towards them spiritually; but they were put to the proof whether, though they loved Him not yet as their God, they could love Him at least as a wayfarer.
+
+[Responsory2]
+R. The Good Shepherd, Who laid down His life for the sheep, yea, Who was contented even to die for His flock, the Good Shepherd is risen again.
+* Alleluia, alleluia, alleluia.
+V. For even Christ our Passover is sacrificed for us.
+R. Alleluia, alleluia, alleluia.
+&Gloria
+R. Alleluia, alleluia, alleluia.
+
+[Lectio3]
+But since it was impossible, that they with whom Truth walked, should be loveless, they asked Him as a wayfarer to take of their hospitality. But why say we that they asked Him, when it is written: And they constrained Him? From their example we learn that we ought not only to bid, but also to urge, wayfarers to our hospitable entertainment. They laid a table therefore, and set before Him bread and meat; and that God Whom they had not known in the expounding of the Holy Scripture, they knew in the breaking of bread. In hearing the commandments of God they were not enlightened, but they were enlightened in the doing of them: as it is written: Not the hearers of the law are just before God, but the doers of the law shall be justified. (Rom. ii. 13.) Whosoever therefore will understand that which he heareth, let him make haste to practice in his works that which he hath already been able to hear. Behold, the Lord was not known while He spake, but He was contented to be known when He broke bread.
+&teDeum
+
+[Ant 2]
+Ježíš se přidal * ke svým učedníkům na cestě, a kráčel s nimi; jejich oči však byly zadržovány, aby jej nepoznali; a on je pokáral těmito slovy: O hlupáci, pomalí srdcem uvěřit v tom, co pravili Proroci, alleluja.
+
+[Ant 3]
+Co je to za řeči, * které jste si sdělovali navzájem, když jste šli, a jste <i>kvůli nim</i> smutní? alleluja.
+
+[Ant 2] (rubrica cisterciensis)
+Co je to za řeči, * které jste si sdělovali navzájem, když jste šli, a jste <i>kvůli nim</i> smutní? alleluja, alleluja. Odpověděl mu jeden, který se jmenoval Kleofáš, a řekl jemu: „Ty jsi jediný poutník v Jerusalémě, který neví, co se tam stalo v těchto dnech?” alleluja. Na to jim Pán řekl: „Co?” oni řekli: „O Ježíši Nazaretském, který byl Prorokem, mocný ve skutcích i slovech před Bohem, i před vším lidem,” alleluja, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+Neplanulo snad naše srdce, * kvůli Ježíšovi, když s námi mluvil na cestě? alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc0-2.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc0-2.txt
@@ -1,0 +1,63 @@
+[Rank]
+Die III infra octavam Paschae;;Duplex I classis;;6;;ex Pasc0-0
+
+[Rank] (rubrica cisterciensis) 
+Úterý ve velikonočním Oktávu;;MM. maj.;;7;;ex Pasc0-0
+
+[Rule]
+ex Pasc0-0;
+1 nocturn;
+Omit Hymnus Preces Suffragium;
+no commemoratio;
+Minores sine Antiphona;
+Capitulum Versum 2;
+Psalmi Dominica;
+
+[Oratio]
+Bože, jenž svou Církve rozmnožuješ vždy novými plody; uděl svým služebníkům, aby za života obdrželi tu svátost, již vírou pociťovali.
+$Per Dominum
+
+[Ant Matutinum]
+@Tempora/Pasc0-0::s/^V\..*//sm
+R. The Lord is risen, indeed. alleluia.
+V. And hath appeared to Simon, alleluia. 
+
+[Lectio1]
+Continuation of the Holy Gospel according to Luke
+!Luke 24:36-47
+At that time: Now whilst they were speaking these things, Jesus stood in the midst of them, and saith to them: Peace be to you; it is I, fear not. And so forth.
+_
+Homily by St. Ambrose, Bishop (of Milan.)
+!Bk. x Comm. on Luke xxiv
+We see here the marvelous nature of the Lord's glorified Body. It could enter unseen, and then become seen. It could easily be touched, but Its nature is hard to understand. The disciples were affrighted, and supposed that they had seen a spirit. And therefore the Lord, that He might show us the evidence of His Resurrection, said: Handle Me, and see; for a spirit hath not flesh and bones as ye see Me have. Therefore it was not by being in a disembodied state, but by the peculiar qualities of the risen and glorified Body that He had passed through closed doors. (John xx. 19.) For that which is touched or handled is a body.
+
+[Responsory1]
+R. With great power gave the Apostles
+* Witness of the Resurrection of our Lord Jesus Christ, alleluia, alleluia.
+V. They were all filled with the Holy Ghost, and they spoke the Word of God with boldness.
+R. Witness of the Resurrection of our Lord Jesus Christ, alleluia, alleluia.
+
+[Lectio2]
+We shall all rise again with our bodies. But it is sown a natural body; it is~
+raised a spiritual body. (1. Cor. xv. 44.) The spiritual body is the finer, and the natural body is the grosser, besodden as yet by the corruption of earth. Was not That a real Body, wherein remained those marks of His Wounds, those holes of the nail-prints, which the Lord bade His disciples to handle? Hereby, also, He hath not only strengthened our faith, but also quickened our love, since we know that it has been His will to carry to heaven those Wounds which He bore for our sake, and wherewith He would not make away; but plainly showeth to His Eternal Father the price of our freedom. It is as marked with these Wounds and embracing the trophy of our salvation that the Father hath said to Him, Sit Thou at My right Hand: and it is, like Him, marked with their wounds, that He hath shown us that the Martyrs, whose Crown He is, are, and will be with Him there.
+
+[Responsory2]
+R. From the mouth of the wise doth proceed honey, alleluia: the sweetness of honey is under his tongue, alleluia.
+* His lips drop as the honey-comb, alleluia, alleluia.
+V. Wisdom doth abide in his heart, and out of his mouth cometh understanding.
+R. His lips drop as the honey-comb, alleluia, alleluia.
+&Gloria
+R. His lips drop as the honey-comb, alleluia, alleluia.
+
+[Lectio3]
+And now, since our Lesson from Luke here faileth, let us have recourse to John, and consider how that, according to him, (xx. 20,) then were the disciples glad when they saw the Lord, and received the grace of faith. According to Luke, He upbraided them with their unbelief, but according to John He said also, Receive ye the Holy Ghost. Luke, not John, hath, Tarry ye in the city of Jerusalem, until ye be endued with power from on high. Indeed, to me it seemeth as though the one Evangelist had busied himself with the greater and higher matters, and the other with the narrative, and such things as are more human: the one with the course, the other with the essence, of history. For as it is impossible to doubt the word of him who testifieth of these things, (John xxi. 24,) and who saw these things, and concerning whom we know that his testimony is true, (xxi. 24,) so is it sinful to think of negligence or falsehood as attaching to the other, even Luke, who earned to himself to be an Evangelist, albeit he was not an Apostle, and therefore we hold that both are truthful, neither are they at variance one with the other, either in the difference of the words they use, or in the sacredness of their characters as Evangelists. For though Luke saith that at the first the Apostles believed not, yet he showeth that afterward they believed: and although, if we regard only the first fact, the Evangelists seem divergent one from the other, yet, when we consider what cometh afterward, we see that they are at one.
+&teDeum
+
+[Ant 2]
+Ježíš se postavil * doprostřed svých učedníků, a řekl jim: „Pokoj vám,” alleluja, alleluja.
+
+[Ant 3]
+Pohleďte na mé ruce * a na mé nohy, že to jsem opravdu já, alleluja, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+Přinesli * učedníci Pánu kousek pečené ryby, a plástev medu, alleluja, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc0-3.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc0-3.txt
@@ -1,0 +1,59 @@
+[Rank]
+Die IV infra octavam Paschae;;Semiduplex I classis;;6;;ex Pasc0-0
+
+[Rule]
+ex Pasc0-0;
+1 nocturn;
+Omit Hymnus Preces Suffragium;
+Minores sine Antiphona;
+Capitulum Versum 2;
+Psalmi Dominica;
+
+[Oratio]
+Bože, jenž nás každoroční slavností Zmrtvýchvstání oblažuješ; uděl laskavě, abychom skrze časné svátky, které slavíme, zasloužili si dojít k věčným radostem.
+$Per eumdem
+
+[Ant Matutinum]
+@Tempora/Pasc0-0::s/^V\..*//sm
+V. The disciples therefore were glad, alleluia.
+R. When they saw the Lord, alleluia.
+
+[Lectio1]
+Continuation of the Holy Gospel according to John
+!John 21:1-14
+At that time: After this, Jesus showed himself again to the disciples at the sea~
+of Tiberias. And he showed himself after this manner. There were together Simon Peter, and Thomas, who is called Didymus, And so forth.
+_
+Homily by Pope St. Gregory (the Great.)
+!24th on the Gospels
+Dearly beloved brethren, the portion of the Holy Gospel which hath but now been read in your ears, knocketh loudly at the door of your heart, with a certain question, the answer whereto calleth for thought. This same question is: Wherefore did Peter, who had before his conversion been a fisher, wherefore did he, after his conversion, again go a-fishing? since the Truth hath said: No man, having put his hand to the plough, and looking back, is fit for the kingdom of God? (Luke ix. 62.) Wherefore did Peter return to that which he had left? But we thought we see the answer to his question. The trade which was harmless before his conversion, did not become harmful because he had been inverted.
+
+[Responsory1]
+R. Behold, the Lion of the tribe of Judah, the Root of David, hath prevailed to open the Book, and to loose the seven seals thereof.
+* Alleluia, alleluia, alleluia.
+V. Worthy is the Lamb That was slain to receive power, and riches, in wisdom, and strength, and honour, and glory, and blessing.
+R. Alleluia, alleluia, alleluia.
+
+[Lectio2]
+We know that Peter had been a fisherman, and Matthew a publican, and that Peter after his conversion went back to his fishing, but Matthew did not return to the receipt of custom. It is one thing to seek a livelihood by fishing, and another to amass money by farming of taxes. There are many kinds of business in which it is difficult or impossible to be engaged without committing sin, and to such kinds of business as these, he which hath once been converted must not again betake himself.
+
+[Responsory2]
+R. I am the True Vine, and ye are the branches;
+* He that abideth in Me, and I in him, the same bringeth forth much fruit, alleluia, alleluia.
+V. As the Father hath loved Me, so have I loved you.
+R. He that abideth in Me, and I in him, the same bringeth forth much fruit, alleluia, alleluia.
+&Gloria
+R. He that abideth in Me, and I in him, the same bringeth forth much fruit, alleluia, alleluia.
+
+[Lectio3]
+It may likewise be asked why, when the disciples were toiling in the sea, the Lord, after His Resurrection, stood on the shore, whereas, before His Resurrection, He had walked on the waves before them all. The reason of this is quickly known if we will think of the end which it then served. The sea is a figure of this present world, tossed to and fro by changing fortune, and continually ebbing and flowing with the diverse tides of life. The stableness of the shore is an image of the never-ending rest of the eternal home. The disciples therefore, for that they were yet tossed to and fro upon the waves of a dying life, were toiling in the sea, but He our Redeemer, Who had already laid aside that which in this body is subject to corruption, and had risen again from the dead, He stood upon the shore.
+&teDeum
+
+[Ant 2]
+Nahoďte síť na pravý bok * loďky, a naleznete <i>úlovek</i>, alleluja.
+
+[Ant 3]
+Řekl Ježíš * svým učedníkům: Přineste něco z ryb, které jste právě chytili. Vstal tedy Šimon Petr, a přitáhl síť plnou velkých ryb, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+To bylo již potřetí, * co se Ježíš ukázal poté, co vstal z mrtvých, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc0-4.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc0-4.txt
@@ -1,0 +1,50 @@
+[Rank]
+Die V infra octavam Paschae;;Semiduplex I classis;;6;;ex Pasc0-0
+
+[Rule]
+ex Pasc0-0;
+1 nocturn;
+Omit Hymnus Preces Suffragium;
+Minores sine Antiphona;
+Capitulum Versum 2;
+Psalmi Dominica;
+
+[Oratio]
+Bože, jenž jsi rozličné národy sjednotil ve vyznání tvého jména; dej, aby ti, kdo byli znovu narozeni z křestního pramene, měli jednu víru v mysli a jednu zbožnost ve skutcích.
+$Per Dominum
+
+[Lectio1]
+Continuation of the Holy Gospel according to John
+!John 20:11-18
+At that time: But Mary stood at the sepulchre without, weeping. Now as she was weeping, she stooped down, and looked into the sepulchre. And so forth.
+_
+Homily by Pope St. Gregory (the Great.)
+!25th on the Gospels
+Mary Magdalene, a woman in the city, who was a sinner, through love of the truth washed away by her tears the befoulment of her sin, and the word of the Truth was fulfilled which He spake: Her sins, which are many, are forgiven: for she loved much. (Luke vii. 47.) She that had remained cold while she sinned, became burning when she loved. For after that she had been to the Sepulchre, and had not found there the Body of the Lord, and had believed that It had been taken away, and had told His disciples, they came and saw, and thought it was even as the woman had said, and it is written: Then the disciples went away again unto their own home but Mary stood without at the sepulchre, weeping.
+
+[Responsory1]
+R. They have taken away my Lord, and I know not where they have laid Him. The Angels say unto her: Woman, why weepest thou? He is risen, as He said.
+* He goeth before you into Galilee; there shall ye see Him, alleluia, alleluia.
+V. And as she wept, she stooped down and looked into the Sepulchre, and saw two Angels in white, sitting; and they say unto her:
+R. He goeth before you into Galilee; there shall ye see Him, alleluia, alleluia.
+
+[Lectio2]
+In connection with this matter, we ought to ponder what great store of love there was in that woman's heart, who, when even His disciples were gone away, could not tear herself from the grave of the Lord. She sought Him Whom she had not found there, and as she sought, she wept, and the fire of love in her heart yearned after Him, Who she believed had been taken away. And so it came to pass that she, who had lingered to seek Him, was the only one who then saw Him, since the back-bone of a good work is endurance, and the voice of the Truth Himself hath said: He that endureth to the end shall be saved. (Matth. x. 22; xxiv. 13.)
+
+[Responsory2]
+R. Rejoice with me, all ye that love the Lord: for I sought Him and He hath appeared unto me;
+* And while as I was weeping at the Sepulchre, I saw the Lord, alleluia, alleluia.
+V. When His disciples were gone away, I tarried still; and the fire of love in mine heart glowed for Him.
+R. And while as I was weeping at the Sepulchre, I saw the Lord, alleluia, alleluia.
+&Gloria
+R. And while as I was weeping at the Sepulchre, I saw the Lord, alleluia, alleluia.
+
+[Lectio3]
+As Mary wept there, she stooped down and looked into the Sepulchre. It was but a little while and she had seen how the Sepulchre was empty, and had told that the Lord was taken away. Why then should she stoop down and look in again? But she loved Him so well, that one look was not enough; the energy of her affection constrained her to search again and again. She began by searching and not finding; but she endured in her search, and, behold, it came to pass that she found. And this was done that our own longings for Christ's presence might be taught to expand, and know that as they expand they will meet with Him to Whom they aspire.
+&teDeum
+
+[Ant 2]
+Marie stála * u hrobu a plakala, když uviděla dva Anděly v bílém, jak tam sedí, a roušku, která byla na hlavě Ježíšově, alleluja.
+
+[Ant 3]
+Odnesli mého Pána, * a nevím, kam jej položili; pokud jsi jej odnesl ty, řekni mi to hned, alleluja, a já půjdu a odnesu jej, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc0-5.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc0-5.txt
@@ -1,0 +1,50 @@
+[Rank]
+Die VI infra octavam Paschæ;;Semiduplex I class;;6;;ex Pasc0-0
+
+[Rule]
+ex Pasc0-0;
+1 nocturn;
+Omit Hymnus Preces Suffragium;
+Minores sine Antiphona;
+Capitulum Versum 2;
+Psalmi Dominica;
+
+[Oratio]
+Všemohoucí věčný Bože, jenž jsi udělil velikonoční tajemství na smírnou úmluvu pro člověka; dej našim myslím, aby to, co vyznáním oslavujeme, jsme i skutky napodobovali.
+$Per Dominum
+
+[Lectio1]
+Continuation of the Holy Gospel according to Matthew
+!Matt 28:16-20
+At that time: And the eleven disciples went into Galilee, unto the mountain where Jesus had appointed them. And so forth.
+_
+Homily by St. Jerome, Priest (at Bethlehem.)
+!Bk. iv Comm. on the end of Matth.
+After His Resurrection Jesus was seen on a mountain in Galilee, and there He was worshipped; and, albeit some doubted, their doubts have led to a further establishing of our faith. Then He showed Himself more openly unto Thomas, and made him handle the Side That was pierced with the spear, and the Hands wherein were the holes of the nails. And Jesus came and spake unto them, saying: All power is given unto Me in heaven and in earth. Yea, all power is given unto Him Who but a little while before had been crucified, and buried in the grave, and had lain among the dead, but Who also had risen again. Power is given unto Him in heaven and in earth, that He Who of everlasting had been King of heaven, might have a Monarchy on earth also, through the faith of them which believe in Him.
+
+[Responsory1]
+R. After that our Lord Jesus was risen again, He came and stood in the midst of His disciples, and said unto them:
+* Peace be unto you, alleluia. Then were the disciples glad, when they saw the Lord, alleluia.
+V. The first day of the week, when the doors were shut where the disciples were assembled, came Jesus, and stood in the midst, and said unto them:
+R. Peace be unto you, alleluia. Then were the disciples glad, when they saw the Lord, alleluia.
+
+[Lectio2]
+Go ye therefore and teach all nations, baptizing them in the Name of the Father, and of the Son, and of the Holy Ghost. First, they teach all nations; then, they wash with water them whom they have taught. For it is impossible for the body to receive the Sacrament of Baptism, unless the mind first receive the truth of the faith. And they are baptized In the Name of the Father, and of the Son, and of the Holy Ghost for, even as the Godhead of the Father, and of the Son, and of the Holy Ghost, is all One, so is the one grace of Baptism the gift of all the Three Divine Persons: and the Name of the Trinity is the Name of One God.
+
+[Responsory2]
+R. Purge out the old leaven, that ye may be new dough: for even Christ our Passover is sacrificed for us:
+* Therefore let us keep the Feast, in the Lord, alleluia.
+V. He died for our offences, and rose again for our justification.
+R. Therefore let us keep the Feast, in the Lord, alleluia.
+&Gloria
+R. Therefore let us keep the Feast, in the Lord, alleluia.
+
+[Lectio3]
+Preaching them to observe all things whatsoever I have commanded you. The order of the Lord's commands to the Apostles is markedly this. First, to teach all nations; secondly, to make them partake in the Sacrament of the faith; thirdly, when they had believed and been baptized, to teach them what to observe. And lest we should think that He commanded things light and few, He hath said: All things whatsoever I have commanded you, so that all, who have believed and been baptized in the Name of the Trinity, are bound to observe all things whatsoever He hath commanded. And, lo, I am with you alway, even unto the end of the world. He Who promiseth that He will be with His disciples even unto the end of the world, doth give them thereby to know that they will be always conquerors, and that He will never fail any who believe in Him.
+&teDeum
+
+[Ant 2]
+Jedenáct učedníků, * když v Galileji uviděli Pána, klaněli se mu, alleluja.
+
+[Ant 3]
+Dána jest mi * veškerá moc na nebi i na zemi, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc0-6.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc0-6.txt
@@ -1,0 +1,47 @@
+[Rank]
+Sabbato in Albis;;Semiduplex I class;;6;;ex Pasc0-0
+
+[Rule]
+ex Pasc0-0;
+1 nocturn;
+Omit Hymnus Preces Suffragium;
+Minores sine Antiphona;
+Capitulum Versum 2;
+Psalmi Dominica;
+
+[Oratio]
+Uděl, prosíme, všemohoucí Bože, abychom, když s úctou slavíme velikonoční svátky, skrze ně si zasloužíme dosáhnout radostí věčných.
+$Per Dominum
+
+[Lectio1]
+Continuation of the Holy Gospel according to John
+!John 20:1-9
+And on the first day of the week, Mary Magdalen cometh early, when it was yet dark, unto the sepulchre. And so forth.
+_
+Homily by Pope St. Gregory (the Great.)
+!22nd on the Gospels
+Dearly beloved brethren, the portion of the Holy Gospel which hath just now been read in your ears, is exceeding simple on the face of it, which is its historical sense; but the mystic sense, which underlieth that other, requireth from us a little searching. Mary Magdalene came unto the Sepulchre when it was yet dark. The historic sense telleth us what was the hour of day; the mystic sense, the state of her understanding who sought. Mary Magdalene sought for Him, by Whom all things were made, and Whom she had seen die, as concerning the flesh; she sought for Him, I say, in the grave, and finding Him not, she believed that He had been stolen away. Yea, it was yet dark, when she came unto the sepulchre. Then she ran and told the disciples, but they who had loved Him most, namely Peter and John, did outrun the others.
+
+[Responsory1]
+R. Knowing that Christ rising again from the dead, dieth now no more, death shall no more have dominion over him. For in that he died to sin, he died once;
+* In that he liveth, he liveth unto God, alleluia, alleluia.
+V. He died once for the sins, and he rose for our justification.
+R. In that he liveth, he liveth unto God, alleluia, alleluia.
+
+[Lectio2]
+So they ran both together, but John did outrun Peter, and came first to the Sepulchre, but yet took he not upon himself to go in first. Then cometh Peter following him, and went in. What, my brethren, what did the racing of these Apostles signify? Can we believe that the description given by the deepest of the Evangelists is without a mystic interpretation? By no means. John had never told how that he did outrun Peter, and yet went not into the Sepulchre, if he had not believed that his hesitation veiled some mystery. What signifieth John but the Synagogue? or Peter, but the Church?
+
+[Responsory2]
+R. These are the new lambs, who have proclaimed, alleluia: they came but just now to the well
+* They are all filled with light, alleluia, alleluia.
+V. In the presence of the Lamb they are clothed with white robes, and hold palms in their hands.
+R. They are all filled with light, alleluia, alleluia.
+&Gloria
+R. They are all filled with light, alleluia, alleluia.
+
+[Lectio3]
+Neither must ye take it as strange that the elder Apostle should represent the Church, and the younger the Synagogue: for although the Synagogue was first to worship God, yet the herd of Gentiles is in the world older than the Synagogue, as witnesseth Paul where he saith: That was not first which is spiritual, but that which is natural. (i Cor. xv. 46.) By Peter, then, who was the elder, is signified the Church of the Gentiles; and by John, who was the younger, the Synagogue of the Jews. They run both of them together, for from the time of her birth until now, and so will it be until the end, the Church of the Gentiles hath run in a parallel road and manywise a common road with the Synagogue, albeit not with equal understandings. The Synagogue came first to the Sepulchre, but she hath not yet entered in; for, though she hath received the commandments of the law, and hath heard the Prophets tell of the Incarnation and Passion of the Lord, she will not believe in Him Who died for her.
+&teDeum
+
+[Ant 2]
+Běželi oba spolu, * ale onen druhý učedník předběhl Petra, a přišel první ke hrobu, alleluia.

--- a/web/www/horas/Bohemice/Tempora/Pasc1-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc1-0.txt
@@ -1,0 +1,103 @@
+[Rank]
+Bílé Neděle ve velikonočním Oktávu;;Duplex majus I. classis;;7;;
+
+[Rule]
+9 Lectiones
+Duplex
+Una Antiphona
+
+[Ant 1]
+Když již bylo pozdě * v onen první den v týdnu, a dveře byly zavřené tam, kde se učedníci shromáždili, postavil se Ježíš uprostřed nich, a řekl jim: „Pokoj vám,” alleluja.
+
+[Oratio]
+Uděl, prosíme, všemohoucí Bože; abychom, když slavíme velikonoční svátky, toto, s tvou štědrou pomocí, udržovali ve svých mravech i životech.
+$Per Dominum
+
+[Lectio1]
+Lesson from the letter of St. Paul the Apostle to the Colossians
+!Col 3:1-7
+1 Therefore, if you be risen with Christ, seek the things that are above; where Christ is sitting at the right hand of God:
+2 Mind the things that are above, not the things that are upon the earth.
+3 For you are dead; and your life is hid with Christ in God.
+4 When Christ shall appear, who is your life, then you also shall appear with him in glory.
+5 Mortify therefore your members which are upon the earth; fornication, uncleanness, lust, evil concupiscence, and covetousness, which is the service of idols.
+6 For which things the wrath of God cometh upon the children of unbelief,
+7 In which you also walked some time, when you lived in them.
+
+[Responsory1]
+@Tempora/Pasc0-0::s/&Gloria.*//s
+
+[Lectio2]
+!Col 3:8-13
+8 But now put you also all away: anger, indignation, malice, blasphemy, filthy speech out of your mouth.
+9 Lie not one to another: stripping yourselves of the old man with his deeds,
+10 And putting on the new, him who is renewed unto knowledge, according to the image of him that created him.
+11 Where there is neither Gentile nor Jew, circumcision nor uncircumcision, Barbarian nor Scythian, bond nor free. But Christ is all, and in all.
+12 Put ye on therefore, as the elect of God, holy, and beloved, the bowels of mercy, benignity, humility, modesty, patience:
+13 Bearing with one another, and forgiving one another, if any have a complaint against another: even as the Lord hath forgiven you, so do you also
+
+[Responsory2]
+R. The Angel of the Lord spake unto the woman, saying: Whom seek ye? Seek ye Jesus? He is risen now:
+* Come and see, alleluia, alleluia.
+V. Seek ye Jesus of Nazareth, Which was crucified? He is risen, He is not here.
+R. Come and see, alleluia, alleluia.
+
+[Lectio3]
+!Col 3:14-17
+14 But above all these things have charity, which is the bond of perfection:
+15 And let the peace of Christ rejoice in your hearts, wherein also you are called in one body: and be ye thankful.
+16 Let the word of Christ dwell in you abundantly, in all wisdom: teaching and admonishing one another in psalms, hymns, and spiritual canticles, singing in grace in your hearts to God.
+17 All whatsoever you do in word or in work, do all in the name of the Lord Jesus Christ, giving thanks to God and the Father by him
+
+[Lectio4]
+From the Sermons of St. Augustine, Bishop (of Hippo.)
+!1st Sermon for the Octave of the Passover, being the 157th for the Seasons.
+The Feast of this day is the end of the Paschal solemnity, and therefore it is today that the Newly-Baptized put off their white garments: but, though they lay aside the outward mark of washing in their raiment, the mark of that washing in their souls remaineth to eternity. Now are the days of the Pass-over, that is, of God's Passing-over our iniquity by His pardon and remission; and therefore our first duty is so to sanctify the mirth of these holy days, that our bodily recreation may be taken without defilement to our spiritual cleanness. Let us strive that our relaxation may be sober and our freedom holy, holding ourselves carefully aloof from anything like excess, drunkenness or lechery. Let us try so to keep in our souls their Lenten cleansing, that if our Fasting hath left us aught yet unwon, we may still be able to seek it.
+
+[Lectio5]
+At discourse concerneth all them which are committed unto my spiritual charge; but, nevertheless, since the first happy week of your Sacramental life draweth this day to a close, I address myself in especial to you who are the new olive-plants of holiness round about the Table of the Lord, (Ps. cxxvii. 4,) to you, who have but a little while been born again of water and the Holy Ghost, (John iii. 5,) to you, O holy generation (1 Pet. ii. 9) to you, O new creation, (Gal. vi. 15,) to you, the excellency of my dignity, (Gen. xlix. 3,) and the fruit of my labour, my brethren dearly beloved and longed for, my joy and my crown, all ye who now stand so fast in the Lord. (Phil. iv. i.) To you I address the words of the Apostle (Rom. xiii. 12.) Behold! the night is past! the day is come! Cast off therefore the works of darkness, and put on the armour of light. Let us walk honestly, as in the day; not in rioting and drunkenness, not in chambering and wantonness, not in strife and envying: but put ye on the Lord Jesus Christ.
+
+[Lectio6]
+We have, saith Peter, (2 Peter i. 19,) a more sure word of Prophecy, whereunto ye do well that ye take heed, as unto a light that shineth in a dark place, until the day dawn, and the day-star arise in your hearts. Let your loins therefore be girded about, and your lights burning in your hands, and ye yourselves like unto men that wait for their lord, when he will return from the wedding. (Luke xii. 36.) Behold, the days come, whereof the Lord saith, (John xvi. 16, 17, 19,) A little while, and ye shall not see Me, and again a little while and ye shall see Me. Now is the hour whereof He said (20), Ye shall weep and lament, but the work shall rejoice that is to say, this present life, wherein we walk as strangers and pilgrims, (1 Pet. ii. 11,) far away from Him Who is our Home, this present life is very full of trials. But, saith Jesus, but I will see you again, and your heart shall rejoice, and your joy no man taketh from you. (22.)
+
+[Lectio7]
+From the Holy Gospel according to John
+!John 20:19-31
+At that time: Now when it was late that same day, the first of the week, and the doors were shut, where the disciples were gathered together, for fear of the Jews, Jesus came and stood in the midst, and said to them: Peace be to you. And so forth.
+_
+Homily by Pope St. Gregory (the Great.)
+!26th on the Gospels
+When we hear this passage of the Gospel read, a question straightway knocketh at the door of our mind. How was it that the Body of the Risen Lord was a real Body, if It was able to pass through closed doors into the assembly of His disciples? But we ought to know that the works of God are no more wonderful when they can be understood by man's reason, and faith has lost her worth when her subject-matter is the subject-matter of human demonstration. Nevertheless, those very works of our Redeemer which are in themselves impossible to be understood, must be thought over in connection with other of His works, that we may be led to believe in things wonderful, by mean of things more wonderful still. That Body of the Lord, Which came into the assembly of the disciples through closed doors, was the Same, Which at Its birth, had become manifest to the eyes of men by passing out of the cloister of the Virgin's womb without breaking the seal thereof. What wonder is it if that Body Which had come out of the Virgin's womb, without opening the matrix, albeit It was then on Its way to die, now that It was risen again from the dead and instinct for ever with undying life, what wonder is it, I say, if that Body passed through closed doors?
+
+[Lectio8]
+But since the beholders doubted of the reality of that Body Which they saw, He showed unto them His Hands and His Side, and allowed them to handle that Same Flesh Which had just passed through the closed doors. (Luke xxiv. 39.) In this there were two strange things manifested; yea, things which, according to our understanding, are contrary the one to the other. His Risen Body was incorruptible and yet palpable. For whatever can be touched, must needs be subject to corruption; and whatever is not subject to corruption, cannot be touched. But, in a way altogether wonderful and incomprehensible, our Redeemer after His Resurrection revealed Himself in a Body at once palpable and incorruptible: revealed Himself in an incorruptible Body, that we might learn to seek a like glorification; and in a palpable Body, for the strengthening of our faith. He revealed Himself in a Body at once incorruptible and palpable, that He might thereby make manifest the fact that His Risen Body was unaltered in nature, albeit transfigured in glory.
+
+[Lectio9]
+Then said Jesus to them again: Peace be unto you. As My Father hath sent Me, even so send I you that is, as My Father, Who is God, hath sent Me, Who am God, even so do I, Who am Man, send you, who are men. The Father sent the Son, Whom He appointed to be made Man for the redemption of man. Him He willed to send into the world to suffer, albeit He Whom He sent to suffer was the Son of His love. The Lord sendeth His chosen Apostles into the world, not to be happy in the world, but, as He had been Himself sent, to suffer. As the Father loveth the Son and yet sendeth Him to suffer, even so doth the Lord love His disciples, albeit He sendeth them into the world, to suffer therein; and therefore it is well said: “As My Father hath sent Me, even so send I you”; that is, while I send you into the wild storm of persecution, I love you all the same, I love you, yea, I love you with a love like that wherewith the Father loveth Me, Who sent Me into the world to bear agony therein.
+&teDeum
+
+[Capitulum Laudes]
+!1 Janův 5:4
+v. Milovaní: Vše, co je zrozeno z Boha, vítězí nad světem. A to je vítězství, které přemohlo svět: naše víra.
+$Deo gratias
+
+[Capitulum Sexta]
+!1 Janův 5:5-6
+v. Kdo tedy vítězí nad světem, ne-li ten, kdo věří, že Ježíš je Syn Boží? Ježíš Kristus je ten, který přišel skrze vodu a krev; nejen skrze vodu, ale skrze vodu a krev. A to dosvědčuje Duch, protože Duch je pravda.
+$Deo gratias
+
+[Capitulum Nona]
+!1 Janův 5:9-10
+v. Když přijímáme svědectví lidské, tím větší (platnost) má svědectví Boží. To je totiž svědectví Boží, které Bůh vydal o svém Synu: kdo věří v Božího Syna, má o tom svědectví sám v sobě. Kdo Bohu nevěří, dělá z něho lháře, protože nevěří svědectví, které Bůh vydává o svém Synu.
+$Deo gratias
+
+[Ant 3]
+Po osmi dnech * vešel Pán zavřenými dveřmi a řekl jim: „Pokoj vám,” alleluja, alleluja.
+
+[Ant 2] (rubrica cisterciensis)
+Po osmi dnech * vešel Pán zavřenými dveřmi a řekl jim: „Pokoj vám,” alleluja, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+Mnohá totiž * i další znamení učil Ježíš před zrakem svých učedníků, alleluja, ovšem ta nejsou v této knize zapsána, alleluja.
+
+

--- a/web/www/horas/Bohemice/Tempora/Pasc1-1.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc1-1.txt
@@ -1,0 +1,52 @@
+[Rank]
+Feria Secunda infra Hebdomadam I post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 1:1-8
+1 The former treatise I made, O Theophilus, of all things which Jesus began to do and to teach,
+2 Until the day on which, giving commandments by the Holy Ghost to the apostles whom he had chosen, he was taken up.
+3 To whom also he showed himself alive after his passion, by many proofs, for forty days appearing to them, and speaking of the kingdom of God.
+4 And eating together with them, he commanded them, that they should not depart from Jerusalem, but should wait for the promise of the Father, which you have heard (saith he) by my mouth.
+5 For John indeed baptized with water, but you shall be baptized with the Holy Ghost, not many days hence.
+6 They therefore who were come together, asked him, saying: Lord, wilt thou at this time restore again the kingdom to Israel?
+7 But he said to them: It is not for you to know the times or moments, which the Father hath put in his own power:
+8 But you shall receive the power of the Holy Ghost coming upon you, and you shall be witnesses unto me in Jerusalem, and in all Judea, and Samaria, and even to the uttermost part of the earth.
+
+[Lectio2]
+!Acts 1:9-14
+9 And when he had said these things, while they looked on, he was raised up: and a cloud received him out of their sight.
+10 And while they were beholding him going up to heaven, behold two men stood by them in white garments.
+11 Who also said: Ye men of Galilee, why stand you looking up to heaven? This Jesus who is taken up from you into heaven, shall so come, as you have seen him going into heaven.
+12 Then they returned to Jerusalem from the mount that is called Olivet, which is nigh Jerusalem, within a sabbath day's journey.
+13 And when they were come in, they went up into an upper room, where abode Peter and John, James and Andrew, Philip and Thomas, Bartholomew and Matthew, James of Alpheus, and Simon Zelotes, and Jude the brother of James.
+14 All these were persevering with one mind in prayer with the women, and Mary the mother of Jesus, and with his brethren
+
+[Lectio3]
+!Acts 1:15-26
+15 In those days Peter rising up in the midst of the brethren, said: (now the number of persons together was about an hundred and twenty:)
+16 Men, brethren, the scripture must needs be fulfilled, which the Holy Ghost spoke before by the mouth of David concerning Judas, who was the leader of them that apprehended Jesus:
+17 Who was numbered with us, and had obtained part of this ministry.
+18 And he indeed hath possessed a field of the reward of iniquity, and being hanged, burst asunder in the midst: and all his bowels gushed out.
+19 And it became known to all the inhabitants of Jerusalem: so that the same field was called in their tongue, Haceldama, that is to say, The field of blood.
+20 For it is written in the book of Psalms: Let their habitation become desolate, and let there be none to dwell therein. And his bishopric let another take.
+21 Wherefore of these men who have companied with us all the time that the Lord Jesus came in and went out among us,
+22 Beginning from the baptism of John, until the day wherein he was taken up from us, one of these must be made a witness with us of his resurrection.
+23 And they appointed two, Joseph, called Barsabas, who was surnamed Justus, and Matthias.
+24 And praying, they said: Thou, Lord, who knowest the hearts of all men, show whether of these two thou hast chosen,
+25 To take the place of this ministry and apostleship, from which Judas hath by transgression fallen, that he might go to his own place.
+26 And they gave them lots, and the lot fell upon Matthias, and he was numbered with the eleven apostles.
+
+[Ant 2]
+Když vstal Ježíš z mrtvých, * ráno prvního dne v týdnu, ukázal se nejdříve Marii Magdaléně, z níž vyhnal sedm zlých duchů, alleluja.
+
+[Ant 3]
+Pokoj vám, * já jsem to, alleluja: nebojte se, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+Ježíš, kterého hledáte ukřižovaného, * zde není, nýbrž vstal z mrtvých: vzpomeňte si, jak k vám mluvil, dokud byl ještě v Galileji, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc1-2.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc1-2.txt
@@ -1,0 +1,51 @@
+[Rank]
+Feria Tertia infra Hebdomadam I post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 2:1-8
+1 And when the days of the Pentecost were accomplished, they were all together in one place:
+2 And suddenly there came a sound from heaven, as of a mighty wind coming, and it filled the whole house where they were sitting.
+3 And there appeared to them parted tongues as it were of fire, and it sat upon every one of them:
+4 And they were all filled with the Holy Ghost, and they began to speak with diverse tongues, according as the Holy Ghost gave them to speak.
+5 Now there were dwelling at Jerusalem, Jews, devout men, out of every nation under heaven.
+6 And when this was noised abroad, the multitude came together, and were confounded in mind, because that every man heard them speak in his own tongue.
+7 And they were all amazed, and wondered, saying: Behold, are not all these, that speak, Galileans?
+8 And how have we heard, every man our own tongue wherein we were born?
+
+[Lectio2]
+!Acts 2:14-21
+14 But Peter standing up with the eleven, lifted up his voice, and spoke to them: Ye men of Judea, and all you that dwell in Jerusalem, be this known to you, and with your ears receive my words.
+15 For these are not drunk, as you suppose, seeing it is but the third hour of the day:
+16 But this is that which was spoken of by the prophet Joel:
+17 And it shall come to pass, in the last days, (saith the Lord,) I will pour out of my Spirit upon all flesh: and your sons and your daughters shall prophesy, and your young men shall see visions, and your old men shall dream dreams.
+18 And upon my servants indeed, and upon my handmaids will I pour out in those days of my spirit, and they shall prophesy.
+19 And I will show wonders in the heaven above, and signs on the earth beneath: blood and fire, and vapour of smoke.
+20 The sun shall be turned into darkness, and the moon into blood, before the great and manifest day of the Lord come.
+21 And it shall come to pass, that whosoever shall call upon the name of the Lord, shall be saved.
+
+[Lectio3]
+!Acts 2:22-27
+22 Ye men of Israel, hear these words: Jesus of Nazareth, a man approved of God among you, by miracles, and wonders, and signs, which God did by him, in the midst of you, as you also know:
+23 This same being delivered up, by the determinate counsel and foreknowledge of God, you by the hands of wicked men have crucified and slain.
+24 Whom God hath raised up, having loosed the sorrows of hell, as it was impossible that he should be holden by it.
+25 For David saith concerning him: I foresaw the Lord before my face: because he is at my right hand, that I may not be moved.
+26 For this my heart hath been glad, and any tongue hath rejoiced: moreover my flesh also shall rest in hope.
+27 Because thou wilt not leave my soul in hell, nor suffer thy Holy One to see corruption.
+
+[Ant 2]
+Půjdu před vámo * do Galileje, tam mě uvidíte, jak jsem vám řekl, alleluja, alleluja. 
+
+[Ant 3]
+Přilož svou ruku * a dotkni se míst po hřebech, alleluja; a nebuď už nevěřící, ale věřící, alleluja. 
+
+[Ant 2] (rubrica cisterciensis)
+V Galileji * Ježíše uvidíte, jak vám sám řekl, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+Vstal totiž Pán z mrtvých, * jak sám řekl, a půjde před vámi do Galileje, alleluja: tam jej uvidíte, alleluja, alleluja, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc1-3.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc1-3.txt
@@ -1,0 +1,45 @@
+[Rank]
+Feria Quarta infra Hebdomadam I post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 3:1-6
+1 Now Peter and John went up into the temple at the ninth hour of prayer.
+2 And a certain man who was lame from his mother's womb, was carried: whom they laid every day at the gate of the temple, which is called Beautiful, that he might ask alms of them that went into the temple.
+3 He, when he had seen Peter and John about to go into the temple, asked to receive an alms.
+4 But Peter with John fastening his eyes upon him, said: Look upon us.
+5 But he looked earnestly upon them, hoping that he should receive something of them.
+6 But Peter said: Silver and gold I have none; but what I have, I give thee: In the name of Jesus Christ of Nazareth, arise, and walk.
+
+[Lectio2]
+!Acts 3:7-11
+7 And taking him by the right hand, he lifted him up, and forthwith his feet and soles received strength.
+8 And he leaping up, stood, and walked, and went in with them into the temple, walking, and leaping, and praising God.
+9 And all the people saw him walking and praising God.
+10 And they knew him, that it was he who sat begging alms at the Beautiful gate of the temple: and they were filled with wonder and amazement at that which had happened to him.
+11 And as he held Peter and John, all the people ran to them to the porch which is called Solomon's, greatly wondering
+
+[Lectio3]
+!Acts 3:12-16
+12 But Peter seeing, made answer to the people: Ye men of Israel, why wonder you at this? or why look you upon us, as if by our strength or power we had made this man to walk?
+13 The God of Abraham, and the God of Isaac, and the God of Jacob, the God of our fathers, hath glorified his Son Jesus, whom you indeed delivered up and denied before the face of Pilate, when he judged he should be released.
+14 But you denied the Holy One and the Just, and desired a murderer to be granted unto you.
+15 But the author of life you killed, whom God hath raised from the dead, of which we are witnesses.
+16 And in the faith of his name, this man, whom you have seen and known, hath his name strengthened; and the faith which is by him, hath given this perfect soundness in the sight of you all.
+
+[Ant 2]
+I am the True Vine. * Alleluia. And ye are My branches indeed.
+
+[Ant 3]
+Thomas because thou hast seen Me, thou hast believed * blessed are they that have not seen and yet have believed. Alleluia.
+
+[Ant 2] (rubrica cisterciensis)
+Vstal * Pán z hrobu, ten, který z nás visel na dřevě <i>kříže</i>, alleluja, alleluja, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+Anděl Páně totiž * sestoupil z nebe, et accédens revólvit lápidem, et sedébat super eum, allelúia, allelúia.

--- a/web/www/horas/Bohemice/Tempora/Pasc1-4.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc1-4.txt
@@ -1,0 +1,45 @@
+[Rank]
+Feria Quinta infra Hebdomadam I post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 5:1-6
+1 But a certain man named Ananias, with Saphira his wife, sold a piece of land,
+2 And by fraud kept back part of the price of the land, his wife being privy thereunto: and bringing a certain part of it, laid it at the feet of the apostles.
+3 But Peter said: Ananias, why hath Satan tempted thy heart, that thou shouldst lie to the Holy Ghost, and by fraud keep part of the price of the land?
+4 Whilst it remained, did it not remain to thee? and after it was sold, was it not in thy power? Why hast thou conceived this thing in thy heart? Thou hast not lied to men, but to God.
+5 And Ananias hearing these words, fell down, and gave up the ghost. And there came great fear upon all that heard it.
+6 And the young men rising up, removed him, and carrying him out, buried him.
+
+[Lectio2]
+!Acts 5:7-11
+7 And it was about the space of three hours after, when his wife, not knowing what had happened, came in.
+8 And Peter said to her: Tell me, woman, whether you sold the land for so much? And she said: Yea, for so much.
+9 And Peter said unto her: Why have you agreed together to tempt the Spirit of the Lord? Behold the feet of them who have buried thy husband are at the door, and they shall carry thee out.
+10 Immediately she fell down before his feet, and gave up the ghost. And the young men coming in, found her dead: and carried her out, and buried her by her husband.
+11 And there came great fear upon the whole church, and upon all that heard these things._
+
+[Lectio3]
+!Acts 5:12-16
+12 And by the hands of the apostles were many signs and wonders wrought among the people. And they were all with one accord in Solomon's porch.
+13 But of the rest no man durst join himself unto them; but the people magnified them.
+14 And the multitude of men and women who believed in the Lord, was more increased:
+15 Insomuch that they brought forth the sick into the streets, and laid them on beds and couches, that when Peter came, his shadow at the least, might overshadow any of them, and they might be delivered from their infirmities.
+16 And there came also together to Jerusalem a multitude out of the neighboring cities, bringing sick persons, and such as were troubled with unclean spirits; who were all healed.
+
+[Ant 2]
+Mé srdce hoří, * toužím spatřit svého Pána; hledám, a nemohu najít, kam jej položili, alleluja, alleluja.
+
+[Ant 3]
+Vložil jsem svůj prst * do otvorů po hřebech, a svou ruku do jeho boku, a řekl jsem: Pán můj a Bůh můj, alleluja.
+
+[Ant 2] (rubrica cisterciensis)
+Byl pak * jeho vzhled jako blesk, a oděv jeho jako sníh, alleluja, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+Ze strachu před ním * ochromeni byli jeho strážci, a byli jako mrtví, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc1-5.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc1-5.txt
@@ -1,0 +1,40 @@
+[Rank]
+Feria Sexta infra Hebdomadam I post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 8:9-13
+9 There was therefore great joy in that city. Now there was a certain man named Simon, who before had been a magician in that city, seducing the people of Samaria, giving out that he was some great one:
+10 To whom they all gave ear, from the least to the greatest, saying: This man is the power of God, which is called great.
+11 And they were attentive to him, because, for a long time, he had bewitched them with his magical practices.
+12 But when they had believed Philip preaching of the kingdom of God, in the name of Jesus Christ, they were baptized, both men and women.
+13 Then Simon himself believed also; and being baptized, he adhered to Philip. And being astonished, wondered to see the signs and exceeding great miracles which were done.
+
+[Lectio2]
+!Acts 8:14-19
+14 Now when the apostles, who were in Jerusalem, had heard that Samaria had received the word of God, they sent unto them Peter and John.
+15 Who, when they were come, prayed for them, that they might receive the Holy Ghost.
+16 For he was not as yet come upon any of them; but they were only baptized in the name of the Lord Jesus.
+17 Then they laid their hands upon them, and they received the Holy Ghost.
+18 And when Simon saw, that by the imposition of the hands of the apostles, the Holy Ghost was given, he offered them money,
+19 Saying: Give me also this power, that on whomsoever I shall lay my hands, he may receive the Holy Ghost.
+
+[Lectio3]
+!Acts 8:19-24
+19 But Peter said to him:
+20 Keep thy money to thyself, to perish with thee, because thou hast thought that the gift of God may be purchased with money.
+21 Thou hast no part nor lot in this matter. For thy heart is not right in the sight of God.
+22 Do penance therefore for this thy wickedness; and pray to God, that perhaps this thought of thy heart may be forgiven thee.
+23 For I see thou art in the gall of bitterness, and in the bonds of iniquity.
+24 Then Simon answering, said: Pray you for me to the Lord, that none of these things which you have spoken may come upon me.
+
+[Ant 2]
+Přišly ke hrobu * Maria Magdaléna a druhá Marie, aby navštívili hrobku, alleluja.
+
+[Ant 2] (rubrica cisterciensis)
+I pohlédly * a viděly, že kámen byl již odvalen; byl totiž velmi veliký, allelúia.

--- a/web/www/horas/Bohemice/Tempora/Pasc1-6.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc1-6.txt
@@ -1,0 +1,48 @@
+[Rank]
+Sabbato infra Hebdomadam I post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 10:1-8
+1 And there was a certain man in Caesarea, named Cornelius, a centurion of that which is called the Italian band; 
+2 A religious man, and fearing God with all his house, giving much alms to the people, and always praying to God. 
+3 This man saw in a vision manifestly, about the ninth hour of the day, an angel of God coming in unto him, and saying to him: Cornelius. 
+4 And he, beholding him, being seized with fear, said: What is it, Lord? And he said to him: thy prayers and thy alms are ascended for a memorial in the sight of God. 
+5 And now send men to Joppe, and call hither one Simon, who is surnamed Peter:
+6 He lodgeth with one Simon a tanner, whose house is by the sea side. He will tell thee what thou must do. 
+7 And when the angel who spoke to him was departed, he called two of his household servants, and a soldier who feared the Lord, of them that were under him. 
+8 To whom when he had related all, he sent them to Joppe.
+
+[Lectio2]
+!Acts 10:9-17
+9 And on the next day, whilst they were going on their journey, and drawing nigh to the city, Peter went up to the higher parts of the house to pray, about the sixth hour. 
+10 And being hungry, he was desirous to taste somewhat. And as they were preparing, there came upon him an ecstasy of mind.
+11 And he saw the heaven opened, and a certain vessel descending, as it were a great linen sheet let down by the four corners from heaven to the earth: 
+12 Wherein were all manner of fourfooted beasts, and creeping things of the earth, and fowls of the air. 
+13 And there came a voice to him: Arise, Peter; kill and eat. 
+14 But Peter said: Far be it from me; for I never did eat any thing that is common and unclean. 
+15 And the voice spoke to him again the second time: That which God hath cleansed, do not thou call common.
+16 And this was done thrice; and presently the vessel was taken up into heaven. 
+17 Now, whilst Peter was doubting within himself, what the vision that he had seen should mean, behold the men who were sent from Cornelius, inquiring for Simon's house, stood at the gate.
+
+[Lectio3]
+!Acts 10:34-41
+34 And Peter opening his mouth, said: In very deed I perceive, that God is not a respecter of persons. 
+35 But in every nation, he that feareth him, and worketh justice, is acceptable to him.
+36 God sent the word to the children of Israel, preaching peace by Jesus Christ: (he is Lord of all.) 
+37 You know the word which hath been published through all Judea: for it began from Galilee, after the baptism which John preached, 
+38 Jesus of Nazareth: how God anointed him with the Holy Ghost, and with power, who went about doing good, and healing all that were oppressed by the devil, for God was with him. 
+39 And we are witnesses of all things that he did in the land of the Jews and in Jerusalem, whom they killed, hanging him upon a tree. 
+40 Him God raised up the third day, and gave him to be made manifest,
+41 Not to all the people, but to witnesses preordained by God, even to us, who did eat and drink with him after he arose again from the dead;
+
+[Responsory3]
+@Tempora/Pasc0-3:Responsory1
+
+[Ant 2]
+Osvěť, Pane, * sedící v temnotách a stínu smrti, a směřuj naše kroky na cestu pokoje.

--- a/web/www/horas/Bohemice/Tempora/Pasc2-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-0.txt
@@ -1,0 +1,99 @@
+[Rank]
+Dominica II Post Pascha;;Semiduplex;;5;;
+
+[Rule]
+9 Lectiones
+Una Antiphona
+
+[Ant 1]
+Já jsem * pastýř ovcí; já jsem cesta a pravda; já jsem dobrý pastýř, a znám své ovce, a mé ovce znají mne, alleluja, alleluja.
+
+[Oratio]
+Bože, jenž jsi v pokoře svého Syna pozvedl ležící svět; svým věřícím uděl radost, abys těm, které jsi vytrhl z pádů věčné smrti, dal radovati se v radostech věčných.
+$Per eumdem
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 13:13-20
+13 Now when Paul and they that were with him had sailed from Paphos, they came to Perge in Pamphylia. And John departing from them, returned to Jerusalem.
+14 But they passing through Perge, came to Antioch in Pisidia: and entering into the synagogue on the sabbath day, they sat down.
+15 And after the reading of the law and the prophets, the rulers of the synagogue sent to them, saying: Ye men, brethren, if you have any word of exhortation to make to the people, speak.
+16 Then Paul rising up, and with his hand bespeaking silence, said: Ye men of Israel, and you that fear God, give ear.
+17 The God of the people of Israel chose our fathers, and exalted the people when they were sojourners in the land of Egypt, and with an high arm brought them out from thence,
+18 And for the space of forty years endured their manners in the desert.
+19 And destroying seven nations in the land of Chanaan, divided their land among them, by lot,
+20 As it were, after four hundred and fifty years: and after these things, he gave unto them judges, until Samuel the prophet.
+
+[Lectio2]
+!Acts 13:21-25
+21 And after that they desired a king: and God gave them Saul the son of Cis, a man of the tribe of Benjamin, forty years.
+22 And when he had removed him, he raised them up David to be king: to whom giving testimony, he said: I have found David, the son of Jesse, a man according to my own heart, who shall do all my wills.
+23 Of this man's seed God according to his promise, hath raised up to Israel a Saviour, Jesus:
+24 John first preaching, before his coming, the baptism of penance to all the people of Israel.
+25 And when John was fulfilling his course, he said: I am not he, whom you think me to be: but behold, there cometh one after me, whose shoes of his feet I am not worthy to loose.
+
+[Lectio3]
+!Acts 13:26-33
+26 Men, brethren, children of the stock of Abraham, and whosoever among you fear God, to you the word of this salvation is sent.
+27 For they that inhabited Jerusalem, and the rulers thereof, not knowing him, nor the voices of the prophets, which are read every sabbath, judging him have fulfilled them.
+28 And finding no cause of death in him, they desired of Pilate, that they might kill him.
+29 And when they had fulfilled all things that were written of him, taking him down from the tree, they laid him in a sepulchre.
+30 But God raised him up from the dead the third day:
+31 Who was seen for many days, by them who came up with him from Galilee to Jerusalem, who to this present are his witnesses to the people.
+32 And we declare unto you, that the promise which was made to our fathers,
+33 This same God hath fulfilled to our children, raising up Jesus, as in the second psalm also is written: Thou art my Son, this day have I begotten thee.
+
+[Lectio4]
+From the Sermons of Pope St. Leo (the Great)
+!1st for the Lord's Ascension
+Dearly beloved brethren, the days which passed between the Resurrection and the Ascension of the Lord, wore not idly by, but in them were established great Sacraments, and great Mysteries were revealed. In them was abolished the terror of that fearful death, and it was shown that not the soul only, but the body also, will not die eternally. In them the breathing of the Lord on His Apostles shed upon them the Holy Ghost, and the Blessed Apostle Peter, being given the keys of the kingdom of heaven, was chosen out of the rest to receive the chief care of the Lord's fold.
+
+[Lectio5]
+It was during those days, that as two of His disciples were walking together, the Lord Himself joined them, and made Himself One of three companions. Then that, to clear away all shadow of doubt from our mind, He rebuked the slowness of such as still feared and trembled. Their hearts enlightened by faith, caught the flame; and, whereas they had afore been cold, they glowed again as the Lord opened to them the Scriptures. In the breaking of bread their eyes were opened, and they knew Him. And, O, how much happier were they with their eyes opened, and gazing upon the glorification of our nature in His Person, than were the first father and mother of our race, upon whom their own transgression had brought shame!
+
+[Lectio6]
+Amid these and other miracles, while the disciples were still troubled with fearful thoughts, the Lord manifested Himself in the midst of them, and said: Peace be unto you. And lest their reason should be deceived by the vain imaginations which lurked in their hearts, (for they thought that What they saw was a spirit, and not Flesh,) He rebuked thoughts so inconsistent with the truth; and pointed out to the eyes of the doubters the marks of crucifixion which still remained in His Hands and His Feet, and bade them handle Him more closely. Those open Wounds made by the nails and spear in His Body remain ever open to close the wounds in unbelievers' hearts: that we may hold, not with doubtful faith, but with most firm and absolute knowledge, that the Manhood Which lay in the grave is the Same Which now sitteth at the right hand of God the Father.
+
+[Lectio7]
+From the Holy Gospel according to John
+!John 10:11-16
+At that time, Jesus said unto the Pharisees: I am the Good Shepherd. The Good Shepherd giveth His life for His sheep. And so on.
+_
+Homily by Pope St. Gregory (the Great.)
+!14th on the Gospels
+Dearly beloved brethren, ye have heard from the Holy Gospel what is at once your~
+instruction, and our danger. Behold, how He Who, not by the varying gifts of nature, but of the very essence of His being, is Good, behold how He saith: I am the Good Shepherd. And then He saith what is the character of His goodness, even of that goodness of His which we must strive to copy: The Good Shepherd giveth His life for the Sheep. As He had foretold, even so did He; as He had commanded, so gave He example. The Good Shepherd gave His life for the sheep, and made His Own Body and His Own Blood to be our Sacramental Food, pasturing upon His Own Flesh the sheep whom He had bought.
+
+[Lectio8]
+He, by despising death, hath shown us how to do the like; He hath set before us the mould wherein it behoveth us to be cast. Our first duty is, freely and tenderly to spend our outward things for His sheep, but lastly, if need be, to serve the same by our death also. From the light offering of the first, we go on to the stern offering of the last, and, if we be ready to give our life for the sheep, why should we scruple to give our substance, seeing how much more is the life than meat? (Matth. vi. 25.)
+
+[Lectio9]
+And some there be which love the things of this world better than they love the sheep; and such as they deserve no longer to be called shepherds. These are they of whom it is written: But he that is an hireling, and not the shepherd, whose own the sheep are not, seeth the wolf coming, and leaveth the sheep, and fleeth (12.) He is not a shepherd but an hireling which feedeth the Lord's sheep, not because he loveth their souls, but because he doth gain earthly wealth thereby. He that taketh a shepherd's place, but seeketh not gain of souls, that same is but an hireling; such an one is ever ready for creature comforts, he loveth his pre-eminence, he groweth sleek upon his income, and he liketh well to see men bow down to him.
+&teDeum
+
+[Capitulum Laudes]
+!1 Petrův 2:21-22
+v. Milovaní, Kristus trpěl za nás, a zanechal vám tak příklad, abyste šli v jeho šlépějích. On nezhřešil a nikdo od něho neslyšel nic neupřímného.
+$Deo gratias
+
+[Capitulum Sexta]
+!1 Petrův 2:23-24
+v. Vydal se totiž tomu, který jej soudil nespravedlivě. On sám na svém těle vynesl naše hříchy na dřevo <i>kříže,</i> abychom byli mrtví hříchům a žili spravedlivě. Jeho ranami jste uzdraveni.
+$Deo gratias
+
+[Capitulum Nona]
+!1 Petrův 2:25
+v. Byli jste kdysi jako bludné ovce, ale nyní jste se vrátili k pastýři a střážci svých duší.
+$Deo gratias
+
+[Ant 3]
+Já jsem * dobrý pastýř, já pasu své ovce, a pro své ovce dávám svůj život, alleluja.
+
+[Ant 1] (rubrica cisterciensis)
+Toto totiž bylo napsáno, * abyste uvěřili, že Ježíš je Kristus<i>, Boží Pomazaný</i>, Syn Boží, a abyste věříce měli život v jeho jménu, alleluja.
+
+[Ant 2] (rubrica cisterciensis)
+Já jsem * dobrý pastýř, já pasu své ovce, a pro své ovce dávám svůj život, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+Já jsem * pastýř ovcí; já jsem cesta a pravda; já jsem dobrý pastýř, a znám své ovce, a mé ovce znají mne, alleluja, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc2-1.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-1.txt
@@ -1,0 +1,54 @@
+[Rank]
+Feria Secunda infra Hebdomadam II post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 15:5-12
+5 But there arose some of the sect of the Pharisees that believed, saying: They must be circumcised, and be commanded to observe the law of Moses.
+6 And the apostles and ancients assembled to consider of this matter.
+7 And when there had been much disputing, Peter, rising up, said to them: Men, brethren, you know, that in former days God made choice among us, that by my mouth the Gentiles should hear the word of the gospel, and believe.
+8 And God, who knoweth the hearts, gave testimony, giving unto them the Holy Ghost, as well as to us;
+9 And put no difference between us and them, purifying their hearts by faith.
+10 Now therefore, why tempt you God to put a yoke upon the necks of the disciples, which neither our fathers nor we have been able to bear?
+11 But by the grace of the Lord Jesus Christ, we believe to be saved, in like manner as they also.
+12 And all the multitude held their peace; and they heard Barnabas and Paul telling what great signs and wonders God had wrought among the Gentiles by them
+
+[Lectio2]
+!Acts 15:13-21
+13 And after they had held their peace, James answered, saying: Men, brethren, hear me.
+14 Simon hath related how God first visited to take of the Gentiles a people to his name.
+15 And to this agree the words of the prophets, as it is written:
+16 After these things I will return, and will rebuild the tabernacle of David, which is fallen down; and the ruins thereof I will rebuild, and I will set it up:
+17 That the residue of men may seek after the Lord, and all nations upon whom my name is invoked, saith the Lord, who doth these things.
+18 To the Lord was his own work known from the beginning of the world.
+19 For which cause I judge that they, who from among the Gentiles are converted to God, are not to be disquieted.
+20 But that we write unto them, that they refrain themselves from the pollutions of idols, and from fornication, and from things strangled, and from blood.
+21 For Moses of old time hath in every city them that preach him in the synagogues, where he is read every sabbath.
+
+[Lectio3]
+!Acts 15:22-29
+22 Then it pleased the apostles and ancients, with the whole church, to choose men of their own company, and to send to Antioch, with Paul and Barnabas, namely, Judas, who was surnamed Barsabas, and Silas, chief men among the brethren.
+23 Writing by their hands: The apostles and ancients, brethren, to the brethren of the Gentiles that are at Antioch, and in Syria and Cilicia, greeting.
+24 Forasmuch as we have heard, that some going out from us have troubled you with words, subverting your souls; to whom we gave no commandment:
+25 It hath seemed good to us, being assembled together, to choose out men, and to send them unto you, with our well beloved Barnabas and Paul:
+26 Men that have given their lives for the name of our Lord Jesus Christ.
+27 We have sent therefore Judas and Silas, who themselves also will, by word of mouth, tell you the same things.
+28 For it hath seemed good to the Holy Ghost and to us, to lay no further burden upon you than these necessary things: 
+29 That you abstain from things sacrificed to idols, and from blood, and from things strangled, and from fornication; from which things keeping yourselves, you shall do well. Fare ye well.
+
+[Ant 2]
+Go * into the whole world, alleluia: and teach all the nations, alleluia.
+
+[Ant 3]
+The good shepherd * gives his life to his sheep, alleluia.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-1
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-1

--- a/web/www/horas/Bohemice/Tempora/Pasc2-2.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-2.txt
@@ -1,0 +1,46 @@
+[Rank]
+Feria Tertia infra Hebdomadam II post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 17:22-27
+22 But Paul standing in the midst of the Areopagus, said: Ye men of Athens, I perceive that in all things you are too superstitious.
+23 For passing by, and seeing your idols, I found an altar also, on which was written: To the unknown God. What therefore you worship, without knowing it, that I preach to you:
+24 God, who made the world, and all things therein; he, being Lord of heaven and earth, dwelleth not in temples made with hands;
+25 Neither is he served with men's hands, as though he needed any thing; seeing it is he who giveth to all life, and breath, and all things:
+26 And hath made of one, all mankind, to dwell upon the whole face of the earth, determining appointed times, and the limits of their habitation.
+27 That they should seek God, if happily they may feel after him or find him, although he be not far from every one of us:
+
+[Lectio2]
+!Acts 17:28-33
+28 For in him we live, and move, and are; as some also of your own poets said: For we are also his offspring.
+29 Being therefore the offspring of God, we must not suppose the divinity to be like unto gold, or silver, or stone, the graving of art, and device of man.
+30 And God indeed having winked at the times of this ignorance, now declareth unto men, that all should every where do penance.
+31 Because he hath appointed a day wherein he will judge the world in equity, by the man whom he hath appointed; giving faith to all, by raising him up from the dead.
+32 And when they had heard of the resurrection of the dead, some indeed mocked, but others said: We will hear thee again concerning this matter.
+33 So Paul went out from among them.
+
+[Lectio3]
+!Acts 17:34, 18:1-4
+34 But certain men adhering to him, did believe; among whom was also Dionysius, the Areopagite, and a woman named Damaris, and others with them.
+1 After these things, departing from Athens, he came to Corinth.
+2 And finding a certain Jew, named Aquila, born in Pontus, lately come from Italy, with Priscilla his wife, (because that Claudius had commanded all Jews to depart from Rome,) he came to them.
+3 And because he was of the same trade, he remained with them, and wrought; (now they were tentmakers by trade.)
+4 And he reasoned in the synagogue every sabbath, bringing in the name of the Lord Jesus; and he persuaded the Jews and the Greeks.
+
+[Ant 2]
+Going therefore * teach ye all nations; baptising them in the name of the Father, and of the Son, and of the Holy Ghost, alleluia.
+
+[Ant 3]
+But the hireling * and he that is not the shepherd, whose own the sheep are not, seeth the wolf coming, and leaveth the sheep, and flieth: and the wolf catcheth, and scattereth the sheep, alleluia.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-2
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-2

--- a/web/www/horas/Bohemice/Tempora/Pasc2-2t.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-2t.txt
@@ -1,0 +1,48 @@
+[Rank]
+Feria Tertia infra Hebdomadam II post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 17:22-28
+22 But Paul standing in the midst of the Areopagus, said: Ye men of Athens, I perceive that in all things you are too superstitious.
+23 For passing by, and seeing your idols, I found an altar also, on which was written: To the unknown God. What therefore you worship, without knowing it, that I preach to you:
+24 God, who made the world, and all things therein; he, being Lord of heaven and earth, dwelleth not in temples made with hands;
+25 Neither is he served with men's hands, as though he needed any thing; seeing it is he who giveth to all life, and breath, and all things:
+26 And hath made of one, all mankind, to dwell upon the whole face of the earth, determining appointed times, and the limits of their habitation.
+27 That they should seek God, if happily they may feel after him or find him, although he be not far from every one of us:
+28 For in him we live, and move, and are; as some also of your own poets said: For we are also his offspring.
+
+[Responsory1]
+@Tempora/Pasc0-3:Responsory2
+
+[Lectio2]
+!Acts 17:29-34
+29 Being therefore the offspring of God, we must not suppose the divinity to be like unto gold, or silver, or stone, the graving of art, and device of man.
+30 And God indeed having winked at the times of this ignorance, now declareth unto men, that all should every where do penance.
+31 Because he hath appointed a day wherein he will judge the world in equity, by the man whom he hath appointed; giving faith to all, by raising him up from the dead.
+32 And when they had heard of the resurrection of the dead, some indeed mocked, but others said: We will hear thee again concerning this matter.
+33 So Paul went out from among them.
+34 But certain men adhering to him, did believe; among whom was also Dionysius, the Areopagite, and a woman named Damaris, and others with them.
+
+[Lectio3]
+!Acts 18:1-4
+1 After these things, departing from Athens, he came to Corinth.
+2 And finding a certain Jew, named Aquila, born in Pontus, lately come from Italy, with Priscilla his wife, (because that Claudius had commanded all Jews to depart from Rome,) he came to them.
+3 And because he was of the same trade, he remained with them, and wrought; (now they were tentmakers by trade.)
+4 And he reasoned in the synagogue every sabbath, bringing in the name of the Lord Jesus; and he persuaded the Jews and the Greeks.
+5 And when Silas and Timothy were come from Macedonia, Paul was earnest in preaching, testifying to the Jews, that Jesus is the Christ.
+6 But they gainsaying and blaspheming, he shook his garments, and said to them: Your blood be upon your own heads; I am clean: from henceforth I will go unto the Gentiles.
+
+[Responsory3]
+@Tempora/Pasc0-5:Responsory2
+
+[Ant 2]
+Going therefore * teach ye all nations; baptising them in the name of the Father, and of the Son, and of the Holy Ghost, alleluia.
+
+[Ant 3]
+But the hireling * and he that is not the shepherd, whose own the sheep are not, seeth the wolf coming, and leaveth the sheep, and flieth: and the wolf catcheth, and scattereth the sheep, alleluia.

--- a/web/www/horas/Bohemice/Tempora/Pasc2-3.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-3.txt
@@ -1,0 +1,243 @@
+[Rank]
+Patrocinii St. Joseph Confessoris Sponsi B.M.V. confessoris;;Duplex I classis;;6;;
+
+[Rule]
+proper
+Psalmi Dominica
+Antiphonas horas
+9 lectiones;
+Psalm5 Vespera=116
+
+[Ant Vespera]
+And Jacob begat Joseph, * the husband of Mary, of whom was born Jesus, Who is called Christ. Alleluia.
+The Angel Gabriel * was sent from God, unto a city of Galilee, named Nazareth, to a Virgin espoused to a man whose name was Joseph. Alleluia.
+And Joseph also went up * from Galilee, out of the city of Nazareth, unto Judea, unto the city of David, which is called Bethlehem. Alleluia.
+And they came with haste, * and found Mary and Joseph, and the Babe lying in a manger. Alleluia.
+And Jesus Himself began to be about thirty years of age, being (as was supposed) the Son of Joseph. Alleluia.
+
+[Ant Vespera] (rubrica cisterciensis)
+Alleluja, * alleluja, alleluja.
+
+[Versum 1]
+V. Učinil jej pánem svého domu, alleluja.
+R. A vládcem nad veškerým svým majetkem, alleluja.
+
+[Ant 1]
+Když byla zasnoubena * Matka Ježíšova, Maria, s Josefem, ještě než spolu začali bydlet, shledala, že je čeká dítě z Ducha svatého, alleluja.
+
+[Oratio]
+Bože, jenž jsi ve své nevýslovné prozřetelnosti ráčil vyvolit svatého Josefa za snoubence své přesvaté Rodičky; uděl, prosíme, aby ten, jejž jako ochránce ctíme na zemi, zasloužili si míti jako přímluvce v nebi;
+$Qui vivis
+
+[Invit]
+In worshipful remembrance of our blessed Defender Joseph,* let us praise our God.
+
+[Ant Matutinum]
+The Angel of the Lord appeareth to Joseph in a dream, saying Arise, and take the young Child and His Mother, and flee into Egypt, and be thou there until I bring thee word. Alleluia;;1
+;;2
+;;3
+V. Budu vyznávat tvé jméno, alleluja.
+R. Neboť ses stal mým pomocníkem a ochráncem, alleluja.
+An Angel of the Lord appeareth in a dream to Joseph (in Egypt) saying Arise, and take the young Child and His Mother, and go into the land of Israel for they are dead which sought the young Child's life. Alleluia;;4
+;;5
+;;8
+V. Shlédni s nebe, a pohleď, a navštiv tuto vinici, alleluja.
+R. A ochraňuj ji, alleluja.
+Joseph arose, and took the young Child and His Mother, and came into the land of Israel, and dwelt in a city called Nazareth. Alleluia;;14
+;;20
+;;23
+V. Vzýval jsem Pána, Otce mého Pána, alleluja.
+R. Aby mě neopustil v den soužení, alleluja.
+
+[Nocturn 1 Versum]
+V. Budu vyznávat tvé jméno, alleluja.
+R. Neboť ses stal mým pomocníkem a ochráncem, alleluja.
+
+[Nocturn 2 Versum]
+V. Shlédni s nebe, a pohleď, a navštiv tuto vinici, alleluja.
+R. A ochraňuj ji, alleluja.
+
+[Nocturn 3 Versum]
+V. Vzýval jsem Pána, Otce mého Pána, alleluja.
+R. Aby mě neopustil v den soužení, alleluja.
+
+[Lectio1]
+Lesson from the book of Genesis
+!Gen 39:1-6
+1 And Joseph was brought into Egypt, and Putiphar an eunuch of Pharao, chief captain of the army, an Egyptian, bought him of the Ismaelites, by whom he was brought.
+2 And the Lord was with him, and he was a prosperous man in all things: and he dwelt in his master's house,
+3 Who knew very well that the Lord was with him, and made all that he did to prosper in his hand.
+4 And Joseph found favour in the sight of his master, and ministered to him: and being set over all by him, he governed the house committed to him, and all things that were delivered to him:
+5 And the Lord blessed the house of the Egyptian for Joseph's sake, and multiplied all his substance, both at home, and in the fields.
+6 Neither knew he any other thing, but the bread which he ate. And Joseph was of a beautiful countenance, and comely to behold.
+
+[Responsory1]
+R. The people cried to Pharaoh for bread
+* And he answered them Go unto Joseph. Alleluia.
+V. The saving of our lives is in thy hand; only let us find grace in thy sight, and we will gladly be Pharaoh's servants.
+R. And he answered them Go unto Joseph. Alleluia.
+
+[Lectio2]
+!Gen 41:37-43
+37 The counsel pleased Pharao and all his servants.
+38 And he said to them: Can we find such another man, that is full of the spirit of God?
+39 He said therefore to Joseph: Seeing God hath shown thee all that thou hast said, can I find one wiser and one like unto thee?
+40 Thou shalt be over my house, and at the commandment of thy mouth all the people shall obey: only in the kingly throne will I be above thee.
+41 And again Pharao said to Joseph: Behold, I have appointed thee over the whole land of Egypt.
+42 And he took his ring from his own hand, and gave it into his hand: and he put upon him a robe of silk, and put a chain of gold about his neck.
+43 And he made him go up into his second chariot, the crier proclaiming that all should bow their knee before him, and that they should know he was made governor over the whole land of Egypt.
+
+[Responsory2]
+R. God hath made me as a father to Pharaoh, and lord of all his house.
+* He hath made me great, to save much people alive. Alleluia.
+V. Come unto me, and I wili give you all the good of the land of Egypt, and ye shall eat the fat of the land.
+R. He hath made me great, to save much people alive. Alleluia.
+
+[Lectio3]
+!Gen 41:44-49
+44 And the king said to Joseph: I am Pharao; without thy commandment no man shall move hand or foot in all the land of Egypt.
+45 And he turned his name, and called him in the Egyptian tongue, The saviour of the world. And he gave him to wife Aseneth the daughter of Putiphare priest of Heliopolis. Then Joseph went out to the land of Egypt:
+46 (Now he was thirty years old when he stood before king Pharao) and he went round all the countries of Egypt.
+47 And the fruitfulness of the seven years came: and the corn being bound up into sheaves was gathered together into the barns of Egypt.
+48 And all the abundance of grain was laid up in every city.
+49 And there was so great abundance of wheat, that it was equal to the sand of the sea, and the plenty exceeded measure.
+
+[Responsory3]
+R. Now shall I die happy, since I have seen thy face, and do leave thee behind me. I am not disappointed of seeing thee.
+* The Lord hath showed me also thy seed. Alleluia.
+V. He That hath fed me from my youth up, bless the lads, and let my name be named on them.
+R. The Lord hath showed me also thy seed. Alleluia.
+&Gloria
+R. The Lord hath showed me also thy seed. Alleluia.
+
+[Lectio4]
+From the Sermons of St. Bernardine of Siena.
+!1st of St. Joseph.)
+When any special favours are conferred upon a reasonable being, it is the common rule that whenever the grace of God electeth such and such an one for such and such a grace, or for such and such an high post of duty, the person so elected receiveth all the gifts of grace which be needful for him in that state of life whereunto he is called, and receiveth them abundantly. Of this there is an excellent instance in the case of the holy Joseph, the socalled father of our Lord Jesus Christ, and the real husband of her, who is Queen of the world, and Lady of Angels. He had been elected by the Eternal Father to be the faithful nurse and warder of His two chief treasures, that is, His Son, and Joseph's own Wife. This duty Joseph faithfully discharged, and consequently the Lord hath said to him: Well done, thou good and faithful servant enter thou into the joy~
+of thy Lord. (Matth. xxv. 21.)
+
+[Responsory4]
+R. Thou hast given me the shield of thy salvation, and thy right hand hath holden me up.
+* My buckler, and the horn of my salvation, and my refuge. Alleluia.
+V. I am thy shield and thy exceeding great reward.
+R. My buckler, and the horn of my salvation, and my refuge. Alleluia.
+
+[Lectio5]
+This man Joseph, if we compare him with the Universal Church of Christ, is he not that elect and chosen one, through whom, and under whom, Christ is orderly and honestly brought into the world? If, then, the Holy Universal Church be under a debt to the Virgin Mother, because it is through her that she hath been made to receive Christ, next to Mary she oweth love and worship to Joseph. Joseph is the key of the (Church of the Saints) which were under the Old Testament, in whose person the noble structure of Patriarchs and Prophets reacheth her completion and realiseth her promises. He is the only one of them who actually enjoyed in full fruition what God had been pleased to promise before to them. It is, therefore, with good reason that we see a type of him in that Patriarch Joseph who stored up corn for the people. But the second Joseph hath a more excellent dignity than the first, seeing that the first only gave to the Egyptians bread for the body, but the second was the watchful guardian for all the elect of that Living Bread Which came down from heaven, of Which whosoever eateth will never die.
+
+[Responsory5]
+R. He shall set his children under her shelter, and shall lodge under her branches by her shall he be covered from heat,
+* And in her glory shall he dwell. Alleluia.
+V. Trust in Him, ye congregation of the people, pour out your heart before Him.
+R. And in her glory shall he dwell. Alleluia.
+
+[Lectio6]
+There can be no doubt that Christ still treateth Joseph in heaven with that familiarity, honour, and most high condescension which He paid him, like a Son to a father, while He walked among men; nay, rather, that He hath now crowned and completed those habits. We may very reasonably suspect that it was with a peculiar meaning that Christ said (to him) Enter thou into the joy of thy Lord. The joy of being blessed for ever entereth into the heart of man, but when the Lord said (to Joseph), Enter thou into joy, He probably meant mystically to bid him realise a joy which should not be within him only, but outside him also, above him, and below him, and all round about him, and overflowing him as it~
+were a great bottomless pit of joy to swallow him up altogether. Therefore, O thou blessed Joseph! remember us! In thy helpful prayers, make intercession for us with Him Who vouchsafed to be supposed thy Son! Likewise, obtain some pity for us from that most blessed Maiden who was thy wife, and the Mother of Him, Who, with the Father and the Holy Ghost, liveth and reigneth, one God, world without end. Amen.
+
+[Responsory6]
+R. Though an host should encamp against me, my heart shall not fear.
+* Though war should rise against me, in this will I be confident. Alleluia.
+V. My praise shall be continually of thee, for Thou art my strong refuge.
+R.* Though war should rise against me, in this will I be confident. Alleluia.
+&Gloria
+R. Though war should rise against me, in this will I be confident. Alleluia.
+
+[Lectio7]
+From the Holy Gospel according to Luke
+!Luke 3:21
+At that time: When all the people were baptized, it came to pass, that Jesus also being baptized and praying, the heaven was opened. And so on.
+_
+Homily by St. Augustine, Bishop (of Hippo.)
+!Book ii., on the Harmony of the Evangelists.
+And Jesus Himself began to be about thirty years of age, being (as was supposed) the Son of Joseph. These words, as was supposed, were evidently here written for the correction of such as might think that the Lord was the Son of Joseph, in the same sense as other men are called the children of their fathers. Those who find any trouble in the fact that the ancestors reckoned downward by Matthew from David to Joseph, are other than those reckoned upward by Luke from Joseph to David, such, I say, as are troubled by this, may get over it by supposing that Joseph had two fathers; one, that is, who begat him, and another who adopted him. The custom of adopting children, whereby those who have none of their own surround themselves with a family, is very ancient, even among the people of God. Hence, Luke is understood to have included in his Gospel, under the name of father of Joseph, that, not of the father by whom he was begotten, but of him by whom he was adopted, and it is the ancestors of this adoptive father who are reckoned up as far as David.
+
+[Responsory7]
+R. Joseph, thou Son of David, fear not to take unto thee Mary thy wife; for That Which is conceived in her is of the Holy Ghost and she shall bring forth a Son;
+* And thou shalt call His Name Jesus. Alleluia.
+V. For He shall save His people from their sins.
+R. And thou shalt call His Name Jesus. Alleluia.
+
+[Lectio8]
+Thus since we are behoven to believe that what each of the Evangelists said was true, Matthew as well as Luke; and therefore that one of them nameth the father who begat, and the other, the father who adopted, Joseph; we naturally suppose that the Evangelist, who nameth the adoptive father, was he who abstaineth from using the term beget.Matthew beginneth (i. 2) Abraham begat Isaac; and Isaac begat Jacob, and so on, always with the use of this word begat, till he cometh to: and Jacob begat Joseph. By the word which he useth he doth sufficiently indicate that the genealogy which he is giving is that of him who begat.
+
+[Responsory8]
+R. Arise, and take the young Child, and His Mother, and flee into Egypt;
+* And be thou there until I bring thee word. Alleluia.
+V. That it might be fulfilled which was spoken of the Lord by the Prophets, saying Out of Egypt have I called My Son.
+R. And be thou there until I bring thee word. Alleluia.
+&Gloria
+R. And be thou there until I bring thee word. Alleluia.
+
+[Lectio9]
+Luke saith Joseph was the son of Heli, not Joseph was begotten of Heli; but even if he had said the latter, it would not have troubled this interpretation of ours, that one Evangelist nameth the natural, and the other the adoptive father of Joseph. It is not an outrageous thing to say that one who adopteth another hath begotten him, albeit he hath done it, not carnally, but by love. Even so hath God given to us the power to become His sons, albeit He hath not begotten us of His Own Nature and Substance, as He hath His Only - Begotten Son, but only reckoneth us, in His love, among His children.
+&teDeum
+
+[Capitulum Laudes]
+!Gen 49:26
+v. Požehnání tvého otce, větší než požehnání mých předků, dokud nepřijde Touha věčných pahorků; ať sestoupí na hlavu Josefovu, na témě vyvoleného - Nazarejce - mezi svými bratry.
+$Deo gratias
+
+[Versum 2]
+V. Dal jsi mi ochranu své spásy, alleluja.
+R. A tvá pravice mě podpírá, alleluja.
+
+[Ant 2]
+Josefe, synu Davidův, * neboj se přijmout Marii za svou snoubenku; dítě, které se z ní narodí, je z Ducha Svatého, alleluja.
+
+[Lectio Prima]
+!Gen 49:22
+v. Josef je plodný výhonek, plodný strom nad pramenem, jeho větve visí pres ohradu.
+
+[Responsory Tertia]
+R.br. Ustanovil jej pánem svého domu. Alleluja, Alleluja.
+R. Ustanovil jej pánem svého domu. Alleluja, Alleluja.
+V. A vládcem nad veškerým svým majetkem.
+R. Alleluja, Alleluja.
+&Gloria
+R. Ustanovil jej pánem svého domu. Alleluja, Alleluja.
+_
+V. Budu vyznávat tvé jméno, alleluja.
+R. Neboť ses stal mým pomocníkem a ochráncem, alleluja.
+
+[Capitulum Sexta]
+!Gen 49:25
+v. Bůh tvého otce bude tvým pomocníkem, a Všemohoucí ti bude dobrořečit požehnáními z nebe nad námi.
+$Deo gratias
+
+[Responsory Sexta]
+R.br. Budu vyznávat tvé jméno. * Alleluja, Alleluja.
+R. Budu vyznávat tvé jméno. * Alleluja, Alleluja.
+V. Neboť ses stal mým pomocníkem a ochráncem.
+R. Alleluja, Alleluja.
+&Gloria
+R. Budu vyznávat tvé jméno. * Alleluja, Alleluja.
+_
+V. Spravedlivý poroste jako lilie, alleluja.
+R. A kvést bude navěky před Hospodinem, alleluja.
+
+[Capitulum Nona]
+!Gen 49:22
+v. Josef je plodný výhonek, plodný strom nad pramenem, jeho větve visí pres ohradu.
+$Deo gratias
+
+[Responsory Nona]
+R.br. Spravedlivý poroste jako lilie. * Alleluja, Alleluja.
+R. Spravedlivý poroste jako lilie. * Alleluja, Alleluja.
+V. A kvést bude navěky před Hospodinem.
+R. Alleluja, Alleluja.
+&Gloria
+R. Spravedlivý poroste jako lilie. * Alleluja, Alleluja.
+_
+V. Zasazeni v domě Hospodinově, alleluja.
+R. V nádvořích domu našeho Boha, alleluja.
+
+[Versum 3]
+V. Ve stínu toho, jejž jsem si zamilovala, jsem seděla, alleluja.
+R. A jeho plod je sladký mému hrdlu, alleluja.
+
+[Versum 3] (rubrica cisterciensis)
+@:Versum 1
+
+[Ant 3]
+Synu, proč jsi nám to takto udělal? * Hle, tvůj otec a já jsme tě v bolestech hledali, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc2-3Feria.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-3Feria.txt
@@ -1,0 +1,45 @@
+[Rank]
+Feria Quarta infra Hebdomadam II post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 20:17-24
+17 And sending from Miletus to Ephesus, he called the ancients of the church.
+18 And when they were come to him, and were together, he said to them: You know from the first day that I came into Asia, in what manner I have been with you, for all the time,
+19 Serving the Lord with all humility, and with tears, and temptations which befell me by the conspiracies of the Jews;
+20 How I have kept back nothing that was profitable to you, but have preached it to you, and taught you publicly, and from house to house,
+21 Testifying both to Jews and Gentiles penance towards God, and faith in our Lord Jesus Christ.
+22 And now, behold, being bound in the spirit, I go to Jerusalem: not knowing the things which shall befall me there:
+23 Save that the Holy Ghost in every city witnesseth to me, saying: That bands and afflictions wait for me at Jerusalem.
+24 But I fear none of these things, neither do I count my life more precious than myself, so that I may consummate my course and the ministry of the word which I received from the Lord Jesus, to testify the gospel of the grace of God.
+
+[Lectio2]
+!Acts 20:25-31
+25 And now behold, I know that all you, among whom I have gone preaching the kingdom of God, shall see my face no more.
+26 Wherefore I take you to witness this day, that I am clear from the blood of all men;
+27 For I have not spared to declare unto you all the counsel of God.
+28 Take heed to yourselves, and to the whole flock, wherein the Holy Ghost hath placed you bishops, to rule the church of God, which he hath purchased with his own blood.
+29 I know that, after my departure, ravening wolves will enter in among you, not sparing the flock.
+30 And of your own selves shall arise men speaking perverse things, to draw away disciples after them.
+31 Therefore watch, keeping in memory, that for three years I ceased not, with tears to admonish every one of you night and day
+
+[Lectio3]
+!Acts 20:32-38
+32 And now I commend you to God, and to the word of his grace, who is able to build up, and to give an inheritance among all the sanctified.
+33 I have not coveted any man's silver, gold, or apparel, as
+34 You yourselves know: for such things as were needful for me and them that are with me, these hands have furnished.
+35 I have showed you all things, how that so labouring you ought to support the weak, and to remember the word of the Lord Jesus, how he said: It is a more blessed thing to give, rather than to receive.
+36 And when he had said these things, kneeling down, he prayed with them all.
+37 And there was much weeping among them all; and falling on the neck of Paul, they kissed him,
+38 Being grieved most of all for the word which he had said, that they should see his face no more. And they brought him on his way to the ship.
+
+[Ant 2]
+Go, tell my brethren alleluia * that they go into Galilee, alleluia, there they shall see me, alleluia, alleluia, alleluia.
+
+[Ant 3]
+As the Father * knoweth me, and I know the Father: and I lay down my life for my sheep. alleluia.

--- a/web/www/horas/Bohemice/Tempora/Pasc2-4.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-4.txt
@@ -1,0 +1,61 @@
+[Rank]
+Die II Infra Octavam S. Joseph;;Semiduplex;;2;;vide Tempora/Pasc2-3
+
+[Rule]
+vide Tempora/Pasc2-3
+9 lectiones
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 24:10-16
+10 Then Paul answered, (the governor making a sign to him to speak:) Knowing that for many years thou hast been judge over this nation, I will with good courage answer for myself.
+11 For thou mayest understand, that there are yet but twelve days, since I went up to adore in Jerusalem: 
+12 And neither in the temple did they find me disputing with any man, or causing any concourse of the people, neither in the synagogues, nor in the city: 
+13 Neither can they prove unto thee the things whereof they now accuse me. 
+14 But this I confess to thee, that according to the way, which they call a heresy, so do I serve the Father and my God, believing all things which are written in the law and the prophets: 
+15 Having hope in God, which these also themselves look for, that there shall be a resurrection of the just and unjust.
+16 And herein do I endeavour to have always a conscience without offence toward God, and towards men. 
+
+[Lectio2]
+!Acts 24:17-21
+17 Now after many years, I came to bring alms to my nation, and offerings, and vows. 
+18 In which I was found purified in the temple: neither with multitude, nor with tumult. 
+19 But certain Jews of Asia, who ought to be present before thee, and to accuse, if they had any thing against me: 
+20 Or let these men themselves say, if they found in me any iniquity, when standing before the council,
+21 Except it be for this one voice only that I cried, standing among them, Concerning the resurrection of the dead am I judged this day by you.
+
+[Lectio3]
+!Acts 24:22-27
+22 And Felix put them off, having most certain knowledge of this way, saying: When Lysias the tribune shall come down, I will hear you. 
+23 And he commanded a centurion to keep him, and that he should be easy, and that he should not prohibit any of his friends to minister unto him. 
+24 And after some days, Felix, coming with Drusilla his wife, who was a Jew, sent for Paul, and heard of him the faith, that is in Christ Jesus. 
+25 And as he treated of justice, and chastity, and of the judgment to come, Felix being terrified, answered: For this time, go thy way: but when I have a convenient time, I will send for thee.
+26 Hoping also withal, that money should be given him by Paul; for which cause also oftentimes sending for him, he spoke with him. 
+27 But when two years were ended, Felix had for successor Portius Festus. And Felix being willing to show the Jews a pleasure, left Paul bound. 
+
+[Lectio4]
+From a Sermon by St. Bernardine of Siena
+!Sermo de S. Joseph
+The marriage between Mary and Joseph was a real marriage, for it was contracted under divine inspiration. Now in marriage there is so close a union of souls that the bridegroom and the bride are said to be one person, for which reason marriage is like unto the very perfection of unity. Hence how can any discerning mind think that the Holy Spirit would unite, in a union of this intimacy, a mind such as the Virgin's, with the soul of a man who had not within him the operation of a godliness like unto hers? Wherefore I believe that this Joseph was holy, the chastest of men and a virgin, completely humble, burning with a passion of charity towards God, and full of the highest graces of contemplation. And since the Virgin knew that he was given her by the Holy Spirit to be her spouse, and the faithful guardian of her virginity, and to share besides in devoted love and affectionate care towards that One who was in the divinest fashion the very offspring of God; therefore I believe that she sincerely loved Saint Joseph with all the affection of her heart.
+
+[Lectio5]
+Now Joseph was most ardent in his love for Christ. For who, pray, would deny that Christ, whether as a child or as a grown man, would most deeply inspire ineffable affection, and the peculiar joys which he alone could give? And what would be the effect on one who held him in his arms, and conversed at will with him? And besides all this, who can reckon the bliss of receiving from the Christ Child those gazes of filial love? or his words spoken as a devoted son? or the giving of his trustful embraces? O how sweet were the kisses that Joseph received from him! O how sweet to hear little One lisp the name of father, and how delightful to feel his gentle carresses! Think again how often (when the little Jesus was growing bigger, and was wearied with much walking on the journeys which they made) Joseph must have been filled with compassion, and so carried him at rest in his bosom. For Joseph bore towards Jesus all the fulness of an adoptive love, as to a most dear son, given to him by the Holy Ghost in his Virgin bride.
+
+[Lectio6]
+Hence it was that a most prudent Mother, who knew the devotion of Joseph to Jesus, said to her Son, when she found him in the temple: Son, why hast thou thus dealt with us? behold, thy father and I have sought thee sorrowing. In order to understand this, we must note that Christ hath within himself, as it were, two savours, sweetness and bitterness. And since the most holy Joseph was in a wonderful manner (as we shall see) a partaker of these two savours, therefore the Blessed Virgin doth bestow upon him in a special sense the title of Father of Christ. This is the only place where we read that she did call Saint Joseph the father of Jesus, doubtless because the bitterness of sorrow which he felt at the loss of Jesus showed the fatherly affection which he bore him. For if according to human laws, which are approved by God, a man can adopt as his son the child of another family, how much more truly ought the Son of God to be called the Son of Joseph. For he was given to this Joseph by his most holy Spouse, in the wonderful mystery of a virginal marriage. And so it is also to be believed that in Joseph there were the two savours of Jesus, sweetness and bitterness, which were manifested as the sweetness of paternal love, and the bitterness of his compassion, towards his beloved Jesus.
+
+[Lectio7]
+From the Holy Gospel according to Luke
+!Luke 3:21-23
+At that time: When all the people were baptized, it came to pass, that Jesus also being baptized and praying, the heaven was opened. And so on, and that which followeth.
+_
+A Homily by St. Augustine the Bishop
+!Liber 2 de Consensu Evang.
+Joseph cannot be denied the name of father of Christ, merely because he did not beget him by coition. For he would have been called the father of any child whom he adopted, even if the child were not the issue of his wife, but from another family. It is true that Christ was supposed to be the son of Joseph in another sense; namely, in that of having been actually begotten by Joseph according to the flesh. But this supposition was made only by those from whom Mary's virginity was concealed. It is of this that Luke saith: And Jesus himself began to be about thirty years of age, being (as was supposed) the son of Joseph. However, Luke sheweth no hesitation in giving the name of parent, not to Mary only, but also to Joseph, when in another place he saith: And the child grew, and waxed strong in spirit, filled with wisdom: and the grace of God was upon him: Now his parents went every year to Jerusalem, at the Feast of Passover.
+
+[Lectio8]
+But lest anyone should think that by the word Parents there is here to understood Mary and her forbears only, we must take into account what Luke recordeth earlier, And Joseph and his mother marvelled at those things which were spoken of him. Since, therefore, Luke witnesseth that Christ was born, not by the begetting of Joseph, but of the Virgin Mary, how can he call Joseph the father of Jesus, except in the sense that Joseph was a real husband to Mary by virtue of the true bond of marriage, saving only that there never was any carnal intercourse between them? And yet, on account of this bond of marriage, Joseph was the father of Jesus in a much closer sense (seeing that the Christ Child was born of his wife) than if Joseph had adopted Jesus from another family. Hence, also, if anyone could prove that Mary did not trace her origin from David, the same reasoning by which Joseph is called the father of Christ would be sufficient reason for giving Christ the name, Son of David.
+
+[Lectio9]
+Luke giveth the genealogy, not at the beginning of his Gospel, but after the account of the Baptism of Christ. And he giveth it, not in the descending order, but in the ascending, more as if he were pointing to Christ as Priest, making atonement for sins. This was the occasion when the voice spake in testimony from heaven. And also at this time John himself gave testimony, saying: Behold the Lamb of God, which taketh away the sin of the world.  By thus beginning with Jesus and tracing back, Luke passeth up through Abraham and eventually cometh to God, to whom we are reconciled after purification and atonement. Rightly then doth Luke give the origin by adoption, for through adoption and faith in the Son of God we become God's sons. In this fashion, Luke sheweth clearly enough why he nameth Joseph as the son of Heli; that is, not because Joseph was betotten by Heli, but because he was adopted by him. For Luke calleth Adam himself the son of God, and this because he was made by God, being set in the paradise of Eden as a son by virtue of the grace which afterwards he lost in sinning.
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc2-4Feria.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-4Feria.txt
@@ -1,0 +1,19 @@
+[Rank]
+Feria Quinta infra Hebdomadam II post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Ant 2]
+Art thou only a stranger to Jerusalem * and hast not heard about Jesus, how they gave him to condemnation to death? Alleluia.
+
+[Ant 3]
+And other sheep I have, * that are not of this fold: them also I must bring, and they shall hear my voice, and there shall be one fold and one shepherd, alleluia.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-4
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-4

--- a/web/www/horas/Bohemice/Tempora/Pasc2-5.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-5.txt
@@ -1,0 +1,55 @@
+[Rank]
+Die III Infra Octavam S. Joseph;;Semiduplex;;2;;vide Tempora/Pasc2-3
+
+[Rule]
+vide Tempora/Pasc2-3;
+9 lectiones
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 25:1-5
+1 Now when Festus was come into the province, after three days, he went up to Jerusalem from Caesarea.
+2 And the chief priests, and principal men of the Jews, went unto him against Paul: and they besought him,
+3 Requesting favour against him, that he would command him to be brought to Jerusalem, laying wait to kill him in the way.
+4 But Festus answered: That Paul was kept in Caesarea, and that he himself would very shortly depart thither.
+5 Let them, therefore, saith he, among you that are able, go down with me, and accuse him, if there be any crime in the man.
+
+[Lectio2]
+!Acts 25:6-8
+6 And having tarried among them no more than eight or ten days, he went down to Caesarea, and the next day he sat in the judgment seat; and commanded Paul to be brought.
+7 Who being brought, the Jews stood about him, who were come down from Jerusalem, objecting many and grievous causes, which they could not prove;
+8 Paul making answer for himself: Neither against the law of the Jews, nor against the temple, nor against Caesar, have I offended in any thing.
+
+[Lectio3]
+!Acts 25:9-12
+9 But Festus, willing to show the Jews a pleasure, answering Paul, said: Wilt thou go up to Jerusalem, and there be judged of these things before me?
+10 Then Paul said: I stand at Caesar's judgment seat, where I ought to be judged. To the Jews I have done no injury, as thou very well knowest.
+11 For if I have injured them, or have committed any thing worthy of death, I refuse not to die. But if there be none of these things whereof they accuse me, no man may deliver me to them: I appeal to Caesar.
+12 Then Festus having conferred with the council, answered: Hast thou appealed to Caesar? To Caesar shalt thou go.
+
+[Lectio4]
+The Lesson is taken from a Sermon by St. John Chrysostom
+Homilia 4 in Matth.
+It was the custom in ancient times for betrothed brides to dwell in the houses of their bridegrooms. And it would seem that Mary thus dwelt with her Spouse. And herein we find answer to the question: Why did not the virgin conception take place before Mary was wedded? In order that the mystery might be hid in the meantime, and that the Virgin might escape all danger of evil suspicion. For Joseph had the best right to be moved by jealousy. Yet we see that he not only refrained from sending away his Espoused, or branding her with infamy, but that he received her as his own, and did cherish her after she conceived. And verily, it is evident that he would never have kept her in his house, or ministered to all her needs, if he had not clearly come to know that she had conceived by the operation of the Holy Ghost.
+
+[Lectio5]
+Joseph being a just man, and not willing to make her a publick example, was minded to put her away privily. After the Evangelist hath told us that she was with child, of the Holy Ghost, and not of any sexual commerce, Luke bringeth testimony from another source to confirm the statement. For lest anyone should say: And how can this be proved? who saw it? who ever heard of any such thing having happened? and lest you might think that a disciple had invented this tale to please his Master, the Evangelist thus bringeth forward the grief of Joseph, and what he did thereafter, to confirm the story, as if to say: If ye will not believe me, or if ye hold my testimony in suspicion, at least believe the husband.
+
+[Lectio6]
+He saith: Joseph her husband, being a just man. To be just, as the word is here used, implieth that full growth of righteousness which cometh from the habitual service of God. Being therefore a just man (that is, a worthy and good man), he was minded to put her away privily. Thus the Evangelist recordeth the grief of this just man before he knew the secret of the virgin conception, lest thou shouldst have doubts concerning what happened after he knew that secret. And certainly if Mary had been such as suspicion would make her out to be, she would have deserved not only to be denounced, but to be punished by the authority of the Law. But Joseph was not only unwilling to condemn her, but even to denounce her. Herein thou dost see an instance of a man full of spiritual understanding, and free from the tyranny of suspicion. But was this a matter of mere suspicion, seeing that the very swelling of her body seemed to prove a fact? Nonetheless, this man was so pure, and free from that kind of jealousy, that he would not cause the Virgin even the slightest grief. And although he lived under the Law, his spiritual understanding was above the Law. For now that the reign of grace was approaching, it was fitting that there should be a shining example of a more sublime spirituality than was common under the Law.
+
+[Lectio7]
+From the Holy Gospel according to Luke
+!Luke 3:21-23
+At that time: When all the people were baptized, it came to pass, that Jesus also being baptized and praying, the heaven was opened. And so on, and that which followeth.
+_
+A Homily by St. Augustine the Bishop
+!Liber 23 contra Faust. cap. 7-8
+The words uttered from heaven over the river Jordan: This is my beloved Son, in whom I am well pleased: were said also on the Mount of the Transfigurátion. Now these words should not be understood to imply that he was not the Son of God before the voice from heaven was heard. For we know that he who received the form of a servant from the Virgin's womb, being in the form of God, thought it not robbery to be equal with God. Indeed, the same Apostle Paul clearly declareth elsewhere: But when the fulness of the time was come, God sent forth his Son, made of a Woman, made under the Law, that he might redeem them that were under the Law, that we might receive the adoption of sons. He therefore is the Son of God, who is according to his divinity the Lord of David, and at the same time according to the flesh the Son of David, and of the seed of David. 	
+
+[Lectio8]
+Except it were profitable to believe this, the same Apostle would not have exhorted Timothy so earnestly, saying: Remember that Jesus Christ, of the seed of David, is risen again from the dead, according to my Gospel. Why then should any follower of the holy Gospel be troubled concerning this; to wit, that Christ, who was born of the Virgin without cohabitation with Joseph, hath his line of descent traced by the Evangelist Matthew through Joseph rather than through Mary; or again, that because of Joseph's descent from David, the Evangelist should call Christ the Son of David? For we know good reasons for this. The first is that the genealogy of her husband would be preferred to hers as a matter of honour to the male sex. For even though he was not joined to her in cohabitation, he was not on that account any the less her husband, since Matthew himself witnesseth that Mary was called the wife of Joseph by the Angel, and yet he also saith that she had conceived by the Holy Ghost.
+
+[Lectio9]
+Note that one and the same narrátor both maketh and approveth all these statements: to wit, that Joseph was the husband of Mary; that the Mother of Christ was a Virgin; that Christ was of the seed of David; and that Joseph was in the line of Christ's ancestors from David. From all this we perceive several other reasons for the giving of Joseph's genealogy: to wit, that Mary was not without blood-relationship to David; and that in consideration of their union as souls, according to the due order of sex, she was not falsely given the title of Joseph's wife; and that Joseph, chiefly on account of his dignity as a man, was not to be separated from the line of their common genealogy, lest he should appear as separated from that Woman, to whom the affection of his soul bound him.
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc2-5Feria.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-5Feria.txt
@@ -1,0 +1,13 @@
+[Rank]
+Feria Sexta infra Hebdomadam II post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Ant 2]
+Ought not Christ * to have suffered these things, and so to enter into his glory? alleluia.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-5

--- a/web/www/horas/Bohemice/Tempora/Pasc2-6.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-6.txt
@@ -1,0 +1,59 @@
+[Rank]
+III Infra Octavam S. Joseph;;Semiduplex;;2;;vide Tempora/Pasc2-3
+
+[Rule]
+vide Tempora/Pasc2-3;
+9 lectiones
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 28:16-20
+16 And when we were come to Rome, Paul was suffered to dwell by himself, with a soldier that kept him. 
+17 And after the third day, he called together the chief of the Jews. And when they were assembled, he said to them: Men, brethren, I, having done nothing against the people, or the custom of our fathers, was delivered prisoner from Jerusalem into the hands of the Romans; 
+18 Who, when they had examined me, would have released me, for that there was no cause of death in me; 
+19 But the Jews contradicting it, I was constrained to appeal unto Caesar; not that I had any thing to accuse my nation of. 
+20 For this cause therefore I desired to see you, and to speak to you. Because that for the hope of Israel, I am bound with this chain.
+
+[Lectio2]
+!Acts 28:21-24
+21 But they said to him: We neither received letters concerning thee from Judea, neither did any of the brethren that came hither, relate or speak any evil of thee. 
+22 But we desire to hear of thee what thou thinkest; for as concerning this sect, we know that it is every where contradicted. 
+23 And when they had appointed him a day, there came very many to him unto his lodgings; to whom he expounded, testifying the kingdom of God, and persuading them concerning Jesus, out of the law of Moses and the prophets, from morning until evening. 
+24 And some believed the things that were said; but some believed not. 
+
+[Lectio3]
+!Acts 28:25-31
+25 And when they agreed not among themselves, they departed, Paul speaking this one word: Well did the Holy Ghost speak to our fathers by Isaias the prophet,
+26 Saying: Go to this people, and say to them: With the ear you shall hear, and shall not understand; and seeing you shall see, and shall not perceive. 
+27 For the heart of this people is grown gross, and with their ears have they heard heavily, and their eyes they have shut; lest perhaps they should see with their eyes, and hear with their ears, and understand with their heart, and should be converted, and I should heal them. 
+28 Be it known therefore to you, that this salvation of God is sent to the Gentiles, and they will hear it. 
+29 And when he had said these things, the Jews went out from him, having much reasoning among themselves. 
+30 And he remained two whole years in his own hired lodging; and he received all that came in to him,
+31 Preaching the kingdom of God, and teaching the things which concern the Lord Jesus Christ, with all confidence, without prohibition.
+
+[Lectio4]
+From a Sermon by St. John Chrysostom
+!Homilia 4 in Matth.
+Joseph, thou son of David, fear not to take unto thee Mary thy wife. But what is: To take? Undoubtedly, to maintain, and that in his own house. For he had already sent her away in his mind. But now the Angel commandeth: Her whom thou wouldst send away, maintain; her, do thou, and not her parents, maintain, for God joineth her to thee; her, God verily joineth to thee, not in the sacred commerce of marriage, but in the fellowship of a common home; and her, God joineth to thee through the ministry of my words. Just as Christ himself later entrusted her to the care of his disciple, so now the Angel giveth her to her spouse; in such manner that she may have the consolation of his company without other conjugal rights. By this means her confinement would be explained in a worthier and more honourable way, and suspicion would be allayed. It is as though the Angel said: Not only was she not dishonoured by an unlawful embrace, but indeed she is fruitful in a manner above nature and usage; therefore grieve not at the happy confinement of thy Bride, but break forth into greater joy! For that which is conceived in her is of the Holy Ghost.
+
+[Lectio5]
+And she shall bring forth a Son, and thou shalt call his Name Jesus. That is: Think not that the ministry of this great dispensation, because it is of the Holy Ghost, is a thing apart from thee. For even thought thou hast no part in his generation, since the Virgin remaineth ínviolate, yet do I readily grant thee this, namely; that thine are all the rights of a father, in so far as they obscure not the dignity of the Virgin; thou shalt certainly give the new-born his Name; thou shalt be the first to call him by his Name.  For even though he who is born is not thy son, nonetheless thou shalt shew him the care and solicitude of a parent; and therefore I unite thee to him by this immediate giving of the Name. But, lest anyone might think from this that Joseph was the begetter of Christ, the Angel was first careful to say: She shall bring forth a Son. He doth not say: She shall bear thee a son: but maketh his statement in an undetermined and indefinite way. For Mary did not bear a son to Joseph, but brought forth Christ to the whole world.
+
+[Lectio6]
+Therefore the Evangelist relateth that the Angel brought his Name from heaven, so that thus might be shewn how wonderful was his birth, seeing that he himself taught his Name to Joseph by an Angel sent from God. For this Name, which verily containeth a thousand treasures of good, was not given without meaning. Therefore the Angel doth himself interpret it, thereby consoling Joseph's grief with good hopes; and thus also inviting him to believe these words. For we are easily summoned to that which is pleasant, and give prompt credence unto good tidings. Wherefore the Angel said: He shall save his people from their sins. This also sheweth the novelty of the gift. For he announceth that this people are to be saved, not indeed from external wars, nor from the swords of barbarians, but from what is far greater than these: From their sins. And no mere man could ever accomplish this.
+
+[Lectio7]
+From the Holy Gospel according to Luke
+!Luke 3:21-23
+At that time: When all the people were baptized, it came to pass, that Jesus also being baptized and praying, the heaven was opened. And so on, and that which followeth.
+_
+A Homily by St. Ambrose the Bishop
+!Expositio in Luc. lib. 3
+No one should be troubled at the words: As was supposed, the son of Joseph. For it was no more than a supposition, seeing that Christ was not the son of Joseph by nature. Albeit, it was so supposed because Mary who was espoused to her husband Joseph, gave Christ birth. And so, referring to Joseph as father, it is written: Is not this the carpenter's son? We have already discussed why the Lord of salvation chose to be born of a Virgin. We have also discussed why she was an espoused Virgin when her conception took place; and why it took place at the time of the enrollment for taxing. Hence it is not fitting to explain why Christ had a working-man for his father. For thereby is figured Christ's divine Father, who as Maker of all things, framed the world. Even though human and divine matters be not equal to each other, yet is this figure a complete one. Christ's Father worketh by fire and by breathing on things. Yea, like a good carpenter of the soul, he chippeth away our defects. Promptly doth he lay his axe to the barren trees and hew them down. Skilful is he in correcting whatever is built scantily, and in buttressing whatever is to be built magnificently. He tempereth the hardness of hearts as with fire, and with his gentle Breath. And by his diverse workings he formeth the quality of the human race.	
+
+[Lectio8]
+We might wonder why the genealogy of Joseph, rather than of Mary, is given (since Mary conceived Christ by the Holy Ghost, and Joseph had not part in the Lord's conception), were it not that the Holy Scripture teacheth us how it was the custom to trace descent on the male side. For in this fashion the person of the man is set forth as pre-eminent, and his dignity maintained, even as it is wont to be done in the Senate and the other high places of the commonwealth. And how unseemly it would have been to have passed over the lineage of the father, and to have given that of the mother, since the so doing would have appeared to proclaim to all the people in the world that Christ had not father. It is a world-wide custom to trace the genealogy of a family in the male line. Therefore, be not perplexed that the lineage of Joseph is given. Forasmuch as Christ was born in the flesh, he was bound to follow this custom of the flesh. And he who came into the world had to be enrolled for taxing in the worldly manner, the more so that Joseph's descent was the same as Mary's.
+
+[Lectio9]
+But some explanation is required as to why Saint Matthew reckoneth Christ's descent from Abraham forward, whilst Saint Luke traceth the same from Christ backward to the creation of Adam by God. By this, Luke would have us understand that Christ's lineage should be traced to God, because God was Christ's true Progenitor, both as his Father whereof he was begotten, and as the Author, in the laver of baptism, of the mystical gift of the Spirit. Wherefore Luke doth not begin his Gospel with the reckoning of Christ's lineage, but recordeth it after the account of the baptism, thereby shewing forth in baptism the working of God, the Author of all things. Thus also Luke asserteth that Christ came forth from God according to a certain rule of orderliness. For he weaveth all things together to prove that Christ is by nature, by grace, and in the flesh, the Son of God. But what more evident proof of Christ's divine descent could we have than what Luke giveth? For before the Evangelist reckoneth the genealogy of Christ, he giveth the words of the Father himself: This is my beloved Son, in whom I am well pleased.
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc2-6Feria.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc2-6Feria.txt
@@ -1,0 +1,7 @@
+[Rank]
+Sabbato infra Hebdomadam II post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum

--- a/web/www/horas/Bohemice/Tempora/Pasc3-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc3-0.txt
@@ -1,0 +1,153 @@
+[Rank]
+Dominica III post Pascha;;Semiduplex;;5;;
+
+[Rule]
+9 Lectiones
+Duplex
+Una Antiphona
+
+[Ant 1]
+Už jen krátký čas, * a neuvidíte mě, praví Pán; a opět krátký čas, a uvidíte mě, neboť odcházím k Otci, alleluja, alleluja.
+
+[Oratio]
+Bože, jenž bloudícím ukazuješ světlo své pravdy, aby se mohli vrátit na cestu spravedlnosti; dej všem, kteří se považují za Kristovy následovníky, aby zavrhli to, co je tomuto jménu nepřátelské, a následovali to, co je vhodné.
+$Per Dominum
+
+[Lectio1]
+Lesson from the book of Revelation
+!Rev 1:1-6
+1 The Revelation of Jesus Christ, which God gave unto him, to make known to his servants the things which must shortly come to pass: and signified, sending by his angel to his servant John, who hath given testimony to the word of God, and the testimony of Jesus Christ, what things soever he hath seen.
+3 Blessed is he, that readeth and heareth the words of this prophecy; and keepeth those things which are written in it; for the time is at hand.
+4 John to the seven churches which are in Asia. Grace be unto you and peace from him that is, and that was, and that is to come, and from the seven spirits which are before his throne,
+5 And from Jesus Christ, who is the faithful witness, the first begotten of the dead, and the prince of the kings of the earth, who hath loved us, and washed us from our sins in his own blood,
+6 And hath made us a kingdom, and priests to God and his Father, to him be glory~
+and empire for ever and ever. Amen.
+
+[Responsory1]
+R. Thou art worthy, O Lord, to take the book, and to open the seals thereof; alleluia: because thou wast slain, and hast redeemed us to God,
+* In thy blood, alleluia.
+V. And hast made us to our God a kingdom and priests.
+R. In thy blood, alleluia.
+
+[Lectio2]
+!Rev 1:7-11
+7 Behold, he cometh with the clouds, and every eye shall see him, and they also that pierced him. And all the tribes of the earth shall bewail themselves because of him. Even so. Amen.
+8 I am Alpha and Omega, the beginning and the end, saith the Lord God, who is, and who was, and who is to come, the Almighty.
+9 I John, your brother and your partner in tribulation, and in the kingdom, and patience in Christ Jesus, was in the island, which is called Patmos, for the word of God, and for the testimony of Jesus.
+10 I was in the spirit on the Lord's day, and heard behind me a great voice, as of a trumpet,
+11 Saying: What thou seest, write in a book, and send to the seven churches which are in Asia, to Ephesus, and to Smyrna, and to Pergamus, and to Thyatira, and to Sardis, and to Philadelphia, and to Laodicea.
+
+[Responsory2]
+R. As the vine I have brought forth a pleasant odour, alleluia.
+* Come over to me, all ye that desire me, and be filled with my fruits, alleluia, alleluia.
+V. in me is all hope of life and of virtue.
+R. Come over to me, all ye that desire me, and be filled with my fruits, alleluia, alleluia.
+
+[Lectio3]
+!Rev 1:12-19
+12 And I turned to see the voice that spoke with me. And being turned, I saw seven golden candlesticks:
+13 And in the midst of the seven golden candlesticks, one like to the Son of man, clothed with a garment down to the feet, and girt about the paps with a golden girdle.
+14 And his head and his hairs were white, as white wool, and as snow, and his eyes were as a flame of fire,
+15 And his feet like unto fine brass, as in a burning furnace. And his voice as the sound of many waters.
+16 And he had in his right hand seven stars. And from his mouth came out a sharp two edged sword: and his face was as the sun shineth in his power.
+17 And when I had seen him, I fell at his feet as dead. And he laid his right hand upon me, saying: Fear not. I am the First and the Last,
+18 And alive, and was dead, and behold I am living for ever and ever, and have the keys of death and of hell.
+19 Write therefore the things which thou hast seen, and which are, and which must be done hereafter.
+
+[Responsory3]
+R. And I heard a voice from heaven, the voice of great thunder, alleluia: the Lord our God shall reign for ever, alleluia:
+* Now is come salvation, and strength, and the power of his Christ, alleluia, alleluia.
+V. And a voice came out from the throne, saying: Give praise to our God, all saints of Him that fear him, little and great.
+R. Now is come salvation, and strength, and the power of his Christ, alleluia, alleluia.
+&Gloria
+R. Now is come salvation, and strength, and the power of his Christ, alleluia, alleluia.
+
+[Lectio4]
+Sermon from St. Augustine, Bishop (of Hippo)
+!Sermo 147 de Tempore
+During these Holy Days in commemoration of the Lord's resurrection, we purpose to preach, so far as he will empower us, the doctrine of the resurrection of the body. For this is the Faith, to wit: the gift of resurrection, which was bestowed upon the flesh of our Lord Jesus Christ, is what is promised to us, for it was first made manifest in him that we might know what to hope for ourselves. What he hath thus promised would come to us at the last, he willed not only to foretell but to demonstrate. Those who were present at that time (even though they were terrified and affrighted, and supposed they had seen a spirit), handled him, and saw that a spirit would not have flesh and bones, such as they saw him to have. Thus he spake to them, not only in words which they could hear, but in a body which they could see; as if it had not been enough to shew himself to their sight, but must needs even offer himself to be touched and handled.
+
+[Responsory4]
+R. One of the seven Angels talked with me, saying: Come hither, I will show thee the bride, the Lamb's wife.
+* And I saw Jerusalem descending out of heaven, adorned with her jewels. Alleluia, Alleluia, Alleluia.
+V. And he carried me away in the Spirit to a great and high mountain
+R. And I saw Jerusalem descending out of heaven, adorned with her jewels. Alleluia, Alleluia, Alleluia.
+
+[Lectio5]
+For he said: Why are ye troubled? and why do thoughts arise in your hearts? For they supposed that they had seen a spirit. Therefore he added: Behold my hands and my feet, that it is I myself; handle me and see; for a spirit hath not flesh and bones, as ye see me have.  Of course, men have disputed this evidence; for what else could men do, seeing that they are wise only according to man's wisdom, which thus permitteth them to dispute concerning God in spite of what God hath shewn them of himself. He is God, they are men.  But God knoweth the thoughts of man, that they are but vain.
+
+[Responsory5]
+R. I heard in heaven the voice of many Angels, saying
+* Fear the Lord, and give glory to Him, and worship Him That made heaven and earth, the sea, and the fountains of waters. Alleluia, Alleluia.
+V. I saw a strong Angel of God fly through the midst of heaven, crying with a loud voice and saying
+R. Fear the Lord, and give glory to Him, and worship Him That made heaven and earth, the sea, and the fountains of waters. Alleluia, Alleluia.
+&Gloria
+R. Fear the Lord, and give glory to Him, and worship Him That made heaven and earth, the sea, and the fountains of waters. Alleluia, Alleluia.
+
+[Lectio6]
+To carnal men, the one rule of understanding is his ordinary experience; seeing is believing. What men are accustomed to see, that they credit; what they are not accustomed to see, that they deem incredible. But God often worketh wonders (that is, things contrary to what we are accustomed), because he is God. Every day many men are born that previously had no existence at all; and this is a greater miracle than that a few, who did exist, have been raised from the dead.  Yet this wonder is not recognized as such; on the contrary, it is disregarded because man is accustomed to it. Christ rose again from the dead; that is a fact. He had a body: he took flesh, he hung upon the cross, he gave up the ghost; his flesh was laid in the tomb. After that, he shewed his flesh as alive again, he lived again the flesh. Why wonder, why deny it? God wrought this.
+
+[Responsory6]
+R. Coming from Lebanon how sweet she is, alleluia:
+* And the sweet smell of her garments, above all aromatical spices, alleluia, alleluia.
+V. Thy lips are as a dropping honeycomb, honey and milk are under thy tongue.
+R. And the sweet smell of her garments, above all aromatical spices, alleluia, alleluia.
+&Gloria
+R. And the sweet smell of her garments, above all aromatical spices, alleluia, alleluia.
+
+[Lectio7]
+From the Holy Gospel according to John
+!John 16:16-22
+At that time, Jesus said to his disciples: A little while, and now you shall not see me; and again a little while, and you shall see me: because I go to the Father. And so on.
+_
+Homily by St. Augustine, Bishop (of Hippo.)
+!Tract 101 of John
+This little while is the whole duration of this present world. In the same sense this same Evangelist saith in his Epistle (ii. 18): It is the last time. The words, because I go to the Father, refer to the first clause of the text, namely, A little while and ye shall not see Me, and not to the latter clause, that is, and again a little while, and ye shall see Me. By His going to the Father He was about to bring it to pass that they should see Him no more. And thus it was that He said, not that He was about to die, and that after His death they should not see Him until He rose again, but that He was going to the Father, which He did when, after that He was risen again and had manifested Himself to them for forty days, He ascended up into heaven.
+
+[Responsory7]
+R. The people of Israel sung: Alleluia, and all the multitude of Jacob sung in measure.
+* And David was with the singers, (and) played upon an harp in the house of the Lord, and sung praises unto God. Alleluia, Alleluia.
+V. So the Priests and the Levites were sanctified, and all Israel brought up the ark of the covenant of the Lord with shouting.
+R. And David was with the singers, (and) played upon an harp in the house of the Lord, and sung praises unto God. Alleluia, Alleluia.
+&Gloria
+R. And David was with the singers, (and) played upon an harp in the house of the Lord, and sung praises unto God. Alleluia, Alleluia.
+
+[Lectio8]
+But now, to them which were looking on Him in the Body, He saith: A little while, and ye shall not see Me, a little while, and they who now saw Him clad in a dying nature, should see Him so no more, because He was about to go to the Father. But He saith: And again a little while, and ye shall see Me, and these words are a promise to the Universal Church, just as are those others: Lo, I am with you alway, even unto the end of the world (Matth. xxviii. 20.) Our Lord delayeth not His promised coming. Again a little while, and we shall see Him. We shall see Him. And, O, when we shall see Him, then we shall beg, we shall ask no more; for no desire will be unsatisfied, and no riddle unsolved.
+
+[Responsory8]
+R. Your sorrow, alleluia,
+* Shall be turned into joy. Alleluia.
+V. The world shall rejoice; and you shall be made sorrowful: but your sorrow
+R. Shall be turned into joy. Alleluia.
+&Gloria
+R. Shall be turned into joy. Alleluia.
+
+[Lectio9]
+This little while seemeth a very long while to us now, while as it is still going on, but when it is over we shall feel indeed how truly it is but a little while. Therefore, may our rejoicing never be like the rejoicing of that world whereof it is said: The world shall rejoice. A woman when she is in travail hath sorrow, and yet, while hitherto our gladness is still coming to the birth through throes of sorrow, let us not be altogether sorrowful, but, as the Apostle hath it (Rom. xii. 12): Rejoicing in hope: patient in tribulation. A woman, when she is in travail hath sorrow, because her hour is come: but as soon as she is delivered of the child, she remembereth no more the anguish, for joy that a man is born into the world. And so will it be with us. And with that let me end my discourse. The next passage is one of extreme difficulty; nor is it possible to treat it briefly, if, (with the will of God,) it is to be treated satisfactorily.
+&teDeum
+
+[Capitulum Laudes]
+!1 Pet 2:11
+v. Milovaní, jako cizince a přistěhovalce vás napomínám: zdržujte se tělesných žádostí, protože ony bojují proti duši.
+$Deo gratias
+
+[Capitulum Sexta]
+!1 Pet 2:13-14
+v. Kvůli Pánu se podřizujte každému lidskému zřízení: ať už je to král jako svrchovaný vládce, nebo místodržitelé, kteří jsou od něho posíláni trestat zločince a vyznamenávat ty, kdo jednají správně.
+$Deo gratias
+
+[Capitulum Nona]
+!1 Pet 2:18-19
+v. Vy, kdo sloužíte, poslouchejte s všemožnou (povinnou) úctou své pány, a to nejen dobré a mírné, ale i tvrdé. Neboť to je zásluha, jestliže někdo snáší špatné zacházení a trpí nezaslouženě s vědomím, že to od něho Bůh žádá.
+$Deo gratias
+
+[Ant 3]
+Amen pravím vám, * že vy budete plakat a naříkat, zatímco svět se bude radovat, vy sice budete smutní, ale váš smutek se obrátí v jásot, alleluja.
+
+[Commemoratio]
+!Commemoratio for the Octave of St. Joseph
+@Tempora/Pasc2-3:Oratio
+
+[Ant 1 Cist]
+Mám ještě jiné ovce, * které nejsou z tohoto ovčince; a je třeba, abych je přivedl, aby slyšely můj hlas, a byl už jen jeden ovčinec a jeden pastýř, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc3-1Feria.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc3-1Feria.txt
@@ -1,0 +1,22 @@
+[Rank]
+Feria Secunda infra Hebdomadam III post Octavam Paschae;;Feria;;1
+
+[Rule]
+Una Antiphona
+Feria Te Deum
+
+[Ant 2]
+And beginning at Moses * and all the Prophets, He expounded unto them the Scriptures concerning Himself. Alleluia.
+
+[Ant 3]
+Your sorrow * shall be turned into joy, Alleluia and your joy no man take that from you. Alleluia, Alleluia. 
+
+[Oratio 3]
+Almighty God, Who showest to them that be in error the light of thy truth, to the intent that they may return into the way of righteousness grant unto all them that are admitted into the fellowship of Christ's Religion, that they may eschew those things that are contrary to their profession, and follow all such things as are agreeable to the same.
+$Per Dominum
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-1
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-1

--- a/web/www/horas/Bohemice/Tempora/Pasc3-2Feria.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc3-2Feria.txt
@@ -1,0 +1,18 @@
+[Rank]
+Feria Tertia infra Hebdomadam III post Octavam Paschae;;Feria;;1
+
+[Rule]
+Una Antiphona
+Feria Te Deum
+
+[Ant 2]
+And they constrained Him, * saying Lord, abide with us, for it is toward evening. Alleluia.
+
+[Ant 3]
+Sorrow hath filled your heart, * and your joy no man shall take from you. Alleluia, Alleluia. 
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-2
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-2

--- a/web/www/horas/Bohemice/Tempora/Pasc3-3Feria.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc3-3Feria.txt
@@ -1,0 +1,18 @@
+[Rank]
+Feria Quarta infra Hebdomadam III post Octavam Paschae;;Feria;;1
+
+[Rule]
+Una Antiphona
+Feria Te Deum
+
+[Ant 2]
+Abide with us * for it is toward evening, and the day is far spent. Alleluia.
+
+[Ant 3]
+Your sorrow, Alleluia * shall be turned into joy Alleluia.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-3
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-3

--- a/web/www/horas/Bohemice/Tempora/Pasc3-4.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc3-4.txt
@@ -1,0 +1,50 @@
+[Rank]
+Feria Quinta infra Hebdomadam III post Octavam Paschae;;Feria;;1
+
+[Rule]
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the book of Revelation
+!Rev 15:1-4
+1 And I saw another sign in heaven, great and wonderful: seven angels having the seven last plagues. For in them is filled up the wrath of God.
+2 And I saw as it were a sea of glass mingled with fire, and them that had overcome the beast, and his image, and the number of his name, standing on the sea of glass, having the harps of God:
+3 And singing the canticle of Moses, the servant of God, and the canticle of the Lamb, saying: Great and wonderful are thy works, O Lord God Almighty; just and true are thy ways, O King of ages.
+4 Who shall not fear thee, O Lord, and magnify thy name? For thou only art holy: for all nations shall come, and shall adore in thy sight, because thy judgments are manifest.
+
+[Lectio2]
+!Rev 15:5-8
+5 And after these things I looked; and behold, the temple of the tabernacle of the testimony in heaven was opened:
+6 And the seven angels came out of the temple, having the seven plagues, clothed with clean and white linen, and girt about the breasts with golden girdles.
+7 And one of the four living creatures gave to the seven angels seven golden vials, full of the wrath of God, who liveth for ever and ever.
+8 And the temple was filled with smoke from the majesty of God, and from his power; and no man was able to enter into the temple, till the seven plagues of the seven angels were fulfilled.
+
+[Responsory2]
+R. As the vine brought I forth pleasant savour, Alleluia.
+* Come unto me, all ye that be desirous of me, and fill yourselves with my fruits. Alleluia, Alleluia.
+V. In me is the favour of the way and the truth in me is the hope of life and strength.
+R. Come unto me, all ye that be desirous of me, and fill yourselves with my fruits. Alleluia, Alleluia.
+&Gloria
+R. Come unto me, all ye that be desirous of me, and fill yourselves with my fruits. Alleluia, Alleluia.
+
+[Lectio3]
+!Rev 16:1-6
+1 And I heard a great voice out of the temple, saying to the seven angels: Go, and pour out the seven vials of the wrath of God upon the earth.
+2 And the first went, and poured out his vial upon the earth, and there fell a sore and grievous wound upon men, who had the character of the beast; and upon them that adored the image thereof.
+3 And the second angel poured out his vial upon the sea, and there came blood as it were of a dead man; and every living soul died in the sea.
+4 And the third poured out his vial upon the rivers and the fountains of waters; and there was made blood.
+5 And I heard the angel of the waters saying: Thou art just, O Lord, who art, and who wast, the Holy One, because thou hast judged these things:
+6 For they have shed the blood of saints and prophets, and thou hast given them blood to drink; for they are worthy.
+
+[Ant 2]
+And He went in with them. * And it came to pass, as He sat at meat with them, He took bread, and blessed it and brake, and gave to them. Alleluia, Alleluia.
+
+[Ant 3]
+Amen, Amen, I say unto you, that I will see you again, * am your heart shall rejoice, and your jo; no man taketh from you. Alleluia.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-4
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-4

--- a/web/www/horas/Bohemice/Tempora/Pasc3-5.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc3-5.txt
@@ -1,0 +1,47 @@
+ [Rank]
+Feria Sexta infra Hebdomadam III post Octavam Paschae;;Feria;;1
+
+[Rule]
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the book of Revelation
+!Rev 19:1-5
+1 After these things I heard as it were the voice of much people in heaven, saying: Alleluia. Salvation, and glory, and power is to our God.
+2 For true and just are his judgments, who hath judged the great harlot which corrupted the earth with her fornication, and hath revenged the blood of his servants, at her hands.
+3 And again they said: Alleluia. And her smoke ascendeth for ever and ever.
+4 And the four and twenty ancients, and the four living creatures fell down and adored God that sitteth upon the throne, saying: Amen; Alleluia.
+5 And a voice came out from the throne, saying: Give praise to our God, all ye his servants; and you that fear him, little and great.
+
+[Responsory1]
+@Tempora/Pasc3-0:Responsory4
+
+[Lectio2]
+!Rev 19:6-10
+6 And I heard as it were the voice of a great multitude, and as the voice of many waters, and as the voice of great thunders, saying, Alleluia: for the Lord our God the Almighty hath reigned.
+7 Let us be glad and rejoice, and give glory to him; for the marriage of the Lamb is come, and his wife hath prepared herself.
+8 And it is granted to her that she should clothe herself with fine linen, glittering and white. For the fine linen are the justifications of saints.
+9 And he said to me: Write: Blessed are they that are called to the marriage supper of the Lamb. And he saith to me: These words of God are true.
+10 And I fell down before his feet, to adore him. And he saith to me: See thou do it not: I am thy fellow servant, and of thy brethren, who have the testimony of Jesus. Adore God. For the testimony of Jesus is the spirit of prophecy.
+
+[Responsory2]
+@Tempora/Pasc3-0:Responsory5
+
+[Lectio3]
+!Rev 19:11-16
+11 And I saw heaven opened, and behold a white horse; and he that sat upon him was called faithful and true, and with justice doth he judge and fight.
+12 And his eyes were as a flame of fire, and on his head were many diadems, and he had a name written, which no man knoweth but himself.
+13 And he was clothed with a garment sprinkled with blood; and his name is called, the Word of God.
+14 And the armies that are in heaven followed him on white horses, clothed in fine linen, white and clean.
+15 And out of his mouth proceedeth a sharp two edged sword; that with it he may strike the nations. And he shall rule them with a rod of iron; and he treadeth the winepress of the fierceness of the wrath of God the Almighty.
+16 And he hath on his garment, and on his thigh written: King of Kings, and Lord of Lords.
+
+[Ant 2]
+They knew the Lord Jesus * Alin the breaking of bread Alleluia Alleluia. 
+
+[Ant 3] (rubrica 1960)
+Amen, amen I say to you * that you shall lament and weep, but the world shall rejoice; and you shall be made sorrowful, but your sorrow shall be turned into joy.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-5

--- a/web/www/horas/Bohemice/Tempora/Pasc3-6.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc3-6.txt
@@ -1,0 +1,37 @@
+[Rank]
+Sabbato infra Hebdomadam III post Octavam Paschae;;Feria;;1
+
+[Rule]
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the book of Revelation
+!Rev 22:1-7
+1 And he showed me a river of water of life, clear as crystal, proceeding from the throne of God and of the Lamb.
+2 In the midst of the street thereof, and on both sides of the river, was the tree of life, bearing twelve fruits, yielding its fruits every month, and the leaves of the tree were for the healing of the nations.
+3 And there shall be no curse any more; but the throne of God and of the Lamb shall be in it, and his servants shall serve him.
+4 And they shall see his face: and his name shall be on their foreheads.
+5 And night shall be no more: and they shall not need the light of the lamp, nor the light of the sun, because the Lord God shall enlighten them, and they shall reign for ever and ever.
+6 And he said to me: These words are most faithful and true. And the Lord God of the spirits of the prophets sent his angel to show his servants the things which must be done shortly.
+7 And, Behold I come quickly. Blessed is he that keepeth the words of the prophecy of this book.
+
+[Lectio2]
+!Rev 22:8-12
+8 And I, John, who have heard and seen these things. And after I had heard and seen, I fell down to adore before the feet of the angel, who showed me these things.
+9 And he said to me: See thou do it not: for I am thy fellow servant, and of thy brethren the prophets, and of them that keep the words of the prophecy of this book. Adore God.
+10 And he saith to me: Seal not the words of the prophecy of this book: for the time is at hand.
+11 He that hurteth, let him hurt still: and he that is filthy, let him be filthy still: and he that is just, let him be justified still: and he that is holy, let him be sanctified still.
+12 Behold, I come quickly; and my reward is with me, to render to every man according to his works.
+
+[Lectio3]
+!Rev 22:13-21
+13 I am Alpha and Omega, the first and the last, the beginning and the end.
+14 Blessed are they that wash their robes in the blood of the Lamb: that they may have a right to the tree of life, and may enter in by the gates into the city.
+15 Without are dogs, and sorcerers, and unchaste, and murderers, and servers of idols, and every one that loveth and maketh a lie.
+16 I Jesus have sent my angel, to testify to you these things in the churches. I am the root and stock of David, the bright and morning star.
+17 And the spirit and the bride say: Come. And he that heareth, let him say: Come. And he that thirsteth, let him come: and he that will, let him take the water of life, freely.
+18 For I testify to every one that heareth the words of the prophecy of this book: If any man shall add to these things, God shall add unto him the plagues written in this book.
+19 And if any man shall take away from the words of the book of this prophecy, God shall take away his part out of the book of life, and out of the holy city, and from these things that are written in this book.
+20 He that giveth testimony of these things, saith, Surely I come quickly: Amen. Come, Lord Jesus.
+21 The grace of our Lord Jesus Christ be with you all. Amen.

--- a/web/www/horas/Bohemice/Tempora/Pasc4-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc4-0.txt
@@ -1,0 +1,150 @@
+[Rank]
+Neděle 4. po Velikonocích;;Semiduplex;;5;;
+
+[Rule]
+9 Lectiones
+Una Antiphona
+StJamesRule=Jas
+
+[Ant 1]
+Odcházím k tomu, * který mě poslal; a nikdo z vás se mě neptá: Kam jdeš? Alleluja, Alleluja.
+
+[Oratio]
+Bože, jenž mysli svých věřících podmaňuješ jedné vůli; dej svým národům milovat to, co přikazuješ, a toužit po tom, co slibuješ; aby uprostřed nestálostí světa byla naše srdce upřena tam, kde jsou pravé radosti.
+$Per Dominum
+
+[Lectio1]
+Lesson from the letter of St. James the Apostle
+!Jas 1:1-6
+1 James the servant of God, and of our Lord Jesus Christ, to the twelve tribes which are scattered abroad, greeting.
+2 My brethren, count it all joy, when you shall fall into diverse temptations;
+3 Knowing that the trying of your faith worketh patience.
+4 And patience hath a perfect work; that you may be perfect and entire, failing in nothing.
+5 But if any of you want wisdom, let him ask of God, who giveth to all men abundantly, and upbraideth not; and it shall be given him.
+6 But let him ask in faith, nothing wavering.
+
+[Responsory1]
+R. If I forget thee, Alleluia, let my right hand forget me.
+* If I do not remember thee, let my tongue cleave to the roof of my mouth, alleluia, alleluia.
+V. By the rivers of Babylon there we sat down and wept, when we remembered thee, O Zion.
+R. If I do not remember thee, let my tongue cleave to the roof of my mouth, alleluia, alleluia.
+
+[Lectio2]
+!Jas 1:6-11
+6 For he that wavereth is like a wave of the sea, which is moved and carried about by the wind. 
+7 Therefore let not that man think that he shall receive any thing of the Lord.
+8 A double minded man is inconstant in all his ways.
+9 But let the brother of low condition glory in his exaltation:
+10 And the rich, in his being low; because as the flower of the grass shall he pass away.
+11 For the sun rose with a burning heat, and parched the grass, and the flower thereof fell off, and the beauty of the shape thereof perished: so also shall the rich man fade away in his ways.
+
+[Responsory2]
+R. The waters saw thee, O God, the waters saw thee and they were afraid.
+* There was a noise as of many waters the clouds sent out a sound, alleluia, alleluia, alleluia.
+V. thy lightnings lightened the world the earth saw it and shook.
+R. There was a noise as of many waters the clouds sent out a sound, alleluia, alleluia, alleluia.
+
+[Lectio3]
+!Jas 1:12-16
+12 Blessed is the man that endureth temptation; for when he hath been proved, he shall receive a crown of life, which God hath promised to them that love him.
+13 Let no man, when he is tempted, say that he is tempted by God. For God is not a tempter of evils, and he tempteth no man.
+14 But every man is tempted by his own concupiscence, being drawn away and allured.
+15 Then when concupiscence hath conceived, it bringeth forth sin. But sin, when it is completed, begetteth death.
+16 Do not err, therefore, my dearest brethren.
+
+[Responsory3]
+R. I will declare thy Name unto my brethren, alleluia.
+* In the midst of the congregation will I praise thee, alleluia, alleluia.
+V. I will praise thee, O Lord, among the people, and sing unto thee among the nations.
+R. In the midst of the congregation will I praise thee, alleluia, alleluia.
+&Gloria
+R. In the midst of the congregation will I praise thee, alleluia, alleluia.
+
+[Lectio4]
+From the exposition of St. Cyprian, Bishop and Martyr, on the good of patience.
+!Sermone 3. initio.
+In speaking of patience, beloved brethren, and in preaching on its benefits and advantages, how can I better begin than by pointing out the fact that now, just for you to listen to me, I see that patience is necessary, as you could not even do this, namely, listen and learn, without patience. For only then is the word of God and way of salvation~
+effectively learned, if one listens with patience to what is being said. Dearly beloved brethren, there are diverse paths of heavenly wisdom, wherein we are invited to walk, if we would reach in the end the reward which God hath prepared to crown hope and faith but I find no path more useful toward life, nor more sure toward glory than this, that while we humbly strive, in all fear, and in all godliness, to obey the commandments of the Lord, we should set our chiefest guard in an unceasing watch over our patience. The philosophers also say that they take this path, but their patience is as much a sham as their wisdom is a cheat, for who can be wise or patient who knoweth nothing of God's wisdom or God's patience are the lives of servers and worshippers of God. Let it be ours, then, to show forth by spiritual watchfulness that patience which is a part of the teaching which we have learnt from heaven. Patience is one of His Own virtues whereof God hath made us partakers with Him our Great Head is the Captain of the patient, and it is through patience that He hath crowned Himself with glory and honour.
+
+[Responsory4]
+R. Bless ye God in the congregations, alleluia.
+* Even the Lord, ye that are of the fountains of Israel, alleluia, alleluia.
+V. Sing forth the honour of His Name, make His praise glorious.
+R. Even the Lord, ye that are of the fountains of Israel, alleluia, alleluia.
+
+[Lectio5]
+But as for us, dearly beloved brethren, we are the real philosophers, whose wisdom lieth not in words but in deeds, and is manifested not in dresses but in the truth. We are they whose knowledge hath the inward consciousness, not the idle boasting, of strength. We are not speakers of high-sounding words, but our lives. Yea, God is Himself the Source, the Fountain, and the Greatness of patience, and it behoveth man to love what is beloved of God. That good thing which he loveth is commended unto him of God's Majesty. If God be our Lord and Father, let us follow after the example of our Lord and Father's patience, since it is the duty of servants to be obedient, and of sons to be home-minded.
+
+[Responsory5]
+R. With my whole heart, alleluia, have I sought thee, alleluia.
+* O let me not wander from thy commandments, alleluia, alleluia.
+V. Blessed art Thou, O Lord; teach me thy statutes.
+R. O let me not wander from thy commandments, alleluia, alleluia.
+
+[Lectio6]
+By our patience God draweth us toward Himself, and keepeth us His Own. Patience doth soothe anger, bridle the tongue, govern the mind, keep peace, set rules of self-control, break the onset of lust, still the swelling of temper, put out the fire begotten of hatred, make the rich meek, and relieve the need of the poor patience doth guard in virgins their blessed wholeness in widows, their careful purity in such as be married, their single-hearted love one toward the other. Patience doth teach such as be successful to be lowly-minded such as be unfortunate, to be brave and all to be gentle when they are wronged and insulted. Patience maketh a man soon to forgive them that trespass against him, and if he have trespassed against any, long and humbly to ask his pardon. Patience doth fight down temptations, bear persecution, and endure unto the end in suffering, and in uplifting of our testimony. Patience is the moat that guardeth the stout foundations of the castle of our faith.
+
+[Responsory6]
+R. Sing us a song, alleluia.
+* How shall we sing the Lord's song in a strange land, alleluia, alleluia.
+V. There they that carried us away captive required of us a song.
+R. How shall we sing the Lord's song in a strange land, alleluia, alleluia.
+&Gloria
+R. How shall we sing the Lord's song in a strange land, alleluia, alleluia.
+
+[Lectio7]
+From the Holy Gospel according to John
+!John 16:5-14
+At that time, Jesus said unto His disciples: I go My way to Him That sent Me, and none of you asketh Me: Whither goest Thou? And so on.
+_
+Homily by St. Augustine, Bishop of Hippo
+!94th Tract on John
+The Lord Jesus told His disciples what things they should suffer after that He was gone away from them, and then He said: "These things I said not unto you at the beginning, because I was with you; but now I go My way to Him That sent Me." Let us first see whether it had been that He had not told them before this what they were to suffer in time coming. That He had done so amply before the night of the last Supper, is testified by the three first Evangelists, but it was when that Supper was ended that, according to John, He said: "These things I said not unto you at the beginning, because I was with you."
+
+[Responsory7]
+R. I will sing a new song unto thee, O God, alleluia.
+* Upon a psaltery of ten strings will I sing praises unto thee, alleluia, alleluia.
+V. Thou art my God, and I will praise thee Thou art my God, and I will exalt thee.
+R. Upon a psaltery of ten strings will I sing praises unto thee, alleluia, alleluia.
+
+[Lectio8]
+Are we then to try and loose the knot of this difficulty by asserting that, according to these three Evangelists, it was on the eve of the Passion, albeit before the Supper, that He had said these things unto them, and therefore not at the beginning, when He was with them, but when He was about to leave them, and go His way to the Father And in this way we might reconcile the truthfulness of what this Evangelist saith here "These things I said not unto you at the beginning" with the truthfulness of the! other three. But this explanation is rendered impossible by the Gospel according to Matthew, who telleth us how that the Lord spake to His Apostles concerning their sufferings to come, not only when He was on the point of eating the Passover with them, but at the very beginning, when the names of the twelve are first given, and they were sent forth to do the work of God. (Matth. x. 17-42.)
+
+[Responsory8]
+R. It is a good thing to give thanks unto the Lord, alleluia.
+* And to sing praises, alleluia.
+V. Upon an instrument of ten strings, upon the harp with a solemn sound.
+R. And to sing praises, alleluia.
+&Gloria
+R. And to sing praises, alleluia.
+
+[Lectio9]
+It would seem then that when He said: "These things I said not unto you at the beginning, because I was with you," He meant by "these things," not the sufferings which they were to bear for His sake, but His promise of the Comforter Who should come to them, and testify while they suffered, (xv. 26, 27.) This Comforter then, or Advocate, (for the Greek word "Parakletos" will bear either interpretation,) would be needful to them when they saw Christ no more, and therefore it was that Christ spoke not of Him "at the beginning" (of the Gospel Dispensation) while He Himself "was with" His disciples, because His visible Presence was then their sufficient comfort.
+&teDeum
+
+[Capitulum Laudes]
+!Jakub 1:17
+v. Milovaní, každý dobrý úděl, každý dokonalý dar přichází shora, sestupuje od Otce světel, u něhož není změna ani ztemnění, (jaké je působeno u hvězd) otáčením.
+$Deo gratias
+
+[Capitulum Sexta]
+!Jakub 1:19-20
+v. Pamatujte si toto, moji milovaní bratři: člověk má být čilý, když něčemu naslouchá, ale váhavý než začne mluvit nebo než se rozzlobí. Když se totiž člověk rozzlobí, nedělá, co je před Bohem spravedlivé.
+$Deo gratias
+
+[Capitulum Nona]
+!Jakub 1:21
+v. Proto odložte všechno, co je špatné, všechno, v čem se zlo dere dopředu, a v tichosti buďte vnímaví pro slovo, které do vás bylo vloženo jako semeno a může zachránit vaši duši.
+$Deo gratias
+
+[Ant 3]
+Odcházím k tomu, * který mě poslal; ale protože jsem vám to řekl, smutek naplnil vaše srdce, alleluja.
+
+[Ant 1] (rubrica cisterciensis)
+Znovu vás pak * uvidím, a radovat se bude vaše srdce, alleluja, a vaši radost vám už nikdo nevezme, alleluja.
+
+[Ant 2] (rubrica cisterciensis)
+Odcházím k tomu, * který mě poslal; ale protože jsem vám to řekl, smutek naplnil vaše srdce, alleluja.
+
+[Ant 3] (rubrica cisterciensis)
+Ještě mnoho * vám mám co říci, ale nyní byste to ještě nesnesli; až ovšem přijde Duch pravdy, naučí vás veškerou pravdu, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc4-1.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc4-1.txt
@@ -1,0 +1,54 @@
+ [Rank]
+Feria Secunda infra Hebdomadam IV post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the letter of St. James the Apostle
+!Jas 1:17-20
+17 Every best gift, and every perfect gift, is from above, coming down from the Father of lights, with whom there is no change, nor shadow of alteration.
+18 For of his own will hath he begotten us by the word of truth, that we might be some beginning of his creatures.
+19 You know, my dearest brethren. And let every man be swift to hear, but slow to speak, and slow to anger.
+20 For the anger of man worketh not the justice of God.
+
+[Responsory1]
+R. Let now the redeemed of the Lord, alleluia.
+* Say, alleluia, alleluia, alleluia.
+V. Let them whom He hath redeemed from the hand of the enemy, and gathered them out of the lands. 
+R. Say, alleluia, alleluia, alleluia.
+
+[Lectio2]
+!Jas 1:21-24
+21 Wherefore casting away all uncleanness, and abundance of naughtiness, with meekness receive the ingrafted word, which is able to save your souls.
+22 But be ye doers of the word, and not hearers only, deceiving your own selves.
+23 For if a man be a hearer of the word, and not a doer, he shall be compared to a man beholding his own countenance in a glass.
+24 For he beheld himself, and went his way, and presently forgot what manner of man he was.
+
+[Responsory2]
+R. O sing unto the Lord, alleluia.
+* Sing unto Him, alleluia.
+V. Give unto the Lord glory and honour, give unto the Lord the glory due unto His Name.
+R. Sing unto Him, alleluia.
+&Gloria
+R. Sing unto Him, alleluia.
+
+[Lectio3]
+!Jas 1:25-27
+25 But he that hath looked into the perfect law of liberty, and hath continued therein, not becoming a forgetful hearer, but a doer of the work; this man shall be blessed in his deed.
+26 And if any man think himself to be religious, not bridling his tongue, but deceiving his own heart, this man's religion is vain.
+27 Religion clean and undefiled before God and the Father, is this: to visit the fatherless and widows in their tribulation: and to keep one's self unspotted from this world.
+
+[Ant 2]
+Did not our heart burn within us, at the thought of Jesus, * while he talked with us by the way? Alleluia.
+
+[Ant 3]
+I tell you the truth: * it is expedient for you that I go away, for if I go not away, the Comforter will not come unto you, alleluia. 
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-1
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-1

--- a/web/www/horas/Bohemice/Tempora/Pasc4-2.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc4-2.txt
@@ -1,0 +1,49 @@
+ [Rank]
+Feria Tertia infra Hebdomadam IV post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the letter of St. James the Apostle
+!Jas 2:1-4
+1 My brethren, have not the faith of our Lord Jesus Christ of glory with respect of persons. For if there shall come into your assembly a man having a golden ring, in fine apparel, and there shall come in also a poor man in mean attire,
+3 And you have respect to him that is clothed with the fine apparel, and shall say to him: Sit thou here well; but say to the poor man: Stand thou there, or sit under my footstool:
+4 Do you not judge within yourselves, and are become judges of unjust thoughts?
+
+[Lectio2]
+!Jas 2:5-9
+5 Hearken, my dearest brethren: hath not God chosen the poor in this world, rich in faith, and heirs of the kingdom which God hath promised to them that love him?
+6 But you have dishonoured the poor man. Do not the rich oppress you by might? and do not they draw you before the judgment seats?
+7 Do not they blaspheme the good name that is invoked upon you?
+8 If then you fulfill the royal law, according to the scriptures, Thou shalt love thy neighbour as thyself; you do well.
+9 But if you have respect to persons, you commit sin, being reproved by the law as transgressors.
+
+[Responsory2]
+R. With my whole heart, alleluia, have I sought thee, alleluia.
+* O let me not wander from thy commandments, alleluia, alleluia.
+V. Blessed art Thou, O Lord, teach me thy statutes.
+R. O let me not wander from thy commandments, alleluia, alleluia.
+&Gloria
+R. O let me not wander from thy commandments, alleluia, alleluia.
+
+[Lectio3]
+!Jas 2:10-13
+10 And whosoever shall keep the whole law, but offend in one point, is become guilty of all.
+11 For he that said, Thou shalt not commit adultery, said also, Thou shalt not kill. Now if thou do not commit adultery, but shalt kill, thou art become a transgressor of the law.
+12 So speak ye, and so do, as being to be judged by the law of liberty.
+13 For judgment without mercy to him that hath not done mercy. And mercy exalteth itself above judgment
+
+[Ant 2]
+Peace be unto you, * it is I, alleluia; fear not, alleluia.
+
+[Ant 3]
+When the Comforter, the Spirit of truth, is come, * He will reprove the world of sin, and of righteousness, and of judgment. Alleluia. 
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-2
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-2

--- a/web/www/horas/Bohemice/Tempora/Pasc4-3.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc4-3.txt
@@ -1,0 +1,50 @@
+ [Rank]
+Feria Quarta infra Hebdomadam IV post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the letter of St. James the Apostle
+!Jas 2:14-17
+14 What shall it profit, my brethren, if a man say he hath faith, but hath not works? Shall faith be able to save him?
+15 And if a brother or sister be naked, and want daily food:
+16 And one of you say to them: Go in peace, be ye warmed and filled; yet give them not those things that are necessary for the body, what shall it profit?
+17 So faith also, if it have not works, is dead in itself.
+
+[Lectio2]
+!Jas 2:18-22
+18 But some man will say: Thou hast faith, and I have works: show me thy faith without works; and I will show thee, by works, my faith.
+19 Thou believest that there is one God. Thou dost well: the devils also believe and tremble.
+20 But wilt thou know, O vain man, that faith without works is dead?
+21 Was not Abraham our father justified by works, offering up Isaac his son upon the altar?
+22 Seest thou, that faith did co-operate with his works; and by works faith was made perfect?
+
+[Lectio3]
+!Jas 2:23-26
+23 And the scripture was fulfilled, saying: Abraham believed God, and it was reputed to him to justice, and he was called the friend of God.
+24 Do you see that by works a man is justified; and not by faith only?
+25 And in like manner also Rahab the harlot, was not she justified by works, receiving the messengers, and sending them out another way?
+26 For even as the body without the spirit is dead; so also faith without works is dead.
+
+[Responsory3]
+R. Let now the redeemed of the Lord. Alleluia.
+* Say: Alleluia, Alleluia, Alleluia.
+V. Let them whom He hath redeemed from the hand of the enemy, and gathered them out of the lands.
+R. Say: Alleluia, Alleluia, Alleluia.
+&Gloria
+R. Say: Alleluia, Alleluia, Alleluia.
+
+[Ant 2]
+A spirit hath not flesh and bones, * as ye see Me have now believe. Alleluia.
+
+[Ant 3]
+I have yet many things to say unto you, but ye cannot bear them now. * Howbeit, when He, the Spirit of truth, is come, He will guide you into all truth. Alleluia. 
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-3
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-3

--- a/web/www/horas/Bohemice/Tempora/Pasc4-4.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc4-4.txt
@@ -1,0 +1,48 @@
+ [Rank]
+Feria Quinta infra Hebdomadam IV post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the letter of St. James the Apostle
+!Jas 3:1-3
+1 Be ye not many masters, my brethren, knowing that you receive the greater judgment.
+2 For in many things we all offend. If any man offend not in word, the same is a perfect man. He is able also with a bridle to lead about the whole body.
+3 For if we put bits into the mouths of horses, that they may obey us, and we turn about their whole body.
+
+[Lectio2]
+!Jas 3:4-6
+4 Behold also ships, whereas they are great, and are driven by strong winds, yet are they turned about with a small helm, whithersoever the force of the governor willeth.
+5 Even so the tongue is indeed a little member, and boasteth great things. Behold how small a fire kindleth a great wood.
+6 And the tongue is a fire, a world of iniquity.
+
+[Responsory2]
+R. The waters saw thee, O God, the waters saw thee and they were afraid.
+* There was a noise as of many waters the clouds sent out a sound. Alleluia, Alleluia, Alleluia.
+V. thy lightnings lightened the world the earth saw it and shook.
+R. There was a noise as of many waters the clouds sent out a sound. Alleluia, Alleluia, Alleluia.
+&Gloria
+R. There was a noise as of many waters the clouds sent out a sound. Alleluia, Alleluia, Alleluia.
+
+[Lectio3]
+!Jas 3:6-10
+6 The tongue is placed among our members, which defileth the whole body, and inflameth the wheel of our nativity, being set on fire by hell.
+7 For every nature of beasts, and of birds, and of serpents, and of the rest, is tamed, and hath been tamed, by the nature of man:
+8 But the tongue no man can tame, an unquiet evil, full of deadly poison.
+9 By it we bless God and the Father: and by it we curse men, who are made after the likeness of God.
+10 Out of the same mouth proceedeth blessing and cursing. My brethren, these things ought not so to be.
+
+[Ant 2]
+The disciples gave the Lord a piece * of a broiled fish, and of an honeycomb, alleluia, alleluia.
+
+[Ant 3]
+For He shall not speak of Himself; * but whatsoever He shall hear, that shall He speak and He will show you things to come, alleluia. 
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-4
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-4

--- a/web/www/horas/Bohemice/Tempora/Pasc4-5.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc4-5.txt
@@ -1,0 +1,46 @@
+ [Rank]
+Feria Sexta infra Hebdomadam IV post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the letter of St. James the Apostle
+!Jas 4:1-4
+1 From whence are wars and contentions among you? Are they not hence, from your concupiscences, which war in your members?
+2 You covet, and have not: you kill, and envy, and can not obtain. You contend and war, and you have not, because you ask not.
+3 You ask, and receive not; because you ask amiss: that you may consume it on your concupiscences.
+4 Adulterers, know you not that the friendship of this world is the enemy of God? Whosoever therefore will be a friend of this world, becometh an enemy of God.
+
+[Lectio2]
+!Jas 4:5-10
+5 Or do you think that the scripture saith in vain: To envy doth the spirit covet which dwelleth in you?
+6 But he giveth greater grace. Wherefore he saith: God resisteth the proud, and giveth grace to the humble.
+7 Be subject therefore to God, but resist the devil, and he will fly from you.
+8 Draw nigh to God, and he will draw nigh to you. Cleanse your hands, ye sinners: and purify your hearts, ye double minded.
+9 Be afflicted, and mourn, and weep: let your laughter be turned into mourning, and your joy into sorrow.
+10 Be humbled in the sight of the Lord, and he will exalt you.
+
+[Responsory2]
+R. With my whole heart, alleluia, have I sought thee, alleluia.
+* O let me not wander from thy commandments. Alleluia, Alleluia.
+V. Blessed art Thou, O Lord, teach me thy statutes.
+R. O let me not wander from thy commandments. Alleluia, Alleluia.
+&Gloria
+R. O let me not wander from thy commandments. Alleluia, Alleluia.
+
+[Lectio3]
+!Jas 4:11-15
+11 Detract not one another, my brethren. He that detracteth his brother, or he that judgeth his brother, detracteth the law, and judgeth the law. But if thou judge the law, thou art not a doer of the law, but a judge.
+12 There is one lawgiver, and judge, that is able to destroy and to deliver.
+13 But who art thou that judgest thy neighbour? Behold, now you that say: Today or tomorrow we will go into such a city, and there we will spend a year, and will traffic, and make our gain.
+14 Whereas you know not what shall be on the morrow.
+15 For what is your life? It is a vapour which appeareth for a little while, and afterwards shall vanish away. For that you should say: If the Lord will, and if we shall live, we will do this or that.
+
+[Ant 2]
+These are the words * which I spake unto you, while I was with you. Alleluia, Alleluia.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-5

--- a/web/www/horas/Bohemice/Tempora/Pasc4-6.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc4-6.txt
@@ -1,0 +1,41 @@
+[Rank]
+Sabbato infra Hebdomadam IV post Octavam Paschae;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+
+[Lectio1]
+Lesson from the letter of St. James the Apostle
+!Jas 5:1-6
+1 Go to now, ye rich men, weep and howl in your miseries, which shall come upon you.
+2 Your riches are corrupted: and your garments are moth-eaten.
+3 Your gold and silver is cankered: and the rust of them shall be for a testimony against you, and shall eat your flesh like fire. You have stored up to yourselves wrath against the last days.
+4 Behold the hire of the labourers, who have reaped down your fields, which by fraud has been kept back by you, crieth: and the cry of them hath entered into the ears of the Lord of Sabaoth.
+5 You have feasted upon earth: and in riotousness you have nourished your hearts, in the day of slaughter.
+6 You have condemned and put to death the Just One, and he resisted you not.
+
+[Lectio2]
+!Jas 5:7-11
+7 Be patient therefore, brethren, until the coming of the Lord. Behold, the husbandman waiteth for the precious fruit of the earth: patiently bearing till he receive the early and latter rain.
+8 Be you therefore also patient, and strengthen your hearts: for the coming of the Lord is at hand.
+9 Grudge not, brethren, one against another, that you may not be judged. Behold the judge standeth before the door.
+10 Take, my brethren, for an example of suffering evil, of labour and patience, the prophets, who spoke in the name of the Lord.
+11 Behold, we account them blessed who have endured. You have heard of the patience of Job, and you have seen the end of the Lord, that the Lord is merciful and compassionate
+
+[Responsory2]
+R. It is a good thing to give thanks unto the Lord. Alleluia.
+* And to sing praises. Alleluia.
+V. Upon an instrument of ten strings, upon the harp with a solemn sound.
+R. And to sing praises. Alleluia.
+&Gloria
+R. And to sing praises. Alleluia.
+
+[Lectio3]
+!Jas 5:12-16
+12 But above all things, my brethren, swear not, neither by heaven, nor by the earth, nor by any other oath. But let your speech be, yea, yea: no, no: that you fall not under judgment.
+13 Is any of you sad? Let him pray. Is he cheerful in mind? Let him sing.
+14 Is any man sick among you? Let him bring in the priests of the church, and let them pray over him, anointing him with oil in the name of the Lord.
+15 And the prayer of faith shall save the sick man: and the Lord shall raise him up: and if he be in sins, they shall be forgiven him.
+16 Confess therefore your sins one to another: and pray one for another, that you may be saved. For the continual prayer of a just man availeth much.

--- a/web/www/horas/Bohemice/Tempora/Pasc5-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc5-0.txt
@@ -1,0 +1,100 @@
+[Rank]
+Dominica V Post Pascha;;Semiduplex;;5;;
+
+[Rule]
+9 Lectiones
+Una Antiphona
+Doxology=Pasc
+
+[Ant 1]
+Zatím * jste neprosili o nic v mém jménu; proste, a dostanete, alleluja.
+
+[Oratio]
+Bože, z nějž všechno vychází, uděl nám, kteří tě prosíme; abychom mysleli, tebou naladěni, pouze to, co je správné, a s tvým vedením tyto věci konali.
+$Per Dominum
+
+[Lectio1]
+Lesson from the first letter of St. Peter the Apostle
+!1 Pet 1:1-5
+1 Peter, an apostle of Jesus Christ, to the strangers dispersed through Pontus, Galatia, Cappadocia, Asia, and Bithynia, elect,
+2 According to the foreknowledge of God the Father, unto the sanctification of the Spirit, unto obedience and sprinkling of the blood of Jesus Christ: Grace unto you and peace be multiplied.
+3 Blessed be the God and Father of our Lord Jesus Christ, who according to his great mercy hath regenerated us unto a lively hope, by the resurrection of Jesus Christ from the dead,
+4 Unto an inheritance incorruptible, and undefiled, and that can not fade, reserved in heaven for you,
+5 Who, by the power of God, are kept by faith unto salvation, ready to be revealed in the last time.
+
+[Lectio2]
+!1 Pet 1:6-12
+6 Wherein you shall greatly rejoice, if now you must be for a little time made sorrowful in diverse temptations:
+7 That the trial of your faith (much more precious than gold which is tried by the fire) may be found unto praise and glory and honour at the appearing of Jesus Christ:
+8 Whom having not seen, you love: in whom also now, though you see him not, you believe: and believing shall rejoice with joy unspeakable and glorified;
+9 Receiving the end of your faith, even the salvation of your souls.
+10 Of which salvation the prophets have inquired and diligently searched, who prophesied of the grace to come in you.
+11 Searching what or what manner of time the Spirit of Christ in them did signify: when it foretold those sufferings that are in Christ, and the glories that should follow:
+12 To whom it was revealed, that not to themselves, but to you they ministered those things which are now declared to you by them that have preached the gospel to you, the Holy Ghost being sent down from heaven, on whom the angels desire to look.
+
+[Lectio3]
+!1 Pet 1:13-21
+13 Wherefore having the loins of your mind girt up, being sober, trust perfectly in the grace which is offered you in the revelation of Jesus Christ,
+14 As children of obedience, not fashioned according to the former desires of your ignorance:
+15 But according to him that hath called you, who is holy, be you also in all manner of conversation holy:
+16 Because it is written: You shall be holy, for I am holy.
+17 And if you invoke as Father him who, without respect of persons, judgeth according to every one's work: converse in fear during the time of your sojourning here.
+18 Knowing that you were not redeemed with corruptible things as gold or silver, from your vain conversation of the tradition of your fathers:
+19 But with the precious blood of Christ, as of a lamb unspotted and undefiled,
+20 Foreknown indeed before the foundation of the world, but manifested in the last times for you,
+21 Who through him are faithful in God, who raised him up from the dead, and hath given him glory, that your faith and hope might be in God.
+
+[Lectio4]
+From the Book written by St. Ambrose, Bishop of Milan, on belief in the Resurrection.
+!After middle
+Since it was impossible that the Wisdom of God could die, and that which could not die could not rise from the dead, He took to Himself Flesh Which could die, that That Whose nature it was to die might die, and rise again. Neither was it possible that the resurrection of the dead should come otherwise than by man, "for since by man came death, by Man came also the resurrection of the dead." (1~
+Cor. xv. 21.) Man He rose since Man He died, the Manhood quickened but the~
+Godhead Quickener. Man then, as touching the Flesh God now, over all things. For now we know Christ no longer after the Flesh, but we owe it to the Flesh~
+that we know Him as "become the First-fruits of them that slept" (1 Cor. xv. 23) "and the First-begotten of the dead" (Apoc. i. 5.)
+
+[Lectio5]
+The first-fruits are of the same kind and nature as the other fruits, and they are brought as an offering to God l to win His blessing on the in-gathering, an holy offering made on behalf of all, and as it were the homage of restored nature. Christ then is the First-fruits of them that sleep. But is He the First-fruits of only His own loved ones that fall asleep in Him, and lie as it were untouched by death, wrapt in a sweet slumber Or is He the First-fruits of all the dead? But "as in Adam all die, even so in Christ shall all be made~
+alive." (1 Cor. xv. 22.) So that, as in Adam were the first-fruits of the death wherein all die, even so in Christ were the first-fruits of the resurrection, wherein all rise again. But let no man be hopeless, neither let it be a grief to the righteous to remember that to rise again will be common to all men, when he looketh for that day wherein the harvest of his life will nobly realise itself. All shall rise again, "but," as saith the Apostle (23,) "every man in his own order." The harvest of God's mercy will be for all, but in reward one man shall differ from another.
+
+[Lectio6]
+I tell you how grievous an outrage against God it is not to believe in the resurrection. If we shall Is this not rise again, then did Christ die in vain, then is Christ not risen For if [if He rose at all,] He rose for us, and if He had not us to rise for, then He is plainly not risen. In Him the world, in Him the heavens, in Him the earth rose again. For there shall be "a new heaven, and a new earth" (Apoc. xxi. 1.) For Himself He needed not to rise Whom the bands of death held not. For although He died as Man, yet was He free in the netherworld itself. Wouldest thou hear how free "I am as a man that hath no strength, free among the dead" (Ps. Ixxxvii. 6.) O how free Who was able to take up his life again at will (John x. 18), even as it is written that He said "Destroy this Temple, and in three days I will raise it up" (John ii. 19.) O how free Who descended into hell only to redeem others therefrom.
+
+[Lectio7]
+From the Holy Gospel according to John
+!John 16:23-30
+At that time, Jesus said unto His disciples: Amen, Amen, I say unto you: Whatsoever ye shall ask the Father in My Name, He will give it you. And so on.
+_
+Homily by St. Augustine, Bishop of Hippo.
+!102nd Tract on John.
+We have now to consider these words of the Lord "Amen, Amen, I say unto you, Whatsoever ye shall ask the Father in My Name, He will give it you." It hath already been said in the earlier part of this discourse of the Lord, for the sake of some who ask the Father in Christ's Name and receive not, that whatsoever is asked, which tendeth not to salvation, is not asked in the Name of the Saviour. By the words "In My Name" we must not understand the vocalization of letters and syllables, but the meaning of what is said, the honest and true meaning.
+
+[Lectio8]
+Therefore, whosoever thinketh of Christ as he ought not to think of the Only Son of God, such an one doth not ask anything in Christ's Name, although he do actually utter letters and syllables to that effect, because by these sounds he meaneth not the Real Christ, but a fancied being who hath no existence except in the speaker's imagination. But on the other hand, whosoever thinketh of Christ as he ought to think, the same asketh in Christ's Name, and receiveth, provided only it be nothing against his own everlasting salvation but if it is good for him to receive, he receiveth. Some things are not given at once, but kept over till a more fitting season. Such is the true interpretation of the words "He will give it you" namely, that those things will be given which are good for them to ask. All the Saints also are heard when they ask for themselves, but not necessarily when they ask for their friends, or their enemies, or others, even as it is written, not simply "He will give it" but "He will give it you."
+
+[Lectio9]
+Hitherto saith the Lord, have ye asked nothing in My Name? "Ask, and ye shall receive, that your joy may be full." This their joy, whereof He saith that it shall be full, is to be understood not of fleshly but of spiritual joy and when that joy is so great that it can be increased no more, then shall it without doubt be full. Whatsoever therefore we ask for the fulfilling of this joy, (that is, if we thereby mean grace, if we ask for that life which is the really blessed one,) that is a thing which it is meet to ask in Christ's Name. If we ask anything else than this, we ask nothing, although we do actually ask something, because all things are nothing in comparison with this.
+&teDeum
+
+[Capitulum Laudes]
+!Jakub 1:22-24
+v. Milovaní, buďte činiteli slova, a ne pouhými posluchači. To byste klamali sami sebe. Neboť když někdo to slovo jenom poslouchá, ale nejedná podle něho, ten se podobá člověku, který pozoruje svůj vzhled v zrcadle: podívá se na sebe, odejde, a hned zapomene, jak vypadá.
+$Deo gratias
+
+[Capitulum Sexta]
+!Jakub 1:25
+v. Kdo se však důkladně zahledí do dokonalého zákona svobody a přitom vytrvá, kdo není jen posluchač zapomnětlivý, ale skutečně podle toho jedná, ten v tom jednání najde svou blaženost.
+$Deo gratias
+
+[Capitulum Nona]
+!Jakub 1:27
+v. Zbožnost ryzí a bezvadná před Bohem a Otcem je toto: ujímat se sirotků a vdov v jejich tísni a uchovat se neposkvrněný od světa.
+$Deo gratias
+
+[Ant 3]
+Proste, a dostanete, * aby vaše radost byla dokonalá; sám Otec vás totiž miluje, neboť vy jste milovali mě, a uvěřili jste <i>ve mě</i>, alleluja.
+
+[Ant 1] (rubrica cisterciensis)
+On mě oslaví, * neboť z mého přijal, a oznámí vám to, alleluja.
+
+[Ant 2] (rubrica cisterciensis)
+Zatím * jste neprosili o nic v mém jménu; proste, a dostanete, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc5-1.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc5-1.txt
@@ -1,0 +1,35 @@
+ [Rank]
+Pondělí Prosebných dnů
+
+[Rule]
+Una Antiphona
+Laudes Litania
+Doxology=Pasc
+
+[Lectio1]
+Continuation of the Holy Gospel according to Luke
+!Luke 11:5-13
+At that time Jesus said unto His disciples Which of you shall have a friend, and shall go unto him at midnight, and say unto him Friend, lend me three loaves. And so on.
+_
+Homily by St. Ambrose, Bishop of Milan.
+!Book vii. on Luke xi.
+We gather from this commandment, among other things, that we ought to pray, not only by day, but also by night. Thou seest how that he which arose at midnight to ask three loaves of his friend, and endured in supplication, was not disappointed of that which he sought. Of what are these three loaves a figure, but of that our Mysterious Bread Which cometh down from heaven Thou seest that if thou lovest the Lord thy God, thou mayest win His bounty, not only for thyself, but for others likewise. And who can deserve more to be called our "Friend" than He Which gave His Own Body for us
+
+[Lectio2]
+From this Friend it was that David asked bread at midnight, and received it, as he saith "At midnight I rise to give thanks unto thee." (Ps. cxviii. 62.) Even thus did he obtain those loaves of spiritual nourishment which he still setteth before us for our refreshment. How he asked it, we know from that he saith " Every night wash I my bed." (Ps. vi. 7.) He knew that there was no fear of waking Him Who sleepeth not. (Ps. cxx. 3.) Therefore let us keep in mind the things which are written for our learning, and be instant in prayer both by day and by night, to ask pardon of our sins.
+
+[Lectio3]
+If David, who was such a Saint, and whose time was so taken up by the cares of a kingdom, praised the Lord seven times a day, (Ps. cxviii. 164,) and was always present with godly zeal at the morning and evening sacrifice, what ought we to do, (who have so much the more need to pray, as the weakness of our body and mind doth so much oftener make us to fall, ) that we, wearied with this pilgrimage, and worn out by the gradual waning of our earthly day, and the changes of life, that we, I say, may not be | starved of that life-giving Bread Which strengtheneth man's heart. The Lord teacheth us to be watchful, all of us, and that, not at midnight only, but always. And if He shall come in the second watch, or come in the third watch, and find them so blessed are those servants whom the Lord, when He cometh, shall find watching. (Luke xii. 37.)
+
+[Ant 2]
+Proste, a dostanete, * hledejte, a naleznete, klepejte, a bude vám otevřeno, alleluja.
+
+[Oratio 2]
+Uděl, prosíme, všemohoucí Bože; abychom, když se ve svém trápení svěřujeme tvé laskavosti, proti všem protivenstvím byli vždy obrněni tvou ochranou.
+$Per Dominum.
+
+[Ant 3]
+The Father Himself loveth you, * because ye have loved Me, and have believed in Me. Alleluia.
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-1

--- a/web/www/horas/Bohemice/Tempora/Pasc5-2.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc5-2.txt
@@ -1,0 +1,62 @@
+[Rank]
+Feria Tertia in Rogationibus;;Feria;;1.6
+
+[Rank1960]
+Feria Tertia in Rogationibus;;Feria;;1
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+Laudes Litania
+Doxology=Pasc
+
+[Lectio1]
+Lesson from the first letter of St. Peter the Apostle
+!1 Pet 4:1-7
+1 Christ therefore having suffered in the flesh, be you also armed with the same thought: for he that hath suffered in the flesh, hath ceased from sins:
+2 That now he may live the rest of his time in the flesh, not after the desires of men, but according to the will of God.
+3 For the time past is sufficient to have fulfilled the will of the Gentiles, for them who have walked in riotousness, lusts, excess of wine, revellings, banquetings, and unlawful worshipping of idols.
+4 Wherein they think it strange, that you run not with them into the same confusion of riotousness, speaking evil of you.
+5 Who shall render account to him, who is ready to judge the living and the dead.
+6 For, for this cause was the gospel preached also to the dead: that they might be judged indeed according to men, in the flesh; but may live according to God, in the Spirit.
+7 But the end of all is at hand.
+
+[Lectio2]
+!1 Pet 4:7-11
+7 Be prudent therefore, and watch in prayers. 
+8 But before all things have a constant mutual charity among yourselves: for charity covereth a multitude of sins.
+9 Using hospitality one towards another, without murmuring,
+10 As every man hath received grace, ministering the same one to another: as good stewards of the manifold grace of God.
+11 If any man speak, let him speak, as the words of God. If any man minister, let him do it, as of the power, which God administereth: that in all things God may be honoured through Jesus Christ: to whom is glory and empire for ever and~
+ever. Amen.
+
+[Responsory2]
+R. With my whole heart, alleluia, have I sought thee, alleluia.
+* O let me not wander from thy commandments. Alleluia, Alleluia.
+V. Blessed art Thou, O Lord teach me thy statutes.
+R. O let me not wander from thy commandments. Alleluia, Alleluia.
+&Gloria
+R. O let me not wander from thy commandments. Alleluia, Alleluia.
+
+[Lectio3]
+!1 Pet 4:12-17
+12 Dearly beloved, think not strange the burning heat which is to try you, as if some new thing happened to you;
+13 But if you partake of the sufferings of Christ, rejoice that when his glory shall be revealed, you may also be glad with exceeding joy.
+14 If you be reproached for the name of Christ, you shall be blessed: for that which is of the honour, glory, and power of God, and that which is his Spirit, resteth upon you.
+15 But let none of you suffer as a murderer, or a thief, or a railer, or a coveter of other men's things.
+16 But if as a Christian, let him not be ashamed, but let him glorify God in that name.
+17 For the time is, that judgment should begin at the house of God. 
+
+[Ant 2]
+Christ ought to have suffered, * and to have risen again from the dead. Alleluia.
+
+[Ant 3]
+I came forth from the Father, * and am come into the world; again I leave the~
+world, and go to the Father. Alleluia.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-2
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-2

--- a/web/www/horas/Bohemice/Tempora/Pasc5-3.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc5-3.txt
@@ -1,0 +1,39 @@
+[Rank]
+Feria Quarta in Rogationibus in Vigilia Ascensionis;;Feria;;2
+
+[Rank1960]
+In Vigilia Ascensionis;;Feria;;5
+
+[Rule]
+Oratio Dominica
+Una Antiphona
+Feria Te Deum
+Laudes Litania
+Doxology=Pasc
+
+[Lectio1]
+Continuation of the Holy Gospel according to John
+!John 17:1-11
+At that time, Jesus lifted up His Eyes to heaven, and spoke these words: Father, the hour is come; glorify thy Son. And so on.
+_
+Homily by St. Augustine, Bishop of Hippo
+!104th Tract on John
+Our Lord, the Only-begotten and co-eternal Son of the Father, was able, if need were, in and from the form of a servant, to pray in silence, but He thus manifested Himself in prayer, remembering that He is our Teacher. Thus He made known unto us the prayer which He made for us since He was so great a Master that, not only His discourse to them, but His prayer to the Father for them, is an up-building to His disciples. And if it was so for them who were there to hear, truly it is so for us also, for whose instruction it hath been written down.
+
+[Lectio2]
+Wherefore, by these words: "Father, the hour is come, glorify thy Son," He showeth that all time, and all whatsoever He doth, or alloweth to be done, and the season wherein He will do or allow it, is alike ordained of Him Who is Himself not subject to time. Yea, all things which were then to come, or are yet to come now, have the reason why they should be, in the Wisdom of God, Which is Itself independent of all time. "The hour is come." We must not believe that that hour was brought on by the march of destiny, but was by ordination of God. No stars decreed irresistibly that the time was come for Christ to suffer God forbid that the revolutions of His planets should force death on Him Who made them.
+
+[Lectio3]
+Come think that the glorification of the Son by the Father was that "He spared Him not, but delivered Him up for us all." (Rom. viii. 32.) But if we say that He was glorified by suffering, how much more shall we say that He was glorified by rising again While He suffered, His humbleness was more manifested than His glory, as witnesseth the Apostle, where he saith "He humbled Himself, and became obedient unto death, even the death of the cross" then he addeth touching His glorification "Wherefore God also hath highly exalted Him, and given Him a Name which is above every name, that at the Name of Jesus every knee should bow, of things in heaven, and things in earth, and things under the earth and that every tongue should confess that our Lord Jesus Christ is in the glory of God the Father." (Phil. ii. 8-11.) This is the glorification of our Lord Jesus Christ, that glorification whose first rays dawned on the Resurrection morning.
+
+[Responsory3]
+R. Let now the redeemed of the Lord. Alleluia.
+* Say, Alleluia, Alleluia, Alleluia.
+V. Let them whom He hath redeemed from the hand of the enemy, and gathered them out of the lands.
+R. Say, Alleluia, Alleluia, Alleluia.
+&Gloria
+R. Say, Alleluia, Alleluia, Alleluia.
+
+[Ant 2]
+Otče, přichází hodina, * oslav svého Syna jasností, kterou jsem měl ještě než vznikl svět, u tebe, alleluja.
+

--- a/web/www/horas/Bohemice/Tempora/Pasc5-4.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc5-4.txt
@@ -1,0 +1,306 @@
+[Rank]
+In Ascensione Domini;;Duplex I classis cum Octava Privilegiata III;;7
+
+[Rank1960]
+In Ascensione Domini;;Duplex I classis;;7
+
+[Rule]
+Psalmi Dominica
+Antiphonas horas
+9 Lectiones
+Duplex
+Doxology=Asc
+Psalm5 vespera=116
+No Commemoration
+
+[Ant Vespera]
+Ye men of Galilee, * why stand ye gazing up into heaven? This same Jesus, Which is taken up from you into heaven, shall so come in like manner, alleluia.
+And while they looked * steadfastly towards heaven, as He went up, they said, alleluia.
+He lifted up His Hands, * and blessed them, and was carried up into heaven, alleluia.
+Extol the King of kings, * and ascribe praise to God, alleluia.
+While they beheld, * He was taken up, and a cloud received Him in heaven, alleluia.
+
+[Capitulum Vespera]
+!Act. 1:1-2
+v. Ve své dřívější knize jsem pojednal, milý Theofile, o všem, co Ježíš konal a čemu učil až do dne, kdy poté, co dal Apoštolům příkazy skrze Ducha svatého, byl vzat do nebe.
+$Deo gratias
+
+[HymnusM Vespera]
+@:Hymnus Vespera
+
+[Hymnus Vespera]
+v. Výkupné naše, Ježíši,
+lásko a tužbo nejčistší,
+tys Tvůrce věcí stvořených
+a člověk věků posledních.
+_
+Jaký tě musil soucit vést,
+žes naše hříchy sám chtěl nést,
+že sám ses kruté smrti vzdal,
+bys kletbu smrti z lidí sňal.
+_
+Pronikáš v žalář pekelný,
+propouštíš z něj své zajatce.
+Vítězi, slávou oděný,
+po pravici Otce trůníš.
+_
+Kéž donutí tě soucit týž,
+že rány vin v nás zacelíš,
+nás podle slibu ušetříš
+a vlídnou tváří potěšíš.
+_
+Ty budiž naší radostí,
+odměnou ve tvé věčnosti,
+kéž naše sláva veškerá
+jen z tebe věčně vyvěrá.
+Amen.
+
+[Versum 1]
+V. Bůh vystupuje v jásotu, alleluja.
+R. A Pán za zvuku trumpet, alleluja.
+
+[Ant 1]
+Otče, * zjevným jsem učinil tvé jméno lidem, které jsi mi dal: nyní však za ně prosím, ne za svět, neboť jdu k tobě, alleluja.
+
+[Oratio]
+Popřej, prosíme, všemohoucí Bože, abychom my, jež věříme, že dnešního dne tvůj Jednorozený, Vykupitel náš, na nebesa vystoupil, sami také myslí v nebesích dleli. 
+$Per eumdem
+
+[Invit]
+Alleluia. The Lord Christ hath ascended up into heaven. * O come let us worship Him. Alleluia.
+
+[Hymnus Matutinum]
+v. Eternal Monarch, King most high,
+Whose blood hath brought redemption nigh,
+By whom the death of death was wrought,
+And conquering grace's battle fought:
+_
+Ascending by the starry road,
+This day thou wentest home to God,
+By heaven to power unending called,
+And by no human hand installed.
+_
+That so, in nature's triple frame,
+Each heavenly and each earthly name,
+And things in hell's abyss abhorred,
+May bend the knee and own him Lord.
+_
+Yea, angels tremble when they see
+How changed is our humanity;
+That flesh hath purged what flesh had stained,
+And God, the flesh of God, hath reigned.
+_
+Be thou our joy, O mighty Lord,
+As thou wilt be our great reward;
+Earth's joys to thee are nothing worth,
+Thou joy and crown of heaven and earth.
+_
+To thee we therefore humbly pray
+That thou wouldst purge our sins away,
+And draw our hearts by cords of grace
+To thy celestial dwelling-place.
+_
+So when the judgement day shall come,
+And all must rise to meet their doom,
+Thou wilt remit the debts we owe,
+And our lost crowns again bestow.
+_
+All glory, Lord, to thee we pay,
+Ascending o'er the stars today;
+All glory, as is ever meet,
+To Father and to Paraclete.
+Amen.
+
+[Ant Matutinum]
+Thy magnificence is elevated * above the heavens, O God, alleluia.;;8
+The Lord is in His holy Temple, * the Lord's throne is in heaven, alleluia.;;10
+His going out is from the end of heaven, * and his circuit even to the end thereof, alleluia.;;18
+V. God is ascended with jubilee, alleluia.
+R. And the Lord with the sound of trumpet, alleluia.
+Be thou exalted, O Lord, * in thy own strength: we will sing and praise, alleluia.;;20
+I will extol thee, * O Lord, for thou hast upheld me, alleluia.;;29
+God is ascended * with jubilee, and the Lord with the sound of trumpet, alleluia.;;46
+V. When Christ ascended up on high, alleluia.
+R. He led captivity captive, alleluia.
+He is exalted exceedingly, * alleluia: above all gods, alleluia.;;96
+The Lord in Sion, * alleluia: is great and high, alleluia.;;98
+The Lord in heaven, * alleluia: hath prepared his throne, alleluia.;;102
+V. I ascend to my Father and to your Father, alleluia.
+R. To my God and your God, alleluia.
+
+[Lectio1]
+Lesson from the Acts of the Apostles
+!Acts 1:1-5
+1 The former treatise I made, O Theophilus, of all things which Jesus began to do and to teach,
+2 Until the day on which, giving commandments by the Holy Ghost to the apostles whom he had chosen, he was taken up.
+3 To whom also he showed himself alive after his passion, by many proofs, for forty days appearing to them, and speaking of the kingdom of God.
+4 And eating together with them, he commanded them, that they should not depart from Jerusalem, but should wait for the promise of the Father, which you have heard (saith he) by my mouth.
+5 For John indeed baptized with water, but you shall be baptized with the Holy Ghost, not many days hence.
+
+[Responsory1]
+R. Being seen of them forty days after that He had suffered, and speaking of the kingdom of God. Alleluia.
+* And while they beheld, He was taken up, and a cloud received Him out of their sight. Alleluia.
+V. And, eating together with them, He commanded them that they should not depart from Jerusalem, but wait for the Promise of the Father.
+R. And while they beheld, He was taken up, and a cloud received Him out of their sight. Alleluia.
+
+[Lectio2]
+!Acts 1:6-9
+6 They therefore who were come together, asked him, saying: Lord, wilt thou at this time restore again the kingdom to Israel?
+7 But he said to them: It is not for you to know the times or moments, which the Father hath put in his own power:
+8 But you shall receive the power of the Holy Ghost coming upon you, and you shall be witnesses unto me in Jerusalem, and in all Judea, and Samaria, and even to the uttermost part of the earth.
+9 And when he had said these things, while they looked on, he was raised up: and a cloud received him out of their sight.
+
+[Responsory2]
+R. The Lord hath set His beauty above the stars;
+* His loveliness is in the clouds of heaven, and His Name endureth for ever. Alleluia.
+V. His going forth is from the end of the heaven, and His circuit unto the ends of it.
+R. His loveliness is in the clouds of heaven, and His Name endureth for ever. Alleluia.
+
+[Lectio3]
+!Acts 1:10-14
+10 And while they were beholding him going up to heaven, behold two men stood by them in white garments.
+11 Who also said: Ye men of Galilee, why stand you looking up to heaven? This Jesus who is taken up from you into heaven, shall so come, as you have seen him going into heaven.
+12 Then they returned to Jerusalem from the mount that is called Olivet, which is nigh Jerusalem, within a sabbath day's journey.
+13 And when they were come in, they went up into an upper room, where abode Peter and John, James and Andrew, Philip and Thomas, Bartholomew and Matthew, James of Alpheus, and Simon Zelotes, and Jude the brother of James.
+14 All these were persevering with one mind in prayer with the women, and Mary the mother of Jesus, and with his brethren.
+
+[Responsory3]
+R. Be Thou exalted, O Lord. Alleluia.
+* In thine Own strength. Alleluia.
+V. O God, Thou hast set thy glory above the heavens.
+R. In thine Own strength. Alleluia.
+&Gloria
+R. In thine Own strength. Alleluia.
+
+[Lectio4]
+From the Sermons of Pope St. Leo the Great
+!1st on the Lords Ascension
+After the blessed and glorious Resurrection of our Lord Jesus Christ, wherein the Divine Power raised up in three days the true Temple of God Which the iniquity of the Jews had destroyed (John ii. 19,) God was pleased to ordain, by His Most Sacred Will, and in His Providence for our instruction and the profit of our souls, a season of forty days which season, dearly beloved brethren, doth end on this day. During that season the bodily Presence of the Lord still lingered on earth, that the reality of the fact of His having risen again from the dead might be armed with all needful proofs. The death of Christ had troubled the hearts of many of His disciples their thoughts were sad when they remembered His agony upon the Cross, His giving up of the Ghost, and the laying in the grave of His lifeless Body, and a sort of hesitation had begun to weigh on them.
+
+[Responsory4]
+R. My time is come that I should return unto Him That sent Me, saith the Lord. Be not sorrowful, neither let your heart be troubled.
+* I pray the Father for you, that He may keep you. Alleluia, Alleluia.
+V. If I go not away, the Comforter will not come unto you; where I am ascended, I will send Him unto you.
+R. I pray the Father for you, that He may keep you. Alleluia, Alleluia.
+
+[Lectio5]
+Hence the most blessed Apostles and all the disciples, who had been fearful at the finishing on the Cross, and doubtful of the trustworthiness of the rising again, were so strengthened by the clear demonstration of the fact, that, when they saw the Lord going up into the height of heaven, they sorrowed not, nay they were even filled with great joy And, in all verity, it was a great an unspeakable cause for joy to see the Manhood, in the presence of that the multitude of believers, exalted above all creatures even heavenly, rising above the ranks of the angelic armies and speeding Its glorious way where the most noble of the Archangels lie far behind, to rest no lower than that place where high above all principality and power, It taketh Its seat at the right hand of the Eternal Father, Sharer of His throne, and Partaker of His glory, and still of the very man's nature which the Son hath taken upon Him.
+
+[Responsory5]
+R. Let not your heart be troubled; I go unto the Father, and when I am taken from you, I will send unto you, alleluia,
+* The Spirit of truth, and your heart shall rejoice. Alleluia.
+V. I will pray the Father, and He shall give you another Comforter.
+R. The Spirit of truth, and your heart shall rejoice. Alleluia.
+
+[Lectio6]
+Therefore, dearly beloved brethren, let us also rejoice with worthy joy, for the Ascension of Christ is exaltation for us, and whither the glory of the Head of the Church is passed in, thither is the hope of the body of the Church called on to follow. Let us rejoice with exceeding great joy, and give God glad thanks. This day is not only the possession of Paradise made sure unto us, but in the Person of our Head we are actually begun to enter into the heavenly mansions above. Through the unspeakable goodness of Christ we have gained more than ever we lost by the envy of the devil. We, whom our~
+venomous enemy thrust from our first happy home, we, being made of one body with the Son of God, have by Him been given a place at the right hand of the Father with Whom He liveth and reigneth, in the unity of the Holy Ghost, one God, world without end. Amen.
+
+[Responsory6]
+R. When Christ ascended up on high, He led captivity captive,
+* He gave gifts unto men. Alleluia, Alleluia, Alleluia.
+V. God is gone up with a shout, and the Lord with the sound of a trumpet.
+R. He gave gifts unto men. Alleluia, Alleluia, Alleluia.
+&Gloria
+R. He gave gifts unto men. Alleluia, Alleluia, Alleluia.
+
+[Lectio7]
+From the Holy Gospel according to Mark
+!Mark 16:14-20
+At that time, Jesus appeared unto the eleven disciples as they sat at meat, and upbraided them with their unbelief and hardness of heart, because they believed not them which had seen Him after He was risen. And so on.
+_
+Homily by Pope St. Gregory the Great
+!29th on the Gospels
+I may be allowed to say that the disciples' slowness to believe that the Lord had indeed risen from the dead, was not so much their weakness as our strength. In consequence of their doubts, the fact of the Resurrection was demonstrated by many infallible proofs. These proofs we read and acknowledge. What then assureth our faith, if not their doubt? For my part, I put my trust in Thomas, who doubted long, much more than in Mary Magdalene, who believed at once. Through his doubting, he came actually to handle the holes of the Wounds, and thereby closed up any wound of doubt in our hearts.
+
+[Responsory7]
+R. I will pray the Father, and He shall give you another Comforter,
+* That He may abide with you for ever, even the Spirit of truth. Alleluia.
+V. For if I go not away, the Comforter will not come unto you; but if I depart, I will send Him unto you.
+R. That He may abide with you for ever, even the Spirit of truth. Alleluia.
+
+[Lectio8]
+Now confirm to our minds the trustworthiness of the fact that our Lord did indeed rise again from the dead, it is well for us to remark one of the statements of Luke (Acts i. 4.) "Eating together with them, He commanded them that they should not (1 John xiv. 16, 17 xvi. 7.) depart from Jerusalem and a little afterward: "While they beheld, He was taken up, and a cloud received Him out of their sight." Consider these words, note well these mysteries. After "eating together with them He was taken up." He ate and ascended: that the fact of His eating might show the reality of the Body in Which He went up. But Mark telleth us that before the Lord ascended into heaven, He upbraided His disciples; with their unbelief and hardness of heart. From this I know not why we should gather, but that the Lord then upbraided His disciples, for whom He was about to be parted in the body, to the end that the words which He spoke unto them as He left them might be the deeper imprinted on their hearts.
+
+[Responsory8]
+R. Thou makest the clouds the chariot, O Lord,
+* Thou walkest upon the wings of the wind. Alleluia.
+V. Thou art clothed with honour and majesty, covering thyself with light as with a garment;
+R. Thou walkest upon the wings of the wind. Alleluia.
+&Gloria
+R. Thou walkest upon the wings of the wind. Alleluia.
+
+[Lectio9]
+When then, He had rebuked the hardness of their heart, what command did He give~
+them? Let us hear. "Go ye into all the world and preach the Gospel to every creature." Was the Holy Gospel, then my brethren, to be preached to thing insensate, or to brute beasts, that the Lord said to His disciples: "Preach the Gospel to every creature"? Nay, but by the words "every creature" we must understand man, in whom are combined qualities of all creatures. Being he hath in common with stones, life in common with trees, feeling in common with beasts, understanding in common with angels. If, then, man hath something in common with every creature, man is to a certain extent every creature. The Gospel, then, if it be preached to man only, is preached to every creature.
+&teDeum
+
+[Versum 2]
+V. Pán v nebesích, alleluja.
+R. Připravil si svůj trůn, alleluja.
+
+[Ant 2]
+Vystupuji * ke svému Otci, i vašemu Otci, k mému Bohu, i k vašemu Bohu, alleluja.
+
+[Octava 2]
+Ant. I ascend to my Father * and to your Father: to my God and your God, alleluia.
+_
+V. The Lord hath prepared, alleluia.
+R. His throne in heaven, alleluia.
+_
+Grant, we beseech thee, Almighty God, that just as we do believe thine Only-Begotten Son, our Saviour, to have this day ascended into the heavens, so we may also in heart and mind thither ascend, and with Him continually dwell.
+$Per eumdem
+
+[Lectio Prima]
+!Acts 1:11
+v. Muži galilejští, proč tak stojíte a hledíte k nebi? Tento Ježíš, který byl vzat od vás do nebe, přijde zase právě tak, jak jste ho viděli odcházet do nebe.
+
+[Responsory Tertia]
+R.br. Vystoupil Bůh za jásotu. * Alleluja, alleluja.
+R. Vystoupil Bůh za jásotu. * Alleluja, alleluja.
+V. A Pán za zvuku trumpet.
+R. Alleluja, alleluja.
+&Gloria
+R. God is gone up with jubilation. * Alleluja, alleluja.
+_
+V. When Christ ascended up on high, alleluia.
+R. He led captivity captive, alleluia.
+
+[Capitulum Sexta]
+!Acts 1:4-5
+v. Když s nimi jedl, přikázal jim, aby neodcházeli z Jerusaléma, ale čekali na Otcovo zaslíbení: „Vždyť jste přece o tom ode mne slyšeli: Jan křtil vodou, ale vy budete pokřtěni Duchem svatým za několik málo dní.“
+$Deo gratias
+
+[Responsory Sexta]
+R.br. When Christ ascended up on high. * Alleluia, alleluia.
+R. When Christ ascended up on high. * Alleluia, alleluia.
+V. He led captivity captive.
+R. Alleluia, alleluia.
+&Gloria
+R. When Christ ascended up on high. * Alleluia, alleluia.
+_
+V. I ascend to my Father and to your Father, alleluia.
+R. To my God and your God, alleluia.
+
+[Responsory Nona]
+R.br. Vystupuji ke svému Otci, i vašemu Otci. * Alleluja, alleluja.
+R. Vystupuji ke svému Otci, i vašemu Otci. * Alleluja, alleluja.
+V. K mému Bohu, i k vašemu Bohu.
+R. Alleluja, alleluja.
+&Gloria
+R. Vystupuji ke svému Otci, i vašemu Otci. * Alleluia, alleluia.
+_
+V. The Lord in heaven, alleluia.
+R. Hath prepared his throne, alleluia.
+
+[Ant 3]
+O Králi slávy, * Hospodine zástupů, jenž jsi jako vítěz dnes vystoupil nad nebesa, nezanechávej nás sirotky; ale pošli příslib Otce mezi nás, Ducha pravdy, alleluja.
+
+[Octava 3]
+Ant. O King of glory, Lord of hosts, * Who hast this day exalted thine Own Self, with great triumph, above all the heavens, leave us not orphans but send unto us the Promise of the Father, even the Spirit of truth, alleluia.
+_
+V. The Lord hath prepared, alleluia.
+R. His throne in heaven, alleluia.
+_
+Grant, we beseech thee, Almighty God, that just as we do believe thine Only-Begotten Son, our Saviour, to have this day ascended into the heavens, so we may also in heart and mind thither ascend, and with Him continually dwell.
+$Per eumdem

--- a/web/www/horas/Bohemice/Tempora/Pasc5-5.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc5-5.txt
@@ -1,0 +1,64 @@
+[Rank]
+Feria VI infra Octavam Ascensionis;;Semiduplex;;2;;ex Tempora/Pasc5-4
+
+[Rank1960]
+Feria VI post Ascension;;Feria;;1;;vide Tempora/Pasc5-4
+
+[Rule]
+ex Tempora/Pasc5-4;
+9 Lectiones
+Doxology=Asc
+Feria Te Deum 
+
+[Lectio1]
+Lesson from the second letter of St. Peter the Apostle
+!2 Pet 1:1-4
+1 Simon Peter, servant and apostle of Jesus Christ, to them that have obtained equal faith with us in the justice of our God and Saviour Jesus Christ.
+2 Grace to you and peace be accomplished in the knowledge of God and of Christ Jesus our Lord:
+3 As all things of his divine power which appertain to life and godliness, are given us, through the knowledge of him who hath called us by his own proper glory and virtue.
+4 By whom he hath given us most great and precious promises: that by these you may be made partakers of the divine nature: flying the corruption of that concupiscence which is in the world.
+
+[Lectio2]
+!2 Pet 1:5-9
+5 And you, employing all care, minister in your faith, virtue; and in virtue, knowledge;
+6 And in knowledge, abstinence; and in abstinence, patience; and in patience, godliness;
+7 And in godliness, love of brotherhood; and in love of brotherhood, charity.
+8 For if these things be with you and abound, they will make you to be neither empty nor unfruitful in the knowledge of our Lord Jesus Christ.
+9 For he that hath not these things with him, is blind, and groping, having forgotten that he was purged from his old sins.
+
+[Lectio3]
+!2 Pet 1:10-15
+10 Wherefore, brethren, labour the more, that by good works you may make sure your calling and election. For doing these things, you shall not sin at any time.
+11 For so an entrance shall be ministered to you abundantly into the everlasting kingdom of our Lord and Saviour Jesus Christ.
+12 For which cause I will begin to put you always in remembrance of these things: though indeed you know them, and are confirmed in the present truth.
+13 But I think it meet as long as I am in this tabernacle, to stir you up by putting you in remembrance.
+14 Being assured that the laying away of this my tabernacle is at hand, according as our Lord Jesus Christ also hath signified to me.
+15 And I will endeavour, that you frequently have after my decease, whereby you may keep a memory of these things. 
+
+[Lectio4]
+From the Sermons of Pope St. Leo the Great.
+!2nd for the Lord's Ascension.
+Dearly beloved brethren, that mysterious thing, our salvation, which the Maker of the universe thought worth purchasing with His Own Precious Blood, was aimed at by Him, in the dispensation of His humility, from the hour wherein He was born as touching the flesh, till the moment when, at the end of the Passion, He cried on the Cross: "It is finished." Although from under the form of a servant many marks of His Godhead shone forth, yet, as a whole, the work of those three-and-thirty years was to manifest the verity of the Manhood Which the Son of God had taken into Himself. But when the suffering was all over, and the bands of death were broken, (that death which had lost all his power by seeking to bind Him Who knew no sin,) then was weakness changed into strength, mortality into immortality, insult into that glory which the Lord Jesus Christ, on so many occasions, made manifest by so many and infallible proofs, until the day came when that triumphant procession of victory, which He had led from the realms of shattered death, followed Him with unimaginable pomp into the heavens.
+
+[Lectio5]
+On the solemn Feast of the Passover the cause of our joy was that Christ was risen again. This day we rejoice because that He is ascended up into heaven. We call to mind and justly celebrate that day whereon our lowly nature was, in the Person of Christ, borne up high above all the heavenly armies, above all the circles of Angels, beyond the heights of all the Powers, even to where Christ is~
+sitting on the right hand of the Father. Our foundations are laid, and our house is built upon this succession of the works of God and His grace is made more wonderful by this, that, though the visible Object of worship is removed from among men, the faith of the Church doth not grow weak, nor her hope wavering, nor her love cold.
+
+[Lectio6]
+It is the back-bone of a strong mind and the eye of a trusty soul, to believe unhesitatingly that which is not seen with the bodily eyes, and to centre all love where there can be no experimental knowledge. This it is which is the only thing we can have of godliness for how could a man be justified through faith, if the saving objects were objects of sight There was a man who would not believe in the Resurrection of Christ until he had examined by sight, and touched the marks of the Passion in the Divine Body, and the Lord said to him Because thou hast seen Me, thou hast believed blessed are they that have not seen, and yet have believed." (John xx. 29.)
+
+[Lectio7]
+From the Holy Gospel according to Mark
+!Mark 16:14-20
+At that time: Jesus appeared unto the eleven disciples as they sat at meat, and upbraided them with their unbelief and hardness of heart because they believed not them which had seen Him after He was risen. And so on.
+_
+Homily by Pope St. Gregory the Great.
+!Same as before.
+"He that believeth, and is baptized, shall be saved but he that believeth not shall be damned." Perchance some man will say within himself: "I have already believed, and therefore I shall be saved." Thou hast well said, if thou showest thy faith by thy works. He only hath a true faith whose life doth not give the lie to his confession. Hence it is that Paul saith, touching some who were falsely faithful: "They profess that they know God but in works they deny Him." (Tit. i. 16.) And John likewise saith: "He that saith, I know Him and keepeth not His commandments, is a liar." (I. ii. 4.)
+
+[Lectio8]
+Once, then, it so standeth, it is to our lives we must look for proof of the reality of our faith. Then only are we truly Christ's faithful people when our works are the fulfilment of our profession. The day whereon we were baptized we bound ourselves to renounce all the works of the old enemy, and all his pomps. Therefore let every one of you now turn his inward eye upon his own behaviour, and if, since his baptism, he hath kept that promise which he made before it, let him know that he is in very truth one of Christ's faithful ones and let him rejoice.
+
+[Lectio9]
+But if he hath utterly broken his promise, if he hath fallen away to work iniquity, and to lust after the pomps of the world, let us see if he now knoweth how to weep over his backsliding. By the merciful Judge that man is not punished as a perjurer who in the end telleth the truth, even though he hath first lied. Because Almighty God doth, in His tender kindness, so receive our contrition, that, in His judgment, He declareth us not guilty of that which we have done amiss.
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc5-6.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc5-6.txt
@@ -1,0 +1,67 @@
+[Rank]
+Sabbato infra Octavam Ascensionis;;Semiduplex;;2;;ex Tempora/Pasc5-4
+
+[Rank1960]
+Sabbato post Ascensionem;;Feria;;1;;vide Tempora/Pasc5-4
+
+[Rule]
+ex Tempora/Pasc5-4;
+9 Lectiones
+Doxology=Asc
+Feria Te Deum 
+
+[Lectio1]
+Lesson from the second letter of St. Peter the Apostle
+!2 Pet 3:1-7
+1 Behold this second epistle I write to you, my dearly beloved, in which I stir up by way of admonition your sincere mind:
+2 That you may be mindful of those words which I told you before from the holy prophets, and of your apostles, of the precepts of the Lord and Saviour.
+3 Knowing this first, that in the last days there shall come deceitful scoffers, walking after their own lusts,
+4 Saying: Where is his promise or his coming? for since the time that the fathers slept, all things continue as they were from the beginning of the creation.
+5 For this they are wilfully ignorant of, that the heavens were before, and the earth out of water, and through water, consisting by the word of God.
+6 Whereby the world that then was, being overflowed with water, perished.
+7 But the heavens and the earth which are now, by the same word are kept in store, reserved unto fire against the day of judgment and perdition of the ungodly men.
+
+[Lectio2]
+!2 Pet 3:8-13
+8 But of this one thing be not ignorant, my beloved, that one day with the Lord is as a thousand years, and a thousand years as one day.
+9 The Lord delayeth not his promise, as some imagine, but dealeth patiently for your sake, not willing that any should perish, but that all should return to penance.
+10 But the day of the Lord shall come as a thief, in which the heavens shall pass away with great violence, and the elements shall be melted with heat, and the earth and the works which are in it, shall be burnt up.
+11 Seeing then that all these things are to be dissolved, what manner of people ought you to be in holy conversation and godliness?
+12 Looking for and hasting unto the coming of the day of the Lord, by which the heavens being on fire shall be dissolved, and the elements shall melt with the burning heat?
+13 But we look for new heavens and a new earth according to his promises, in which justice dwelleth.
+
+[Lectio3]
+!2 Pet 3:14-18
+14 Wherefore, dearly beloved, waiting for these things, be diligent that you may be found before him unspotted and blameless in peace.
+15 And account the longsuffering of our Lord, salvation; as also our most dear brother Paul, according to the wisdom given him, hath written to you:
+16 As also in all his epistles, speaking in them of these things; in which are certain things hard to be understood, which the unlearned and unstable wrest, as they do also the other scriptures, to their own destruction.
+17 You therefore, brethren, knowing these things before, take heed, lest being led aside by the error of the unwise, you fall from your own steadfastness.
+18 But grow in grace, and in the knowledge of our Lord and Saviour Jesus Christ. To him be glory both now and unto the day of eternity. Amen.
+
+[Lectio4]
+From the Sermons of Pope St. Leo the Great.
+!2nd on the Ascension.
+And so the seen Presence of our Redeemer in the Body was changed for an unseen Presence in the Sacraments, and hearing was given to the Church in place of seeing, that her faith, rightly so called, might be the more victorious and stedfast and that teaching, which the hearts of all her children are called on to hear, is a teaching enlightened by rays from heaven. This faith, strengthened by the Ascension of the Lord, and established by the gift of the Holy Ghost, neither bonds, nor imprisonment, nor exile, nor famine, nor fire, nor savage beasts, nor those forms of death, finewrought in cruelty, wherein they that persecute us are well skilled, have been able to scare. For this faith there have striven throughout the whole world, even unto the out-pouring of their blood, not men only, but women also, not little lads only, but tender maidens. This is the faith which hath cast out devils, healed diseases, raised the dead.
+
+[Lectio5]
+Hence even the blessed Apostles themselves, who had been comforted by so many miracles and taught by so many discourses, were sickened by the horrors of their Lord's Passion, and received but doubtfully the assurance of His Resurrection, till after the Lord's Ascension and then fared on so bravely, that all that had been fearful to them before became joyful then. The reason was that they had lifted up all their mind to think of the Godhead of Him Who sitteth at the right~
+hand of the Father. They asked no longer for a seen Presence, when their spiritual eye had caught the fact that, even as, when He had come down to earth, He had not left His Father, so now that He was gone up into heaven, He had not left His disciples. So then it was, dearly beloved brethren, that the Son of man more excellently and more sacredly revealed Himself as the Son of God, when He had withdrawn Himself again into that glory which He had with the Father before the world was. In some unspeakable way He began to be more present, as touching His Godhead, when He removed Himself farther from us, as touching His Manhood.
+
+[Lectio6]
+Then it was that a better instructed faith began intellectually to approach the idea of a Son equal to the Father, and no longer to need to handle in Christ the bodily Matter, Which is of a nature as touching which He is inferior to the Father since, Its nature still remaining in the glorified Body, the faith of believers was summoned to that place where the Only-Begotten Son, Who is equal to the Father, is felt, not by the application of a bodily hand, but by the effort of a spiritualminded intellect. Hence it was that after His Resurrection, when Mary Magdalene, (in whom was there represented the Person of the whole Church,) wished to handle the Lord, He said: "Touch Me not, for I am not yet ascended to My Father", that is, "I will no more that thy nearness to Me should be a nearness of body to Body, nor that thine experience of Me should henceforward be one proceeding from fleshly experiment for that, I appoint thee an higher world, I make ready for thee a nobler form of it than this after that I have ascended to My Father, a time will come when thou shalt indeed touch Me, but after a manner more perfect, more real than this, even a time when thou shalt lay hold on that which thou touchest not now, and believe that which thou seest not now."
+
+[Lectio7]
+From the Holy Gospel according to Mark
+!Mark 16:14-20
+At that time Jesus appeared unto the eleven disciples as they sat at meat, and upbraided them with their unbelief and hardness of heart because they believed not them which had seen Him after He was risen. And so on.
+_
+Homily by Pope St. Gregory the Great.
+!Same as before.
+"And these signs shall follow them that believe In My Name they shall cast out devils they shall speak with new tongues they shall take up serpents and if they drink any deadly thing, it shall not hurt them they shall lay hands on the sick, and they shall recover." My brethren, these signs do not follow us. Do we, then, not believe Nay. The truth is, these things were needful when the Church was young. That she might grow by the increase of the faithful, she needed to be nourished with miracles. Even so we, when we plant a young tree, continually water and tend it till we see that it hath taken firm root in the earth but when once it hath taken firm root, it can grow of itself. Hence, Paul saith of tongues: "Tongues are for a sign, not to them that believe, but to them that believe not." (1 Cor. xiv. 22.)
+
+[Lectio8]
+We have a deeper matter of thought touching these signs and mighty works. It is the work of the holy Church to do every day spiritually that which the Apostles then did carnally. When her Priests, armed with the power of exorcism, lay their hands upon believers, and command evil spirits to dwell no longer in their souls, what is it they do but cast out devils When Christ's faithful people themselves give up the language of their old life, and speak the wonderful works of God, the glory and power of their Maker, telling of them with all their strength, what is it they do then but speak with new tongues When either the one or the other doth by his exhortation charm the wickedness out of his neighbour's heart, what is it he doth but take up serpents?
+
+[Lectio9]
+When they hear the voice of temptation inviting to deadly sin, but are not drawn thereby to work iniquity, do they not then drink a deadly thing, and it doth not hurt them? As often as they see their neighbour fainting in well-doing, and run to help him with all their might, so that their example braceth the feeble life of the waverer, what do they but lay hands on the sick and they recover And indeed, such miracles as these are the greatest miracles, which are spiritual the greatest, for they bring health, not to the dying body, but to the immortal soul.
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc6-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc6-0.txt
@@ -1,0 +1,119 @@
+[Rank]
+Dominica infra Octavam Ascensionis;;Semiduplex;;5;;vide Tempora/Pasc5-4
+
+[Rank1960]
+Dominica post Ascensionem;;Semiduplex;;5;;vide Tempora/Pasc5-4
+
+[Rule]
+vide Tempora/Pasc5-4;
+9 lectiones
+Doxology=Asc
+StJamesRule=John,Rev
+
+[Capitulum Vespera]
+!1 Petrův 4:7-8
+v. Nejmilejší, buďte moudří a bděte na modlitbách. Především se mějte navzájem vroucně rádi, protože láska přikrývá mnohé hříchy.
+$Deo gratias
+
+[Ant 1]
+Až přijde * Utěšitel, kterého vám sešlu, co Ducha pravdy, který z Otce vychází, on bude vydávat svědectví o mě, alleluja.
+
+[Oratio]
+Všemohoucí, věčný Bože; učiň, abychom tobě vždy oddaně podřizovali svou vůli, a zároveň tvé Vznešenosti sloužili s upřímným srdcem. 
+$Per Dominum
+
+[Commemoratio 1]
+!Commemoration of the Octave of the Ascension
+Ant. O King of glory, Lord of hosts, * Who hast this day exalted thine Own Self, with great triumph, above all the heavens, leave us not orphans but send unto us the Promise of the Father, even the Spirit of truth. Alleluia.
+_
+(deinde dicitur)
+V. God is gone up with a shout, alleluia.
+R. And the Lord with the sound of a trumpet, alleluia.
+(sed rubrica tridentina loco huius versus dicitur)
+V. The Lord in heaven, alleluia.
+R. Hath prepared his throne, alleluia.
+(deinde dicitur)
+_
+$Oremus
+Grant, we beseech thee, Almighty God, that like as we do believe thine Only-Begotten Son our Saviour to have this day ascended into the heavens, so we may also in heart and mind thither ascend, and with Him continually dwell.
+$Per eumdem
+
+[Lectio1]
+Lesson from the first letter of St. John the Apostle
+!1 John 1:1-5
+1 That which was from the beginning, which we have heard, which we have seen with our eyes, which we have looked upon, and our hands have handled, of the word of life:
+2 For the life was manifested; and we have seen and do bear witness, and declare unto you the life eternal, which was with the Father, and hath appeared to us:
+3 That which we have seen and have heard, we declare unto you, that you also may have fellowship with us, and our fellowship may be with the Father, and with his Son Jesus Christ.
+4 And these things we write to you, that you may rejoice, and your joy may be full.
+5 And this is the declaration which we have heard from him, and declare unto you: That God is light, and in him there is no darkness.
+
+[Lectio2]
+!John 1:6-10
+6 If we say that we have fellowship with him, and walk in darkness, we lie, and do not the truth.
+7 But if we walk in the light, as he also is in the light, we have fellowship one with another, and the blood of Jesus Christ his Son cleanseth us from all sin.
+8 If we say that we have no sin, we deceive ourselves, and the truth is not in us.
+9 If we confess our sins, he is faithful and just, to forgive us our sins, and to cleanse us from all iniquity.
+10 If we say that we have not sinned, we make him a liar, and his word is not in us.
+
+[Lectio3]
+!1 John 2:1-6
+1 My little children, these things I write to you, that you may not sin. But if any man sin, we have an advocate with the Father, Jesus Christ the just:
+2 And he is the propitiation for our sins: and not for ours only, but also for those of the whole world.
+3 And by this we know that we have known him, if we keep his commandments.
+4 He who saith that he knoweth him, and keepeth not his commandments, is a liar, and the truth is not in him.
+5 But he that keepeth his word, in him in very deed the charity of God is perfected; and by this we know that we are in him.
+6 He that saith he abideth in him, ought himself also to walk, even as he walked.
+
+[Lectio4]
+From the Sermons of St. Augustine, Bishop of Hippo.
+!2nd on the Ascension
+Dearly beloved brethren, our Saviour is gone up from us into heaven, but let us not be troubled on earth. Let only our heart be there with Him, and we shall have peace here. Let us in heart thither ascend with Christ in the mean while, and when that glad day which He hath promised cometh, our body will follow. But we must know, my brethren, that there are some things that cannot ascend with Christ pride cannot, nor covetousness, nor brutishness no one of our diseases can ascend thither where our Healer is. And, therefore, if we would follow our Healer, we must needs leave our diseases and sins behind us. All such things tie us down, as it were, with bands, and hamper us in the meshes of a net of sins but, with God's help, we will say with the Psalmist: "Let us break their bands asunder," (ii. 3,) that we may be able honestly to say to the Lord: "Thou hast loosed my bonds, I will offer to thee the sacrifice of thanksgiving.” (cxv. 16, 17.)
+
+[Lectio5]
+The Resurrection of the Lord is our hope the Ascension of the Lord is our glorification. To-day we keep the solemn holiday of the Ascension. If, therefore, our keeping of this holiday is to be a right, faithful, earnest, holy, godly keeping, we must in mind likewise ascend, and lift up our hearts unto the Lord. When we ascend we must not be high-minded, nor flatter ourselves with our good works, as though they were our own. We must lift up our hearts unto the Lord. When man's heart is lifted up, but not unto the Lord, such lifting-up is pride to lift up the heart unto the Lord, is to make the Most High our Refuge. Behold, my brethren, a great wonder. God is high, but if thou art lifted up He fleeth from thee, whereas, if thou humblest thyself, He cometh down to thee. Wherefore? "The Lord is high, yet hath He respect unto the lowly but the proud He knoweth from afar." (Ps. cxxxvii. 6.) To the lowly He hath respect, that He may raise them up the proud He knoweth from afar, that He may thrust them down.
+
+[Lectio6]
+Christ arose again, to give us hope that this mortal will yet put on immortality He hath assured against an hopeless death, and against the thought that death endeth life. We were troubled, eyen as touching the soul but Christ, arising from the grave, hath assured to us the resurrection of the body also. Believe therefore, that thou mayest be made pure. First it behoveth thee to believe, if by faith thou wouldest in the end worthily see God. And wouldest thou see God Give ear to His own words " Blessed are the pure in heart, for they shall see God." (Matth. v. 8.) Think first, then, how to purify thine heart; take from it whatsoever thou seest in it which displeaseth God.
+
+[Lectio7]
+From the Holy Gospel according to John
+!John 15:26-27; 16:1-4
+At that time, Jesus said unto His disciples: When the Comforter is come, Whom I will send unto you from the Father, even the Spirit of truth, Which proceedeth from the Father, He shall testify of Me. And so on.
+_
+Homily by St. Augustine, Bishop of Hippo
+!Tract 92 on John
+The Lord Jesus, in that discourse which He addressed to His disciples after the Last Supper, when He was on the very eve of the Passion, when He was, as it were, about to go away and leave them as touching His bodily Presence, albeit as touching His spiritual Presence, He is with us alway even unto the end of the world, (Matth. xxviii. 20,) in that discourse He exhorted them to bear patiently the persecution of wicked men, of whom He speaketh as "the world", out of which world, nevertheless, He saith that He hath chosen even His disciples themselves, (xv. 19,) that they might know that it was by the grace of God that they were what they were, (1 Cor. xv. 10,) whereas it was by their own sins that they had been what they had been.
+
+[Lectio8]
+If they have persecuted Me, they will also persecute you." Here He clearly pointeth to the Jews, the persecutors both of Himself and of His disciples, so that we see that they which persecute His holy ones are as much citizens of the world of damnation as they which persecuted Himself. He saith: "They know not Him That sent Me," (21,) and yet again, (24,) "They have hated both Me and My Father," (xv. 24,) that is to say, both the Sender and the Sent, the meaning of which words we have already treated in other discourses and with that He cometh to the words "That the word might be fulfilled that is written in their law They hated Me without a cause."
+
+[Responsory8]
+R. For if I go not away, the Comforter will not come unto you; but if I depart, I will send Him unto you;
+* And when He is come, He will guide you into all truth. Alleluia.
+V. For He shall not speak of Himself; but whatsoever He shall hear, that shall He speak and He will show you things to come.
+R. And when He is come, He will guide you into all truth. Alleluia.
+&Gloria
+R. And when He is come, He will guide you into all truth. Alleluia.
+
+[Lectio9]
+Then saith the Lord, as though in continuation "But when the Comforter is come, Whom I will send unto you from the Father, even the Spirit of truth, Which proceedeth from the Father, He shall testify of Me. And ye also shall bear witness, because ye have been with Me from the beginning." What connection hath this with the words: "Now have they both seen and hated both Me and My Father but that the word might be fulfilled that is written in their law They hated Me without a cause.” Is it that when the Comforter is come, even the Spirit of truth, He will confound by irrefragable testimony them who have both seen and hated both God the Son and God the Father? Yea, indeed, some there were who had seen and still hated, whom the testimony of the Comforter converted to the faith which worketh by love.
+&teDeum
+
+[Capitulum Laudes]
+@:Capitulum Vespera
+
+[Capitulum Tertia]
+@:Capitulum Vespera
+
+[Capitulum Sexta]
+!1. Petrův 4:9-10
+v. Buďte jeden k druhému pohostinní bez reptání. Navzájem si pomáhejte podle toho, jakou jste přijali Boží milost, jako dobří správcové rozmanité Boží milosti.
+$Deo gratias
+
+[Capitulum Nona]
+!1 Peter 4:11
+v. 4,11 Kdo má dar řeči, (ať si je vědom, že přednáší) slovo Boží. Kdo slouží, ať to dělá v síle, kterou udílí Bůh, aby ve všem byl oslavován Bůh skrze Ježíše Krista, našeho Pána.
+$Deo gratias
+
+[Ant 3]
+Tyto věci jsem vám řekl, * aby, až přijde jejich čas, jste se na ně rozpomněli, že jsem vám je říkal, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc6-1.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc6-1.txt
@@ -1,0 +1,67 @@
+[Rank]
+Feria II infra Octavam Ascensionis;;Semiduplex;;2;;ex Tempora/Pasc5-4
+
+[Rank1960]
+Feria II post Ascensionem;;Feria;;1;;vide Tempora/Pasc5-4
+
+[Rule]
+ex Tempora/Pasc5-4;
+9 Lectiones
+Doxology=Asc
+Feria Te Deum 
+
+[Lectio1]
+Lesson from the first letter of St. John the Apostle
+!1 John 3:1-6
+1 Behold what manner of charity the Father hath bestowed upon us, that we should be called, and should be the sons of God. Therefore the world knoweth not us, because it knew not him.
+2 Dearly beloved, we are now the sons of God; and it hath not yet appeared what we shall be. We know, that, when he shall appear, we shall be like to him: because we shall see him as he is.
+3 And every one that hath this hope in him, sanctifieth himself, as he also is holy.
+4 Whosoever committeth sin committeth also iniquity; and sin is iniquity.
+5 And you know that he appeared to take away our sins, and in him there is no sin.
+6 Whosoever abideth in him, sinneth not; and whosoever sinneth, hath not seen him, nor known him.
+
+[Lectio2]
+!John 3:7-12.
+7 Little children, let no man deceive you. He that doth justice is just, even as he is just.
+8 He that committeth sin is of the devil: for the devil sinneth from the beginning. For this purpose, the Son of God appeared, that he might destroy the works of the devil.
+9 Whosoever is born of God, committeth not sin: for his seed abideth in him, and he can not sin, because he is born of God.
+10 In this the children of God are manifest, and the children of the devil. Whosoever is not just, is not of God, nor he that loveth not his brother.
+11 For this is the declaration, which you have heard from the beginning, that you should love one another.
+12 Not as Cain, who was of the wicked one, and killed his brother. And wherefore did he kill him? Because his own works were wicked: and his brother's just
+
+[Lectio3]
+!1 John 3:13-18
+13 Wonder not, brethren, if the world hate you.
+14 We know that we have passed from death to life, because we love the brethren. He that loveth not, abideth in death.
+15 Whosoever hateth his brother is a murderer. And you know that no murderer hath eternal life abiding in himself.
+16 In this we have known the charity of God, because he hath laid down his life for us: and we ought to lay down our lives for the brethren.
+17 He that hath the substance of this world, and shall see his brother in need, and shall shut up his bowels from him: how doth the charity of God abide in him? 
+18 My little children, let us not love in word, nor in tongue, but in deed, and in truth. 
+
+[Lectio4]
+From the Sermons of St. John Chrysostom, Patriarch of Constantinople.
+!On the Ascension, tom 3
+Then Christ went up into heaven, He offered unto the Father the First-fruits of our nature, and the Father marvelled at the offering, seeing the Majesty of the Priest and the Spotlessness of the oblation. He received the Sacrifice into His Own hands, He made It to sit upon His Throne, nay, more, He gave It a place at His Own Right Hand. Let us ask what nature was His Who heard the words: "Sit Thou at My right hand," (Ps. cix. 1,) ” what nature was His to Whom God said " Be Thou Partaker of My Throne?" It was the same nature as was his who heard the sentence " Dust thou art, and unto dust shalt thou return." (Gen. iii. 19.) Archangels beheld our nature upon the Throne of the Lord, refulgent with eternal glory.
+
+[Lectio5]
+It was not enough of glory for Him to be exalted above the heavens, nor to be ranked with angels but He was exalted above the heavens, He went up above the Cherubim, He ascended beyond the Seraphim, neither found He His rank beneath the Throne of the Lord of lords. Behold how high the heaven is above the earth, and the earth above hell, how high above the heaven is the heaven of heavens, how high above the heaven of heavens the Angels, above the Angels the Higher Powers, and above the Higher Powers the Throne of the Lord. Above all these hath One of our nature been exalted, so that man, which had fallen so low that there was no farther fall for him, is now in place so high, that there is thence no ascending.
+
+[Lectio6]
+Paul also, dwelling on this, saith: "He That descended is the Same also That ascended up far above all heavens," even as he had said: "Now, that He ascended, what is it but that He also descended first into the lower parts of~
+the earth." (Eph. iv. 9, 10.) Learn hence Who it was That ascended, and with what nature He was exalted. And with this thought I wish to bring my sermon to an end. From the thought of that glorified Manhood let us learn with amazement what the goodness of God is that goodness which hath crowned with an honour, higher than which is none, and a glory, greater than which is none, a Person Sharer of our nature, even That Person Which this day hath taken the place which is His of right, above all things other than Himself.
+
+[Lectio7]
+From the Holy Gospel according to Mark
+!Mark 16:14-20
+At that time, Jesus appeared unto the eleven disciples as they sat at meat, and upbraided them with their unbelief and hardness of heart because they believed not them which had seen Him after He was risen. And so on.
+_
+Homily by Pope St. Gregory the Great.
+!Same as before.
+"So then, after the Lord Jesus had spoken unto them, He was received up into heaven, and sat on the right hand of God." We learn in the Old Testament, (4 Kings ii.,) that Elijah was taken up into heaven. But this word "heaven" may mean either the terrestrial atmosphere, or the space external to the sphere of this planet. Of these the atmosphere closely surrounds the earth, and we call the birds "the fowls of the heaven," because we see them fly therein. It was only up into this that Elijah was taken, that he might be carried off suddenly into some part of the earth, to us unknown, and there live in profound peace of body and soul, until the end of the world, when he will return and pay the debt of nature. For him, therefore, death waiteth, but is not escaped. But our Redeemer made it not to wait for Him, but conquered it, and by rising again shattered it, and by His Ascension showed forth the glory of His Again-rising.
+
+[Lectio8]
+We must mark also, how that Elijah was taken up in a chariot, as though to show plainly that for a mere man some outward help was needful. This help was given to him by Angels, as plainly appeareth, since it was impossible for one whom a weak nature yet weighed down earthward, to fly up even into the atmosphere. But of our Redeemer we read not that He was borne up in a chariot, or by Angels, since He by Whom all things were made, clearly rose above all things by His Own Power. He returned unto Him with Whom He was, and whither He returned, there He abode, for albeit as touching His Manhood He ascended up into heaven, yet, as touching His Godhead, He still comprehended both heaven and earth.
+
+[Lectio9]
+But as the sale of Joseph by his brethren was a type of the sale of Christ, so were the translations of Enoch and Elijah types of His Ascension. The Lord therefore had had forerunners and witnesses of His Ascension, the one before the Law, the other under the Law, that Himself might one day come, Who was able indeed to pass into the heavens. Hence also there is some difference to be observed in the manner wherein each was translated. Enoch was seen no more, (Gen. v. 24,) for God took him Elijah was carried up by a whirlwind into heaven He That came after them was not taken up, nor carried up, but went up through space by His Own Power.
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc6-2.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc6-2.txt
@@ -1,0 +1,70 @@
+[Rank]
+Feria III infra Octavam Ascensionis;;Semiduplex;;2;;ex Tempora/Pasc5-4
+
+[Rank1960]
+Feria III post Ascensionem;;Feria;;1;;vide Tempora/Pasc5-4
+
+[Rule]
+ex Tempora/Pasc5-4;
+9 Lectiones
+Doxology=Asc
+Feria Te Deum 
+
+[Lectio1]
+Lesson from the first letter of St. John the Apostle
+!1 John 4:1-6
+1 Dearly beloved, believe not every spirit, but try the spirits if they be of God: because many false prophets are gone out into the world.
+2 By this is the spirit of God known. Every spirit which confesseth that Jesus Christ is come in the flesh, is of God:
+3 And every spirit that dissolveth Jesus, is not of God: and this is Antichrist, of whom you have heard that he cometh, and he is now already in the world.
+4 You are of God, little children, and have overcome him. Because greater is he that is in you, than he that is in the world.
+5 They are of the world: therefore of the world they speak, and the world heareth them.
+6 We are of God. He that knoweth God, heareth us. He that is not of God, heareth us not. By this we know the spirit of truth, and the spirit of error.
+
+[Lectio2]
+!1 John 4:7-14
+7 Dearly beloved, let us love one another, for charity is of God. And every one that loveth, is born of God, and knoweth God.
+8 He that loveth not, knoweth not God: for God is charity.
+9 By this hath the charity of God appeared towards us, because God hath sent his only begotten Son into the world, that we may live by him.
+10 In this is charity: not as though we had loved God, but because he hath first loved us, and sent his Son to be a propitiation for our sins.
+11 My dearest, if God hath so loved us; we also ought to love one another.
+12 No man hath seen God at any time. If we love one another, God abideth in us, and his charity is perfected in us.
+13 In this we know that we abide in him, and he in us: because he hath given us of his spirit.
+14 And we have seen, and do testify, that the Father hath sent his Son to be the Saviour of the world.
+
+[Lectio3]
+!1 John 4:15-21
+15 Whosoever shall confess that Jesus is the Son of God, God abideth in him, and he in God.
+16 And we have known, and have believed the charity, which God hath to us. God is charity: and he that abideth in charity, abideth in God, and God in him.
+17 In this is the charity of God perfected with us, that we may have confidence in the day of judgment: because as he is, we also are in this world.
+18 Fear is not in charity: but perfect charity casteth out fear, because fear hath pain. And he that feareth, is not perfected in charity.
+19 Let us therefore love God, because God first hath loved us.
+20 If any man say, I love God, and hateth his brother; he is a liar. For he that loveth not his brother, whom he seeth, how can he love God, whom he seeth not?
+21 And this commandment we have from God, that he, who loveth God, love also his brother.
+
+[Lectio4]
+From the Sermons of St. Maximus, Bishop of Turin.
+!43rd, 2nd on Pentecost.
+My holy brethren, ye remember that I have likened the Saviour to that eagle, touching which it is written in the Book of Psalms, (cii.
+5,) "thy youth is renewed like the eagle's." There are many points of likeness. The eagle riseth above ground, wingeth his way aloft, and mounteth skyward even so did the Saviour rise from the depth of the grave, mount up unto the exalted mansions of Paradise, and enter the heights of heaven. The eagle leaveth below him the foul mists of earth, flieth above, and drinketh in health from a purer air even so did the Lord leave below Him the filthy slough of sinners on earth, and rejoice Himself with the honesty of a purer life, when He soared again into His Own holy home.
+
+[Lectio5]
+In all ways, therefore, is the Saviour aptly likened to an eagle. But what can we make of this, that the eagle is a bird of prey, oft-times a plunderer. Even in this he is like to the Saviour. He bore off His prey, when He carried off from the jaws of hell to heaven the Manhood Which He had swooped to take to Himself, yea, when He led captive to an higher home him whom He had delivered from the mastership of another lord, namely the devil, even as it is written in the Prophet, (Ps. lxvii. 19,) "Thou hast ascended on high, Thou hast led captivity captive, Thou hast received gifts among men."
+
+[Lectio6]
+"Thou hast ascended on high, Thou hast led captivity captive." O how nobly doth the Prophet paint the Triumph of the Lord We hear how that of old time, when kings marched in triumph, the procession of prisoners walked before the chariot of their conqueror. Lo, the Lord entereth the heavens, not after, but amid a most glorious band of captives. That band are not led before His chariot, but themselves bear up their Saviour. In some mystic sense, when the Son of God bore to heaven the Son of man, captivity both led and was led.
+
+[Lectio7]
+From the Holy Gospel according to Mark
+!Mark 16:14-20
+At that time, Jesus appeared unto the eleven disciples as they sat at meat, and upbraided them with their unbelief and hardness of heart, because they believed not them which had seen Him after He was risen. And so on.
+_
+Homily by Pope St. Gregory the Great.
+!Same as before.
+We must ponder the meaning of these words of Mark, "He sat on the right hand of God," and how that Stephen said, (Acts vii. 56,) "Behold, I see the heavens opened, and the Son of man standing on the right hand of God." Wherefore doth Mark say that He sat, whereas Stephen testifieth that he saw Him standing But ye know, my brethren, that to sit is for him that judgeth, to stand, for him that fighteth, or helpeth.
+
+[Lectio8]
+Since therefore, our Redeemer is ascended up into heaven, and even now is Judge of all, beside that at the end of the world He will so come, therefore doth Mark say that He sitteth where He hath gone up, because we look for Him, after that His glorious Ascension, that He will come again at the end to be our Judge. But Stephen, while yet he was in the throes of the battle, saw Him That was helping him standing. Stephen on earth was overcoming the unbelief of his persecutors, but it was the grace of Him That is in heaven that fought in him all the while.
+
+[Lectio9]
+"And they went forth and preached everywhere, the Lord working with them, and confirming the word with signs following." What are we to see in this, what are we to remember, but that obedience followed commandment, and signs obedience But now, since, by the will of God, we have lightly run over our reading from the Gospel, it remaineth that we should say somewhat by way of reflection on this great Festival.
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc6-3.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc6-3.txt
@@ -1,0 +1,62 @@
+[Rank]
+Feria IV infra Octavam Ascensionis;;Semiduplex;;2;;ex Tempora/Pasc5-4
+
+[Rank1960]
+Feria IV post Ascensionem;;Feria;;1;;vide Tempora/Pasc5-4
+
+[Rule]
+ex Tempora/Pasc5-4;
+9 Lectiones
+Doxology=Asc
+Feria Te Deum 
+
+[Lectio1]
+Lesson from the second letter of St. John the Apostle
+!2 John 1:1-5
+1 The ancient to the lady Elect, and her children, whom I love in the truth, and not I only, but also all they that have known the truth,
+2 For the sake of the truth which dwelleth in us, and shall be with us for ever.
+3 Grace be with you, mercy, and peace from God the Father, and from Christ Jesus the Son of the Father; in truth and charity.
+4 I was exceeding glad, that I found of thy children walking in truth, as we have received a commandment from the Father.
+5 And now I beseech thee, lady, not as writing a new commandment to thee, but that which we have had from the beginning, that we love one another.
+
+[Lectio2]
+!2 John 1:6-9
+6 And this is charity, that we walk according to his commandments. For this is the commandment, that, as you have heard from the beginning, you should walk in the same:
+7 For many seducers are gone out into the world, who confess not that Jesus Christ is come in the flesh: this is a seducer and an antichrist.
+8 Look to yourselves, that you lose not the things which you have wrought: but that you may receive a full reward.
+9 Whosoever revolteth, and continueth not in the doctrine of Christ, hath not God. He that continueth in the doctrine, the same hath both the Father and the Son.
+
+[Lectio3]
+!2 John 1:10-13
+10 If any man come to you, and bring not this doctrine, receive him not into the house nor say to him, God speed you.
+11 For he that saith unto him, God speed you, communicateth with his wicked works.
+12 Having more things to write unto you, I would not by paper and ink: for I hope that I shall be with you, and speak face to face: that your joy may be full.
+13 The children of thy sister Elect salute thee.
+
+[Lectio4]
+From the Sermons of St. Gregory, Bishop of Nyssa.
+!Discourse on the Lords Ascension.
+The very thought of this day's Festival is great enough in itself, but the Prophet David hath much inflamed our joyful enthusiasm by the Psalms. This noble Prophet hath, as it were, gone out of himself, as though the body were a weight duller than his spirit could bear he joineth company with the Powers of heaven, and telleth what they said when they went with the Lord heavenward, and cried in tones of command to those Angels who work on earth, and by whose heralding the Birth of the Incarnate One had been proclaimed "Lift up your gates, O ye princes, and be ye lift up, ye everlasting doors, and the King of glory shall come in." (Ps. xxiii. 7, 9.)
+
+[Lectio5]
+He, Who containeth all things, is everywhere, but for the sake of them which receive Him, He is pleased to make Himself a local Presence which hath bounds. Not only did He become a Man among men, but when conversing among Angels, He alloweth that title also to be given Him. The gatekeepers therefore ask "Who is this King of glory?" and it is answered them that He is "The Lord, strong and mighty, the Lord, mighty in battle," the Lord, Whose work it had been to fight him who held mankind in bondage, and to "destroy him that had the power of death, that is, the devil" (Heb. ii. 14) that now that dark enemy was trampled down, and man had had won for him freedom and peace.
+
+[Lectio6]
+The keepers run to the gates, and bid the doors unfold, that the Lord may enter in, to take again the glory which He had there among them before. But when they see Him, clad in the likeness of sinful flesh, (Rom.viii. 3,) they know Him not, even Him Who is red in His apparel, because that He hath trodden Alone the winepress of human pain, and the blood is sprinkled upon His garments. Therefore they cry again to their fellows that bear Him company: "Who is this King of glory?" And they answer them no more: "The Lord, strong and mighty, the Lord mighty in battle" but "The Lord of hosts the Lord, Whose Own are become the kingdoms of the world the Lord, Who hath made Himself the Head of all things the Lord, Who hath made all things new (Apoc. xxi. 5.)" He is the King of glory!
+
+[Lectio7]
+From the Holy Gospel according to Mark
+!Mark 16:14-20
+At that time, Jesus appeared unto the eleven disciples as they sat at meat, and upbraided them with their unbelief and hardness of heart, because they believed not them which had seen Him after He was risen. And so on.
+_
+Homily by Pope St. Gregory the Great.
+!Same as before.
+The first question we have to ask is why we read that Angels appeared at the time of the Birth of the Lord, but we read not that they appeared in white apparel whereas, when the Lord ascended into heaven, it is written that the angels which appeared were clad in white. "While they beheld, He was taken up, and a cloud received Him out of their sight. And while they looked steadfastly toward heaven, as He went up, behold, two men stood by them in white apparel," (Acts i. 9,
+10.) White raiment is an outward sign of solemn inward joy. That the occasion of God-made-Man entering into heaven was a great Festival for Angels, is the reason which we see why angels are specially named as robed in white at His Ascension, and not at His Birth. At the Birth of the Lord the Godhead was manifested veiled under the form of a servant, but at His Ascension the Manhood was seen exalted and white vestments are more apt to exaltation than humiliation.
+
+[Lectio8]
+Therefore were the angels bound to appear in white apparel at the Ascension at His Birth He Who thought it not robbery to be equal with God, was seen in the form in which He had humbled Himself; at His Ascension the Manhood Which He had taken into God was seen glorified. Again, dearly beloved brethren, we must remember today, how that Christ hath "blotted out the hand-writing that was against us," and reversed the sentence which doomed us to corruption. That same nature to which it was said, "Dust thou art, and unto dust shalt thou return," that same nature is His Who hath this day ascended up into heaven. It is because of this up-lifting of our flesh that blessed Job, by a figure, calleth the Lord a bird. The Jews could not understand the Mystery of the Ascension, and in view of this their unbelief, blessed Job said mystically "He knew not the path of the bird."
+
+[Lectio9]
+The name of a bird is well given to the Lord, Who bodily soared up into heaven. And the path of that Bird knoweth no man, who believeth not in the Ascension into heaven. It is of this glorious occasion that the Psalmist saith: "Who hast set thy glory above the heavens," (viii. 2,) and again "God is gone up with a shout, and the Lord with the sound of a trumpet," (xlvi. 6.) And yet again he saith "Thou hast ascended on high, Thou hast led captivity captive," (lxvii. 19.) "When Christ ascended up on high, He led captivity captive," (Eph. iv. 8,) because by His Own incorruptibility He swallowed up our corruptibility. "He gave gifts unto men," because by sending the Spirit from above, He gave "to one, the word of wisdom to another, the word of knowledge to another, the working of miracles to another, the gifts of healing; to another, diverse kinds of tongues to another, the interpretation of tongues," (1 Cor. xii. 8-10.)
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc6-4.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc6-4.txt
@@ -1,0 +1,71 @@
+[Rank]
+Feria V in Octava Ascensionis;;Duplex majus;;4;;ex Tempora/Pasc5-4
+
+[Rank1960]
+Feria V in Hebdomadam post Ascensionem;;Feria;;1;;vide Tempora/Pasc5-4
+
+[Rule]
+ex Tempora/Pasc5-4;
+Feria Te Deum
+Psalmi Dominica
+Antiphonas Horas
+9 Lectiones
+Doxology=Asc
+
+[Lectio1]
+Lesson from the letter of St. Paul the Apostle to the Ephesians
+!Eph 4:1-8
+1 I therefore, a prisoner in the Lord, beseech you that you walk worthy of the vocation in which you are called,
+2 With all humility and mildness, with patience, supporting one another in charity.
+3 Careful to keep the unity of the Spirit in the bond of peace.
+4 One body and one Spirit; as you are called in one hope of your calling.
+5 One Lord, one faith, one baptism.
+6 One God and Father of all, who is above all, and through all, and in us all.
+7 But to every one of us is given grace, according to the measure of the giving of Christ.
+8 Wherefore he saith: Ascending on high, he led captivity captive; he gave gifts to men.
+
+[Lectio2]
+!Eph 4:9-14
+9 Now that he ascended, what is it, but because he also descended first into the lower parts of the earth?
+10 He that descended is the same also that ascended above all the heavens, that he might fill all things.
+11 And he gave some apostles, and some prophets, and other some evangelists, and other some pastors and doctors, 
+12 For the perfecting of the saints, for the work of the ministry, for the edifying of the body of Christ:
+13 Until we all meet into the unity of faith, and of the knowledge of the Son of God, unto a perfect man, unto the measure of the age of the fulness of Christ;
+14 That henceforth we be no more children tossed to and fro, and carried about with every wind of doctrine by the wickedness of men, by cunning craftiness, by which they lie in wait to deceive.
+
+[Lectio3]
+!Eph 4:15-21
+15 But doing the truth in charity, we may in all things grow up in him who is the head, even Christ:
+16 From whom the whole body, being compacted and fitly joined together, by what every joint supplieth, according to the operation in the measure of every part, maketh increase of the body, unto the edifying of itself in charity.
+17 This then I say and testify in the Lord: That henceforward you walk not as also the Gentiles walk in the vanity of their mind,
+18 Having their understanding darkened, being alienated from the life of God through the ignorance that is in them, because of the blindness of their hearts.
+19 Who despairing, have given themselves up to lasciviousness, unto the working of all uncleanness, unto the working of all uncleanness, unto covetousness.
+20 But you have not so learned Christ;
+21 If so be that you have heard him, and have been taught in him.
+
+[Lectio4]
+From the Sermons of St. Augustine, Bishop of Hippo.
+!3rd on the Ascension, 176th on the Season.
+Dearly beloved brethren, all the wonderful works which our Lord Jesus Christ did in this world, under the weakness of our nature, are profitable for us when He exalted His Manhood above the stars, He showed that heaven may open for a believer and while He, the Conqueror of death, went up into the heavenly mansions, He showed to him that overcometh, whither he also may follow. Therefore, the ascension of the Lord is the seal of the Catholic Faith, which assureth in us the hope of the gift which is yet to come to us, from a miracle whereof we already feel the fruits. Thus let every one that is faithful, having already received so much, learn to hope for that which is promised, on the ground of that which he knoweth to have been given, and hold the goodness of God in times which have been, and times which now are, as a sure pledge of the same in times to come.
+
+[Lectio5]
+An earthly Body, then, is now lifted up above the heights of heaven the Bones, Which but a little while before had lain within the narrow walls of the grave, have made their entry among the angelic hosts human nature hath been given a place in the lap of immortality and therefore the Apostle whose account we have heard read, saith "When He had spoken these things, while they beheld, He was taken up." (Acts i. 9.) While thou hearest these words, " taken up," thou must understand thereby the ministry of the angelic army whereby this Festival revealeth to us the Mystery of Him who is both God and Man. United in One Person, we see in Him who lifted up, Divine Power, and in Him Who was lifted up, very Man.
+
+[Lectio6]
+Therefore are utterly to be loathed those pestiferous teachings of Eastern falsehood, those brand-new inventions of ungodliness which dare to assert that He Who in One Person is both Son of God and Son of Man, hath but one nature. On the one hand, if a man say that Christ is not Partaker of the Divine nature, he hath denied the glory of his Maker on the other, he who saith that the Manhood is not of the nature of man, hath denied the mercy of his Saviour. As touching these points, it is well-nigh impossible for an Arian to believe that the Gospel writers are any better than liars, since they distinctly assert in some places that the Son of God is equal, and, in others, that He is inferior, to the Father. Further, if a man be given over to this soul-slaying delusion of believing that our Saviour hath only one nature, he must of necessity admit either that it was only God, or that it was only man who was crucified. But it was not so. If He had been of no nature but the Divine, He could not have suffered, and if He had been of no nature but the human, He could not have conquered death.
+
+[Lectio7]
+From the Holy Gospel according to Mark
+!Mark 16:14-20
+At that time, Jesus appeared unto the eleven disciples as they sat at meat, and upbraided them with their unbelief and hardness of heart, because they believed not them which had seen Him after He was risen. And so on.
+_
+Homily by Pope St. Gregory the Great.
+!Same as before.
+The Prophet Habakkuk also hath spoken of the glory of Christ's Ascension in the words "The sun was lifted up on high, and the moon stood still in her habitation," Who is here signified by the Sun, if not the Saviour or by the Moon, if not the Church? Until the Lord was withdrawn from her sight, (that is, by His Ascension,) His Holy Church was pale before the hostile glare of the world, but after He was ascended, she waxed stronger, and distinctly shed forth the beams of that faith which had hitherto dwelt hiddenly in her. "The sun was lifted up, and the moon stood still in her habitation" when the Lord was gone away into heaven, His holy Church waxed stronger in her enlightening power.
+
+[Lectio8]
+Hence it is that Solomon hath put into the mouth of the, (same) Church the words: "Behold,; He cometh! leaping upon the mountains, skipping upon the hills These hills are his lofty and; noble achievements. "Behold, He cometh leaping upon the mountains.” When He came to redeem us, He came, if I may so say, in leaps. My dearly beloved brethren, would you know what His leaps were? From heaven he leapt into the womb of the Virgin, from the womb into the manger, from the manger on to the Cross, from the Cross into the grave, and from the grave up to heaven. Lo, how the Truth made manifest in the Flesh did leap for our sakes, that He might draw us to run after Him for this end did He " rejoice, as a strong man to run a race,
+
+[Lectio9]
+Therefore, dearly beloved brethren, it behoveth us in heart and mind thither to ascend, where we believe Him to have already ascended bodily. Let us fly earthly lusts for us, who have a Father in heaven, let nothing be sweet below And very much must we keep in our minds this thought, that He Which ascended up in peace, will return in dreadful Majesty and will require from us with justice an account of our keeping of those commandments which He gave us in mercy. Let no man therefore reckon lightly this season which is given unto us that we may repent ourselves, nor be reckless touching the state of his soul; our Redeemer will be all the sterner, when He cometh to judgment, as He hath been wondrously long-suffering before.
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc6-5.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc6-5.txt
@@ -1,0 +1,43 @@
+@Tempora/Pasc6-0
+(sed rubrica 1960 omittitur)
+
+[Rank]
+Feria VI Post Octavam Ascensionis;;Semiduplex;;2;;ex Tempora/Pasc5-4
+
+[Rank1960]
+Feria VI infra Hebdomadam post Ascensionem;;Feria;;1;;vide Tempora/Pasc5-4
+
+[Rule]
+ex Tempora/Pasc5-4;
+9 Lectiones
+Doxology=Asc
+Feria Te Deum 
+No suffragium
+
+[Lectio4]
+From the Sermons of St. Augustine, Bishop of Hippo.
+!Same as before.
+Dearly beloved brethren, if the Flesh wherein our Saviour trampled down the devil had not been of our nature, He would indeed have exercised Himself, but He would not have conquered for us. If the Body wherein He rose from the grave had not been of our nature, His Resurrection would not have affected our state. Whoso asserteth this, that Christ hath but one nature, he doth not understand why Christ took Flesh upon Him, he confoundeth the order, and maketh void the benefit of the Incarnation. If the Flesh wherein our Healer came was not sharer in human | nature, then all that by His Birth He took from man would have been degradation. O may such dangerous! dreams be far from our thoughts What He took is ours, what He gave is His. I testify that the first Adam, who fell, and the second Adam, Who rose from the dead, are both of the same human nature that I am of. I testify that What lay in the grave, and What ascended into heaven, is of the same human nature that I am of.
+
+[Lectio5]
+It was therefore just because His Body was of our nature, that Christ's Death hath quickened us, His Resurrection raised us up, His Ascension sanctified us. It was just because His Body was of our nature, that His Presence in the heavenly kingdoms is a pledge that we also shall one day be there. Let us therefore strive, dearly beloved brethren, since the Lord hath on this day gone up on high in a Body of our nature, ourselves, as far as we can, to ascend thither in hope, to follow Him with our heart. Let us ascend to Him in love, and speed keeping pace with love, even by our very sins and passions. If every one of us would strive to get above them, and accustom himself to tread on them, he might make of even them a stepping-stone to mount to higher things. Such things lift us up if they are underneath us.
+
+[Lectio6]
+We make our vices a ladder, if we tread them down. With the Author of goodness there ascended no spite with the Son of the Virgin, no lust or sensuality. I say vices do not follow to heaven the Father of perfection, sin the Holy One of God, neither weakness nor disease the Divine Healer. If therefore we would enter into the kingdom of that Healer, we must first take heed to our sores. We must so order and guard in us the mutual relations of our soul and body, that the soul, the nobler part of man, may not be dragged down to hell by her grovelling companion, but may rather, being herself of a nature more glorious, bear with her to heaven at the last a sanctified body, by the help of Him Who liveth and~
+reigneth for ever and ever. Amen.
+
+[Lectio7]
+From the Holy Gospel according to John
+!John 15:26-27; 16:1-4
+At that time, Jesus said unto His disciples: When the Comforter is come, whom I will send unto you from the Father, even the Spirit of truth, Which proceedeth from the Father, He shall testify of Me. And so on.
+_
+Homily by St. Augustine, Bishop of Hippo.
+!92nd Tract on John.
+Upon the day of Pentecost the Holy Ghost came down upon a congregation of an hundred and twenty men, among whom were all the Apostles. These men, after they had been filled with the Spirit, began to speak with the tongues of all nations, and many of the bystanders, amazed at the marvel, when they saw in the discourse of Peter, how great and how Divine a witness was borne to the fact that the Christ, Whom they had murdered, and Whom they reckoned among the dead, had risen again and was alive, many of these bystanders were pricked in their heart (Acts ii. 37) and were converted. They received pardon from that noble Blood, Which they had so sacrilegiously and so brutally shed, seeing that that Blood had redeemed even Its Own out-pourers.
+
+[Lectio8]
+The Blood of Christ "Which is shed for many for the remission of sins" was so effectually shed, that It could remit even the very sin that shed It. Toward this looked the Lord when He said " They hated Me without a cause but when the Comforter is come, Whom I will send unto you from the Father, He shall testify of Me." This was as though He had said They have hated Me and slain Me while they see Me, but when they shall see Me no more, the Comforter shall bear such testimony of Me, as will compel them to believe in Me. "And ye also," saith He, "shall bear witness, because ye have been with Me from the beginning," the Holy Ghost shall bear witness, and ye also shall bear witness. "Because ye have been with Me from the beginning," ye are able to speak that ye do know, (John iii. 11,) which ye do not now, while as yet the fulness of the Spirit is not come upon you.
+
+[Lectio9]
+He shall testify of Me and ye also shall bear witness when the love of God is shed abroad in your hearts by the Holy Ghost Which shall be given unto you, and maketh you not ashamed to lift up your testimony. This love had not been so shed abroad in Peter's heart when he was frightened by the questioning of the maid-servant, and could not bear witness to the truth, but brake his promise, and was driven by strong fear to deny Christ thrice. "There is no such fear in love; but perfect love casteth out fear." Before the Passion of the Lord, Peter's slavish fear was questioned by a bondwoman but after the Resurrection of the Lord, his free love was asked by the very Prince of freedom, and therefore the first questioning shook him, but under the second he was at peace at the first he denied Him Whom he had loved at the second he loved Him Whom he had denied. But, even so, his love was weak and narrow, until the Holy Ghost had strengthened and widened it.
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc6-6.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc6-6.txt
@@ -1,0 +1,52 @@
+[LectioJudae1]
+Beginning of the letter of the blessed Apostle Jude
+!Jude 1:1-4
+1 Jude, the servant of Jesus Christ, and brother of James: to them that are beloved in God the Father, and preserved in Jesus Christ, and called.
+2 Mercy unto you, and peace, and charity be fulfilled.
+3 Dearly beloved, taking all care to write unto you concerning your common salvation, I was under a necessity to write unto you: to beseech you to contend earnestly for the faith once delivered to the saints.
+4 For certain men are secretly entered in, (who were written of long ago unto this judgment,) ungodly men, turning the grace of our Lord God into riotousness, and denying the only sovereign Ruler, and our Lord Jesus Christ.
+
+[LectioJudae2]
+!Jude 1:5-8
+5 I will therefore admonish you, though ye once knew all things, that Jesus, having saved the people out of the land of Egypt, did afterwards destroy them that believed not:
+6 And the angels who kept not their principality, but forsook their own habitation, he hath reserved under darkness in everlasting chains, unto the judgment of the great day.
+7 As Sodom and Gomorrha, and the neighbouring cities, in like manner, having given themselves to fornication, and going after other flesh, were made an example, suffering the punishment of eternal fire.
+8 In like manner these men also defile the flesh, and despise dominion, and blaspheme majesty.
+
+[LectioJudae3]
+!Jude 1:9-13
+9 When Michael the archangel, disputing with the devil, contended about the body of Moses, he durst not bring against him the judgment of railing speech, but said: The Lord command thee.
+10 But these men blaspheme whatever things they know not: and what things soever they naturally know, like dumb beasts, in these they are corrupted.
+11 Woe unto them, for they have gone in the way of Cain: and after the error of Balaam they have for reward poured out themselves, and have perished in the contradiction of Core.
+12 These are spots in their banquets, feasting together without fear, feeding themselves, clouds without water, which are carried about by winds, trees of the autumn, unfruitful, twice dead, plucked up by the roots,
+13 Raging waves of the sea, foaming out their own confusion; wandering stars, to whom the storm of darkness is reserved for ever.
+
+[Lectio4]
+From the Treatise upon the Creed, addressed to Catechumens by St. Augustine, Bishop of Hippo
+!Bk. iv. ch. I. tom. 9
+We are yet the unborn offspring of a great Mother. Our Holy Mother the Church hath by the most sacred sign of the Cross received you into her womb, and from thence she is now just about to bring you forth, as she hath already brought forth your brethren, with thrills of spiritual joy. But until, through the washing of regeneration, she bringeth you forth into true light, she feedeth you in her womb with such food as becometh your condition, and in gladness matureth her children for the glad moment of her delivery. This Mother is not stricken by the doom of Eve, to bring forth children in sorrow, and they themselves oftenertimes weeping than laughing. Rather doth your spiritual Mother annul the sentence of your earthly Eve, by disobedience, endowed her offspring with death the Church, by obedience, giveth them newness of life. All the mystic prayers and ceremonies which have been and are still being performed over you by the ministry of the servants of God, exorcisms, prayers, spiritual songs, onbreathings, haircloth, prostrations, baring of the feet, the dread which ye feel, albeit so safe, all these things, I say unto you, are the nourishment which ye are ever. drawing from your Mother while yet ye are in her womb, that at the baptismal birth she may be able to present you strong and laughing babes unto Christ.
+
+[Lectio5]
+We have also received the Creed, which is the shield of the travailing Mother against the venom of the dragon. In the Apocalypse of the Apostle John (xii. 4) it is written "And the dragon stood before the woman which was ready to be delivered, for to devour her child as soon as it was born." That this dragon is the devil ye all know. Ye know likewise that by the woman is signified the Virgin Mary, who, herself a Virgin, bore our Virgin Head, and who is revealed unto us as a type of the Holy Church, in that, even as Mary, though she bore a Son, remained a Virgin, so the Church doth in all times give birth to all her members, and yet is ever presented a chaste virgin to Christ. I have undertaken, with the help of the Lord, to expound every clause of the Creed, that I may bring home to your understandings what each containeth. Your hearts are ready, for the enemy hath been shut out of your hearts.
+
+[Lectio6]
+We have made profession of renouncing the enemy. At the moment of that profession it was not before men only, but in the presence of God and His Angels that ye said: "I do renounce him." Renounce him, not only in your words, but in your ways not only with your voices, but with your lives not only with your lips, but in your works. Know ye well that the wrestling which ye have undertaken is a strife with an enemy who is subtle, and old, and patient now that ye have once renounced him, let him never again find in you his works never again give him the right to bring you into bondage. O Christian thou wilt be caught and exposed, if thou dost one thing and professest another, if thou art faithful in name, and makest it to be evident by thy works that thou hast broken the faith pledged by this promise if some while thou goest into a church to pray, and anon to the shows to join in applauding obscene representations. What hast thou to do any more with the pomps of the devil, which thou hast renounced?
+
+[Lectio7]
+From the Holy Gospel according to John
+!John 14:15-21
+At that time, Jesus said unto His disciples: If ye love Me, keep My commandments. And I will pray the Father, and He shall give you another Comforter. And so on.
+_
+Homily by St. Augustine, Bishop of Hippo
+!74th and 75th Tracts on John
+By these words of the Lord: "I will pray the Father, and He shall give you another Comforter", He doth imply that Himself is a Comforter. The Greek word used, namely "Parakletos," signifieth also an Advocate, and is used in that sense where it is written "We have an Advocate Parakleton with the Father, Jesus Christ the Righteous." "Even the Spirit of truth, Whom the world cannot receive," because as we read elsewhere, "the carnal mind is enmity against God; for it is not subject to the law of God, neither indeed can it be" as we may say plainly nothing can make unrighteousness righteous. By "the world," in this place, we must understand the lovers of the world, a love which cometh not of the Father. And therefore it is that this love of the world, which we strive to lessen and to destroy in ourselves, is contrary to "the love of God, which is shed abroad in our hearts by the Holy Ghost which is given unto us."
+
+[Lectio8]
+The Spirit of truth Whom the world cannot receive, because it seeth Him not, neither knoweth Him "for to love the world is to lack those spiritual eyes, which are able to see Him Who is invisible, the Holy Ghost. "But ye know Him," saith the Lord to His disciples, "for He shall dwell with you, and shall be in you." He will be in them to dwell in them, not dwell in them to be in them for one must first be in a place before one dwell there. But lest the Apostles should think that the words, "He shall dwell with you," signified that He should visibly abide with them for a while, as do guests in the houses of men, the Lord saith in explanation "He shall be in you."
+
+[Lectio9]
+Therefore is He seen That is invisible. If He were not in us we could have in us no knowledge of Him but He is seen in us, as we see our conscience. We see the faces of other men, but we cannot see our Own but of consciences we see none save that within ourselves. But our conscience is never elsewhere but within us whereas the Holy Ghost may be without us, as well as within us. He is given to be within us, and, unless He be within us, we can neither see nor know Him, either within or without us.~
+(deinde dicitur)
+Then, after that He had promised the Holy Ghost, the Lord, lest they should deem that He was to give them that other Comforter instead of Himself, and that He Himself was to be no longer with them, said also "I will not leave you orphans I will come to you." Therefore, although the Son of God hath made us by adoption sons of His Own Father, and hath willed that the Same Who is His Father by nature should be our Father by grace, nevertheless, He showeth that Himself hath toward us a love as of a Father, where He saith "I will not leave you orphans."
+(sed rubrica 1570 omittitur)
+&teDeum

--- a/web/www/horas/Bohemice/Tempora/Pasc7-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc7-0.txt
@@ -1,0 +1,253 @@
+[Rank]
+Dominica Pentecostes;;Duplex I Classis cum Octava privilegiata I ordinis;;7
+
+[Rule]
+1 Nocturn
+Psalmi Dominica;
+Antiphonas horas
+Hymnus Tertia
+Prima=53
+
+[Ant Vespera]
+Když se završilo * Padesát dnů, byli všichni spolu na jednom místě, alleluja.
+Duch Hospodinův * naplnil okrsek světa, alleluja.
+Všichni byli naplněni * Duchem Svatým, a začali mluvit, alleluja, alleluja.
+Prameny, * a vše, co se hýbe ve vodách, vzdejte chválu Bohu, alleluja.
+Apoštolové mluvili * různými jazyky o velikosti Boží, alleluja, alleluja, alleluja.;;116
+
+[Capitulum Vespera]
+!Acts 2:1-2
+v. Když nastal den Letnic, byli všichni shromážděni na jednom místě. Náhle se strhl hukot z nebe, jako když se žene prudký vichr, a naplnil celý dům, kde byli.
+$Deo gratias
+
+[HymnusM Vespera]
+@:Hymnus Vespera
+
+[Hymnus Vespera]
+!První sloku říkáme vkleče.
+v. Přijď, Stvořiteli Duchu, k nám
+A navštiv našich myslí chrám,
+A vylej milost vznešenou
+V hruď naši tebou stvořenou.
+_
+Ty Těšitel jsi nazýván,
+Dar udělený Otcem nám,
+Zdroj živý, oheň, lásky dech
+A pomazání duší všech.
+_
+Jsi sedmitvámý v darech svých,
+Prst mocný rukou Otcových,
+Tys přislíbený Otcem Host,
+Jenž udílí rtům výmluvnost.
+_
+Rač světlo v duších zažehnout,
+Vlít v srdce žhavý lásky proud,
+A těla mdlého slabosti
+Svou posilovat milostí.
+_
+Rač vraha od nás zapudit,
+Dát našim srdcím pravý klid,
+Ať všichni pod tvým vůdcovstvím
+Se vyhneme všem svodům zlým.
+_
+Nás Boha Otce nauč znát,
+nás nauč Syna milovat,
+a v tebe, Duchu přemilý,
+dej, abychom vždy věřili.
+_
+Bohu Otci nechť sláva zní,
+Též Synu jeho, jenž z mrtvých
+dnes vstal, i Duchu svatému,
+s nímž vládneš vždy věku všemu.
+Amen.
+
+[Versum 1]
+V. Všichni byli naplněni Duchem Svatým, alleluja.
+R. A začali mluvit, alleluja.
+
+[Ant 1]
+Nezanechám vás sirotky, * alleluja; Odejdu, ale znovu k vám přijdu, alleluja, a vaše srdce zajásají, alleluja.
+
+[Oratio]
+Bože, jenž jsi dnešního dne srdce věřících osvícením Ducha Svatého poučil, dej nám, ať v témž Duchu správně smýšlíme a vždy se radujeme z jeho útěchy. 
+$Per Dominum eiusdem
+
+[Invit]
+Alleluja, Duch Hospodinův naplnil okrsek světa: * Pojďme a klanějme se mu, alleluja.
+
+[HymnusM Matutinum]
+@:Hymnus Matutinum
+
+[Hymnus Matutinum]
+v. Již vstoupil Kristus k výšinám
+V svůj nadhvězdný se vrátiv stan
+By spolu s Otcem nebeským
+Dal svého Ducha věrným svým.
+_
+Stál ve dveřích den slavnostní,
+Jenž, tajemný kruh sedmi dní
+Když sedmkráte prošla zem,
+Čas milostivý hlásá všem.
+_
+Dne třetí byla hodina,
+Když tu svět náhle zahřímá,
+A Apoštolům zvěstuje,
+Že Svatý Duch k nim sstupuje.
+_
+To z mocné záře Otcovy
+Se lije oheň zlatový,
+Jenž v duších, které k Pánu lnou
+Řeč zážehuje plamennou.
+_
+Hruď plní radost veliká,
+Když Svatý Duch v ni proniká,
+Již mluví v svatém nadšení
+O divech Božích na zemi.
+_
+I rozumí jim všechen lid:
+Řek, Arab, Latin, Barbar, Žid;
+Je jímá úžas veliký,
+Že mluví všemi jazyky.
+_
+Tu nevěřící Židé jen,
+Vždy zarputilí v hněvu svém,
+Kristovy žáky vinili,
+Že vínem se tak opili.
+_
+Než Petr slovy, zázraky
+Lež jejich staví před zraky,
+A Joelem hned v zápětí
+Své tvrzení zas pečetí.
+_
+Zněj Bohu Otci píseň chval,
+I Synu, který z mrtvých vstal,
+I Duchu, který těší nás,
+Ať ozývá se v každý čas.
+Amen.
+!Překlad: P. Josef Škrášek, Kroměříž
+
+[Ant Matutinum]
+Suddenly there came a sound from heaven * as of a rushing mighty wind, alleluia, alleluia.;;47
+Strengthen, O God, that which Thou hast wrought for us, * because of thy holy Temple at Jerusalem, alleluia, alleluia.;;67
+Send forth thy Spirit, and they shall be created * and Thou shalt renew the face of the earth, alleluia, alleluia.;;103
+V. Duch Hospodinův naplnil okrsek světa, alleluja.
+R. A což obsáhne všechny věci dostalo schopnost řeči, alleluja.
+
+[Lectio1]
+Continuation of the Holy Gospel according to John
+!John 14:13-31
+At that time, Jesus said unto His disciples: If a man love Me, He will keep My word, and My Father will love him, and We will come unto him, and make Our abode with him. And so on.
+_
+Homily by Pope St. Gregory the Great
+!30th on the Gospels
+Dearly beloved brethren, our best way will be to run briefly through the words which have been read from the Holy Gospel, and thereafter rest for a while quietly gazing upon the solemn subject of this great Festival. This is the day whereon "suddenly there came a sound from heaven," and the Holy Ghost descended upon the Apostles, and, for fleshly minds, gave them minds wherein the love of God was shed abroad and, while without "there appeared unto them cloven tongues, like as of fire, and it sat upon each of them," within, their hearts were enkindled. While they received the visible presence of God in the form of fire, the flames of His love enwrapped them. The Holy Ghost Himself is love whence it is that John saith "God is love." Whosoever therefore loveth God with all his soul, already hath obtained Him Whom he loveth, for no man is able to love God, if He have not gained Him Whom he loveth.
+
+[Responsory1]
+R. When the day of Pentecost was fully come, they were all with one accord in one place, alleluia, and suddenly there came a sound from heaven, alleluia.
+* as of a mighty rushing wind, and it filled all the house, alleluia, alleluia.
+V. Where the disciples were assembled for fear of the Jews, there suddenly came upon them a sound from heaven.
+R. As of a rushing mighty wind, and it filled all the house, alleluia, alleluia.
+
+[Lectio2]
+But, behold, now, if I shall ask any one of you whether he loveth God, he will answer with all boldness and quietness of spirit: "I do love him." But at the very beginning of this day's Lesson from the Gospel, ye have heard what the Truth saith: "If a man love Me, he will keep My word." The test, then, of love, is whether it is showed by works. Hence the same John hath said in his Epistle (I. iv. 20, v. 3): "If a man say, I love God, and keepeth not His commandments, He is a liar." Then do we indeed love God, and keep His commandments, if we deny ourselves the gratification of our appetites. Whosoever still wandereth after unlawful desires, such an one plainly loveth not God, for he saith, Nay, to that which God willeth.
+
+[Responsory2]
+R. They were all filled with the Holy Ghost, and began to speak, as the Holy Ghost gave them utterance;
+* And the multitude came together, saying: Alleluia.
+V. The Apostles spoke in diverse tongues the wonderful works of God.
+R. And the multitude came together, saying: Alleluia.
+&Gloria
+R. And the multitude came together, saying: Alleluia.
+
+[Lectio3]
+"And My Father will love him, and We will come unto him, and make Our abode with him." O my dearly beloved brethren, think what a dignity is that, to have God abiding as a guest in our heart Surely if some rich man or some powerful friend were to come into our house, we would hasten to have our whole house cleaned, lest, perchance, when he came in, he should see aught to displease his eye. So let him that would make his mind an abode for God, cleanse it from all the filth of works of iniquity. Lo, again, what saith the Truth: "We will come unto him, and make Our abode with him." There are some hearts whereunto God cometh, but maketh not His abode therein with a certain pricking they feel His Presence, but in time of temptation they forget that which hath pricked them and so they turn again to work unrighteousness, even as though they had never repented.
+&teDeum
+
+[Hymnus Laudes]
+v. Blažené nám zas radosti,
+běh světa ráčil přinésti;
+Když Utěšitel Duch Svatý 
+Vlil učedníkům spasení:
+_
+Oheň jeho jasným světlem,
+Co jazyků podobu měl,
+By se v řeči stali zběhlí,
+A v lásce vždycky horliví.
+_
+Když mluvili všech jazyky,
+Dav Pohanů měl obavy,
+Že mladým vínem opilí,
+Jsou ti, jež ten Duch naplní;
+_
+Stalo se tak však tajemně,
+Než Velkonoc čas přeběhne,
+V posvátném tomto počtu dnů,
+V němž přišly desky zákonů.
+_
+Tebe teď, Bože laskavý,
+Zkroušenou žádáme tváří,
+Z výše své nebeské sešli
+Nám Svatého Ducha dary;
+_
+Srdce právě požehnaná
+Tvou milostí jsou zas plná,
+Však hříchy nám odpusť naše,
+A uděl časy pokoje.
+_
+Bohu Otci nechť sláva zní,
+Též Synu jeho, jenž z mrtvých
+dnes vstal, i Duchu svatému,
+s nímž vládneš vždy věku všemu.
+Amen.
+
+[Ant 2]
+Přijměte Ducha Svatého; * komu hříchy odpustíte, tomu budou odpuštěny, alleluia.
+
+[Lectio Prima]
+!Acts 2:11
+v. Tedy my, Židé a Proselyté, Kréťané a Arabové, je slyšíme mluvit v našich jazycích o velkých dílech Božích.
+
+[Responsory Tertia]
+R.br. Duch Páně naplnil okrsek zemský. * Alleluja, alleluja.
+R. Duch Páně naplnil okrsek zemský. * Alleluja, alleluja.
+V. A to, co obsáhne všechno, mělo schopnost mluvit.
+R. Alleluja, alleluja.
+&Gloria
+R. Duch Páně naplnil okrsek zemský. * Alleluja, alleluja.
+_
+V. Svatý Duch, Utěšitel, alleluka.
+R. Naučí vás vše, alleluja.
+
+[Capitulum Sexta]
+!Acts 2:6
+v. Když se však ten zvuk ozval, hodně lidí se sběhlo a byli ohromeni, protože každý z nich je slyšel, jak mluví jeho vlastní řečí.
+$Deo gratias
+
+[Responsory Sexta]
+R.br. The Comforter, Which is the Holy Ghost. * Alleluia, Alleluia.
+R. The Comforter, Which is the Holy Ghost. * Alleluia, Alleluia.
+V. He shall teach you all things.
+R. Alleluia, Alleluia.
+&Gloria
+R. The Comforter, Which is the Holy Ghost. * Alleluia, Alleluia.
+_
+V. Všichni byli naplněni Duchem Svatým, alleluja.
+R. A počali mluviti, alleluja.
+
+[Responsory Nona]
+R.br. Všichni byli naplněni Duchem Svatým. * Alleluja, alleluja.
+R. Všichni byli naplněni Duchem Svatým. * Alleluja, alleluja.
+V. A počali mluviti.
+R. Alleluja, alleluja.
+&Gloria
+R. Všichni byli naplněni Duchem Svatým. * Alleluja, alleluja.
+_
+V. Apoštolové mluvili různými jazyky, alleluja.
+R. O velikých dílech Božích, alleluja.
+
+[Versum 3]
+V. The Apostles spoke in diverse tongues, alleluia.
+R. The wonderful works of God, alleluia.
+
+[Ant 3]
+Dnes se završilo * Padesát dnů, alleluja: dnes se Duch svatý v ohni zjevil učedníkům, a udělil jim duchovní dary; poslal je do celého světa kázat a svědčit: Kdo uvěří a bude pokřtěn, bude též spasen, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc7-1.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc7-1.txt
@@ -1,0 +1,56 @@
+[Rank]
+Die II infra octavam Pentecostes;;Duplex I classis;;6;;ex Pasc7-0
+
+[RankNewcal]
+Feria II post Pentecostes;;Feria;;1;;
+
+[Rule]
+ex Pasc7-0;
+1 nocturn;
+Psalmi Dominica;
+Antiphonas horas
+Hymnus Tertia
+No commemoration
+
+[Lectio1]
+Continuation of the Holy Gospel according to John
+!John 3:16-21
+At that time, Jesus said unto Nicodemus: God so loved the world that He gave His Only-begotten Son, that whosoever believeth in Him should not perish, but have everlasting life. And so on.
+_
+Homily by St. Augustine, Bishop of Hippo
+!12th Tract on John
+The Physician cometh that, as often as in him lieth, he may heal the sick man. He is his own destroyer who will not keep the commandments of the Physician. Into the world came the Saviour. Why is He called the Saviour of the world, but because He came "into the world not to condemn the world, but that the world through Him might be saved"? If thou willest not be saved through Him, thou wilt be condemned of thyself. And why say I that thou wilt be condemned? Because it is written: "He that believeth in Him is not condemned." What then canst thou hope that He will say of "him that believeth not," but that He will be condemned And indeed He doth say farther: "He that believeth not is condemned already." He is condemned already, though the condemnation be not yet openly pronounced.
+
+[Responsory1]
+R. Henceforth I call you not servants, but I have called you My friends, because ye have known all things, whatsoever I have done among you. Alleluia.
+* Receive ye the Holy Ghost, Who is your Comforter within you; the Same is He Whom the Father will send unto you. Alleluia.
+V. Ye are My friends, if ye do whatsoever I command you.
+R. Receive ye the Holy Ghost Who is your Comforter within you; the Same is He Whom the Father will send unto you. Alleluia.
+
+[Lectio2]
+He is condemned already, for "the Lord knoweth them that are His." He knoweth them for whom is laid up the crown, and likewise them that are reserved unto the fire. His eye seeth in the field of the world the distinction of the wheat and of the straw, of the good corn and of the tares. "He that believeth not is condemned already." And why? "Because he hath not believed in the Name of the Only-begotten Son of God. And this is the condemnation that light is come into the world, and men loved darkness rather than light, because their deeds were evil." "Because their deeds were evil”, but, my brethren, is there one man of whom God findeth that his works are good? No, not one. God findeth all works to be (in themselves) bad. How then do we hear that some there be who do truth, and come to the light? For these words come anon: "But he that doeth truth, cometh to the light."
+
+[Responsory2]
+R. The Holy Ghost, Which proceedeth from the Throne, entered unseen into the hearts of the Apostles, with a new token of sanctification, even
+* That all manner of tongues should spring to their lips. Alleluia.
+V. The fire of God fell, not to burn them, but to enlighten them, and gave them gifts of grace.
+R. That all manner of tongues should spring to their lips. Alleluia.
+&Gloria
+R. That all manner of tongues should spring to their lips. Alleluia.
+
+[Lectio3]
+But the Lord saith [of such as these, who are condemned already, because they believe not in Him]: "They loved darkness rather than light." And here He maketh the great point [of difference between such, and them that do the truth.] There are many who have loved their sins there are many who have confessed their sins and he that confessed and denounceth his sin, is working already with God. God denounceth thy sins, and if thou denounce them likewise, then dost thou join thyself with God in His act. The man and the sinner are two different things. God made the man, and the man made the sinner. Put away thy work, and God will save His. Thou art behoven to hate in thyself thine own work, and to love God's work. When thine own works begin to displease thee, then is it that thou beginnest to do well, because thou denouncest thine own evil works. The first thing to do, if thou wouldest do good works, is to acknowledge thine evil ones.
+&teDeum
+
+[Ant 2]
+Tak Bůh miloval svět, * že svého jediného Syna vydal; aby každý, kdo v něj věří, nezahynul, ale měl život věčný. Alleluja.
+
+[Oratio]
+Bože, jenž jsi svý Apoštolům dal Svatého Ducha; uděl svému lidu vyslyšení zbožné prosby, abys těm, kterým jsi dal víru, uštědřil též pokoj.
+$Per Dominum eiusdem
+
+[Ant 3]
+If a Man love Me * he will keep My word and My Father will love him, and We will come unto him, and make Our abode with him. Alleluia.
+
+[Ant 3] (rubrica cisterciensis)
+Bůh totiž neposlal * svého Syna na svět, aby svět soudil, ale aby byl svět spasen skrze něho, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc7-2.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc7-2.txt
@@ -1,0 +1,59 @@
+[Rank]
+Die III infra octavam Pentecostes;;Duplex I classis;;6;;ex Pasc7-0
+
+[RankNewcal]
+Feria III post Pentecostes;;Feria;;1;;
+
+[Rule]
+ex Pasc7-0;
+1 nocturn;
+Psalmi Dominica;
+Antiphonas horas 
+Hymnus Tertia
+No commemoration
+
+[Ant Matutinum]
+@Tempora/Pasc7-0::s/V\. .*/V. The Comforter, Who is the Holy Ghost. Alleluia.\nR. He shall teach you all things. Alleluia./s
+
+[Lectio1]
+Continuation of the Holy Gospel according to John
+!John 10:1-10
+At that time: Jesus said unto the Pharisees: Amen, amen, I say unto you, he that entereth not by the door into the sheep-fold, but climbeth up some other way, the same is a thief and a robber but he that entereth by the door is the shepherd of the sheep. And so on.
+_
+Homily by St. Augustine, Bishop of Hippo
+!45th Tract on John
+In the words of the Gospel which are this day read, the Lord has spoken unto us in similitudes, touching His flock, and the Door whereby entry is made into their fold. The Pagans therefore may say, "We have good lives," but if they enter not in the Door, what doth that profit them whereof they make their boast? Good life is profitable to a man if it lead unto life everlasting, but if he does not have life everlasting, what shall his good life profit him? Neither indeed can it be truly said that they live good lives, who are either so blinded as not to know, or so puffed up as to despise, the end of a good life. And no man can have a true and certain hope of life everlasting, unless he know the true Life, Which is Christ, and enter in by that Door into the sheepfold.
+
+[Responsory1]
+R. There appeared unto the Apostles cloven tongues, like as of fire. Alleluia.
+* And the Holy Ghost sat upon each of them. Alleluia, Alleluia.
+V. And they began to speak with other tongues, as the Holy Ghost gave them utterance.
+R. And the Holy Ghost sat upon each of them. Alleluia, Alleluia.
+
+[Lectio2]
+There are many such, who try to persuade men to live good lives but not to be Christians. These are they who would fain "climb up some other way," "for to kill and to destroy," and are not as the Good Shepherd, Who is come to keep and to save. There have been philosophers who have treated many subtle questions of right and wrong, who have been the authors of many distinctions and definitions, who have completed many exceedingly clever arguments, who have filled many books, and have proclaimed their own wisdom with braying trumpets. These dared to say to men: "Follow us embrace our school of thought, and you will find therein the secret of an happy life." But these were not of them who enter in by the Door; they came not but for to steal, and to kill, and to destroy.
+
+[Responsory2]
+R. The Apostles spake in diverse tongues the wonderful works of God,
+* As the Holy Ghost gave them utterance. Alleluia.
+V. They were all filled with the Holy Ghost, and began to speak
+R. As the Holy Ghost gave them utterance. Alleluia.
+&Gloria
+R. As the Holy Ghost gave them utterance. Alleluia.
+
+[Lectio3]
+Touching these, what shall I say? Behold, the Pharisees themselves read of Christ, and therefore talked of Christ they looked for His coming, and when He came, they knew Him not. They boasted that they themselves were among the Seers, that is, of the wise ones, and they denied Christ, and entered not in by the Door. Therefore they, if they led away any, led them away only to kill and to destroy, not to free them. So much for them. Now let us see if all they who boast the name of Christian enter in by the Door. Some there are, and their number cannot be reckoned, who not only boast that they themselves are among the Seers, but would fain appear as though their hearts were enlightened by Christ but they are heretics.
+&teDeum
+
+[Ant 2]
+Já jsem brána, * praví Pán: a pokud skrze mě někdo vstoupí, bude uzdraven, a nalezne pastvu, alleluja.
+
+[Oratio]
+Budiž s námi, prosíme, Pane, síla Ducha Svatého; jež naše srdce laskavě očistí, a ochrání ode všech protivenství.
+$Per Dominum eiusdem
+
+[Ant 3]
+Peace I leave with you, * My peace I give unto you; not as the world giveth, give I unto you. Alleluia.
+
+[Ant 3] (rubrica cisterciensis)
+Amen, pravím vám, * kdo nevstupuje vchodem do ovčína k ovcím, ale vleze tam jinudy, je zloděj a lotr; kdo však vstupuje vchodem, je pastýř těch ovcí, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc7-3.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc7-3.txt
@@ -1,0 +1,66 @@
+[Rank]
+Feria Quarta Quattuor Temporum;;Semiduplex I classis;;6;;ex Pasc7-0
+
+[Rank1960]
+Feria Quarta Quattuor Temporum Pentecostes;;Semiduplex I classis;;6;;ex Pasc7-0
+
+[RankNewcal]
+Feria IV post Pentecostes;;Feria;;1;;
+
+[Rule]
+ex Pasc7-0;
+1 nocturn;
+Psalmi Dominica;
+Antiphonas horas
+Hymnus Tertia
+Feria Te Deum 
+no93
+
+[Ant Matutinum]
+@Tempora/Pasc7-0::s/V\. .*/V. They were all filled with the Holy Ghost. Alleluia.\nR. And began to speak. Alleluia./s
+
+[Lectio1]
+Continuation of the Holy Gospel according to John
+!John 6:44-52
+At that time, Jesus said unto the multitudes of the Jews: No man can come to Me, except the Father, Which hath sent me, draw him. And so on.
+_
+Homily by St. Augustine, Bishop of Hippo
+!26th Tract on John
+Think not that thou art drawn against thy will; the soul is drawn, not willingly only, but lovingly. Neither must we be afraid lest men who are great weighers of words, and very far from understanding the things of God, should catch us up upon this Gospel doctrine of the Holy Scriptures, and should say to us: How can my faith be willing if am drawn? I answer: Thou art not drawn as touching thy will, but by pleasure. And, now, what is being drawn by pleasure? Delight thyself in the Lord, and He shall give thee the desires of thine heart. (Ps. xxxvi. 4.) There is pleasure in that heart to which the Bread That came down from heaven is sweet. The poet is allowed to say His special pleasure draweth each, but pleasure, which so draweth, is not a necessity, not a bond, but a delight how much more strongly, may we say that men are drawn to Christ, who delight in truth, who delight in blessedness, who delight in righteousness, who delight in life everlasting, since truth and blessedness, and righteousness and everlasting life are all to be found in Christ? Or have the bodily senses pleasure, and the spiritual senses none? If the spiritual sense have no pleasures, wherefore is it written: And the children of men shall put their trust under the shadow of thy wings. They shall be abundantly satisfied with the fatness of thy house, and Thou shalt make them drink of the river of thy pleasures. For with thee is the fountain of life, and in thy light shall we see light. (Ps. xxxv. 8.)
+
+[Responsory1]
+R. The Lord taught them good judgment and knowledge, Alleluia. He established in them the grace of His Spirit, 
+* And filled their hearts with understanding. Alleluia.
+V. For with a sudden sound the Holy Ghost came upon them.
+R. And filled their hearts with understanding. Alleluia.
+
+[Lectio2]
+Give me a lover, and he will catch my meaning; give me one who longs, give me an hungerer, give me a wanderer in this desert, a thirst and gasping for the fountains of the eternal Fatherland; give me such an one, and he will catch my meaning. If I talk to some cold creature, he will not. Such cold creatures were they of whom it is written: The Jews then murmured at Him because He said, I am the Bread Which came down from heaven. And they said: Is not this Jesus the son of Joseph, whose father and Mother we know? How is it then that He saith: I came down from heaven? Jesus therefore answered and said unto them: Murmur not among yourselves. No man can come to Me, except the Father, Which hath sent Me, draw him. (41-44.) But wherefore speaketh Christ of them whom the Father draweth, since He Himself draweth. Why was it His will to say: No man can come to Me except the Father draw him? If we are to be drawn, let us be drawn by Him to Whom one that loved much said: Draw me, we will run after the savour of thy good ointments. (Cant. i. 4.) But let us consider, my brethren, what He meant, and understand it as well as we can. The Father draweth to the Son them who believe in the Son, because they are persuaded that He hath God to His Father. God the Father begetteth to Himself a coequal Son; and whosoever is persuaded, and realiseth unto himself by faith, and thinketh, that He in Whom he believeth is equal to the Father, him the Father is drawing unto the Son.
+
+[Responsory2]
+R. Go ye unto all the world and preach the Gospel. Alleluia.
+* He that believeth, and is baptized, shall be saved. Alleluia, Alleluia, Alleluia.
+V. In My Name shall they cast out devils; they shall speak with new tongues; they shall take up serpents.
+R. He that believeth, and is baptized, shall be saved. Alleluia, Alleluia, Alleluia.
+&Gloria
+R. He that believeth, and is baptized, shall be saved. Alleluia, Alleluia, Alleluia.
+
+[Lectio3]
+Arius, who believed that the Son was made, was not one of them whom the Father draweth since whosoever believeth not that the Father is a Father by the begetting of a coequal Son, such an one knoweth not the Father. What sayest thou, O Arius? What sayest thou, O thou heretic? What is thy profession? What is Christ? He is not, saith Arius, Himself Very God. Then, O Arius, the Father hath not drawn thee; thou hast not understood His dignity as a Father, to Whom thou deniest His Son. Thou dost deny the existence of the Son of God, the Father draweth thee not, and thou art not drawn to the Son, since the Son of whom thou speakest is another son, [existing only in thine imagination,] and not the really existent Son. Photinus said: Christ is a mere man, and not God at all. He who uttered those words was not one of them whom the Father draweth. But whom hath the Father drawn? The Father drew him who said: Thou art the Christ, the Son of the living God. (Matth. xvi. 16, 17.) Show a sheep a green bough, and thou drawest him. Let a boy see some nuts, and he is drawn by them. As they run, they are drawn, drawn by taste, drawn without bodily hurt, drawn by a line bound to their heart. If, then, among earthly things, such as be sweet and pleasant draw such as love them, as soon as they see them, so that it is truth to say, His special pleasure draweth each, doth not that Christ, Whom the Father hath revealed, draw? What stronger object of love can a soul have than the Truth?
+&teDeum
+
+[Ant 2]
+Já jsem Chléb živý, * a sestoupil jsem z nebe, praví Pán. Alleluja, Alleluja.
+
+[Ant 2] (rubrica cisterciensis)
+Já jsem Chléb živý, * a sestoupil jsem z nebe; pokud bude někdo jíst z tohoto chleba, bude žít navěky: a chléb, který já dávám, je mé tělo <i>vydané</i> za život světa, alleluja, alleluja.
+
+[Oratio]
+Mysli naše, prosíme, Pane, ať osvítí Utěšitel, který z tebe vychází; a uvede je do veškeré pravdy, jak slíbil tvůj Syn.
+$Qui tecum eiusdem
+
+[Ant 3]
+I am the Living Bread Which came down from heaven; * if any man eat of this Bread, he shall live for ever, and the Bread that I will give is My Flesh, Which I will give for the life of the world. Alleluia.
+
+[Ant 3] (rubrica cisterciensis)
+Amen, * amen, pravím vám, kdo věří ve mě, bude mít život věčný, alleluja, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc7-4.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc7-4.txt
@@ -1,0 +1,56 @@
+[Rank]
+Feria Quinta infra octavam Pentecostes;;Semiduplex I classis;;6;;ex Pasc7-0
+
+[Rank1960]
+Die Quinta infra octavam Pentecostes;;Semiduplex I classis;;6;;ex Pasc7-0
+
+[RankNewcal]
+Feria V post Pentecostes;;Feria;;1;;
+
+[Rule]
+ex Pasc7-0;
+1 nocturn;
+Psalmi Dominica;
+Antiphonas horas 
+Hymnus Tertia
+Feria Te Deum 
+no93
+
+[Lectio1]
+Continuation of the Holy Gospel according to Luke
+!Luke 9:1-6
+At that time: Jesus called His twelve disciples together, and gave them power and authority over all devils, and to cure diseases. And so on.
+_
+Homily by St. Ambrose, Bishop of Milan
+!Bk. 6 on Luke ix
+We learn from the commandments of the Gospel what manner of men they ought to be who preach the glad tidings of the kingdom of God "Take nothing for your journey neither staves nor scrip, neither bread neither money." Thus let the Apostle destitute of earthly help, and panoplies in faith, deem himself able to do all the more, as he needeth all the less Such as please may also put upon these words a spiritual interpretation in that a man may be said to lay as the encumbrances of the body, not only by abdicating power, and casting away riches, but also by denying the very body itself its pleasures. The first general commandment given to the Apostles touching their manners was to be bringers of peace, (Matth. x. 13,) and to be no gadders about, but keepers of the laws of guests. To wander from house to house, and to abuse the rights of hospitality, are things alien to a preacher of the kingdom of heaven.
+
+[Responsory1]
+R. The fire of God fell, not to burn them, but to enlighten them not to devour them, but to illuminate them and found the hearts of the disciples clean vessels.
+* And He gave them gifts of His grace. Alleluia, Alleluia.
+V. He found them one in love, and the out-poured grace of the Godhead shone through them.
+R. And He gave them gifts of His grace. Alleluia, Alleluia.
+
+[Lectio2]
+But as the kindness of hospitality is to be met with courtesy, so also is it said "Whosoever will not receive you, when ye go out of that city, shake off the very dust from your feet, for a testimony against them." Hereby is it taught that hospitality doth meet with a good reward, since not only do we bring peace to such as receive us, but also, if they be shadowed by some earthly vanities, these defects are taken away, where enter the feet of them that bear the glad tidings of Apostolic preachment. It is well written in Matthew (x. 11): "Into whatsoever city or town ye shall enter, inquire who in it is worthy and there abide till ye go thence" thus avoiding any possible need of going from house to house. But no such selection is commanded to him that giveth hospitality, lest his hospitality itself should be lessened, while he picketh his guests.
+
+[Responsory2]
+R. The Holy Ghost filled all the house where the Apostles were and there appeared unto them cloven tongues like as of fire, and it sat upon each of them.
+* And they were all filled with the Holy Ghost, and began to speak in diverse tongues as the Holy Spirit gave them utterance. Alleluia, Alleluia, Alleluia.
+V. When the disciples were all with one accord in one place, for fear of the Jews, suddenly there came a sound from heaven upon them.
+R. And they were all filled with the Holy Ghost, and began to speak in diverse tongues as the Holy Spirit gave them utterance. Alleluia, Alleluia, Alleluia.
+&Gloria
+R. And they were all filled with the Holy Ghost, and began to speak in diverse tongues, as the Holy Spirit gave them utterance. Alleluia, Alleluia, Alleluia.
+
+[Lectio3]
+This passage, taken according to the plain meaning, is a sacred commandment touching the religious duty of hospitality, but its heavenly words likewise hint at a mystery. When the house is chosen, it is asked if the master thereof be worthy. Let us see if this be not perchance a figure of the Church, and her Master, Christ. What worthier house can the Apostolic preacher enter, than the Holy Church? Or what host is more to be preferred before all others, than Christ, Whose use it is to wash the feet of His guests yea, Who suffereth not that any whom He receiveth into His house should dwell there with foul feet, but, defiled as they are by their former wanderings, doth vouchsafe to change them into new and clean livers. He Alone is He, from Whose house no man ought ever to go forth, nor change His roof for any other shelter, for unto Him it is well said "Lord, to whom shall we go? Thou hast the words of eternal life, and we believe." (John vi. 68, 69.)
+&teDeum
+
+[Ant 2]
+Ježíš svolal * svých dvanáct učedníků, a dal jim sílu a moc nade všemi zlými duchy, a aby léčili neduhy; a poslal je hlásat království Boží, a uzdravovat nemocné, alleluja, alleluja.
+
+[Ant 3]
+The Comforter, * Which proceedeth from the Father, alleluia, He shall glorify Me, alleluia, alleluia.
+
+[Ant 3] (rubrica cisterciensis)
+Vyšlo * dvanáct Apoštolů, a procházeli městy a hlásali Evangelium, a uzdravovali všude, alleluja, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc7-5.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc7-5.txt
@@ -1,0 +1,66 @@
+[Rank]
+Feria Sexta Quattuor Temporum Pentecostes;;Semiduplex I classis;;6;;ex Pasc7-0
+
+[Rank]
+Feria Sexta Quattuor Temporum Pentecostes;;Semiduplex I classis;;6;;ex Pasc7-0
+
+[RankNewcal]
+Feria VI post Pentecostes;;Feria;;1;;
+
+[Rule]
+ex Pasc7-0;
+1 nocturn;
+Psalmi Dominica;
+Antiphonas horas 
+Hymnus Tertia
+Feria Te Deum 
+no93
+
+[Ant Matutinum]
+@Tempora/Pasc7-0::s/V\. .*/V. The Comforter, Who is the Holy Ghost. Alleluia.\nR. He shall teach you all things. Alleluia./s
+
+[Lectio1]
+Continuation of the Holy Gospel according to Luke
+!Luke 5:17-26
+At that time, it came to pass on a certain day, as Jesus sat and taught, that there were Pharisees, and Doctors of the law sitting by, which were come out of every town in Galilee, and Judaea and Jerusalem and the power of the Lord was present to heal them. And so on.
+_
+Homily by St. Ambrose, Bishop of Milan
+!Book 5 on Luke v
+"And, behold, men brought in a bed a man which was taken with a palsy." The healing of this paralytic was not idle, nor its fruits limited to himself. The Lord healed him, or ever he could ask, not because of the entreaties of others, but for example's sake. He gave a pattern to be followed, and sought not the intercession of prayer. In the presence of the Pharisees and doctors of the law, which were come out of every town of Galilee, and Judaea, and Jerusalem, many sick folk were healed, but among them is specially described the healing of this paralytic. First of all, as we have before said, every sick man ought to engage his friends to offer up prayers for his recovery, that so the tottering framework of this our life, and the distorted feet of our works, may be righted by the healing power of the word from heaven.
+
+[Responsory1]
+R. Ye have not chosen Me, but I have chosen you, and ordained you
+* That ye should go and bring forth fruit, and that your fruit should remain. Alleluia, Alleluia.
+V. As My Father hath sent Me, even so send I you.
+R. That ye should go and bring forth fruit, and that your fruit should remain. Alleluia, Alleluia.
+
+[Lectio2]
+Here ought therefore to be advisers, who should rouse up the minds of the sick to higher things, since when the body becometh languid with sickness, the mind is apt to follow its example. With the help of such friends he can be brought and laid on the ground before the Feet of Jesus, and seem worthy of a glance from the Lord for the Lord looketh upon such as lie lowly before Him, "for He hath regarded the lowliness of His handmaiden" (Luke ii. 48.) "And when He saw their faith, He said unto him Man, thy sins are forgiven thee." Great is the Lord, Who, for the sake of some, forgiveth the sins of others Who trieth some, and pardoneth the wanderings of others. Why should thine equal, O man, avail not with thee, if a slave have won power to intercede, and right to obtain, with God?
+
+[Responsory2]
+R. The Spirit of the Lord filleth the world,
+* And That Which containeth all things hath knowledge of the voice. Alleluia, Alleluia.
+V. For [Wisdom] is the worker of all things, having all power, overseeing all things.
+R. And That Which containeth all things hath knowledge of the voice. Alleluia, Alleluia.
+&Gloria
+R. And That Which containeth all things hath knowledge of the voice. Alleluia, Alleluia.
+
+[Lectio3]
+O Thou that judgest, learn to forgive thou that art sick, to pray. If thou doubt of the pardon of thy sins, because of their grievousness, get thee to the Church, that she may pray for thee, and that the Lord, accepting her countenance, may grant to her petitions what He refuses to thine. And although we are bound to accept this history as one of fact, and to believe that the body of the paralytic was healed yet remember thou also his inward cure, unto whom his sins were forgiven. The Jews said: "Who can forgive sins but God alone?” And in these words they confessed the Godhead of Him Who forgave the sins of the paralytic, and themselves condemned their own unbelief in Him Whose work they acknowledged, but Whose Person they denied.
+&teDeum
+
+[Ant 2]
+But that ye may know * that the Son of man hath power upon earth to forgive sins, He said unto the sick of the palsy: I say unto thee, Arise, take up thy couch, and go into thine house. Alleluia.
+
+[Ant 2] (rubrica cisterciensis)
+Stalo se * jeden den, že Ježíš seděl a vyučoval, a seděli tam i Fariseové, a zákoníci, kteří přišli z každého města Galileje, a Judska, i z Jerusaléma, a Pán měl moc je všechny uzdravit, alleluja, alleluja.
+
+[Oratio]
+Dej, prosíme, své Církvi, milosrdný Bože; aby, když ji Duch Svatý shromáždil, se nemusela obávat žádného útoku nepřítele.
+$Per Dominum eiusdem
+
+[Ant 3]
+But the Comforter which is the Holy Ghost, * Whom the Father will send in My Name, He shall teach you all things, and bring all things to your remembrance, whatsoever I have said unto you. Alleluia.
+
+[Ant 3] (rubrica cisterciensis)
+Již s vámi nebudu moc * mluvit, přijde však kníže tohoto světa, a proti mě nebude mít žádné moci; avšak aby poznal svět, že miluji Otce, přikázání, které mi dal Otec, také splním, alleluja.

--- a/web/www/horas/Bohemice/Tempora/Pasc7-6.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc7-6.txt
@@ -1,0 +1,47 @@
+[Rank]
+Sabbato Quattuor Temporum Pentecostes;;Semiduplex I classis;;6;;ex Pasc7-0
+
+[Rank]
+Sabbato Quattuor Temporum Pentecostes;;Semiduplex I classis;;6;;ex Pasc7-0
+
+[RankNewcal]
+Sabbato post Pentecostes;;Feria;;1;;
+
+[Rule]
+ex Pasc7-0;
+1 nocturn;
+Psalmi Dominica;
+Antiphonas horas 
+Hymnus Tertia
+Feria Te Deum 
+no93
+
+[Ant Matutinum]
+@Tempora/Pasc7-0::s/V\. .*/V. They were all filled with the Holy Ghost. Alleluia.\nR. And began to speak. Alleluia./s
+
+[Lectio1]
+Continuation of the Holy Gospel according to Luke
+!Luke 4:38
+At that time Jesus arose out of the synagogue, and entered into Simon's house.~
+And Simon's wife's mother was taken with a great fever. And so on.
+_
+Homily by St. Ambrose, Bishop of Milan
+!Bk. 4 on Luke iv
+Behold here how long-suffering is the Lord our Redeemer! Neither moved to anger against them, nor sickened at their guilt, nor outraged by their attacks, did He leave the Jews' country. Nay, forgetting their iniquity, and mindful only of His mercy, He strove to soften their hard and unbelieving hearts, sometimes by His teaching, and sometimes by freeing some of them, and sometimes by healing them. St. Luke doth well to tell us first of the man who was delivered from an unclean spirit, and then of the healing of a woman. The Lord indeed came to heal both sexes, but that must be healed first which was created first, and then must not she be passed by whose first sin arose rather from fickleness of heart than from depraved will.
+
+[Lectio2]
+That the Lord began to heal on the Sabbath-day showeth in a figure how that the new creation beginneth where the old creation ended. It showeth, moreover, that the Son of God, Who is come not to destroy the law but to fulfill the law, (Matth. v. 17,) is not under the law, but above the law. Neither was it by the law, but by the Word, that the world was created, as it is written "By the Word of the Lord were the heavens made." (Ps. xxxii. 6.) The law, then, is not destroyed, but fulfilled, in the Redemption of fallen man. Whence also the Apostle saith: "Put off, concerning the former conversation, the old man, which is corrupt according to the deceitful lusts and be renewed in the spirit of your mind and put on the new man, which after God is created in righteousness and true holiness." (Eph. iv. 22.)
+
+[Lectio3]
+It was well that He began to heal on the Sabbath, that He might show Himself to be the Creator, weaving in one with another of His works, and continuing that which He had already begun, even as a workman, being to repair a house, beginneth not to take down that which is old from the foundations, but from the roof. Thus doth the Lord begin to lay to His hand again, in that place whence last He hath lifted it then He beginneth with things lesser, that He may go on to things greater. Even men are able to deliver other men from evil spirits, albeit with the word of God to command the dead to rise again is for God's power alone. Perchance, also, this woman, the mother-in-law of Simon and Andrew, was a type of our nature, stricken down with the great fever of sin, and burning with unlawful lusts after diverse objects. Nor would I say that the passion which rageth in the mind is a lesser fire than that fever which burneth the body. Covetousness, and lust, and uncleanness, and vain desires, and strivings, and anger; these be our fevers.
+&teDeum
+
+[Ant 2]
+The charity of God * is poured forth in our hearts, by the Holy Ghost, who is given to us.
+
+[Ant 2] (rubrica cisterciensis)
+Ti, kteří mluví * novými jazyky, jsou Galilejci, a berou hady do ruky, alleluja.
+
+[Oratio]
+Našim myslím, prosíme, Pane, laskavě vlej Ducha svatého; neboť jeho moudrostí jsme stvořeni, a jeho prozřetelností vedeni.
+$Per Dominum eiusdem

--- a/web/www/horas/Bohemice/TemporaM/Pasc0-0.txt
+++ b/web/www/horas/Bohemice/TemporaM/Pasc0-0.txt
@@ -1,0 +1,68 @@
+[Ant Matutinum]
+I am who I am and my counsel is not with the ungodly, my will is in the law of God, alleluia.;;1
+;;2
+;;8
+;;15
+;;23
+;;27
+V. The Lord is risen from the sepulcher, alleluia.
+R. He, who hangeth on the tree, alleluia.
+The earth trembled and was still, when God arose to judgment, alleluia.;;29
+;;63
+;;65
+;;75
+;;87
+;;107
+V. The Lord is risen, indeed, alleluia.
+R. And hath appeared to Simon, alleluia.
+Be not affrighted; * you seek Jesus of Nazareth, who was crucified: he is risen, he is not here, alleluia.;;243;244;245
+V. The disciples therefore were glad, alleluia.
+R. When they saw the Lord, alleluia.
+
+[Lectio1]
+@Sancti/01-03::1-6 s/1-5/2-4/ s/1.*God forbid. /2 /s
+
+[Lectio5]
+Homily of St Gregory Nazianzus
+!2 
+The Passover of the Lord, the Passover, and again, in honour of the Holy Trinity, I say the Passover. This is to us the festival of all festivals and the celebration of all celebrations, not only among the feasts that pertain to men and are established upon earth, but even among those that belong to Christ himself, and are celebrated to His glory, for this feast outshines all others, even as the sun out shines the stars. Yesterday the Lamb was slain and the door posts anointed, while Egypt bewailed her first born, but the Angel of death has passed us by, (for the sign was even to him a thing of terror and awe,) for we were protected by the Precious Blood.
+
+[Lectio6]
+Today we leave Egypt utterly behind us, and Pharaoh our cruel master, and his harsh officers; for we are delivered from the clay and the making of bricks. Nor is there any to forbid us to to celebrate it not with the leaven of our former malice and wickedness, but with the unleavened bread of sincerity and truth, bringing with us nothing of the unholy leaven of Egypt. Yesterday I shared his death, today I am made alive again with him, today with him I arise.
+
+[Lectio7]
+But let us offer gifts to Him who suffered and rose for us.  Do you perhaps think that I speak of gold or silver, or tapestries, or glittering stones of great price, the transient and perishable materials of the world which remain things of earth, and which, for the most part, the wicked and the slaves of earthly goods and the princes of the world usually possess? Rather, let us offer ourselves, that is, the dearest and most pleasing riches to God.  Let us return the glory of our image to the One whose image we are; let us recognise our dignity; let us follow our Exemplar in honour; let us understand the power of this mystery, and for what Christ suffered death. Let us be as Christ, for Christ is also as we. Let us become gods for His sake, for He also was made man for us.
+
+[Lectio8]
+Christ took what was lower, in order that he might give us the higher. He became poor that by his poverty we might be made rich. He took upon him the form of a servant, to set us at liberty. He stooped that we may be exalted. He was tempted, that we might overcome. He was despised, that he might bring us to glory. He died, to bring us to salvation. He ascended on high, to draw unto himself those who were sunk in sin. Let a man give all things to him who gave himself for us as the price of redemption and as the substitute for our guilt. Nothing so great, however, can be given in return, as the offering of ourselves, if we rightly understand this mystery, and if we do for his sake, become all things, whatsoever he for our sakes became.
+
+[Lectio9]
+@Tempora/Pasc0-0:Lectio1:s/ Those women.*//s
+
+[Lectio10]
+@Tempora/Pasc0-0:Lectio1:s/.*Those women/Those women/s s/$/~/
+@Tempora/Pasc0-0:Lectio2:s/ Since.*//s
+
+[Lectio11]
+@Tempora/Pasc0-0:Lectio2:s/.*Since/Since/s
+
+[Versum 2]
+V. Toto je den, který učinil Pán. 
+R. Jásejme a radujme se v něm.
+
+[Capitulum Laudes]
+!1 Cor 5:7
+v. Bratři: Vyčištěte a vyhoďte starý kvas, abyste se mohli stát novým těstem, neboť jste nekvašení. Neboť Kristus náš velikonoční beránek je obětován.
+$Deo gratias
+
+[Capitulum Sexta]
+!1 Cor 5:8
+v. Proto hodujme, ne se starým kvasem, ani s kvasem zloby a nepravosti; ale s nekvašeným chlebem upřímnosti a pravdy.
+$Deo gratias
+
+[Capitulum Nona]
+!1 Col 3:1-2
+v. Když jste s Kristem byli vzkříšeni, usilujte o to, co pochází shůry, kde sedí Kristus po Boží pravici. Na to myslete, co pochází shůry, ne na to, co je na zemi.
+$Deo gratias
+
+

--- a/web/www/horas/Latin/Psalterium/Psalmi/Psalmi major.txt
+++ b/web/www/horas/Latin/Psalterium/Psalmi/Psalmi major.txt
@@ -388,6 +388,10 @@ In cýmbalis * benesonántibus laudáte Deum;;148;149;150
 @:DaymF Laudes:5 s/;;.*/;;50/ s/(.*)(\,.*);;/$1$2$2$2$2$2$2;;/m
 @:DaymF Laudes:2-5 s/.*;;/;;/gm s/99/117/
 
+[Cistercian Laudes] (tempore paschali)
+Allelúja, * allelúja, allelúja.;;50
+@:Monastic Laudes:2-5 s/.*;;/;;/gm
+
 [Daym6F Laudes]
 @:Monastic Laudes:1
 @:Monastic Laudes:2 s/$/(1-'7b')/

--- a/web/www/horas/Latin/Psalterium/Special/Major Special.txt
+++ b/web/www/horas/Latin/Psalterium/Special/Major Special.txt
@@ -1391,6 +1391,8 @@ $Deo gratias
 
 [Responsory Pasch Laudes]
 @Psalterium/Special/Minor Special:Responsory breve Pasch Tertia
+(sed rubrica cisterciensis)
+@Psalterium/Special/Minor Special:Responsory breve Pasch Sexta
 
 [Hymnus Pasch Laudes]
 {:H-Auroracoelum:}v. Auróra cælum púrpurat,
@@ -1474,6 +1476,8 @@ R. Quia Dóminus regnávit a ligno, allelúia.
 
 [Responsory Pasch Vespera]
 @Psalterium/Special/Minor Special:Responsory breve Pasch Sexta
+(sed rubrica cisterciensis)
+@Psalterium/Special/Minor Special:Responsory breve Pasch Tertia
 
 [Hymnus Pasch Vespera]
 {:H-Adregias:}v. Ad régias Agni dapes,

--- a/web/www/horas/Latin/Sancti/04-29.txt
+++ b/web/www/horas/Latin/Sancti/04-29.txt
@@ -3,6 +3,9 @@ S. Petri Martyris;;Duplex;;3;;vide C2
 (sed rubrica 1617)
 S. Petri Martyris;;Semiduplex;;2.2;;vide C2
 
+[Rank] (rubrica cisterciensis)
+S. Petri, Martyris;;iij. Lect. et M.;;1.2;;vide C2
+
 [Rule]
 vide C2;
 9 lectiones

--- a/web/www/horas/Latin/Tempora/Pasc0-0.txt
+++ b/web/www/horas/Latin/Tempora/Pasc0-0.txt
@@ -26,12 +26,18 @@ $Pater noster
 $Ave Maria
 _
 Ant. Allelúja, Allelúja, Allelúja.
+(sed rubrica cisterciensis)
+Ant. Allelúja, * Allelúja, Allelúja.
 &psalm(116)
 Ant. Allelúja, Allelúja, Allelúja.
 _
 Ant. Véspere autem sábbati quæ lucéscit in prima sábbati, venit María Magdaléne et áltera María vidére sepúlcrum, allelúja.
+(sed rubrica cisterciensis)
+Ant. Véspere autem Sábbati.
 &psalm(232)
 Ant. Véspere autem sábbati quæ lucéscit in prima sábbati, venit María Magdaléne et áltera María vidére sepúlcrum, allelúja.
+(sed rubrica cisterciensis)
+Ant. Véspere autem Sábbati, * quæ lucéscit in prima Sábbati, venit María Magdaléne, et áltera María vidére sepúlchrum, allelúia.
 
 &Dominus_vobiscum
 v. Orémus.
@@ -41,7 +47,7 @@ $Per Dominum eiusdem
 
 V. Benedicámus Dómino, allelúja, allelúja.
 R. Deo grátias, allelúja, allelúja.
-$Fidelium animae
+(nisi rubrica cisterciensis) $Fidelium animae
 $Pater noster
 
 [Invit]
@@ -98,6 +104,9 @@ Erat autem * aspéctus ejus sicut fulgur, vestiménta autem ejus sicut nix, alle
 Præ timóre autem ejus * extérriti sunt custódes, et facti sunt velut mórtui, allelúja.
 Respóndens autem Angelus, * dixit muliéribus: Nolíte timére: scio enim quod Jesum quǽritis, allelúja.
 
+[Ant Laudes] (rubrica cisterciensis)
+Allelúia, * allelúia, allelúia.
+
 [Versum 2]
 Ant. Hæc dies * quam fecit Dóminus: exsultémus et lætémur in ea.
 
@@ -109,6 +118,9 @@ Et valde mane * una sabbatórum véniunt ad monuméntum, orto jam sole, allelúj
 
 [Ant 3]
 Et respiciéntes * vidérunt revolútum lápidem: erat quippe magnus valde, allelúja.
+
+[Ant 3] (rubrica cisterciensis)
+Christus * resúrgens ex mórtuis, jam non móritur, mors illi ultra non dominábitur, quod enim vivit, vivit Deo, allelúia, allelúia.
 
 [Ant 41]
 Véspere autem sábbati * quæ lucéscit in prima sábbati, venit María Magdaléne, et áltera María, vidére sepúlcrum, allelúja.

--- a/web/www/horas/Latin/Tempora/Pasc0-1.txt
+++ b/web/www/horas/Latin/Tempora/Pasc0-1.txt
@@ -49,3 +49,9 @@ Jesus junxit se * discípulis suis in via, et ibat cum illis: óculi autem eóru
 
 [Ant 3]
 Qui sunt hi sermónes * quos confértis ad ínvicem ambulántes, et estis tristes? allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+Qui sunt hi sermónes * quos confértis ad ínvicem ambulántes, et estis tristes? allelúia, allelúia. Respóndens unus, cui nomen Cléophas, dixit ei: Tu solus peregrínus es in Jerúsalem, et non cognovísti quæ facta sunt in illa his diébus? allelúia. Quibus ille dixit: Quæ? Et dixérunt: De Jesu Nazaréno, qui fuit vir Prophéta, potens in ópere et sermóne coram Deo, et omni pópulo, allelúia, allelúia.
+
+[Ant 3] (rubrica cisterciensis)
+Nonne cor nostrum * ardens erat in nobis de Jesu, dum loquerétur nobis in via? allelúia.

--- a/web/www/horas/Latin/Tempora/Pasc0-2.txt
+++ b/web/www/horas/Latin/Tempora/Pasc0-2.txt
@@ -54,3 +54,6 @@ Stetit Jesus * in médio discipulórum suórum, et dixit eis: Pax vobis, allelú
 
 [Ant 3]
 Vidéte manus meas * et pedes meos, quia ego ipse sum, allelúja, allelúja.
+
+[Ant 3] (rubrica cisterciensis)
+Obtulérunt * discípuli Dómino partem piscis assi, et favum mellis, allelúia, allelúia.

--- a/web/www/horas/Latin/Tempora/Pasc0-3.txt
+++ b/web/www/horas/Latin/Tempora/Pasc0-3.txt
@@ -1,6 +1,9 @@
 [Rank]
 Die IV infra octavam Paschæ;;Semiduplex I classis;;6.9;;ex Pasc0-0
 
+[Rank] (rubrica cisterciensis)
+Die IV infra octavam Paschæ;;Semiduplex I classis;;5.9;;ex Pasc0-0
+
 [Rule]
 ex Pasc0-0;
 1 nocturn;
@@ -53,3 +56,6 @@ Míttite in déxteram * navígii rete, et inveniétis, allelúja.
 
 [Ant 3]
 Dixit Jesus * discípulis suis: Afférte de píscibus, quos prendidístis nunc. Ascéndit autem Simon Petrus, et traxit rete in terram plenum magnis píscibus, allelúja.
+
+[Ant 3] (rubrica cisterciensis)
+Hoc jam tértio * manifestávit se Jesus, postquam resurréxit a mórtuis, allelúia.

--- a/web/www/horas/Latin/Tempora/Pasc0-4.txt
+++ b/web/www/horas/Latin/Tempora/Pasc0-4.txt
@@ -1,6 +1,9 @@
 [Rank]
 Die V infra octavam Paschæ;;Semiduplex I classis;;6.9;;ex Pasc0-0
 
+[Rank] (rubrica cisterciensis)
+Die V infra octavam Paschæ;;Semiduplex I classis;;5.9;;ex Pasc0-0
+
 [Rule]
 ex Pasc0-0;
 1 nocturn;

--- a/web/www/horas/Latin/Tempora/Pasc0-5.txt
+++ b/web/www/horas/Latin/Tempora/Pasc0-5.txt
@@ -1,6 +1,9 @@
 [Rank]
 Die VI infra octavam Paschæ;;Semiduplex I class;;6.9;;ex Pasc0-0
 
+[Rank] (rubrica cisterciensis)
+Die VI infra octavam Paschæ;;Semiduplex I class;;5.9;;ex Pasc0-0
+
 [Rule]
 ex Pasc0-0;
 1 nocturn;

--- a/web/www/horas/Latin/Tempora/Pasc0-6.txt
+++ b/web/www/horas/Latin/Tempora/Pasc0-6.txt
@@ -1,6 +1,9 @@
 [Rank]
 Sabbato in Albis;;Semiduplex I class;;6.9;;ex Pasc0-0
 
+[Rank] (rubrica cisterciensis)
+Sabbato in Albis;;Semiduplex I class;;5.9;;ex Pasc0-0
+
 [Rule]
 ex Pasc0-0;
 1 nocturn;

--- a/web/www/horas/Latin/Tempora/Pasc1-0.txt
+++ b/web/www/horas/Latin/Tempora/Pasc1-0.txt
@@ -120,3 +120,9 @@ $Deo gratias
 
 [Ant 3]
 Post dies octo * jánuis clausis ingréssus Dóminus dixit eis: Pax vobis, allelúja, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+Post dies octo * jánuis clausis ingréssus Dóminus dixit eis: Pax vobis, allelúia, allelúia.
+
+[Ant 3] (rubrica cisterciensis)
+Multa quidem * et ália signa fecit Jesus in conspéctu discipulórum suórum, allelúia, quæ non sunt scripta in libro hoc, allelúia.

--- a/web/www/horas/Latin/Tempora/Pasc1-1.txt
+++ b/web/www/horas/Latin/Tempora/Pasc1-1.txt
@@ -55,4 +55,7 @@ Incipit liber Actuum Apostolórum
 Surgens Jesus * mane prima sábbati, appáruit primo Maríæ Magdalénæ, de qua ejécerat septem dæmónia, allelúja.
 
 [Ant 3]
-Pax vobis, * ego sum, allelúja: nolíte timére, allelúja. 
+Pax vobis, * ego sum, allelúja: nolíte timére, allelúja.
+
+[Ant 3] (rubrica cisterciensis)
+Jesum quem quæritis crucifíxum, * non est hic, sed surréxit: recordámini quáliter locútus sit vobis, dum adhuc in Galilæa esset, allelúia.

--- a/web/www/horas/Latin/Tempora/Pasc1-2.txt
+++ b/web/www/horas/Latin/Tempora/Pasc1-2.txt
@@ -52,3 +52,9 @@ Præcédam vos * in Galilǽam, ibi me vidébitis, sicut dixi vobis, allelúja, a
 
 [Ant 3]
 Mitte manum tuam, * et cognósce loca clavórum, allelúja: et noli esse incrédulus, sed fidélis, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+In Galilæa * Jesum vidébitis, sicut dixi vobis, allelúia.
+
+[Ant 3] (rubrica cisterciensis)
+Surréxit enim, * sicut dixit Dóminus, et præcédet vos in Galilæam, allelúia: ibi eum vidébitis, allelúia, allelúia, allelúia.

--- a/web/www/horas/Latin/Tempora/Pasc1-3.txt
+++ b/web/www/horas/Latin/Tempora/Pasc1-3.txt
@@ -46,3 +46,9 @@ Ego sum vitis vera, * allelúja: et vos pálmites veri, allelúja.
 
 [Ant 3]
 Quia vidísti me, * Thoma, credidísti: beáti qui non vidérunt, et credidérunt, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+Surréxit * Dóminus de sepúlchro, qui pro nobis pepéndit in ligno, allelúia, allelúia, allelúia.
+
+[Ant 3] (rubrica cisterciensis)
+Angelus autem Dómini, * descéndit de cœlo, et accédens revólvit lápidem, et sedébat super eum, allelúia, allelúia.

--- a/web/www/horas/Latin/Tempora/Pasc1-4.txt
+++ b/web/www/horas/Latin/Tempora/Pasc1-4.txt
@@ -46,3 +46,9 @@ Ardens est cor meum, * desídero vidére Dóminum meum: quæro, et non invénio,
 
 [Ant 3]
 Misi dígitum meum * in fixúras clavórum, et manum meam in latus ejus, et dixi: Dóminus meus, et Deus meus, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+Erat autem * aspéctus ejus sicut fulgur, vertiménta ejus sicut nix, allelúia, allelúia.
+
+[Ant 3] (rubrica cisterciensis)
+Præ timóre autem ejus * exterríti sunt custódes, et facti sunt velut mórtui, allelúia.

--- a/web/www/horas/Latin/Tempora/Pasc1-5.txt
+++ b/web/www/horas/Latin/Tempora/Pasc1-5.txt
@@ -50,3 +50,6 @@ Venérunt ad monuméntum * María Magdaléne, et áltera María, vidére sepúlc
 
 [Ant 3] (rubrica 1960)
 @Tempora/Pasc1-0:Ant 3
+
+[Ant 2] (rubrica cisterciensis)
+Et respícientes * vidérunt revolútum lápidem: erat quippe magnus valde, allelúia.

--- a/web/www/horas/Latin/Tempora/Pasc2-0.txt
+++ b/web/www/horas/Latin/Tempora/Pasc2-0.txt
@@ -104,7 +104,7 @@ $Deo gratias
 
 [Capitulum Sexta]
 !1 Pet 2:23-24
-v. Tradébat autem judicánti se iniúste: qui peccáta nostra ipse pértulit in córpore suo super lignum: ut peccátis mórtui, justítiæ vivámus: cujus livóre sanáti sumus.
+v. Tradébat autem judicánti se injúste: qui peccáta nostra ipse pértulit in córpore suo super lignum: ut peccátis mórtui, justítiæ vivámus: cujus livóre sanáti sumus.
 $Deo gratias
 
 [Capitulum Nona]
@@ -114,3 +114,12 @@ $Deo gratias
 
 [Ant 3]
 Ego sum pastor bonus, * qui pasco oves meas, et pro óvibus meis pono ánimam meam, allelúja.
+
+[Ant 1] (rubrica cisterciensis)
+Hæc autem scripta sunt, * ut credátis quia Jesus est Christus Fílius Dei, et ut credéntes vitam habeátis in nómine ipsíus, allelúia.
+
+[Ant 2] (rubrica cisterciensis)
+Ego sum * pastor bonus, qui pasco oves meas, et pro óvibus meis pono ánimam meam, allelúia.
+
+[Ant 3] (rubrica cisterciensis)
+Ego sum * pastor óvium: ego sum via, véritas, et vita: ego sum pastor bonus, et cognósco oves meas, et cognóscunt me meæ, allelúja, allelúja.

--- a/web/www/horas/Latin/Tempora/Pasc2-1.txt
+++ b/web/www/horas/Latin/Tempora/Pasc2-1.txt
@@ -55,3 +55,9 @@ Eúntes in mundum, * allelúja: docéte omnes gentes, allelúja.
 
 [Ant 3]
 Pastor bonus * ánimam suam ponit pro óvibus suis, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-1
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-1

--- a/web/www/horas/Latin/Tempora/Pasc2-2.txt
+++ b/web/www/horas/Latin/Tempora/Pasc2-2.txt
@@ -47,3 +47,9 @@ Eúntes in mundum, * docéte omnes gentes, baptizántes eos in nómine Patris, e
 
 [Ant 3]
 Mercenárius autem, * cujus non sunt oves própriæ, videt lupum veniéntem, et dimíttit oves, et fugit, et lupus rapit, et dispérgit oves, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-2
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-2

--- a/web/www/horas/Latin/Tempora/Pasc2-3.txt
+++ b/web/www/horas/Latin/Tempora/Pasc2-3.txt
@@ -18,6 +18,12 @@ Ascéndit autem * Joseph a Galilǽa de civitáte Názareth in Judǽam, in civit�
 Et venérunt festinántes, * et invenérunt Maríam, et Joseph, et Infántem pósitum in præsépio, allelúja.
 Et ipse Jesus * erat incípiens quasi annórum trigínta, ut putabátur, fílius Joseph, allelúja.
 
+[Ant Vespera] (rubrica cisterciensis)
+Allelúia, * allelúia, allelúia.
+
+[Responsory Vespera 1] (rubrica cisterciensis)
+@Sancti/03-19
+
 [Hymnus Vespera]
 @Sancti/03-19:Hymnus Vespera
 
@@ -51,6 +57,18 @@ R. Et pérfice eam, allelúja.
 Consúrgens Joseph, * accépit Púerum et Matrem ejus, et venit in terram Israël: et habitávit in civitáte quæ vocátur Názareth, allelúja;;14
 ;;20
 ;;23
+V. Invocávi Dóminum, Patrem Dómini mei, allelúja.
+R. Ut non derelínquat me in die tribulatiónis, allelúja.
+
+[Nocturn 1 Versum]
+V. Confitébor nómini tuo, allelúja.
+R. Quóniam adjútor et protéctor factus es mihi, allelúja.
+
+[Nocturn 2 Versum]
+V. Réspice de cælo, et vide, et vísita víneam istam, allelúja.
+R. Et pérfice eam, allelúja.
+
+[Nocturn 3 Versum]
 V. Invocávi Dóminum, Patrem Dómini mei, allelúja.
 R. Ut non derelínquat me in die tribulatiónis, allelúja.
 
@@ -172,8 +190,14 @@ Quamquam si étiam Lucas génitum díceret Joseph ab Heli, nec sic nos hoc verbu
 v. Benedictiónes patris tui confortátæ sunt benedictiónibus patrum ejus, donec veníret Desidérium cóllium æternórum: fiant in cápite Joseph, et in vértice Nazarǽi inter fratres suos.
 $Deo gratias
 
+[Responsory Laudes] (rubrica cisterciensis)
+@:Responsory Tertia
+
 [Hymnus Laudes]
 @Sancti/03-19:Hymnus Matutinum
+
+[Hymnus Laudes] (rubrica cisterciensis)
+@Sancti/03-19
 
 [Versum 2]
 V. Dedísti mihi protectiónem salútis tuæ, allelúja.
@@ -228,9 +252,15 @@ _
 V. Plantátus in domo Dómini, allelúja.
 R. In átriis domus Dei nostri, allelúja.
 
+[Responsory Vespera] (rubrica cisterciensis)
+@:Responsory Sexta
+
 [Versum 3]
 V. Sub umbra illíus, quem desideráveram, sedi, allelúja.
 R. Et fructus ejus dulcis gútturi meo, allelúja.
+
+[Versum 3] (rubrica cisterciensis)
+@:Versum 1
 
 [Ant 3]
 Fili, quid fecísti * nobis sic? Ecce pater tuus et ego doléntes quærebámus te, allelúja.

--- a/web/www/horas/Latin/Tempora/Pasc2-4Feria.txt
+++ b/web/www/horas/Latin/Tempora/Pasc2-4Feria.txt
@@ -29,3 +29,9 @@ Tu solus peregrínus es, * et non audísti de Jesu, quómodo tradidérunt eum in
 
 [Ant 3]
 Alias oves hábeo, * quæ non sunt ex hoc ovíli: et illas opórtet me addúcere, et vocem meam áudient: et fiet unum ovíle, et unus pastor, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-4
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-4

--- a/web/www/horas/Latin/Tempora/Pasc2-5Feria.txt
+++ b/web/www/horas/Latin/Tempora/Pasc2-5Feria.txt
@@ -32,3 +32,6 @@ Nonne sic opórtuit * pati Christum, et ita intráre in glóriam suam? allelúja
 
 [Ant 3] (rubrica 1960)
 @Tempora/Pasc2-0:Ant 3
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-5

--- a/web/www/horas/Latin/Tempora/Pasc3-0.txt
+++ b/web/www/horas/Latin/Tempora/Pasc3-0.txt
@@ -148,3 +148,7 @@ $Deo gratias
 
 [Ant 3]
 Amen dico vobis, * quia plorábitis et flébitis vos: mundus autem gaudébit, vos vero contristabímini, sed tristítia vestra convertétur in gáudium, allelúja.
+
+[Ant 1 Cist] 
+Alias oves hábeo, * quæ non sunt ex hoc ovíli: et illas opórtet me addúcere, et vocem meam áudient, et fiet unum ovíle, et unus pastor, allelúia.
+

--- a/web/www/horas/Latin/Tempora/Pasc3-0r.txt
+++ b/web/www/horas/Latin/Tempora/Pasc3-0r.txt
@@ -11,6 +11,8 @@ Una Antiphona
 
 [Ant 1]
 @Tempora/Pasc3-0:Ant 1
+(sed rubrica cisterciensis)
+@Tempora/Pasc3-0:Ant 1 Cist
 
 [Oratio]
 @Tempora/Pasc3-0:Oratio
@@ -71,6 +73,8 @@ Una Antiphona
 
 [Ant 2]
 @:Ant 1
+(sed rubrica cisterciensis)
+@Tempora/Pasc3-0:Ant 1
 
 [Capitulum Sexta]
 @Tempora/Pasc3-0:Capitulum Sexta
@@ -80,3 +84,5 @@ Una Antiphona
 
 [Ant 3]
 @Tempora/Pasc3-0:Ant 3
+(sed rubrica cisterciensis)
+@Tempora/Pasc3-0:Ant 3:s/^Amen/Amen, amen/

--- a/web/www/horas/Latin/Tempora/Pasc3-1Feria.txt
+++ b/web/www/horas/Latin/Tempora/Pasc3-1Feria.txt
@@ -34,3 +34,9 @@ Tristítia vestra * vertétur in gáudium, allelúja: et gáudium vestrum nemo t
 
 [Oratio 3]
 @Tempora/Pasc3-0:Oratio
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-1
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-1

--- a/web/www/horas/Latin/Tempora/Pasc3-2Feria.txt
+++ b/web/www/horas/Latin/Tempora/Pasc3-2Feria.txt
@@ -28,3 +28,9 @@ Tristítia implévit * cor vestrum: et gáudium vestrum nemo tollet a vobis, all
 
 [Ant 2]
 Et coëgérunt illum, * dicéntes: Mane nobíscum, Dómine, quóniam advesperáscit, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-2
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-2

--- a/web/www/horas/Latin/Tempora/Pasc3-3Feria.txt
+++ b/web/www/horas/Latin/Tempora/Pasc3-3Feria.txt
@@ -34,3 +34,9 @@ Tristítia vestra * allelúja, vertétur in gáudium, allelúja.
 
 [Oratio 3]
 @Tempora/Pasc3-0:Oratio
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-3
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-3

--- a/web/www/horas/Latin/Tempora/Pasc3-4.txt
+++ b/web/www/horas/Latin/Tempora/Pasc3-4.txt
@@ -51,3 +51,9 @@ Amen, amen dico vobis, * íterum vidébo vos, et gaudébit cor vestrum, et gáud
 
 [Oratio 3]
 @Tempora/Pasc3-0:Oratio
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-4
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-4

--- a/web/www/horas/Latin/Tempora/Pasc3-5.txt
+++ b/web/www/horas/Latin/Tempora/Pasc3-5.txt
@@ -51,3 +51,6 @@ Cognovérunt * Dóminum Jesum, allelúja, in fractióne panis, allelúja.
 
 [Ant 3] (rubrica 1960)
 @Tempora/Pasc3-0
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-5

--- a/web/www/horas/Latin/Tempora/Pasc4-0.txt
+++ b/web/www/horas/Latin/Tempora/Pasc4-0.txt
@@ -141,3 +141,12 @@ $Deo gratias
 
 [Ant 3]
 Vado ad eum * qui misit me: sed quia hæc locútus sum vobis, tristítia implévit cor vestrum, allelúja.
+
+[Ant 1] (rubrica cisterciensis)
+Iterum autem * vidébo vos, et gaudébit cor vestrum, allelúia, et gáudium vestrum nemo tollet a vobis, allelúia.
+
+[Ant 2] (rubrica cisterciensis)
+Vado ad eum * qui misit me: sed quia hæc locútus sum vobis, tristítia implévit cor vestrum, allelúia.
+
+[Ant 3] (rubrica cisterciensis)
+Adhuc multa hábeo * vobis dícere, sed non potéstis portáre modo: cum autem vénerit ille Spíritus veritátis, docébit vos omnem veritátem, allelúia.

--- a/web/www/horas/Latin/Tempora/Pasc4-1.txt
+++ b/web/www/horas/Latin/Tempora/Pasc4-1.txt
@@ -49,3 +49,9 @@ Nonne cor nostrum * ardens erat in nobis de Jesu, dum loquerétur nobis in via? 
 
 [Ant 3]
 Ego veritátem dico * vobis: éxpedit vobis ut ego vadam: si enim non abíero, Paráclitus non véniet ad vos, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-1
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-1

--- a/web/www/horas/Latin/Tempora/Pasc4-2.txt
+++ b/web/www/horas/Latin/Tempora/Pasc4-2.txt
@@ -45,3 +45,9 @@ Pax vobis, * ego sum, allelúja: nolíte timére, allelúja.
 
 [Ant 3]
 Cum vénerit * Paráclitus Spíritus veritátis, ille árguet mundum de peccáto, et de justítia, et de judício, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-2
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-2

--- a/web/www/horas/Latin/Tempora/Pasc4-3.txt
+++ b/web/www/horas/Latin/Tempora/Pasc4-3.txt
@@ -45,3 +45,9 @@ Spíritus * carnem et ossa non habet, sicut me vidétis habére: jam crédite, a
 
 [Ant 3]
 Adhuc multa hábeo * vobis dícere, sed non potéstis portáre modo: cum autem vénerit ille Spíritus veritátis, docébit vos omnem veritátem, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-3
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-3

--- a/web/www/horas/Latin/Tempora/Pasc4-4.txt
+++ b/web/www/horas/Latin/Tempora/Pasc4-4.txt
@@ -43,3 +43,9 @@ Obtulérunt discípuli * Dómino partem piscis assi, et favum mellis, allelúja,
 
 [Ant 3]
 Non enim loquétur * a semetípso: sed quæcúmque áudiet, loquétur: et quæ ventúra sunt, annuntiábit vobis, allelúja.
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-4
+
+[Ant 3] (rubrica cisterciensis)
+@Tempora/Pasc1-4

--- a/web/www/horas/Latin/Tempora/Pasc4-5.txt
+++ b/web/www/horas/Latin/Tempora/Pasc4-5.txt
@@ -50,3 +50,6 @@ Isti sunt sermónes, * quos dicébam vobis, cum essem vobíscum, allelúja, alle
 
 [Ant 3] (rubrica 1960)
 @Tempora/Pasc4-0:Ant 3
+
+[Ant 2] (rubrica cisterciensis)
+@Tempora/Pasc1-5

--- a/web/www/horas/Latin/Tempora/Pasc5-0.txt
+++ b/web/www/horas/Latin/Tempora/Pasc5-0.txt
@@ -114,3 +114,9 @@ $Deo gratias
 
 [Ant 3]
 Pétite, et accipiétis, * ut gáudium vestrum sit plenum: ipse enim Pater amat vos, quia vos me amástis, et credidístis, allelúja.
+
+[Ant 1] (rubrica cisterciensis)
+Ille me clarificábit, * quia de meo accípiet, et annuntiábit vobis, allelúia.
+
+[Ant 2] (rubrica cisterciensis)
+Usque modo * non petístis quidquam in nómine meo: pétite, et accipiétis, allelúja.

--- a/web/www/horas/Latin/TemporaM/Pasc0-3.txt
+++ b/web/www/horas/Latin/TemporaM/Pasc0-3.txt
@@ -3,6 +3,8 @@
 [Rule]
 ex Pasc0-0
 Psalmi Dominica
+(sed rubrica cisterciensis)
+Psalmi Feria
 
 [Responsory3]
 @Tempora/Pasc0-6:Responsory1

--- a/web/www/horas/Latin/TemporaM/Pasc0-4.txt
+++ b/web/www/horas/Latin/TemporaM/Pasc0-4.txt
@@ -3,6 +3,8 @@
 [Rule]
 ex Pasc0-0
 Psalmi Dominica
+(sed rubrica cisterciensis)
+Psalmi Feria
 
 [Responsory3]
 @Tempora/Pasc0-6:Responsory2

--- a/web/www/horas/Latin/TemporaM/Pasc0-5.txt
+++ b/web/www/horas/Latin/TemporaM/Pasc0-5.txt
@@ -3,6 +3,8 @@
 [Rule]
 ex Pasc0-0
 Psalmi Dominica
+(sed rubrica cisterciensis)
+Psalmi Feria
 
 [Responsory3]
 @Tempora/Pasc1-0:Responsory2

--- a/web/www/horas/Latin/TemporaM/Pasc0-6.txt
+++ b/web/www/horas/Latin/TemporaM/Pasc0-6.txt
@@ -3,6 +3,8 @@
 [Rule]
 ex Pasc0-0
 Psalmi Dominica
+(sed rubrica cisterciensis)
+Psalmi Feria
 
 [Responsory3]
 @Tempora/Pasc0-0:Responsory2

--- a/web/www/horas/Latin/TemporaM/Pasc2-3.txt
+++ b/web/www/horas/Latin/TemporaM/Pasc2-3.txt
@@ -9,7 +9,7 @@ Antiphonas horas
 12 lectiones
 Psalmi Dominica
 
-[Versum 1]
+[Versum 1] (nisi rubrica cisterciensis)
 @Tempora/Pasc2-3:Responsory Tertia:s/.*_.//s
 
 [Ant Matutinum]
@@ -91,11 +91,12 @@ Psalmi Dominica
 [LectioE]
 @Tempora/Pasc2-3
 
-[Responsory TertiaM]
+[Responsory TertiaM] (nisi rubrica cisterciensis)
 @Tempora/Pasc2-3:Responsory Tertia:s/.*_.//s
 
-[Responsory SextaM]
+[Responsory SextaM] (nisi rubrica cisterciensis)
 @Tempora/Pasc2-3:Responsory Sexta:s/.*_.//s
 
-[Responsory NonaM]
+[Responsory NonaM] (nisi rubrica cisterciensis)
 @Tempora/Pasc2-3:Responsory Nona:s/.*_.//s
+

--- a/web/www/horas/Latin/TemporaM/Quad6-6.txt
+++ b/web/www/horas/Latin/TemporaM/Quad6-6.txt
@@ -3,6 +3,9 @@
 [Rank]
 Sabbato Sancto;;Feria privilegiata Duplex I classis;;7.1
 
+[Rank] (rubrica cisterciensis)
+Sabbato Sancto;;Feria privilegiata Duplex I classis;;6
+
 [Rule]
 Matutinum Romanum
 Omit Incipit Invitatorium Hymnus Capitulum Lectio Commemoratio Preces Suffragium Conclusion Martyrologium De Officium Capituli


### PR DESCRIPTION
- Updated Cistercian version Tempora up till Dominica V. post Pascha
- Updated Czech translation
- Updated postprocessing of Responsoria prolixa in Eastertide, so that `postprocess_short_resp() `doesn't add second Alleluia after the Verse.
- Added (working) rule `Psalmi Feria(les)` for cases like Easter Octave on Wednesday and further, that needs the Ferial Psalms in the Cistercian Rite