### PR TITLE
docker-compose.yml: Set private SELinux re-labeling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       context: ./
       dockerfile: Dockerfile
     volumes:
-      - ./web:/var/www/web
+      - ./web:/var/www/web:Z
     ports:
       - 8080:80


### PR DESCRIPTION
On systems with SELinux enabled, it is required to set correct labels on the mounted directories. Otherwise, the container does not have access to the directory. This results in the "(13)Permission denied" errors from the Apache server.

Set the SELinux private re-labeling option on the mounted directory to fix the issue.

The SELinux re-labeling option is ignored on platforms without SELinux, so it should not break already existing setups.

Tested on Fedora 41 with podman 5.4.2.

[1] https://docs.docker.com/reference/compose-file/services/#short-syntax-5