### PR TITLE
Cist: Commune Dedicationis Ecclesiæ + Czech

### DIFF
--- a/web/www/horas/Bohemice/Commune/C8.txt
+++ b/web/www/horas/Bohemice/Commune/C8.txt
@@ -64,31 +64,36 @@ Bože, jenž neviditelně obsahuješ úplně všechno, a přece pro spásu lidsk
 $Per Dominum
 
 [Invit]
-Holiness becometh the house of God. * In her let us worship her Bridegroom, even Christ.
+Domu Božímu náleží svatost. * Ženichu jeho Kristu klanějme se v měn.
+
+[Invit] (rubrica cisterciensis)
+Jásejme Hospodinu, nejvyššímu Králi, * Jenž posvětil svůj svatostánek.
+(sed tempore paschali)
+@Commune/C2p
 
 [Ant Matutinum]
-Lift up your gates, O ye princes, * and be ye lift up, ye everlasting doors.;;23
-The Lord shall be my God, * and this stone shall be called God's house.;;45
-Moses built an altar * to the Lord God.;;47
-This is none other but the house of God, and this is the gate of heaven.;;83
-Jacob beheld a ladder set up on the earth, and the top of it reached to heaven, and the angels of God descending on it. And he said: Surely this place is holy.;;86
-Jacob set up the stone for a pillar, and poured oil upon the top of it.;;87
-He that dwelleth in the help of the Most High * shall abide under the shadow of the God of heaven.;;90
-The Temple of the Lord is holy. * The same is God's workmanship and God's building.;;95
-Blessed be the glory of the Lord * from His holy place. Alleluia.;;98
+Zvedněte brány, * své průchody, knížata, a pozdvihněte se, brány věčné.;;23
+Hospodin mi bude * Bohem a tento kámen bude nazván domem Božím.;;45
+Mojžíš * postavil oltář Hospodinu, svému Bohu.;;47
+Není to nic jiného * než dům Boží a brána nebes.;;83
+Jakub viděl žebřík, * jehož vrchol se dotýkal nebes, a anděly sestupující, a řekl: Vpravdě je toto místo svaté.;;86
+Vztyčil Jákob * kámen jako sloup a vylil na něj olej.;;87
+Kdo přebývá * v ochraně Nejvyššího, spočine v záštitě Boha nebeského.;;90
+Chrám Páně * je svatý, je to stavba Boží, je to Boží dílo.;;95
+Požehnaná * je sláva Páně z jeho svatého místa, aleluja.;;98
 
 [Nocturn 2 Versum]
 V. Můj dům. 
 R. Bude se nazývat domem modlitby. 
 
 [Lectio1]
-Lesson from the book of Paralipomenon
-!2 Chr 7:1-5
-1 And when Solomon had made an end of his prayer, fire came down from heaven, and consumed the holocausts and the victims: and the majesty of the Lord filled the house.
-2 Neither could the priests enter into the temple of the Lord, because the majesty of the Lord had filled the temple of the Lord.
-3 Moreover all the children of Israel saw the fire coming down, and the glory of the Lord upon the house: and falling down with their faces to the ground, upon the stone pavement, they adored and praised the Lord: because he is good, because his mercy endureth for ever.
-4 And the king and all the people sacrificed victims before the Lord.
-5 And king Solomon offered a sacrifice of twenty-two thousand oxen, and one hundred and twenty thousand rams: and the king and all the people dedicated the house of God.
+Čtení z druhé knihy Kronik
+!2 Kr 7:1-5
+1 Když Šalomoun dokončil svou modlitbu, sestoupil z nebe oheň a pohltil zápalnou oběť i  obětního hodu a dům naplnila Hospodinova sláva. 
+2 Kněží nemohli do Hospodinova domu vstoupit, neboť Hospodinova sláva naplnila Hospodinův dům.
+3 A všichni synové Israele viděli sestupující oheň i Hospodinovu slávu nad domem, klesli na dlažbu tváří k zemi, klaněli se a vzdávali chválu Hospodinu, protože je dobrý  že jeho milosrdenství je věčné. 
+4 A král i všechen lid slavili před Hospodinem obětní hod.
+5 Král Šalomoun obětoval k obětnímu hodu dvacet dva tisíce  skotu a sto dvacet tisíc  bravu. Tak zasvětil král s veškerým lidem Boží dům.
 
 [Responsory1]
 R. When the Temple was dedicated the people sang praise;
@@ -97,11 +102,11 @@ V. The Lord's house is established in the top of the mountains; and all nations 
 R. And sweet in their mouths was the sound.
 
 [Lectio2]
-!2 Chr 7:6-9
-6 And the priests stood in their offices: and the Levites with the instruments of music of the Lord, which king David made to praise the Lord: because his mercy endureth for ever, singing the hymns of David by their ministry: and the priests sounded with trumpets before them, and all Israel stood.
-7 Solomon also sanctified the middle of the court before the temple of the Lord: for he offered there the holocausts, and the fat of the peace offerings: because the brazen altar, which he had made, could not hold the holocausts and the sacrifices and the fat:
-8 And Solomon kept the solemnity at that time seven days, and all Israel with him, a very great congregation, from the entrance of Emath to the torrent of Egypt.
-9 And he made on the eighth day a solemn assembly, because he had kept the dedication of the altar seven days, and had celebrated the solemnity seven days.
+!2 Kr 7:6-9
+6 Kněží stáli na svých místech, též lévijci s hudebními nástroji k  Hospodina; ty dal zhotovit král David, aby  vzdávali Hospodinu chválu, protože jeho milosrdenství je věčné. Chvalozpěvy Davidovy vyhrávali svýma rukama. Kněží naproti nim troubili a celý Israel stál.
+7 Šalomoun posvětil střed nádvoří, které je před Hospodinovým domem, neboť tam přinesl zápalné oběti a tučné díly pokojných obětí, protože bronzový oltář, který dal Šalomoun zhotovit, nemohl pojmout zápalnou a přídavnou oběť a tučné díly. 
+8 V onen čas slavil Šalomoun a s ním celý Israel slavnost po sedm dní, převeliké shromáždění od cesty do Chamátu až k Egyptskému potoku. 
+9 Osmého dne konali slavnostní shromáždění; zasvěcení oltáře slavili sedm dní, též slavnost  sedm dní.
 
 [Responsory2]
 R. The Lord's house is established in the top of the mountains, and exalted above the hills;
@@ -110,13 +115,13 @@ V. They shall doubtless come again with rejoicing, bringing their sheaves with t
 R. And all nations shall flow unto it, and shall say: Glory be to thee, O Lord!
 
 [Lectio3]
-!2 Chr 7:11-16
-11 And Solomon finished the house of the Lord, and the king's house, and all that he had designed in his heart to do, in the house of the Lord, and in his own house, and he prospered.
-12 And the Lord appeared to him by night, and said: I have heard thy prayer, and I have chosen this place to myself for a house of sacrifice.
-13 If I shut up heaven, and there fall no rain, or if I give orders, and command the locust to devour the land, or if I send pestilence among my people:
-14 And my people, upon whom my name is called, being converted, shall make supplication to me, and seek out my face, and do penance for their most wicked ways: then will I hear from heaven, and will forgive their sins and will heal their land.
-15 My eyes also shall be open, and my ears attentive to the prayer of him that shall pray in this place.
-16 For I have chosen, and have sanctified this place, that my name may be there for ever, and my eyes and my heart may remain there perpetually.
+!2 Kr 7:11-16
+11 Tak dokončil Šalomoun zdárně dům Hospodinův i dům královský a všechno, co si předsevzal udělat v domě Hospodinově i ve svém domě.
+12 Tu se v noci ukázal Šalomounovi Hospodin a řekl mu: „Vyslyšel jsem tvou modlitbu a vyvolil jsem si toto místo za dům  oběti. 
+13 Uzavřu-li nebesa, takže nebude deště, přikážu-li kobylkám, aby hubily zemi, pošlu-li na svůj lid mor,
+14 a můj lid, který se nazývá mým jménem, se pokoří a bude se modlit a vyhledávat mě a odvrátí se od svých zlých cest, tehdy je vyslyším z nebes, odpustím  jejich hřích a uzdravím jejich zemi.
+15 Mé oči budou otevřené a mé uši ochotné slyšet modlitbu na tomto místě. 
+16 Nyní jsem tento dům vyvolil a oddělil jako svatý, aby tam navěky dlelo mé jméno; mé oči a mé srdce tam budou po všechny dny.
 
 [Responsory3]
 R. O Lord, bless this house which I have built unto thy name. whosoever shall come unto this place and pray, then
