### PR TITLE
Resolve #4387 and restore a few accents

### DIFF
--- a/web/cgi-bin/DivinumOfficium/SetupString.pl
+++ b/web/cgi-bin/DivinumOfficium/SetupString.pl
@@ -579,6 +579,7 @@ sub setupstring($$%) {
       } elsif (exists(${$new_sections}{Officium})) {
         my @newrank = split(';;', ${$new_sections}{Rank});
         $newrank[0] = ${$new_sections}{Officium};
+        $newrank[0] =~ s/\s+$//;
         ${$new_sections}{Rank} = join(';;', @newrank);
       }
 

--- a/web/www/horas/Latin/Commune/C5.txt
+++ b/web/www/horas/Latin/Commune/C5.txt
@@ -22,7 +22,7 @@ Serve bone * et fidélis, intra in gáudium Dómini tui.
 Similábo eum * viro sapiénti, qui ædificávit domum suam supra petram.
 
 [Oratio]
-Deus, qui nos beati N. Confessoris tui annua solemnitate lætificas: concede propitius; ut, cuius natalitia colimus, etiam actiones imitemur.
+Deus, qui nos beati N. Confessóris tui ánnua solemnitáte lætíficas: concéde propítius; ut cuius natalítia cólimus, étiam actiónes imitémur.
 $Per Dominum.
 
 [Nocturn 2 Versum]


### PR DESCRIPTION
Fixes: Removes trailing newlines from the Officium hash and restores accented characters in the C5 oratio.

I'll prepare another PR in a day or two to restore more accents lost in the merge of horas and missa.