### PR TITLE
Fix hymn at Laudes for St. Raphael

### DIFF
--- a/web/www/horas/Latin/Sancti/10-24.txt
+++ b/web/www/horas/Latin/Sancti/10-24.txt
@@ -205,7 +205,7 @@ v. Quando orábas cum lácrimis, et sepeliébas mórtuos, et derelinquébas prá
 $Deo gratias
 
 [Hymnus Laudes]
-@Sancti/03-24::s/Robor Dei qui denotas:/Dei medélam dénotans:/ s/Vires adauge languidis,/Morbos repélle córporum,/ s/Confer levamen tristibus./Affer salútem méntibus./
+@Sancti/03-24::s/Robor Dei qui dénotas:/Dei medélam dénotans:/ s/Vires adáuge lánguidis,/Morbos repélle córporum,/ s/Confer levámen trístibus./Affer salútem méntibus./
 
 [Versum 2]
 @Sancti/05-08:Versum 3


### PR DESCRIPTION
Adding accents to the hymn at Laudes for St. Gabriel caused the substitution in the 10-24 file to fail. This PR adds accents to the substitution regexes so they will match.