@@ -127,9 +132,9 @@ R. Hear thou from the excellent throne of thy glory.
 R. Hear Thou from the excellent throne of thy glory.
 
 [Lectio4]
-From the Sermons of St. Augustine, Bishop (of Hippo.)
-!252nd for the Season.
-Dearly beloved brethren, as often as we keep the Dedication-Feast of some Altar or Church, if we think faithfully and carefully, and live holily and righteously, that which is done in temples made with hands, is done in our soul by a spiritual building. He at the Dedication of the Temple. lied not who said: The temple of God is holy; which temple ye are (i Cor. iii. 17,) and again: Know ye not that your body is the temple of the Holy Ghost, Which is in you, (vi. 19.) And therefore, dearly beloved brethren, since by the grace of God, without any foregoing deserts of our own, we have been made meet to become the Temple of God, let us work as hard as we can, with His help, that our Lord may not find in His Temple, that is, in us, anything to offend the eyes of His Majesty.
+Řeč svatého Augustina Biskupa.
+!Řeč 252 přes rok.
+Nejdražší bratři, kdykoliv slavíme slavnost  Oltáře či chrámu, tak pokud se jí věrně a přičinlivě účastníme a žijeme svatě a spravedlivě, pak cokoliv se děje v chrámech postavených lidskýma rukama, nás celé uvnitř naplní duchovní stavbou. Nelhal totiž svatý Pavel, když pravil: „Boží chrám je svatý, a ten chrám jste vy,“ (1. Kor 3, 17) a opět: „Nevíte, že vaše těla jsou chrámem Ducha svatého, který ve vás přebývá?“ (1. Kor 6, 19) A proto, nejdražší bratři, neboť žádnými předchozími zásluhami jsme si nezískali právo státi se skrze Boží milost chrámem Božím, s jeho pomocí se snažme, jak jen můžeme, aby náš Pán ve svém chrámu, tedy v nás samotných, nenašel nic, co by uráželo zrak jeho Vznešenosti.
 
 [Responsory4]
 R. If they pray toward this place,
@@ -138,42 +143,42 @@ V. Give ear, O Shepherd of Israel, thou that leadest Joseph like a flock, thou t
 R. Forgive the sin of thy people, O God, and teach them the good way wherein they should walk, and manifest forth thy glory in this place.
 
 [Lectio5]
-Let the Tabernacle of our heart be swept clean of vices and filled with virtues. Let it be locked to the devil, and thrown open to Christ. Yea, let us so work, that we may be able to open the door of the kingdom of heaven with the key of good works. For even as evil works are so many bolts and bars to close against us the entrance into life, so beyond doubt are good works the key thereto. And therefore, dearly beloved brethren, let each one look into his own conscience, and when he findeth the wounds of guilt there, let him first strive by prayers, fasting, or alms deeds to purge his conscience, and so let him dare to take the Eucharist.
+Příbytek našeho srdce nechť tedy opustí neřesti a naplní se ctnostmi. Nechť se uzavře ďáblu a otevře Kristu. A tak se snažme, abychom si klíči dobrých skutků mohli otevřít bránu do nebeského království. Tak jako špatnými činy se nám jako nějakými závorami či mřížemi uzavírá brána života, tak dobrými skutky se beze vší pochyby otevírá. A proto, nejdražší bratři, každý zapátrej ve svém svědomí, a když někdo pozná, že se nějakým svým přečinem zranil, prve ať se modlitbami, posty či almužnami snaží očistit své svědomí, a pouze tak se odváží přijmout Eucharistii.
 
 [Responsory5]
-R. How dreadful is this place!
-* Surely this is none other but the house of God, and this is the gate of heaven.
-V. This is the house of God, stoutly builded, well founded upon a sure rock.
-R. Surely this is none other but the house of God, and this is the gate of heaven.
+R. Ó, jak děsivé je toto místo!
+* Vpravdě to musí být dům Boží a brána nebeská.
+V. Toto je dům Hospodinův, pevně vystavený, s dobrými základy na pevné skále.
+R. Vpravdě to musí být dům Boží a brána nebeská.
 
 [Lectio6]
-For if he acknowledge his iniquity, and withdraw himself from the Altar of God, he will soon attain unto the mercy of the pardon of God, for, as he that exalted himself shall be abased, so shall he that humbleth himself be exalted. (Luke xiv. n.) He who, as I have said, acknowledging his iniquity, withdraweth himself through lowliness from the Altar of the Church, till he have mended his life, need have but little fear that he will be excommunicated from the eternal marriage supper in heaven.
+Pokud tedy pozná svou poskvrnu, sám nechť odejde od božského Oltáře a rychle se v prosbě o odpuštění utíká k božskému milosrdenství. Neboť tak jako každý, kdo se povyšuje, bude ponížen, tak také naopak, každý, kdo se ponižuje, bude povýšen. Kdo tedy, jak jsem již řekl, by poznal svou poskvrnu a sám z vlastní vůle v pokoře odešel od Oltáře Církve, aby dal do pořádku svůj život, nemusí se jistě bát, že bude navěky vyloučen z nebeské hostiny.	
 
 [Responsory6]
-R. Jacob rose up early in the morning, and set up the stone for a pillar, and poured oil upon the top of it, and vowed a vow unto the Lord.
-* Surely this place is holy, and I knew it not.
-V. And Jacob awaked out of his sleep, and he said
-R. Surely this place is holy, and I knew it not.
+R. Ráno vstal Jákob, vztyčil kámen jako sloup, a vylil na něj olej; přísahal Hospodinu:
+* Zajisté je toto místo svaté, a já jsem to nevěděl.
+V. Jakmile procitl Jákob ze svého spánku, řekl:
+R. Zajisté je toto místo svaté, a já jsem to nevěděl.
 &Gloria
-R. Surely this place is holy, and I knew it not.
+R. Zajisté je toto místo svaté, a já jsem to nevěděl.
 
 [Lectio7]
-From the Holy Gospel according to Luke
-!Luke 19:1-10
-At that time: Jesus entered and passed through Jericho. And, behold, there was a man named Zacchaeus, which was the chief among the publicans, and he was rich. And so on.
+Čtení svatého Evangelia podle Lukáše
+!Lukáš 19:1-10
+Za onoho času procházel Ježíš městem Jericho. A hle, byl zde muž jménem Zacheus. Ten byl vrchním nad celníky a byl bohatý. A ostatní.
 _
