### PR TITLE
Addressed further issues from discussion #4514 + added lessons to St. Wenceslaus

### DIFF
--- a/web/cgi-bin/horas/monastic.pl
+++ b/web/cgi-bin/horas/monastic.pl
@@ -417,18 +417,19 @@ sub lectioE {
     @e = split("\n", $com{Evangelium});
   }
 
-  if ($e[0] =~ s/^@//) {
+  if ($version =~ /Please keep it here for now/ && $e[0] =~ s/^@//) {
 
     # if the Evangelium is just a cross-reference
     my ($w, $s) = split(/:/, $e[0]);
 
     if ($w) {$w .= '.txt';} 
 
+    if (!$ref{$s}) {$s =~ s/(?:LectioE)?/Evangelium/;}
     my %ref = %{setupstring($lang, $w)};
     @e = split("\n", $ref{$s});
   }
 
-  if (!$e[0]) {
+  if (!$e[0] || $e[0] =~ s/^@//) {
 
     # if the Evangelium is missing in the Sanctoral 
     my ($w, $s) = split(/:/, $e[0]);

--- a/web/www/horas/Bohemice/SanctiM/09-28AV.txt
+++ b/web/www/horas/Bohemice/SanctiM/09-28AV.txt
@@ -3,3 +3,33 @@ Sv. Václava, Knížete, Mučedníka a hlavního Patrona Království Českého;
 
 [Name]
 Václava
+
+[Lectio5]
+@Sancti/09-28:Lectio4:s/Ti byli totiž.*//
+
+[Lectio6]
+@Sancti/09-28:Lectio4:s/.*Ti byli totiž/Ti byli totiž/ s/$/~/
+@Sancti/09-28:Lectio5:s/Tento Vládce.*//
+
+[Lectio7]
+@Sancti/09-28:Lectio5:s/.*Tento Vládce/Tento Vládce/ s/$/~/
+@Sancti/09-28:Lectio6:s/Když přišel do.*//
+
+[Lectio8]
+@Sancti/09-28:Lectio6:s/.*Když přišel do/Když přišel do/
+
+[Lectio9]
+Čtení svatého Evangelia podle Matouše. 
+!Mat. 16.
+Za onoho času řekl Ježíš svým učedníkům: „Pokud někdo chce jít za mnou, ať zapře sám sebe, vezme svůj kříž a následuje mne.“ A ostatní. 
+_
+Homilie Svatého Řehoře Papeže.
+Kříž se dá nésti dvěma způsoby, buď zdrženlivostí sužujeme své tělo, nebo soucitem s bližním sužujeme svého ducha. Pomysleme na to, jak Pavel oběma způsoby nesl svůj kříž, neboť pravil: „Trestám své tělo a podrobuji si je, abych snad přesto, že jsem jiným kázal, sám nebyl zavržen.“	
+[Lectio10]
+Hle, slyšeli jsme, že tělesný kříž slouží k sužování těla, poslyšme nyní, jak soucitem s bližním neseme kříž ve své mysli. Apoštol totiž praví: „Kdo je slabý, abych já nebyl slabý spolu s ním? Propadá snad kdo pokušení, abych já se tím také netrápil?“ Je totiž dokonalým Kazatelem, a aby nám dal příklad zdrženlivosti, na svém vlastním těle nesl kříž. Protože na sobě nesl tresty za slabost jiných, svůj kříž nesl v srdci.	
+
+[Lectio11]
+Avšak proto, že těmto ctnostem jsou blízké i některé neřesti, měli bychom si říct: jaká neřest doprovází zdrženlivost těla a jaká soucit duše? Zdrženlivosti těla je totiž často blízká marnivá sláva, která ji doprovází. Neboť když vidíme tělesnou slabost a pohlédneme na bledou tvář, chceme hned pochválit zjevnou ctnost, a tím dříve zazní chvála, čím dříve se lidským očím ukáže půst díky bledému zjevu. 	
+
+[Lectio12]
+Soucit duše pak často provází falešná zbožnost, kterou různé neřesti často dovedou až k pohrdání. Vůči vinám nesmí nikdo cvičit svůj soucit, nýbrž zápal. Soucit sice náleží člověku, avšak neřesti je nutné napravovat. Abychom totiž v jednom a tomtéž člověku milovali dobro, které se stalo, musíme pronásledovat zlé skutky, které učinil. To proto, aby­chom, zatímco lehkomyslně odpouštíme viny, nebyli jati pouze láskou, ale také aby se nezdálo, že z nedbalosti někým pohrdáme.

--- a/web/www/horas/Latin/SanctiM/09-28AV.txt
+++ b/web/www/horas/Latin/SanctiM/09-28AV.txt
@@ -1,4 +1,5 @@
 @Sancti/09-28
+
 [Rank]
 S. Wenceslai, Ducis, Martyris et Patroni Principalis Regni Bohemiæ;;MM. maj.;;4;;ex C2
 
@@ -14,5 +15,33 @@ Lectio=Wenceslái
 [Oratio]
 @Sancti/09-28
 
-[LectioE]
-@Commune/C2:Evangelium
+[Lectio5]
+@Sancti/09-28:Lectio4:s/\; quare,.*/./
+
+[Lectio6]
+@Sancti/09-28:Lectio4:s/.*quare, tyránnici/Quare tyránnici/ s/$/~/
+@Sancti/09-28:Lectio5:s/Miti ánimo.*//
+
+[Lectio7]
+@Sancti/09-28:Lectio5:s/.*Miti ánimo/Miti ánimo/ s/$/~/
+@Sancti/09-28:Lectio6:s/Cum in Germániam.*//
+
+[Lectio8]
+@Sancti/09-28:Lectio6:s/.*Cum in Germániam/Cum in Germániam/
+
+[Lectio9]
+Léctio sancti Evangélii secúndum Matthæum. 
+!Mat 16.
+In illo témpore: Dixit Jesus discípulis suis: Si quis vult veníre post me, ábneget semetípsum, et tollat crucem suam et sequátur me. Et réliqua.
+_
+Homilía Beáti Gregórii Papæ.
+Duóbus modis crux tóllitur, aut cum per abstinéntiam afflígitur corpus aut per compassiónem próximi afflígitur ánimus. Pensémus quáliter utróque modo Paulus crucem suam túlerat, qui dicébat: Castígo corpus meum, et in servitútem rédigo, ne forte prædicans áliis, ipse réprobus effíciar.
+	
+[Lectio10]
+Ecce, in afflictióne córporis audívimus crucem carnis, audiámus nunc in compassióne próximi crucem mentis; Ait enim: Quis infirmátur, et ego non infírmor? quis scandalizátur, et ego non uror? perféctus quippe Prædicátor, ut exémplum daret abstinéntiæ, crucem portábat in córpore: et quia trahébat in se damna infirmitátis aliénæ, crucem portábat in corde.
+
+[Lectio11]
+Sed quia ipsis virtútibus quædam vítia juxta sunt, dicéndum nobis est: quod vítium abstinéntiam carnis et quod obsídeat compassiónem mentis, e vicíno namque abstinéntiam carnis nonnúnquam vana glória óbsidet: quia dum tenúitas in córpore, dum palos in vultu respícitur, virtus patefácta laudátur, et tanto se celérius foras fundit, quanto ad humános óculos per osténsum palórem exit.
+
+[Lectio12]
+Compassiónem vero ánimi plerúmque óbsidet píetas falsa: ut hanc nonnúnquam ad condescéndendum vítiis pértrahat: cum ad culpas quisque non débeat compassiónem exercére, sed zelum: Compássio quippe hómini, et rectitúdo vítiis debétur, ut in uno eodémque hómine diligámus bonum, quod factum est, persequámur mala, quæ fecit: ne dum culpas incáute remíttimus, non jam per charitátem cómpati‚ sed per negligéntiam condescéndere videámur.


### PR DESCRIPTION
The following feasts have lost their Gospel in Matins (Monastic 1930 version tested):

02-10-2025
03-12-2025
03-21-2025
04-29-2026. (i.e., Pasc3-3. Octava S. Joseph)
05-13-2025
05-19-2026 (Octava SSmi Cordis Jesu. Pent03-5)
06-26-2025 (Octave SSmi Corporis Christi, Pent02-4)
07-11-2025
07-18-2025 (Gospel changed from Mt 19 to Joh 15)
11-09-2025
11-13-2025
12-25-2025

Now they all work.