### PR TITLE
For issue #4443

### DIFF
--- a/web/www/horas/Bohemice/Tempora/Pasc6-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pasc6-0.txt
@@ -4,12 +4,6 @@ Dominica infra Octavam Ascensionis
 [Officium] (rubrica 196 aut rubrica 1955)
 Dominica post Ascensionem
 
-[Rule]
-vide Tempora/Pasc5-4;
-9 lectiones
-Doxology=Asc
-StJamesRule=John,Rev
-
 [Ant 1]
 Až přijde * Utěšitel, kterého vám sešlu, co Ducha pravdy, který z Otce vychází, on bude vydávat svědectví o mě, alleluja.
 

--- a/web/www/horas/Bohemice/TemporaM/Pasc6-0.txt
+++ b/web/www/horas/Bohemice/TemporaM/Pasc6-0.txt
@@ -1,2 +1,0 @@
-[Officium]
-Dominica infra Octavam Ascensionis

--- a/web/www/horas/Espanol/TemporaM/Pasc6-0.txt
+++ b/web/www/horas/Espanol/TemporaM/Pasc6-0.txt
@@ -1,2 +1,0 @@
-[Officium]
-Dominica infra Octavam Ascensionis

--- a/web/www/horas/Francais/TemporaM/Pasc6-0.txt
+++ b/web/www/horas/Francais/TemporaM/Pasc6-0.txt
@@ -1,2 +1,0 @@
-[Officium]
-Dominica infra Octavam Ascensionis

--- a/web/www/horas/Italiano/TemporaM/Pasc6-0.txt
+++ b/web/www/horas/Italiano/TemporaM/Pasc6-0.txt
@@ -1,2 +1,0 @@
-[Officium]
-Dominica infra Octavam Ascensionis

--- a/web/www/horas/Magyar/TemporaM/Pasc6-0.txt
+++ b/web/www/horas/Magyar/TemporaM/Pasc6-0.txt
@@ -1,2 +1,0 @@
-[Officium]
-Dominica infra Octavam Ascensionis

--- a/web/www/horas/Nederlands/TemporaM/Pasc6-0.txt
+++ b/web/www/horas/Nederlands/TemporaM/Pasc6-0.txt
@@ -1,2 +1,0 @@
-[Officium]
-Dominica infra Octavam Ascensionis

--- a/web/www/horas/Polski/TemporaM/Pasc6-0.txt
+++ b/web/www/horas/Polski/TemporaM/Pasc6-0.txt
@@ -1,2 +1,0 @@
-[Officium]
-Niedziela w Oktawie Wniebowstąpienia


### PR DESCRIPTION
close #4443

@Augustinus-Altovadensis 
Apparently, since in Latin, `Officium` and `Rank` is only defined in Tempora/Pasc6-0 but not TemporaM/Pasc6-0 there must not be a `Officium` hash in the vernacular versions of TemporaM/Pasc6-0. In Tempora/Pasc6-0 it is fine.