-Homily by St. Ambrose, Bishop (of Milan.)
-!Bk. viii. on Luke.
-Zacchaeus was little of stature, that is, he was not raised aloft among men by nobility of birth, and, like the most of the world, he possessed few merits. When he heard that the Lord and Saviour, Who had come unto His Own, and Whom His Own had not received, (John i. 11,) was coming, he desired to see Him. But the sight of Jesus is not easy; to any on the earth it is impossible. And since Zacchaeus had neither the Prophets, nor yet the Law, as a gracious help to his nature, he climbed up into a sycamore tree, raising his feet above the vanity of the Jews, and straightening the crooked branches of his former life, and therefore he received Jesus to lodge within his house.
+Homilie svatého Ambrože Biskupa.
+!Kniha 8 na Lukáše, poblíž konce.
+Zacheus byl postavou malý, tedy žádná vrozená vznešenost mu nepřidala na výšce, byl malý i zásluhami, stejně jako lid pohans­kých Národů. Když se však dozvěděl o příchodu Pána Spasitele, kterého jeho národ nepřijal, zatoužil jej vidět. Ale Ježíše nikdo jen tak snadno neuvidí. Nikdo, kdo žije na zemi, nedokáže Ježíše spatřit. A protože neměl Proroky ani zákon, využil výhody přírodního útvaru a vylezl na fíkovník, tedy pošlapal marnivost Židů svýma nohama, tím napravil chyby dřívějšího věku a přijal Ježíše jako hosta do nitra svého domu. 
 
 [Responsory7]
-R. My house shall be called the house of prayer, saith the Lord. Therein, he that asketh, receiveth; he that seeketh, findeth;
-* And to him that knocketh, it shall be opened.
-V. Ask, and ye shall receive; seek, and ye shall find.
-R. And to him that knocketh, it shall be opened.
+R. Můj dům bude se nazývat domem modlitby, praví Hospodin; V něm každý, kdo prosí, dostane; a kdo hledá, nalezne;
+* A kdo tluče, tomu bude otevřeno.
+V. Proste a dostanete, hledejte, a naleznete.
+R. A kdo tluče, tomu bude otevřeno.
 
 [Lectio8]
-He did well to climb up into a tree, that a good tree might bring forth good fruits, (Matth. vii. 17,) and that the slip of the wild olive, grafted, contrary to nature, into the good olive, might bring forth the fruits of the law. (Rom. xi. 17, 24.) For the root is holy, however unprofitable the branches. Their barren beauty hath now been overshadowed by the belief of the Gentiles in the Resurrection, as by a material upgrowth. Zacchaeus, then, was in the sycamore tree, and the blind man by the way-side, (xviii. 35.) For the one, Jesus stood waiting to show mercy, and asked him before He healed him, what he would that He should do for him; being unbidden of the other, He bade Himself to be his Guest, knowing how rich was the reward of receiving Him. Nevertheless, albeit He had heard no words of invitation, yet had He seen how his heart went.
+A dobře udělal, že vylezl na strom, neboť dobrý strom přináší dobré plody (Mat. 7, 17). Byl tedy odříznut od planého olivovníku a naroubován na dobrou olivu, plod zákona (Řím. 9; 17, 24) totiž může přinést pouze svatý Kořen, i když větve jsou již bez užitku: jejich neplodnou slávu lid pohanský svou vírou proměnil podobně jako určitým vyvýšením těla na strom. Zacheus byl tedy na fíkovníku, slepec pak u cesty (Ž 18, 35). Jeden z nich čekal na smilování Páně, druhý na povznesení svého domu Jeho vznešeností. Jeden s nadějí žádá o uzdravení, k druhému se dříve nezvaný pozve. Věděl totiž, jak plodnou zásluhou je jeho pohoštění. Avšak přece, i když Pán ještě neslyšel hlas, který jej zve, už viděl jeho lásku.
 
 [Responsory8]
 R. All thy walls are of stones most precious.
@@ -184,7 +189,7 @@ R. The towers of Jerusalem shall be built up with jewels.
 R. The towers of Jerusalem shall be built up with jewels.
 
 [Lectio9]
-But lest we should seem haughtily to pass by the poor blind man, and to hurry on to the rich one, let us stand waiting for him, as the Lord stood and waited; let us ask of him, as Christ asked of him. Let us ask, because we are ignorant; Christ asked, because He knew. Let us ask, that we may know whence he received his cure; Christ asked, that all of us may know from one example where through we are to earn a sight of the Lord. Christ asked, that we might believe that none, save they that confess Him, can be saved.
+Abychom si však nemysleli, že Pán rychle opustil toho chudého slepce jako něco nechutného, a odešel k boháčovi, počkejme si na něj, neboť počkal i Pán, ptejme se ho, neboť ptal se i Kristus. My se ptejme, neboť neznáme odpověď, on se ptá, protože ji zná. My se ptejme, abychom věděli, jak byl slepec uzdraven. Pán se ptal, aby nás v jedné otázce poučil o několika způsobech, jak jej můžeme spatřit. On se totiž ptal proto, abychom uvěřili, že může uzdravit pouze toho, kdo věří. 	
 &teDeum
 
 [Capitulum Laudes]
@@ -279,3 +284,8 @@ R. Po všechny dny.
 
 [Ant 3]
 Ó, jak strašné je * toto místo, opravdu to může být jen dům Boží a brána nebeská.
+
+[Evangelium]
+Pokračování ++ svatého Evangelia podle Lukáše
+!Lukáš 19:1-10
+Za onoho času procházel Ježíš městem Jericho. A hle, byl zde muž jménem Zacheus. Ten byl vrchním nad celníky a byl bohatý. Rád by uviděl Ježíše, jak vypadá, ale nemohl, protože tam bylo plno lidí a on byl malé postavy. Běžel napřed a vylezl na fíkovník, aby ho viděl, protože tudy měl procházet. Když Ježíš přišel k tomu místu, podíval se nahoru a řekl mu: „Zachee, pojď rychle dolů: dnes musím zůstat v tvém domě.“ On rychle slezl dolů a s radostí ho přijal. Všichni, jakmile to uviděli, reptali a říkali: „Vešel jako host k hříšníkovi!“ Zacheus se zastavil a řekl Pánu: „Polovici svého majetku, Pane, dám chudým, a jestli jsem někoho o něco ošidil, nahradím mu to čtyřnásobně!“ Ježíš mu řekl: „Dnes přišla do tohoto domu spása. Vždyť i on je potomek Abrahámův. Syn člověka přišel hledat a zachránit, co zahynulo.“

--- a/web/www/horas/Bohemice/CommuneM/C8.txt
+++ b/web/www/horas/Bohemice/CommuneM/C8.txt
@@ -13,6 +13,36 @@ The Lord is in his holy temple, the Lord’s throne is in heaven.;;10
 Adore ye the Lord in his holy court.;;28
 Blessed are they that dwell in thy house, O Lord: they shall praise thee for ever and ever.;;83
 
+[Ant Matutinum] (rubrica cisterciensis)
+Zvedněte brány, * své průchody, knížata, a pozdvihněte se, brány věčné.;;23
+Přistoupím * k Oltáři Božímu, k Bohu, jenž dává radost mému mládí.;;42
+Zasvětil * Hospodin svůj svatostánek.;;45
+Hospodin mi bude * Bohem, a tento kámen bude nazván domem Božím.;;46
+Vystavěl * Mojžíš oltář Hospodinu, svému Bohu.;;47
+Toto je zajisté * dům Boží a brána nebes.;;64
+Jákob uviděl žebřík, * jehož vrchol se dotýkal nebes, a Anděly sestupující, a řekl: Vpravdě je toto místo svaté.;;83
+Vztyčil Jákob * kámen jako sloup a vylil na něj olej.;;86
+Chrám Páně * je svatý, je to stavba Boží, je to Boží dílo.;;87
+Kdo přebývá * v ochraně Nejvyššího, spočine v záštitě Boha nebeského.;;90
+Požehnaná * je sláva Páně z jeho svatého místa.;;95
+Jakmile procitnul * Jákob ze sna, řekl:  Vpravdě je Hospodin na tomto místě.;;98
+Základy * tohoto chrámu položil Bůh na své moudrosti, a v něm Hospodina z nebes společně chváli Andělé; třebaže se do něj opřou větry či rozvodní řeky, nemohou jím nikterak pohnout; základy má totiž na skále.;;260;261;262
+
+[Ant Matutinum] (tempore paschali et rubrica cisterciensis)
+Alleluja, * alleluja, Alleluja.;;23
+;;42
+;;45
+;;46
+;;47
+;;64
+Alleluja, * alleluja, Alleluja.;;83
+;;86
+;;87
+;;90
+;;95
+;;98
+Alleluja, * alleluja, Alleluja.;;260;261;262
+
 [Nocturn 1 Versum] (rubrica cisterciensis)
 V. Základy má dům Páně.
 R. Nad vycholky hor.
@@ -24,34 +54,75 @@ R. Nad vycholky hor.
 V. Blažení, kdo přebývají ve tvém domě, Pane.
 R. Na věky věkův tě budou chválit.
 
+[Lectio3] (rubrica cisterciensis)
+@Commune/C8:Lectio1:s/1-5/4-6/ s/1.*4/4/s
+@Commune/C8:Lectio2:2:s/, protože.*/./s
+
+[Lectio4]
+@Commune/C8:Lectio3
+(sed rubrica cisterciensis)
+@Commune/C8:Lectio2:1-3:s/-9/-7/ s/6 .*Kněží/6 Kněží/s
+
+[Responsory3] (rubrica cisterciensis)
+@Tempora/111-0:Responsory4:1-2
+V. Kdo se rozpomínáte na Hospodina, nemlčte, a nepřecházejte jej v tichosti.
+@Tempora/111-0:Responsory4:4
+
+[Responsory4_]
+R. Strašné je toto místo! Toto je zajisté dům Boží a brána nebes;
+* Opravdu tedy přebývá Hospodin na tomto místě, a já jsem to nevěděl.
+V. Jákob uviděl ve snu žebřík, jehož vrchol se dotýkal nebes, a Anděly sestupující i vystupující po něm, a řekl: 
+R. Opravdu tedy přebývá Hospodin na tomto místě, a já jsem to nevěděl.
 
 [Responsory4]
-R. How terrible is this place! This is no other but the house of God, and the gate of heaven.
-* Indeed the Lord is in this place, and I knew it not.
-V. Jacob saw in his sleep a ladder standing upon the earth, and the top thereof touching heaven: the angels also of God ascending and descending by it.
-R. Indeed the Lord is in this place, and I knew it not.
+@:Responsory4_
+(sed rubrica cisterciensis)
+@:Responsory4C
 
 [Lectio5]
-@Commune/C8:Lectio4:s/And therefore.*//
+@Commune/C8:Lectio4:s/A proto,.*//
 
 [Lectio6]
-@Commune/C8:Lectio4:3 s/.*(And therefore)/$1/ s/$/~/
-@Commune/C8:Lectio5:s/For even.*//
+@Commune/C8:Lectio4:3 s/.*(A proto,)/$1/ s/$/~/
+@Commune/C8:Lectio5:s/Tak jako.*//
 
 [Lectio7]
-@Commune/C8:Lectio5:s/.*(For even)/$1/
+@Commune/C8:Lectio5:s/.*(Tak jako)/$1/
+
+[Responsory5] (rubrica cisterciensis)
+R. Viděl jsem bránu do města otevřenou na Východ, a jména Apoštolů i Beránka na ní napsaná:
+* A nad jejími zdmi postavenou andělskou stráž.
+V. Viděl jsem svaté město nový Jerusalém, nachystaný jako nevěsta ozdobená pro svého muže.
+R. A nad jejími zdmi postavenou andělskou stráž.
+
+[Responsory6] (rubrica cisterciensis)
+R. Když Jákob vyšel ze své země, uviděl slávu Boží, a řekl:
+* Jak strašné je toto místo! Zajisté to musí být dům Boží a brána nebes.
+V. Vpravdě je Hospodin na tomto místě, a já jsem to nevěděl.
+R. Jak strašné je toto místo! Zajisté to musí být dům Boží a brána nebes.
+
+[Responsory7] (rubrica cisterciensis)
+@Tempora/Quad2-0:Responsory6:1-2
+V. Pokud Hospodin, můj Bůh, bude se mnou na této cestě, po které kráčím, a bude mě střežit,
+@Tempora/Quad2-0:Responsory6:4
 
 [Responsory8]
-R. How lovely are thy tabernacles, O Lord of hosts! My soul longeth and fainteth
-* For the courts of the Lord.
-V. They that dwell in thy house, O Lord they shall praise thee for ever and ever.
-R. For the courts of the Lord.
+R. Jak líbezné jsem tvé stánky, Hospodine zástupů! Touží a chřadne duše má
+* Po síních Hospodinových.
+V. Kdož přebývají v tvém domě, Hospodine, navěky tě budou chválit.
+R. Po síních Hospodinových.
+
+[Responsory8] (rubrica cisterciensis)
+R. Můj dům bude se nazývat domem modlitby, praví Hospodin; 
+* V něm každý, kdo prosí, dostane; a kdo hledá, nalezne; a kdo tluče, tomu bude otevřeno.
+@Commune/C8:Responsory5:3
+R. V něm každý, kdo prosí, dostane; a kdo hledá, nalezne; a kdo tluče, tomu bude otevřeno.
 
 [Lectio10]
-@Commune/C8:Lectio8:s/Zacchaeus, .*//s
+@Commune/C8:Lectio8:s/Zacheus .*//s
 
 [Lectio11]
-@Commune/C8:Lectio8:s/.* Zacchaeus, /Zacchaeus, /s
+@Commune/C8:Lectio8:s/.* Zacheus /Zacheus /s
 
 [Responsory11]
 R. Blessed art thou in the holy temple of thy glory that has been built
@@ -59,13 +130,17 @@ R. Blessed art thou in the holy temple of thy glory that has been built
 V. Bless this house that I have built.
 R. To the praise and glory of your name O Lord.
 
+[Responsory11] (rubrica cisterciensis)
+@Tempora/Pent01-3:Responsory3
+
 [Responsory12]
 R. I saw the holy city, the new Jerusalem, coming down out of heaven from God, prepared as a bride adorned for her husband.
 *And I heard a great voice from the throne, saying: Behold the tabernacle of God with men, and he will dwell with them.
 V. And they shall be his people; and God himself with them shall be their God.
 R. And I heard a great voice from the throne, saying: Behold the tabernacle of God with men, and he will dwell with them.
 
-[Responsorium] (rubrica cisterciensis)
-<font color=» red» >Responsorium.</font> Hrozné je toto místo, avšak není to nic jiného než dům Boží a brána nebeská. * Vpravdě je totiž Hospodin na tomto místě, ale já jsem to nevěděl.
-V. Jakmile procitnul Jákob ze sna, řekl: 
-* Vpravdě je totiž Hospodin na tomto místě, ale já jsem to nevěděl.
+[Responsory12] (rubrica cisterciensis)
+R. Vpravdě blažená matka Církev, již takto osvěcuje čest božského úradku, již takto zdobí slavná krev vítězných Mučedníků;
+* Již vyznání neporušeného panenství odělo v bělostný háv.
+V. Mezi jejími květy nechybí růže ani lilie.
+R. Již vyznání neporušeného panenství odělo v bělostný háv.

--- a/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm260.txt
+++ b/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm260.txt
@@ -1,0 +1,10 @@
+(Tobiášovo Kantikum * Tob 13:10-17)
+13:10 Dobrořečte Hospodinu všichni jeho vyvolení, slavte dny veselé, vzdávejte mu díky.
+13:11 Jerusaleme, tys město Boží, Pán tě potrestá pro skutky tvých rukou.
+13:12 Oslavuj Pána dobrými svými činy, vzdávej chválu Bohu věčných věků, aby zase vystavěl svůj stánek v tobě; 
+13:13 A povolal zpět do tebe všecky zajatce, abys plesal po všecky věky věkův.
+13:13 přejasným světlem se zaskvěješ, všecky končiny země se budou ti klanět.
+13:14 Národové z daleka k tobě přijdou s dary budou se klanět v tobě Pánu; 
+13:15 A půdu tvou za svatou budou považovat, budouť jméno velké v tobě vzývat.
+13:16 Zlořečeni budou, kdo tebou pohrdnou, zavrženi, kdož tě budou tupit; požehnáni však tvoji stavitelé.
+13:17 Ty pak radost budeš mít ze svých synů, neboť všichni budou požehnáni, budou shromážděni u Hospodina.

--- a/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm261.txt
+++ b/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm261.txt
@@ -1,0 +1,6 @@
+(Isajášovo Kantikum * Isa 2:2-3)
+2:2 Stane se v posledních dnech: Pevně bude stát hora s Hospodinovým domem na vrcholu hor;
+2:2 A vyvýšena bude nad pahorky, a budou k ní proudit všechny národy.
+2:3 Budou k ní putovat četné kmeny a řeknou: „Vzhůru, vystupme na Hospodinovu horu, do domu Jakubova Boha!
+2:3 A naučí nás svým cestám, a budeme chodit po jeho stezkách!“ 
+2:3 Ze Siónu vyjde zákon, z Jerusaléma Hospodinovo slovo.

--- a/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm262.txt
+++ b/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm262.txt
@@ -1,0 +1,9 @@
+(Jeremiášovo Kantikum * Jer 7:2-7)
+7:2 Slyšte Hospodinovo slovo, celé Judsko, vy, kteří vcházíte těmito branami, abyste se klaněli Hospodinu!
+7:3 Tak praví Hospodin zástupů, Bůh Israele: 
+7:3 Napravte své chování a skutky, a dám vám přebývat na tomto místě.
+7:4 Nespoléhejte se na klamná slova: Je to chrám Hospodinův, chrám Hospodinův, chrám Hospodinův!
+7:5 Neboť když své jednání a skutky napravíte;
+7:6 Když budete uplatňovat ve vzájemných sporech spravedlnost, když nebudete utiskovat přistěhovalce, sirotky a vdovy;
+7:6 Když nebudete na tomto místě vylévat nevinnou krev, když nebudete na svou vlastní škodu chodit za cizími bohy;
+7:7 Dám vám přebývat na tomto místě, v zemi, kterou jsem dal vašim otcům, od věků až na věky.

--- a/web/www/horas/Bohemice/SanctiM/11-01.txt
+++ b/web/www/horas/Bohemice/SanctiM/11-01.txt
@@ -1,2 +1,9 @@
+
+[Responsory10]
+R. Vpravdě blažená matka Církev, již takto osvěcuje čest božského úradku, již takto zdobí slavná krev vítězných Mučedníků;
+* Již vyznání neporušeného panenství odělo v bělostný háv.
+V. Mezi jejími květy nechybí růže ani lilie.
+R. Již vyznání neporušeného panenství odělo v bělostný háv.
+
 [Ant 2] (rubrica cisterciensis)
 Blažení jste * všichni Boží Svatí, neboť jste si zasloužili státi se účastnými na nebeských mocnostech, a těšit se ze slávy věčné jasnosti; proto prosíme, abyste pamětlivi byli nás, a ráčili se za nás přimlouvat u Hospodina našeho Boha.

--- a/web/www/horas/Bohemice/Tempora/101-1.txt
+++ b/web/www/horas/Bohemice/Tempora/101-1.txt
@@ -1,0 +1,42 @@
+[Lectio1]
+De libro primo Machabæórum
+!1 Mac 1:17-20
+17 Když Antiochos viděl, že se jeho vláda upevnila, rozhodl se stát se také egyptským králem, aby tak kraloval nad dvěma říšemi.
+18 Vtrhl do Egypta s obrovským vojskem, s válečnými vozy, slony, jízdou a s velikým loďstvem;
+19 a svedl bitvu s egyptským králem Ptolemaiem. Ptolemaios se před ním obrátil na útěk, mnoho vojáků bylo raněno a padlo.
+20 Antiochos dobyl egyptská opevněná města a vyplenil celou egyptskou zemi.
+
+[Responsory1]
+R. Řekl Juda Šimonovi, svému bratru: „Vyber si muže a jdi, osvoboď své bratry v Galileji; já pak, a Jonathas, tvůj bratr, půjdeme do Galaaditim:“ 
+* Jakákoliv byla vůle v nebesích, tak se i stane.
+V. Opásejte se, mocní synové, a buďte připraveni; neboť lepší pro nás bude zemřít ve válce, než uzřít porobu našeho národa i svatých míst.
+R. Jakákoliv byla vůle v nebesích, tak se i stane.
+
+[Lectio2]
+!1 Mac 1:21-23
+21 Po porážce Egypta se Antiochos roku sto čtyřicet tři vrátil. Vytáhl proti Izraeli a s obrovským vojskem vstoupil do Jerusaléma.
+22 Zpupně vešel do svatyně a sebral zlatý oltář a svícen se vším příslušenstvím,
+23 stůl na předkladné chleby, obětní misky, číše a zlaté kaditelnice, oponu i věnce. Zlaté zdobení na průčelí chrámu dal všechno sloupat.
+
+[Responsory2]
+R. Ozdobili průčelí chrámu zlatými korunami, a zasvětili oltář Hospodinu;
+* A nastala velká radost mezi lidem.
+V. V chvalozpěvech a vyznáních dobrořečili Hospodinu.
+R. A nastala velká radost mezi lidem.
+
+[Lectio3]
+!1 Mac 1:24-29
+24 Sebral stříbro, zlato i vzácné nádoby a sebral i všechny ukryté poklady, které našel. Všechno to vzal a odtáhl do své země.
+25 Nechal zabít mnoho lidí a mluvil velmi zpupně.
+26 Po celém Israeli začal veliký nářek, v každém jejich městě.
+27 Přední muži a starší sténali, dívky a chlapci chřadli, krása žen vadla.
+28 Ženichové propukali v pláč, nevěsty seděly v ložnici a naříkaly.
+29 Země byla otřesena kvůli svým obyvatelům a celý Jakubův dům se oděl hanbou.
+
+[Responsory3]
+R. V chvalozpěvech a vyznáních dobrořečili Hospodinu,
+* Neboť veliké věci učinil v Israeli, a vítězství jim dal Hospodin všemohoucí.
+V. Ozdobili průčelí chrámu zlatými korunami, a zasvětili oltář Hospodinu.
+R. Neboť veliké věci učinil v Israeli, a vítězství jim dal Hospodin všemohoucí.
+&Gloria
+R. Neboť veliké věci učinil v Israeli, a vítězství jim dal Hospodin všemohoucí.

--- a/web/www/horas/Bohemice/Tempora/111-0.txt
+++ b/web/www/horas/Bohemice/Tempora/111-0.txt
@@ -21,10 +21,10 @@ From the Exposition of the Prophet Ezekiel written by Pope St. Gregory (the Grea
 It is the use of the Prophetic writers first to give name, date, and place, and then to begin to unfold the mysteries of the prophecy thus, to give certainty of trustworthiness, a foundation is laid before, and afterward the fruits of the Spirit are set forth by signs and in figures. Thus Ezekiel saith concerning the date: And it came to pass in the thirtieth year, in the fourth month, in the fifth day of the month. And to show the place, he addeth further: „As I was among the captives by the river of Chebar, the heavens were opened, and I saw visions of God.“ Then he defineth the time even more exactly, saying In the fifth day of the month, which was the fifth year of King Jehoiachim's captivity. And he who had thus clearly indicated his individuality, goeth on farther to state his kin, saying The word of the Lord came unto Ezekiel, the son of Buzi, the Priest.
 
 [Responsory4]
-R. I have set watchmen upon thy walls, O Jerusalem;
-* Which shall never hold their peace day nor night, to praise the name of the Lord.
-V. They shall proclaim My might unto the nations, and declare My glory unto the Gentiles.
-R. Which shall never hold their peace day nor night, to praise the name of the Lord.
+R. Nad tvými zdmi, Jerusaléme, ustanovil jsem strážce;
+* Po celý den a po celou noc neumlkne jejich chvála jména Hospodinova.
+V. Lidem budou hlásat mou sílu, a národům zvěstovat mou slávu.
+R. Po celý den a po celou noc neumlkne jejich chvála jména Hospodinova.
 
 [Lectio5]
 But the first question which meeteth us is: Wherefore doth the Prophet, having hitherto said nothing, begin with the words: „And it came to pass in the thirtieth year.“ Now, this word „And“ is a conjunction, and we know that it is so called because it conjoineth that which cometh after it with that which goeth before it. Wherefore, then, doth he who hath hitherto been silent, commence by And, when there is nothing going before for the conjunction to join to that which cometh after. To explain this, we must consider that our senses perceive only things bodily, while those of Prophets perceive also things ghostly, and to them things exist which to our ignorance seem not to do so. Hence it cometh that in the mind of a Prophet, things outer and things inner are so joined that he seeth both together, and the word which he heareth within him and that which he uttereth come together.

--- a/web/www/horas/Bohemice/Tempora/Pent01-3.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent01-3.txt
@@ -1,0 +1,42 @@
+[Officium]
+středy prvního týdne po Svatodušním Oktávu
+
+[Lectio1]
+Z první knihy Králů
+!1 Král. 2:12-14
+12 Synové Eliho byli ale ničemové, nechtěli znát Hospodina
+13 ani kněžské právo vůči lidu. Když někdo přinášel oběť, přicházel knězův pomocník, zatímco se maso vařilo, s trojzubou vidlicí v ruce
+14 a bodnul do kotle nebo hrnce nebo nádoby nebo hluboké pánve. Všechno, co vidlicí vytáhl, bral si kněz pro sebe. Tak to dělali celému Israeli — těm, kteří tam do Šilo přicházeli.
+
+[Responsory1]
+R. Zhřešil jsem vícekrát než je písku v moři, a znásobily se mé hříchy: a nejsem hoden spatřit vznešenost nebes pro svou velikou nepravost; neboť jsem podnítil tvůj hněv; 
+* A co je před tebou zlé, jsem spáchal.
+V. Neboť já svou nepravost uznávám; a můj hřích je stále přede mnou, neboť proti tobě samotnému jsem zhřešil.
+R. A co je před tebou zlé, jsem spáchal.
+
+[Lectio2]
+!1 Král. 2:15-17
+15 Dokonce než obrátili tuk v kouř z oběti, přicházel knězův pomocník a říkal tomu, kdo přinášel oběť: „Dej knězi maso k opékání. Nevezme však od tebe maso vařené, ale jen syrové.“
+16 A ten člověk mu řekl: „Nejprve se musí obrátit tuk v kouř z oběti jako obvykle, pak si vezmi, po čem tvá duše touží.“ Řekl: „Ne, ale teď dáš. Pokud ne, vezmu si násilím.“
+17 Hřích knězových pomocníků byl před Hospodinem velmi veliký, protože ti muži znevažovali oběť přinášenou Hospodinu.
+
+[Responsory2]
+R. Vyslyšel jsi, Hospodine, prosbu svého služebníka, abych mohl vybudovat chrám tvému jménu; 
+* Dobrořeč tomuto domu a posvěť jej navěky, Bože Israele.
+V. Hospodine, jenž chráníš smlouvu se svými služebníky, jež kráčejí před tebou v upřímnosti svého srdce.
+R. Dobrořeč tomuto domu a posvěť jej navěky, Bože Israele.
+
+[Lectio3]
+!1 Král. 2:18-21
+18 Samuel sloužil před Hospodinem. Chlapec byl přepásán lněným efodem.
+19 Jeho matka mu dělávala malý plášť a přinášela mu ho každý rok, když putovala se svým mužem k výroční oběti.
+20 Elkanovi a jeho ženě Eli požehnal: „Kéž ti Hospodin dá potomstvo z této ženy namísto toho, který jí byl dopřán a kterého ona dopřála Hospodinu.“ A odešli domů.
+21 Hospodin se Anny ujal. Počala a porodila tři syny a dvě dcery. Chlapec Samuel však vyrůstal v Hospodinově přítomnosti.
+
+[Responsory3]
+R. Slyš, Hospodine, chvalozpěv i prosbu, které tvj služebník před tebou dnes přednáší, aby tvé oči byly otevřeny, a tvé uši pozorně nakloněny; 
+* K tomuto domu ve dne i v noci.
+V. Shlédni, Hospodine, ze své svatyně, a ze svého vznešeného nebeského příbytku.
+R. K tomuto domu ve dne i v noci.
+&Gloria
+R. K tomuto domu ve dne i v noci.

--- a/web/www/horas/Bohemice/Tempora/Pent03-2Feria.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent03-2Feria.txt
@@ -1,0 +1,28 @@
+[Officium]
+úterý v třetím týdnu po Svatodušním Oktávu
+
+[Responsory1]
+R. Hospodine, pokud se obrátí tvůj lid, a bude se modlit ve tvém svatostánku;
+* Ty jej vyslyš z nebe, Hospodine, a vysvoboď je z rukou jejich nepřátel.
+V. Pokud proti tobě zhřešil tvůj lid, a obrátí se a bude konat pokání, přijde a bude se modlit na tomto místě.
+R. Ty jej vyslyš z nebe, Hospodine, a vysvoboď je z rukou jejich nepřátel.
+
+[Lectio2]
+@Tempora/Pent03-2
+
+[Responsory2]
+R. Stalo se, když Hospodin uchvátil Eliáše ve vichru do nebe;
+* Eliseus volal a pravil: Otče můj, otče můj, vůz Israele, a jeho vozataj.
+V. Když vyšli a začali spolu mluvit, hle, ohnivý vůz a ohniví koně je navzájem rozdělili, a Eliáš ve vichřici vystoupil do nebe.
+R. Eliseus volal a pravil: Otče můj, otče můj, vůz Israele, a jeho vozataj.
+
+[Lectio3]
+@Tempora/Pent03-2
+
+[Responsory3]
+R. Já jsem tě vzal z domu tvého otce, praví Hospodin, a ustanovil tě, abys pásl stádce mého lidu;
+* A byl jsem s tebou, kamkoliv jsi šel, a navěky upevňoval tvou vládu.
+V. A učinil jsem ti velké jméno, vedle jmen velkých mužů, jež jsou na zemi; a dal jsem ti odpočinout ode všech tvých nepřátel.
+R. A byl jsem s tebou, kamkoliv jsi šel, a navěky upevňoval tvou vládu.
+&Gloria
+R. A byl jsem s tebou, kamkoliv jsi šel, a navěky upevňoval tvou vládu.

--- a/web/www/horas/Bohemice/Tempora/Quad2-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Quad2-0.txt
@@ -90,12 +90,12 @@ R. The Lord shall be my refuge, and this shall be a sign.
 It is impossible to apply the term a “lie” to that mystic aspect of this transaction in which it was true and such an aspect there is, not only in the acts, but in the words. When Isaac said to Jacob: “Who art thou, my son” and Jacob answered: “I am Esau, thy first-born”, if we take this in its sense relative to the two brothers, it will be apparent that it was a lie. If, however, we look at it relatively to that for the sake of which these words and deeds were written down, we shall see that Christ is here signified in His mystic body, the Church. Concerning her, (the younger covenant,) He saith (to them of the older covenant): “Ye shall see Abraham, and Isaac, and Jacob, and all the Prophets in the kingdom of God, and you yourselves thrust out. And they shall come from the east, and from the west, and from the north, and from the south, and shall sit down in the kingdom of God. And, behold, there are last which shall be first, and there are first which shall be last.” (Luke xiii. 28-30.) Thus did the younger take away the title and inheritance from the elder, and acquire it to himself.
 
 [Responsory6]
-R. The Lord shall be my God, and this stone, which I have set for a pillar, shall be called God's house, and of all that Thou shalt give me;
-* I will offer tithes and peace-offerings to thee.
-V. If I come again to my father's house in peace.
-R. I will offer tithes and peace-offerings unto thee.
+R. Hospodin mi bude Bohem, a onen kamen, který jsem vztyčil jako sloup, se bude nazývat domem Božím; a ze všeho, co mi dáš;
+* Budu tobě obětovat jako desátky a smírné oběti.
+V. Pokud se bezpečně vrátím do domu svého otce;
+R. Budu tobě obětovat jako desátky a smírné oběti.
 &Gloria
-R. I will offer tithes and peace-offerings unto thee.
+R. Budu tobě obětovat jako desátky a smírné oběti.
 
 [Lectio7]
 From the Holy Gospel according to Matthew

--- a/web/www/horas/Latin/Commune/C8.txt
+++ b/web/www/horas/Latin/Commune/C8.txt
@@ -62,7 +62,7 @@ Cui laus, potéstas, glória
 Amen.
 
 [HymnusM Vespera]
-v. Urbs beáta Jerúsalem,
+v. Urbs Jerúsalem beáta,
 Dicta pacis vísio,
 Quæ constrúitur in cælis
 Vivis ex lapídibus,
@@ -117,6 +117,11 @@ $Per Dominum
 
 [Invit]
 Domum Dei decet sanctitúdo: * Sponsum ejus Christum adorémus in ea.
+
+[Invit] (rubrica cisterciensis)
+Exultémus Dómino, Regi summo, * Qui suum sanctificávit tabernáculum.
+(sed tempore paschali)
+@Commune/C2p
 
 [Hymnus Matutinum]
 @Commune/C8:Hymnus Vespera

--- a/web/www/horas/Latin/CommuneM/C7.txt
+++ b/web/www/horas/Latin/CommuneM/C7.txt
@@ -30,19 +30,19 @@ Média nocte * clamor factus est: Ecce sponsus venit, exíte óbviam ei.;;97
 Invénta bona margaríta, * dedit ómnia sua, et comparávit eam.;;249;250;251
 
 [Ant Matutinum] (tempore paschali et rubrica cisterciensis)
-Allelúia, * allelúia, Allelúia;;8
+Allelúia, * allelúia, Allelúia.;;8
 ;;18
 ;;23
 ;;44
 ;;45
 ;;47
-Allelúia, * allelúia, Allelúia;;84
+Allelúia, * allelúia, Allelúia.;;84
 ;;86
 ;;95
 ;;96
 ;;97
 ;;98
-Allelúia, * allelúia, Allelúia;;249;250;251
+Allelúia, * allelúia, Allelúia.;;249;250;251
 
 [Nocturn 1 Versum] (rubrica cisterciensis)
 @Commune/C6:Versum 1

--- a/web/www/horas/Latin/CommuneM/C8.txt
+++ b/web/www/horas/Latin/CommuneM/C8.txt
@@ -44,6 +44,36 @@ Beáti, * qui hábitant in domo tua, Dómine; † in sǽcula sæculórum laudáb
 @Commune/C8::9
 @Commune/C8::5 s/86/260;261;262/
 
+[Ant Matutinum] (rubrica cisterciensis)
+Tóllite portas, * príncipes vestras, et elevámini, portæ æternáles.;;23
+Introíbo * ad Altáre Dei, ad Deum, qui lætíficat juventútem meam.;;42
+Sanctificávit * Dóminus tabernáculum suum.;;45
+Erit mihi Dóminus * in Deum, et lapis iste vocábitur domus Dei.;;46
+Ædificávit * Móyses altáre Dómino Deo.;;47
+Non est hic áliud, * nisi domus Dei, et porta cæli.;;64
+Vidit Jacob scalam, * súmmitas ejus cælos tangébat, et descendéntes Angelos, et dixit: Vere locus iste sanctus est.;;83
+Eréxit Jacob * lápidem in títulum, fundens óleum désuper.;;86
+Templum Dómini * sanctum est, Dei structúra est, Dei ædificátio est.;;87
+Qui hábitat * in adjutório Altíssimi, in protectióne Dei cæli commorábitur.;;90
+Benedícta * glória Dómini, de loco sancto suo.;;95
+Cum evigilásset * Jacob a somno, ait:  Vere Dóminus est in loco isto.;;98
+Fundaménta * templi hujus sapiéntia sua fundávit Deus, in quo Dóminum cæli colláudant Angeli; si írruant venti et fluant flúmina, non possunt illud movére umquam: fundátum enim est supra petram.;;260;261;262
+
+[Ant Matutinum] (tempore paschali et rubrica cisterciensis)
+Allelúia, * allelúia, Allelúia.;;23
+;;42
+;;45
+;;46
+;;47
+;;64
+Allelúia, * allelúia, Allelúia.;;83
+;;86
+;;87
+;;90
+;;95
+;;98
+Allelúia, * allelúia, Allelúia.;;260;261;262
+
 [Nocturn 1 Versum] (rubrica cisterciensis)
 V. Fundáta est domus Dómini.
 R. Supra vérticem móntium.
@@ -57,28 +87,67 @@ R. In sæcula sæculórum laudábunt te.
 
 [Lectio1]
 @Commune/C8::1-5 s/-5/-3/
+(sed rubrica cisterciensis)
+@Commune/C8::1-4 s/-5/-2/
 
 [Lectio2]
 @Commune/C8:Lectio1:s/1-5/4-6/ s/1.*4/4/s
 @Commune/C8::2
 
+[Lectio2] (rubrica cisterciensis)
+@Commune/C8:Lectio1:2 s/1-5/3/
+@Commune/C8:Lectio1:5
+
 [Lectio3]
 @Commune/C8:Lectio2:s/6-9/7-9/ s/6.*//
 
+[Lectio3] (rubrica cisterciensis)
+@Commune/C8:Lectio1:s/1-5/4-6/ s/1.*4/4/s
+@Commune/C8:Lectio2:2:s/\: Quóniam.*/./s
+
 [Lectio4]
 @Commune/C8:Lectio3
+(sed rubrica cisterciensis)
+@Commune/C8:Lectio2:1-3:s/-9/-7/ s/6 .*porro/6 Porro/s
 
-[Responsory4]
+[Responsory1] (rubrica cisterciensis)
+@Tempora/101-1:Responsory2
+
+[Responsory2] (rubrica cisterciensis)
+@Tempora/101-1:Responsory3
+
+[Responsory3] (rubrica cisterciensis)
+@Tempora/111-0:Responsory4:1-2
+V. Qui reminiscímini Dómini, ne taceátis, et ne detis siléntium ei.
+@Tempora/111-0:Responsory4:4
+
+[Responsory4_]
 R. Terríbilis est locus iste: † non est hic áliud nisi domus Dei et porta cæli:
 * Vere étenim Dóminus est in loco isto, et ego nesciébam.
 V. Vidit Jacob in somnis scalam, súmmitas ejus cælos tangébat, † et Ángelos Dei descendéntes et ascendéntes per eam, et ait.
 R. Vere étenim Dóminus est in loco isto, et ego nesciébam.
+
+[Responsory4C]
+@:Responsory4_:1-2
+@Commune/C8:Responsory6:3
+@:Responsory4_:4
+
+[Responsory4]
+@:Responsory4_
+(sed rubrica cisterciensis)
+@:Responsory4C
 
 [Lectio5]
 @Commune/C8:Lectio4:s/Et ideo.*//
 
 [Responsory5]
 @Commune/C8:Responsory4
+
+[Responsory5] (rubrica cisterciensis)
+R. Vidi portam civitátis ad Oriéntem pósitam, et Apostolórum nómina et Agni super eam scripta:
+* Et super muros ejus Angelórum custódiam.
+V. Vidi sanctam civitátem Jerúsalem novam, parátam sicut sponsam ornátam viro suo.
+R. Et super muros ejus Angelórum custódiam.
 
 [Lectio6]
 @Commune/C8:Lectio4:3 s/.*(Et ideo)/$1/ s/$/~/
@@ -87,11 +156,22 @@ R. Vere étenim Dóminus est in loco isto, et ego nesciébam.
 [Responsory6]
 @Commune/C8:Responsory5
 
+[Responsory6] (rubrica cisterciensis)
+R. Dum exíret Jacob de terra sua, vidit glóriam Dei, et ait:
+* Quam terríbilis est locus iste! Non est hic áliud, nisi domus Dei, et porta cæli.
+V. Vere Dóminus est in loco isto, et ego nesciébam.
+R. Quam terríbilis est locus iste! Non est hic áliud, nisi domus Dei, et porta cæli.
+
 [Lectio7]
 @Commune/C8:Lectio5:s/.*(Sicut)/$1/
 
 [Responsory7]
 @Commune/C8:Responsory6
+
+[Responsory7] (rubrica cisterciensis)
+@Tempora/Quad2-0:Responsory6:1-2
+V. Si Dóminus Deus meus fúerit mecum in via ista, per quam ego ámbulo, et custodíerit me,
+@Tempora/Quad2-0:Responsory6:4
 
 [Lectio8]
 @Commune/C8:Lectio6
@@ -102,17 +182,27 @@ R. Quam dilécta tabernácula tua, Dómine, virtútum! † concupíscit et défi
 V. Qui hábitant in domo tua, Dómine; in sǽculum sǽculi laudábunt te.
 R. In átria Dómini.
 
+[Responsory8] (rubrica cisterciensis)
+R. Domus mea, domus oratiónis vocábitur, dicit Dóminus: 
+* In ea omnis qui petit, áccipit; et qui quærit, ínvenit: et pulsánti aperiétur.
+@Commune/C8:Responsory5:3
+R. In ea omnis qui petit, áccipit; et qui quærit, ínvenit: et pulsánti aperiétur.
+
 [Lectio9]
 @Commune/C8:Lectio7
 
 [Responsory9]
 @Commune/C8:Responsory7
+(sed rubrica cisterciensis)
+@Tempora/Pent01-3:Responsory2
 
 [Lectio10]
 @Commune/C8:Lectio8:s/Zachǽus .*//s
 
 [Responsory10]
 @Commune/C8:Responsory8
+(sed rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory1
 
 [Lectio11]
 @Commune/C8:Lectio8:s/.* Zachǽus /Zachǽus /s
@@ -123,6 +213,9 @@ R. Benedíctus es in templo sancto glóriæ tuæ quod ædificátum est
 V. Bénedic domum istam quam ædificávi.
 R. Ad laudem et glóriam nóminis tui Dómine.
 
+[Responsory11] (rubrica cisterciensis)
+@Tempora/Pent01-3:Responsory3
+
 [Lectio12]
 @Commune/C8:Lectio9
 
@@ -132,18 +225,19 @@ R. Vidi civitátem sanctam Jerúsalem novam, † descendéntem de cælo a Deo pa
 V. Et ipsi pópulus ejus erunt, † et ipse Deus cum eis erit eórum Deus.
 R. Et audívi vocem de throno dicéntem: Ecce tabernáculam Dei cum homínibus, et habitábit cum eis.
 
+[Responsory12] (rubrica cisterciensis)
+R. Beáta vere mater Ecclésia quam sic honor divínæ dignatiónis illúminat, † quam victoriosórum gloriósus Mártyrum sanguis exórnat
+* Quam invioláta confessiónis cándida índuit virgínitas.
+V. Flóribus ejus nec rosæ nec lília desunt.
+R. Quam invioláta confessiónis cándida índuit virgínitas.
+
 [MM Capitulum]
 @Commune/C8:Capitulum Sexta
 _
 @Commune/C8:Versum Tertia
 
 [Responsorium] (rubrica cisterciensis)
-<font color=”red”>Responsorium.</font> Terríbilis est locus iste: non est hic áliud nisi domus Dei et porta caeli: * Vere étenim Dóminus est in loco isto, et ego nesciébam.
-V. Cumque evigilásset Jacob a somno, ait: 
-* Vere étenim Dóminus est in loco isto, et ego nesciébam.
-
-[Ant Laudes] (tempore paschali et rubrica cisterciensis)
-Allelúia, * allelúia, allelúia.
+@:Responsory4C
 
 [Capitulum Laudes]
 @Commune/C8
@@ -153,17 +247,22 @@ Allelúia, * allelúia, allelúia.
 
 [Ant Sexta] (rubrica cisterciensis)
 @Commune/C8:Ant Vespera:5
+(sed tempore paschali)
+@Psalterium/Psalmi/Psalmi minor:Pasch:4
 
 [Responsory Breve Sexta] (rubrica cisterciensis)
 @:Responsory Breve Nona
 
 [Responsory SextaM]
 @Commune/C8:Versum Tertia
-(sed rubrica cisterciensis)
-@Commune/C8:Versum 3
 
 [Ant Nona] (rubrica cisterciensis)
 @Commune/C8:Ant Vespera:4
+(sed tempore paschali)
+@Psalterium/Psalmi/Psalmi minor:Pasch:5
+
+[Ant Laudes] (tempore paschali et rubrica cisterciensis)
+@Psalterium/Psalmi/Psalmi minor:Pasch
 
 [Versum 3] (rubrica cisterciensis)
 @:Versum 1


### PR DESCRIPTION
Cistercian Version:
- added Commune Dedicationis Ecclesiæ
- added Czech translation
- in the monastic Hymn for Vespers, the first line was "Urbs beáta Jerúsalem", however in Breviario monastico, ed. 1930 and 1963, as well as in Breviario Cisterciense, it says "Urbs Jerúsalem beáta", therefore fixing this as well