### PR TITLE
Cist: added Commune de Beata for Matins + Czech + Corpus Christi

### DIFF
--- a/web/cgi-bin/horas/monastic.pl
+++ b/web/cgi-bin/horas/monastic.pl
@@ -56,8 +56,8 @@ sub psalmi_matutinum_monastic {
   }
 
   #** special antiphons for not Quad weekdays
-  if (($dayofweek > 0 && $dayname[0] !~ /Quad/i)
-    || $winner =~ /Pasc6-0/)
+  if ((($dayofweek > 0 && $dayname[0] !~ /Quad/i)
+    || $winner =~ /Pasc6-0/) && $version != /Cist/i)
   {
     my $start = ($dayname[0] =~ /Pasc|Nat[23]\d/i) ? 0 : 8;
     my @p;

--- a/web/cgi-bin/horas/specmatins.pl
+++ b/web/cgi-bin/horas/specmatins.pl
@@ -508,7 +508,7 @@ sub lectiones {
     push(@s, "\$Pater noster Et") unless $rule =~ /sine absolutio/i;
     push(@s, "Absolutio. $a[0]", '$Amen') unless $version =~ /^Ordo Praedicatorum/ || $rule =~ /sine absolutio/i;
   } elsif ($version !~ /Cist/i || $rule =~ /Matutinum Romanum/i) {
-    push(@s, "\$Pater totum secreto");
+    push(@s, "\$Pater totum secreto") unless $version =~ /Cist/i && $votive =~ /C12/;
   }
   push(@s, "\n");
 

--- a/web/www/horas/Bohemice/Commune/C11.txt
+++ b/web/www/horas/Bohemice/Commune/C11.txt
@@ -66,7 +66,9 @@ Uděl nám, svým služebníkům, prosíme, Pane Bože, stálé zdraví duše i 
 $Per Dominum
 
 [Invit]
-Svatá Panno Maria, * Matko Boží, pros za nás.
+Svatá Maria, Panno a Rodičko Boží, * Přimlouvej se za nás.
+(sed tempore paschali et rubrica cisterciensis)
+@Commune/C2p
 
 [Hymnus Matutinum]
 v. Toho, jenž řídí trojí říš',
@@ -96,13 +98,13 @@ po všechen věčných věků čas.
 Amen.
 
 [Ant MatutinumBMV]
-Požehnaná * jsi mezi ženami, a požehnaný plod života tvého.;;8
-O Holy Mother of God * thou hast yielded a pleasant odor like the best myrrh.;;18
-Sing for us again and again before this maiden's bed * the tender idylls of the play.;;23
-O Holy Mother of God * all we who dwell in thee are in gladness.;;86
-Joy to thee, * O Virgin Mary, thou hast trampled down all the heresies in the whole world.;;95
-Holy Virgin, my praise by thee accepted be; * give me strength against thine enemies.;;96
-After thy delivery thou still remainest a virgin; * undefiled Mother of God, pray for us.;;97
+Požehnaná jsi * mezi ženami a požehnaný plod života tvého.;;8
+Jako vybraná * myrha jsi vydala vůni líbeznosti, svatá Boží Rodičko.;;18
+Před ložem * této Panny zpívejte nám líbezné písně zpěvu.;;23
+V radosti * máme my všichni příbytek v tobě, svatá Boží Rodičko.;;86
+Raduj se, Panno Maria: * tys sama vyhladila všechny bludy po celém světě.;;95
+Rač mi dáti, * abych tě chválil, Panno přesvatá, dej mi sílu proti svým nepřátelům.;;96
+Po porodu * jsi, Panno, zůstala neporušená: Boží Rodičko, přimlouvej se za nás.;;97
 
 [Lectio1]
 Ze Šalamounových Přísloví
@@ -156,6 +158,18 @@ R. Porodila jsi toho, kdo tě stvořil, a navěky zůstáváš Pannou.
 &Gloria
 R. Porodila jsi toho, kdo tě stvořil, a navěky zůstáváš Pannou.
 
+[Responsory4]
+R. Jako cedr vyvýšena jsem byla v Libanonu, a jako cypřiš na hoře Sion; jako vybraná myrha 
+* Jsem vydávala sladkou vůni.
+V. A jako skořice a vonný balšám.
+R. Jsem vydávala sladkou vůni.
+
+[Responsory5]
+R. Kdopak je ta, jež vychází jako slunce, a krásná je jako Jerusalém? 
+* Uzřely ji dcery siónské, a prohlásily ji blaženou, a královny ji pochválily.
+V. A jako jarní dny ji okrášlily květy růží a polních lilií.
+R. Uzřely ji dcery siónské, a prohlásily ji blaženou, a královny ji pochválily.
+
 [Responsory6]
 R. Po dceři jerusalémské, ozdobené řetízky, Hospodin zatoužil: 
 * A když ji uzřely dcery sionské, chválily ji jako přeblaženou, a pravily: * Vylitá mast je tvé jméno.
@@ -169,6 +183,30 @@ R. Šťastná jsi totiž, přesvatá Panno Maria, a nanejvýš hodná veškeré 
 * Neboť z tebe vyšlo slunce spravedlnosti, Kristus, náš Bůh.
 V. Přimlouvej se za věřící lid, prosiž za duchovenstvo, oroduj za oddané ženské pokolení; ať všichni pociťují tvou pomoc, když slaví tvou svatou slavnost.
 R. Neboť z tebe vyšlo slunce spravedlnosti, Kristus, náš Bůh.
+
+[Responsory8]
+R. Blahoslavit mne budou všechna pokolení, 
+* Neboť veliké věci mi učini Hospodin, který je mocný, a svaté je jeho jméno.
+V. A jeho milosrdenství je od pokolení do pokolení těch, kdo se ho bojí.
+R. Neboť veliké věci mi učini Hospodin, který je mocný, a svaté je jeho jméno.
+&Gloria
+R. Neboť veliké věci mi učini Hospodin, který je mocný, a svaté je jeho jméno.
+
+[Lectio7]
+Čtení svatého Evangelia podle Lukáše.
+!Lukáš 11:27-28
+Za onoho času, když Ježíš mluvil k zástupům, pozvedla hlas jakási žena z lidu a řekla mu: „Blahoslavené lůno, které tě nosilo.“ A ostatní.
+_
+Homilie ctihodného Bédy Kněze.
+!Kniha 4. Kapitola 49 na Lk. 11.
+Tato žena prokázala zajisté velkou víru a oddanost. Když Znalci zákona a Farizeové pokoušeli Pána a rouhali se mu, ona poukázala na význam jeho vtělení všechny ostatní převyšující. A vyznala to právě s takovou důvěrou, aby odsoudila pomluvy přítomných velkých mužů i proradnost budoucích bludařů. Neboť stejně jako se tehdy Židé rouhali proti působení Ducha Svatého a popírali, že Bůh Syn má opravdu stejnou podstatu jako Bůh Otec, tak posléze bludaři popírali, že Maria byla vždy Panna, a působením moci Ducha Svatého se z ní v lidském těle narodil jednorozený Syn Boží, vzal na sebe přirozenost mateřského těla a tím měl opravdu stejnou podstatu i s matkou Syna člověka. Říkali, že se to prostě stát nemohlo.
+
+[Lectio8]
+Avšak pokud by tělo Slova Božího, které se narodilo v těle, bylo prohlášeno za odlišné od těla Panenské Matky, zcela zbytečně by bylo blahoslavené lůno, které ho nosilo, a prsy, které ho kojily. Apoštol totiž praví: „Neboť Bůh poslal svého Syna zrozeného ze ženy a podrobeného zákonu.“ Nesmíme tedy naslouchat těm, kteří říkají, že by tam mělo stát: „Narozeného ze ženy, podrobeného zákonu,“ ale opravdu „Zrozeného ze ženy,“ protože byl počat v panenském lůně, tělo přijal nikoliv z ničeho, ani odjinud, ale právě z těla své matky. Jinak by se nemohl vpravdě nazývat Synem člověka, pokud by neměl lidský původ. My tedy, po těchto slovech řečených proti Eutyché, pozvedněme své hlasy spolu s Katolickou Církví, jejíž předobraz přinesla tato žena, pozvedněme i svou mysl z nitra zástupu, a řekněme Spasiteli: „Blahoslavené lůno, které tě nosilo, a prsy, které tě kojily!“ Vpravdě je totiž svatá Rodička, jak již někdo řekl: „dokázala nám poroditi Krále, jenž nebe i zemi vlastniti bude navěky.“
+
+[Lectio9]
+Spíše jsou blahoslavení ti, kdo slyší slovo Boží a zachovávají jej. Spasitel se krásně přidal k uznání ženy, ne pouze jako té, která si zasloužila dáti tělo Slovu Božímu, ale utvrzuje také na cestě k blaženosti všechny, kteří ono Slovo duchovním sluchem ve víře počali, a zachováním dobrého díla jej, ať už v sobě, nebo v srdci bližního uposlechli, a snažili se je v sobě vyživovat. Neboť i sama Boží Rodička byla blažená, neboť skrze ní se Slovo vtělilo v čase, mnohem více však proto, že zůstala věčnou strážkyní jeho lásky. 	
+&teDeum
 
 [Versum 0]
 V. Oroduj za nás, svatá Boží Rodičko.

--- a/web/www/horas/Bohemice/CommuneM/C11.txt
+++ b/web/www/horas/Bohemice/CommuneM/C11.txt
@@ -5,3 +5,55 @@ V. Požehnaná ty mezi ženami, a požehnaný plod života tvého.
 R. Pán s tebou.
 &Gloria
 R. Zdrávas Maria, milosti plná, * Pán s tebou.
+
+[Ant Matutinum 3N]
+Zahrada zapečetěná jsi, * Boží Rodičko, zahrada zapečetěná, pramen označený; povstaň a pospěš, má přítelkyně, a přijď.
+
+[Ant Matutinum] (rubrica cisterciensis)
+Hle, jak jsi krásná, * má přítelkyně, hle, jak jsi krásná; tvé oči jsou jako oči holubice.;;8
+Jako lilie * mezi trním, taková je má přítelkyně mezi ostatními dívkami.;;18
+Plástev přetékající medem * jsou tvé rty, nevěsto, a vůně tvých šatů je jako vůně kadidla.;;23
+Tvá vůně * je jako sad granátových jablek, së zralými plody.;;44
+Pramen v zahradách * je studna vod živých, jež jako bystřiny běží do Libanonu.;;45
+Nechť přijde * můj milovaný do mé zahrady, a pojí ze svých plodů.;;47
+Přijď * do mé zahradě, sestro má a nevěsto, smísil jsem svou myrhu se svými vonnými mastmi.;;84
+Pojedl jsem plástev * s mým medem, popil jsem víno se svým mlékem.;;86
+Duše má * se rozplynula, když promluvil můj milovaný; hledala jsem, avšak nenalezla jsem jej; volala jsem, ale neodpověděl mi; našli mě však strážci města, zbili mě, i zranili mě, sebrali mi plášť, strážci hradeb; dcery jerusalémské, vyřiďte mému milému, že láskou chřadnu.;;95
+Takový je * můj miláček, a on je můj přítel, dcery jerusalémské.;;96
+Sestoupil jsem * do mandlové zahrady, abych viděl údolní jablíčka, a přesvědčil se, že rozkvetla vinice, a urodila se granátová jablka; navrať se, navrať se, Šulamítko, navrať se, navrať se, abychom na tebe popatřili.;;97
+Zahrada zapečetěná jsi, * Boží Rodičko, zahrada zapečetěná, pramen označený; povstaň a pospěš, má přítelkyně, a přijď.;;98
+Z královského pokolení * vzešla Maria a září; abychom obdrželi pomoc jejích přímluv, o to v mysli i duchu nadmíru oddaně prosíme.;;249;250;251
+
+[Responsory4]
+R. Blažené pokolení, z něhož se Kristus narodil.
+* Ó, jak slavná je Panna, jež nebes Krále zrodila!
+V. Šťastná jsi tedy, svatá Panno Maria, a převelice hodná veškeré chvály.
+R. Ó, jak slavná je Panna, jež nebes Krále zrodila!
+
+[Responsory7]
+@Commune/C11:Responsory6:1-3
+R. A když ji uzřely dcery sionské, chválily ji jako přeblaženou, a pravily: * Vylitá mast je tvé jméno.
+
+[Responsory8]
+R. Rozlila se milost na tvých rtech,
+* Proto ti požehnal Bůh navěky.
+V. Myrha, kadidlo a kasie voní z tvých rouch, ze slonovinových paláců; dcery královské tě těší svým půvabem, ve tvé slávě.
+R. Proto ti požehnal Bůh navěky.
+
+[Responsory11]
+R. Požehnaná a úctyhodná jsi, Panno Maria,
+* Jejíž lůno si zasloužilo nosit Krista Pána.
+V. Požehnaná jsi mezi ženami a požehnaný je plod lůna tvého.
+R. Jejíž lůno si zasloužilo nosit Krista Pána.
+
+[Responsory12]
+R. Blažená jsi, Panno Maria, Boží Rodičko, neboť jsi uvěřila Hospodinu; dokonáno jest v tobě, co řečeno bylo tobě: hle, povýšena jsi nad sbory andělské;
+* Přimlouvej se za nás u Pána našeho Boha.
+V. Zdrávas Maria, milostiplná, Pán s tebou.
+R. Přimlouvej se za nás u Pána našeho Boha.
+
+[Lectio10]
+@Commune/C11:Lectio8:s/My tedy.*//s
+
+[Lectio11]
+@Commune/C11:Lectio8:s/.* My tedy/My tedy/s

--- a/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm214.txt
+++ b/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm214.txt
@@ -1,0 +1,10 @@
+(Jeremiášovo Kantikum * Jer 31:10-18)
+31:10 Slyšte, pohané, Hospodinovo slovo, zvěstujte ho na ostrovech v dáli! 
+31:11 Řekněte: Shromáždí Israele ten, kdo ho rozptýlil, bude nad ním bdít jako pastýř nad svým stádem.
+31:12 Vykoupí Hospodin Jakuba a vysvobodí ho z ruky mocnějšího.
+31:13 Přijdou a budou jásat na hoře Siónu, těšit se budou z Hospodinových dobrodiní;
+31:14 Z obilí, vína a oleje, z mláďat bravu a skotu.
+31:15 Jejich duše bude jak zavlažovaná zahrada, nebudou už víc strádat.
+31:16 Tehdy se rozveselí v tanci panna, zaradují se jinoši a starci.
+31:17 Proměním jejich nářek v radost, útěchu a radost jim vleji po jejich smutku.
+31:18 Napojím kněze tukem a můj lid se nasytí mým dobrodiním.

--- a/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm272.txt
+++ b/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm272.txt
@@ -1,0 +1,10 @@
+(Kantikum z Přísloví * Prov. 9:1-6, 10-12)
+9:1 Moudrost si zbudovala palác, opřela jej o sedm sloupů.
+9:2 Pobila dobytek, smísila víno, připravila také svůj stůl.
+9:3 Poslala své služebnice volat z vyvýšenin města:
+9:4 Kdo je nezkušený, ať sem přijde, kdo je bez rozvahy, toho chci učit.
+9:5 Pojďte, můj pokrm jezte, víno, mnou nalité, pijte!
+9:6 Nechte dětinství, a budete žít, po cestě poznání choďte!
+9:10 Počátek moudrosti je bát se Hospodina, poznat Svatého – to je vědění.
+9:11 Neboť skrze něj se tvé dni rozmnoží, rozhojní ti léta života.
+9:12 Jsi-li moudrý, jsi moudrý pro sebe, jsi-li pošetilý, je to tvá škoda.

--- a/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm273.txt
+++ b/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm273.txt
@@ -1,0 +1,8 @@
+(Kantikum Moudrosti * Sap 16:20-21, 26, 29; 17:1)
+16:20 Andělským pokrmem jsi živil svůj lid, a neustále jsi jim poskytoval hotový chléb z nebe bez práce;
+16:20 Který má v sobě každé potěšení, a každou chuť sladkosti.
+16:21 Tvá podstata totiž ukazovala tvou sladkost, kterou chováš ke svým dětem;
+16:21 Neboť vyhovovala přání toho, kdo ji požíval, a přizpůsobovala se chuti, jak si kdo přál.
+16:26 Tak se poučili tvoji synové, které miluješ, Pane, že člověka neživí rozličné druhy plodů, ale tvé slovo že zachovává ty, kdo věří v tebe.
+16:29 Naděje nevděčného totiž roztaje jako zimní jinovatka a odteče jako nepotřebná voda.
+17:1 Veliké a neproniknutelné jsou tvé úradky, Hospodine, a nevýslovná jsou tvá slova; proto nepoučitelné duše upadly v omyl.

--- a/web/www/horas/Bohemice/Sancti/07-16.txt
+++ b/web/www/horas/Bohemice/Sancti/07-16.txt
@@ -6,48 +6,13 @@ Bože, jenž jsi jedinečným titulem nejblahoslavenější vždy Panny a Rodič
 $Qui vivis
 
 [Lectio4]
-Here is a story to the effect that many men who had kept a tradition of the holy~
-Prophets Elijah and Elisha, were made ready by the preaching of John the Baptist~
-to hail the coming of the Messiah, and that, when the Apostles having been~
-filled with the Spirit upon the holy day of Pentecost, spake with diverse tongues~
-and worked miracles by calling upon the Name of Jesus which is above every other~
-name, these men, seeing and being assured of the truth, straightway embraced the~
-faith of the Gospel, and that on account of their singular love toward the Most~
-Blessed Virgin, whose conversation and friendship they were able to enjoy, they~
-paid her the respect of building her a little Chapel, the first which was ever~
-raised in honour of this same most pure Maiden, and which stood upon that part~
-of Mount Carmel whence the servant of Elijah had in old days espied that~
-manifest type of the Virgin, the little cloud like a man's hand, arising out of~
-the sea. (3 Kings xviii. 44.)
+Když ve svatý den Letnic byli Apoštolové ovanuti Duchem svatým z nebe, začali mluvit různými jazyky, a vzýváním převznešeného Ježíšova jména dosáhli mnoha podivuhodných věcí. Mnozí muži (jak se říká), kteří šli ve stopách Proroků Eliáše a Elisea, a kázáním Jana Křtitele byli připraveni na příchod Kristův, pohleděli na tyto věci a potvrdili jejich pravdu, pak ihned přijali víru v Evangelium a zvláštní náklonností nejblahoslavenější Pannu (byli tak šťastni, že její slova i přátelství mohli užívati) tak začali uctívat, že první ze všech právě na místě hory Karmel, kde kdysi Eliáš uzřel stoupající oblak jako předobraz slavné Panny, této nejčistší Panně postavili kapli. (3 Král. 18, 44)
 
 [Lectio5]
-Now this new Chapel they repaired oftentimes day by day, and in their sacred~
-ceremonies, prayers, and praises, honoured the Most Blessed Virgin as the~
-particular Guardian of their Congregation. For this reason they came to be~
-everywhere called the Brethren of Blessed Mary, of Mount Carmel, and the Supreme~
-Pontiffs have not only confirmed to them the right to use this name, but have~
-granted particular indulgences to all those who so call either the Order itself,~
-or any particular member thereof. Her name and protection are not the only gifts~
-which the most bountiful Virgin hath given them yea, she hath given them the~
-badge of the Holy Scapular, which she delivered to the Blessed Englishman Simon~
-Stock, even an heavenly garment whereby this Holy Order is marked, and harnessed~
-against all assaults. Moreover, in old times, when this Order was unknown in~
-Europe, and not a few were instant with Honorius III. to put an end to it, the~
-most gracious Virgin Mary appeared by night to the said Honorius, and flatly~
-commanded him to show kindness to the Order and to the men belonging thereto.
+K této nové kapli pak často i každý den přicházeli a zbožnými obřady, modlitbami i chválami nejblahoslavenější Pannu uctívali jako obzvláštní ochranitelku svého Řádu. Proto je postupně všichni začali nazývat Bratry blahoslavené Marie z Hory Karmel. Toto jméno a právo je užívat pak Svatí Otcové v Římě nejen potvrdili, ale také udělili zvláštní Odpustky všem, kdo tímto jménem nazývali tento Řád či jednotlivé jeho členy. Nejvznešenější Panna jim však neudělila pouze jméno a ochranu. Pravý a slavný svatý Škapulíř, který udělila blahoslavenému Angličanu jménem Simon Stock, aby se tímto nebeským oděvem onen posvátný Řád nejen poznal, ale byl také ochráněn před mnoha různými zly. A později, když kdysi v Evropě byl tento Řád ještě neznámý a mnoho lidí se u papeže Honoria III. přimlouvalo za jeho zrušení, zjevila se Honoriovi nejmilejší Panna Maria a prostě mu přikázala, aby Řád i jeho členy milostivě přijal a schválil.
 
 [Lectio6]
-Many godly persons believe that it is not in this world only that the most~
-Blessed Virgin hath marked with her favour this Order which pleaseth her so well,~
-but that in the next world, where her power and mercy have a freer scope than~
-here, they who belong to the Guild of the Scapular, who have practised an easy~
-abstinence, have been regular in reciting a few prayers enjoined to them, and~
-have kept chastity according to their state of life, are comforted by her~
-motherly love while they are being cleansed in the fire of Purgatory, and by her~
-help are borne forward towards their home in heaven more quickly than others.~
-The Order loaded with so many and so great gifts, hath instituted a solemn~
-Commemoration of the Most Blessed Virgin, to be made year after year, in~
-perpetual observance, for the glory of the same Virgin.
+Nejen na tomto světě obdařila nejblahoslavenější Panna Řád sobě tak milý mnoha přednostmi. Také na tom dalším (kde nadevše platí její moc a slitování) svým synům ve společenství Škapulíře sjednoceným, kteří dodržují mírnou zdrženlivost a nemnohé modlitby, které jsou jim předepsané, a podle svého stavu dodržují čistotu, v zápalu mateřské lásky slíbila, že přežijí, a až budou očištěni ohněm očistcovým, na její přímluvu je milosrdně vysvobodí a rychleji dojdou do vlasti nebeské. Řád, který byl obdařen tolika a tak velikými milostmi, usta­novil, že se každoročně bude slavit přeslavná Památka nejblahoslavenější Panny.	
 
 [Ant 2]
 Hlava tvá * jako Karmel, a vlasy tvé hlavy jako královský purpur, splývající v řasách, alleluja.
@@ -56,5 +21,5 @@ Hlava tvá * jako Karmel, a vlasy tvé hlavy jako královský purpur, splývají
 Sláva Libanonu * je jí dána, krása Karmelu a Šáronu, alleluja.
 
 [Lectio94]
-On the holy day of Pentecost, it is said that many men, who were walking in the footsteps of the holy prophets Elias and Eliseus, embraced the faith of the Gospel, and began to build a chapel to that purest of Virgins on that very spot of Mount Carmel where Elias of old had seen a cloud arising, a remarkable symbol of the Virgin. Honouring this same Most Blessed Virgin as the special protectress of their Order, they were thenceforth called the brethren of Our Lady of Mount Carmel. The special protection of the Most Blessed Virgin hath never failed their Order, which Honorius III was dissuaded by a dream from abolishing, and to which she granted the badge of the holy scapular with the promise that those who are enrolled and observe the slight abstinence and say the few prayers prescribed, will be taken as soon as possible from the fire of Purgatory to the heavenly fatherland. Therefore the Order, laden with so many and such great favours, hath instituted a solemn Commemoration of the Most Blessed Virgin, to be celebrated year by year.
+Když o slavném dni Letnic, jak se praví, mnozí muži, kteří šli ve šlépějích svatých proroků Elijáše a Elizea, přijali víru evangelia, začali právě na tom místě hory Karmel, kde Elijáš kdysi spatřil vystupující obláček, znamení blahoslavené Panny Marie, stavět kapli zasvěcenou té nejčistší Panně; a ji samou pak ctili jako zvláštní ochránkyni řádu, jenž od té doby nese jméno bratří blahoslavené Marie z Hory Karmel.Tomuto řádu nikdy nechyběla zvláštní ochrana nejsvětější Panny, která ve snu odvrátila papeže Honoria III. od záměru řád zrušit a která mu darovala posvátný oděv – škapulíř. Těm, kdo jej nosí, zachovávají skromnou zdrženlivost a věrně se modlí, je podle zbožné víry na její přímluvu dopřáno, aby byli z očistce brzy přeneseni do nebeské vlasti. Protože řád tolikerými dobrodiními oplývá, ustanovil každoroční slavnostní Památku nejsvětější Panny Marie.
 &teDeum

--- a/web/www/horas/Bohemice/Sancti/09-08.txt
+++ b/web/www/horas/Bohemice/Sancti/09-08.txt
@@ -92,10 +92,10 @@ R. This is she whose famous life still sheddeth lustre upon all the Churches.
 Eve wept, but Mary laughed. Eve's womb was big with tears, but Mary's womb was big with gladness. Eve gave birth to a sinner, but Mary gave birth to the sinless One. The mother of our race brought punishment into the world, but the Mother of our Lord brought salvation into the world. Eve was the foundress of sin, but Mary was the foundress of righteousness. Eve welcomed death, but Mary helped in life. Eve smote, but Mary healed. For Eve's disobedience, Mary offered obedience and for Eve's unbelief, Mary offered faith.
 
 [Responsory5]
-R. Let us keep with rejoicing the Birthday of the Blessed Mary,
-* That she may pray for us to our Lord Jesus Christ.
-V. With all our heart and with all our soul let us sing praise to Christ on this the solemn Feastday of Mary the mighty Mother of God.
-R. That she may pray for us to our Lord Jesus Christ.
+R. S radostí oslavujme Narození blažené Panny Marie,
+* Aby se sama za nás přimlouvala u Pana Ježíše Krista.
+V. Z celého srdce i duše pějme slávu Kristu o této posvátné slavnosti převznešené Rodičky Boží Marie.
+R. Aby se sama za nás přimlouvala u Pana Ježíše Krista.
 
 [Lectio6]
 Let Mary now make a loud noise upon the organ, and between its quick notes let the rattling of the Mother's timbrel be heard. Let the gladsome choirs sing with her, and their sweet hymns mingle with the changing music. Hearken to what a song her timbrel will make accompaniment. She saith: “My soul doth magnify the Lord, and my spirit hath rejoiced in God my Saviour. For He hath regarded the lowliness of His hand-maiden, for, behold, from henceforth all generations shall call me blessed for He That is Mighty hath done to me great things.” The new miracle of Mary's delivery hath effaced the curse of the frail backslider, and the singing of Mary hath silenced the wailing of Eve.

--- a/web/www/horas/Bohemice/SanctiM/07-16.txt
+++ b/web/www/horas/Bohemice/SanctiM/07-16.txt
@@ -1,0 +1,30 @@
+[Lectio6]
+@Sancti/07-16:Lectio5:s/ Nejvznešenější .*//
+
+[Lectio7]
+@Sancti/07-16:Lectio5:s/.* (?=Nejvznešenější)//
+
+[Responsory8a]
+@Sancti/09-08:Responsory5:s/Narození/Památku/
+
+[Responsory9]
+@Commune/C11:Responsory7:s/svatou slavnost/slavnou Památku/
+
+[Lectio9] (rubrica cisterciensis)
+Čtení svatého Evangelia podle Lukáše. 
+!Lukáš 11:27-28
+Za onoho času, když mluvil Ježíš k zástupům, zvýšila jedna žena z davu hlas a řekla mu: „Blahoslavené lůno, které tě nosilo.“ A ostatní.
+_
+Homilie svatého Bernarda Opata.
+!Řeč 4. o Nanebevzetí Panny Marie.
+Jaký jen by dokázal jazyk, třebaže by byl Andělský, dostatečně vychválit Pannu a Matku, matku pak ne ledajakou, ale Boží? Dvojí novinka, dvoje přislíbení. Dvojí zázrak, avšak právem velmi přiléhavý i příznačný. Totiž žádný jiný syn neobdržel tu čest býti zrozen z panny, ani Bůh se pak podruhé nezrodil. Pohleď tedy, jak očividně si odpovídají chvalozpěv naší Panny a svatební píseň. Bezpochyby její lůno byla ženichova svatební komnata. Poslyš Marii v Evangeliu: „Shlédl,“ praví, „na poníženost své služebnice.“ Poslechni si ji také ve svatební komnatě: „Když byl Král,“ praví, „na svém lůžku, má myrha vydala svou vůni. Myrha je totiž prostinká rostlina a čistí hruď. To aby bylo zřejmé, že myrhou byla míněna pokora, jejíž vůně a krása nalezla milost u Boha. 	
+
+[Lectio10] (rubrica cisterciensis)
+Nechť mlčí o tvém milosrdenství, blažená Panno, pokud se najde někdo takový, kdo by tě vzýval ve svých potřebách, a pamatoval by si, žes jej opustila. My totiž, tvoji nepatrní služebníci, se v určitých ctnostech radujeme s tebou, avšak v této ctnosti spíše sami se sebou. Panenství chválíme, pokoru obdivujeme, avšak milosrdenství, to chutná sladce spíše ubohým, proto je nám dražší, když je obdržíme, častěji na ně vzpomínáme, a hojněji o ně prosíme. Maria je totiž ta, jež zajistila obnovu celého světa, získala spásu všech. Je totiž jasné, že starost o veškerý lidský rod sužovala tu, jíž bylo řečeno: „Neboj se, Maria, neboť jsi nalezla milost,“ tedy tu, již jsi hledala. Kdo by jen uměl změřit, ó Požehnaná, délku a šířku, výšku i hloubku tvého milosrdenství?
+	
+[Lectio11] (rubrica cisterciensis)
+Délka jejího milosrdenství je taková, že pomůže všem, kdo ji budou vzývat, až do posledního dne. Šířka její naplňuje celý okrsek světa tak, že země je plná tvého milosrdenství. Tak i výška její dosáhla obnovy nebeského města, a hloubka její až v temnotách a stínu smrti získala duším vykoupení. Skrze tebe se totiž naplňuje nebe, vyprazdňuje se peklo, obnovují se trosky nebeského Jerusaléma, a čekajícím ubohým se navrací život, který ztratili. Tvá takto přemocná a předobrá láska překypuje laskavou slitovností i účinnými přímluvami, stejně bohatá je v obou. K tomuto prameni tedy ať spěchá naše žíznivá duše: k této hojnosti milosrdenství ať se s nejvyšším zájmem utíká naše ubohost.	
+
+[Lectio12] (rubrica cisterciensis)
+!Řeč o Narození B. M. V.
+Co bych však mohl říct o její výjimečnosti? Komu z Andělů kdy bylo řečeno? „Duch svatý sestoupí na tebe a moc Nejvyššího tě zastíní. Proto také to Svaté, co se z tebe narodí, bude Syn Boží“? A proto Pravda vzešla ze země, ne z Andělského stvoření. Nepřijala tedy Anděly, ale pokolení Abra­hámovo. Pro Anděla je velikou věcí, když může býti služebníkem Páně. Avšak Maria si zasloužila něco mnohem většího, totiž býti jeho Matkou. Taková plodnost Panny je tedy naprosto výjimečná výsada, jedinečným darem byla učiněna tím vznešenější, než jsou Andělé, čím snáze než všichni služebníci přijala jméno Matky. Takovou milost nalezla ta, která již byla milostiplná, planula láskou, neporušená byla v panenství, oddaná v pokoře, nicméně ještě otěhotněla, aniž by poznala muže, a porodila, aniž by poznala porodní bolesti. Pokud by se to zdálo málo, „Dítě, které se z ní narodilo, je nazváno Svaté, a je to Syn Boží.“

--- a/web/www/horas/Bohemice/Tempora/Pent01-4.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent01-4.txt
@@ -91,6 +91,8 @@ $Qui vivis
 
 [Invit]
 Pojďme a klaňme se Kristu, panovníku národů: * Který dává ducha hojnosti těm, kdo jej požívají.
+(sed rubrica cisterciensis)
+Pojďte ke mně všichni, kdo se lopotíte, * A já vás občerstvím.
 
 [Hymnus Matutinum]
 v. K svátku tajemnému vroucně přistupujme,
@@ -188,7 +190,7 @@ Kázání svatého Tomáše Akvinského
 Nesmírné dary božské štědrosti, které obdržel křesťanský lid, mu udělily nedocenitelnou důstojnost. Žádný jiný národ totiž není ani kdy nebyl tak veliký, že by se mu jejich bohové přiblížili tak, jako se nám přiblížil náš Bůh. Jednorozený Syn Boží totiž chtěl, abychom byli účastni jeho božství, takže přijal naši přirozenost, a aby z lidí učinil bohy, sám se stal člověkem. A navíc to, co z našeho přijal, to všechno nám udělil k naší spáse. Své tělo totiž pro naše smíření obětoval Bohu Otci na oltáři kříže. Krev svou prolil zároveň jako cenu vykoupení i prostředek k obmytí, abychom vykoupeni z ubohého otroctví byli očištěni ode všech hříchů. Aby nám tedy zůstala památka spojená s tak velikým dobrem, zanechal nám své Tělo jako pokrm a svou Krev jako nápoj pod podobou chleba a vína, aby je věřící mohli přijímat.
 
 [Responsory4]
-R. Ještě když večeřeli, vzal Ježíš chléb, požehnal, a lámal, a dal svým učedníkům, a řekl.
+R. Když ještě večeřeli, vzal Ježíš chléb, požehnal, a lámal, a dal svým učedníkům, a řekl.
 * Vezměte a jezte: toto je mé tělo.
 V. Řekli muži mého stánku: Kdo dá něco ze svého těla, abychom se nasytili?
 R. Vezměte a jezte: toto je mé tělo.
@@ -232,7 +234,7 @@ R. Zůstává ve mně a já v něm.
 „Kdo jí mé Tělo a pije mou Krev, zůstává ve mně a já v něm.“ Jísti tedy onen pokrm a píti onen nápoj znamená zůstávat v Kristu a on pak zůstává v nás. (1 Kor. xi. 28,) A proto, pokud kdo nezůstává v Kristu a Kristus nezůstává v něm, beze vší pochyby duchovně nepožívá jeho Tělo ani nepije jeho Krev, i když tělesně a viditelně do svých úst přijme Svátost Těla a Krve Kristovy. Spíše pak takovou Svátost jí a pije ke svému odsouzení, neboť se nečistý opovážil přistoupit ke Kristovým Svátostem, které pokud někdo přijímá a není čistý, přijímá je nehodně. O tom se pak říká: „Blažení čistí srdcem, neboť oni uvidí Boha.“ (Mat. v. 8.)
 
 [Responsory8]
-R. Jak mě poslal živý Otec, a já žiji skrze Otce,
+R. Jako mě poslal živý Otec, a já žiji skrze Otce,
 * Tak i ten, kdo jí mne, bude žít skrze mne.
 V. Živil jej Pán chlebem života a poznání.
 R. Tak i ten, kdo jí mne, bude žít skrze mne.
@@ -240,7 +242,7 @@ R. Tak i ten, kdo jí mne, bude žít skrze mne.
 R. Tak i ten, kdo jí mne, bude žít skrze mne.
 
 [Lectio9]
-Pán praví: „Jako mne poslal živý Otec a já jsem živ skrze Otce, tak i ten, kdo jí mne, živ bude skrze mne.“ (Jan x. 36,) Jako by řekl „Abych já mohl býti živ skrze Otce,“ to znamená, že k němu jako většímu vztahuji svůj život, a on způsobil mé vyprázdnění, v němž mne poslal (Phil. ii. 7, 8.). Aby však člověk žil skrze mne, to způsobí pouze účast na mém Těle. Já tedy ponížen žiji skrze Otce (Jan xiv. 28.), člověk však s hlavou vztyčenou žije skrze mne. It is said „I live by the Father“ that is to say, He is of the Father, not the Father of Him, and yet not so, but that the Father and the Son are co-equal together. Also it is said „So he that eateth Me, even he shall live by Me,“ whereby He showeth the gracious work towards His people of Him Who is the „one Mediator between God and man,“ (1 Tim. ii. 5,) and not that He Which is eaten and he which eateth Him are co-equal together.
+Pán praví: „Jako mne poslal živý Otec a já jsem živ skrze Otce, tak i ten, kdo jí mne, živ bude skrze mne.“ (Jan x. 36,) Jako by řekl „Abych já mohl býti živ skrze Otce,“ to znamená, že k němu jako většímu vztahuji svůj život, a on způsobil mé vyprázdnění, v němž mne poslal (Phil. ii. 7, 8.). Aby však člověk žil skrze mne, to způsobí pouze účast na mém Těle. Já tedy ponížen žiji skrze Otce (Jan xiv. 28.), člověk však s hlavou vztyčenou žije skrze mne. Pokud tedy takto <i>Pán</i> řekl „Žiji skrze Otce,“ neboť Syn je z Otce, nikoliv Otec ze Syna; řekl to bez toho, aby byla porušena jejich rovnost. Ani tím, že řekl „A kdo mě jí, i on bude žít skrze mě,“ však nechce dát najevo svou a naši rovnost, nýbrž ukazuje nám milost prostředníka.
 &teDeum
 
 [Ant Laudes]

--- a/web/www/horas/Bohemice/Tempora/Quad6-4.txt
+++ b/web/www/horas/Bohemice/Tempora/Quad6-4.txt
@@ -116,52 +116,52 @@ R. It had been good for that man if he had not been born.
 R. One of My disciples shall betray Me this night. Woe unto that man by whom I am betrayed. * It had been good for that man if he had not been born.
 
 [Lectio7]
-From the first letter of blessed Apostle Paul to Corinthians
-!1 Cor 11:17-22
-17 Now this I ordain: not praising you, that you come together not for the better, but for the worse.
-18 For first of all I hear that when you come together in the church, there are schisms among you; and in part I believe it.
-19 For there must be also heresies: that they also, who are approved, may be made manifest among you.
-20 When you come therefore together into one place, it is not now to eat the Lord's supper.
-21 For every one taketh before his own supper to eat. And one indeed is hungry and another is drunk.
-22 What, have you not houses to eat and to drink in? Or despise ye the church of God; and put them to shame that have not? What shall I say to you? Do I praise you? In this I praise you not.
+Čtení z prvního listu svatého Apoštola Pavla Korinťanům
+!1 Kor 11:17-22
+17 A když už jsem v tom nařizování: Nemohu chválit, že když se scházíte, je to spíše ke škodě než k užitku.
+18 Předně slyším, že když se shromažďujete v církevní obci, oddělujete se jedni od druhých, a zčásti tomu věřím.
+19 Nedá se tomu vyhnout, že mezi vámi dojde i k rozštěpení. Tak se aspoň ukáže, kteří z vás jsou opravdu dobří.
+20 Když se tedy scházíte, už to není večeře, jak ji ustanovil Pán.
+21 Každý si totiž bere, co si přinesl k jídlu, takže potom jeden má hlad, a druhý je napilý.
+22 Copak nemáte domy, kde byste se mohli najíst a napít? Či pohrdáte církevní obcí Boží, že zahanbujete ty, kdo nic nemají? Co vám na to mám říci? Pochválit vás? V tomhle vás chválit nemohu.
 
 [Responsory7]
-R. I was like a gentle lamb that is brought to the slaughter, and I knew not that mine enemies had devised devices against me, saying:
-* Come, let us put (poison of a deadly) tree into his bread, and let us cut him off from the land of the living.
-V. All they that hate me devised my hurt against me: they plotted together to do me evil, saying:
-R. Come, let us put (poison of a deadly) tree into his bread, and let us cut him off from the land of the living.
+R. Byl jsem jako nevinný beránek; veden jsem byl k obětování, ale nevěděl jsem to; spolčili se proti mě moji nepřátelé, a říkali:
+* Pojďte, nasypeme <i>jedovaté</i> piliny do jeho jídla, a vyřízneme jej ze země živých.
+V. Všichni moji nepřátelé snovaly zlé plány proti mně; zlá slova pronášeli proti mně, a pravili:
+R. Pojďte, nasypeme <i>jedovaté</i> piliny do jeho jídla, a vyřízneme jej ze země živých.
 
 [Lectio8]
-!1 Cor 11:23-26
-23 For I have received of the Lord that which also I delivered unto you, that the Lord Jesus, the same night in which he was betrayed, took bread.
-24 And giving thanks, broke, and said: Take ye, and eat: this is my body, which shall be delivered for you: this do for the commemoration of me.
-25 In like manner also the chalice, after he had supped, saying: This chalice is the new testament in my blood: this do ye, as often as you shall drink, for the commemoration of me.
-26 For as often as you shall eat this bread, and drink the chalice, you shall show the death of the Lord, until he come.
+!1 Kor 11:23-26
+23 Co jsem od Pána přijal, v tom jsem vás také vyučil: Pán Ježíš právě tu noc, kdy byl zrazen, vzal chléb,
+24 vzdal díky, rozlámal ho a řekl: „Toto je moje tělo, které se za vás vydává. To čiňte na mou památku“.
+25 Podobně vzal po večeři i kalich a řekl: „Tento kalich je nová smlouva, potvrzená mou krví. Kdykoli z něho budete pít, čiňte to na mou památku.“
+26 Kdykoli totiž jíte tento chléb a pijete z tohoto kalicha, zvěstujete smrt Páně, dokud on nepřijde.
 
 [Responsory8]
-R. Could ye not watch with Me one hour, ye that called one on the other to die for Me?
-* Or see ye not Judas, how that he sleepeth not, but maketh haste to betray Me to the Jews?
-V. Why sleep ye? Rise, and pray, lest ye enter into temptation.
-R. Or see ye not Judas, how that he sleepeth not, but maketh haste to betray Me to the Jews?
+R. Jedinou hodinu jste nemohli bdít se mnou, vy, kdo jste se předháněli, kdo za mě zemře?
+* Nebo jste neviděli Jidáše, jak nespí, ale pospíchá mě vydat Židům?
+V. Proč spíte? Vstaňte a modlete se, abyste nevešli v pokušení.
+R. Nebo jste neviděli Jidáše, jak nespí, ale pospíchá mě vydat Židům?
 
 [Lectio9]
-!1 Cor 11:27-34
-27 Therefore whosoever shall eat this bread, or drink the chalice of the Lord unworthily, shall be guilty of the body and of the blood of the Lord.
-28 But let a man prove himself: and so let him eat of that bread, and drink of the chalice.
-29 For he that eateth and drinketh unworthily, eateth and drinketh judgment to himself, not discerning the body of the Lord.
-30 Therefore are there many infirm and weak among you, and many sleep.
-31 But if we would judge ourselves, we should not be judged.
-32 But whilst we are judged, we are chastised by the Lord, that we be not condemned with this world.
-33 Wherefore, my brethren, when you come together to eat, wait for one another.
-34 If any man be hungry, let him eat at home; that you come not together unto judgment. And the rest I will set in order, when I come.
+!1 Kor 11:27-34
+27 Kdo by tedy jedl tento chléb nebo pil kalich Páně nehodně, proviní se proti tělu a krvi Páně.
+28 Proto musí člověk sám sebe zkoumat, a tak ať chléb jí a z kalicha pije.
+29 Kdo totiž jí a pije, a tělo Páně nerozlišuje od obyčejného chleba, jí a pije si odsouzení.
+30 Proto je mezi vámi tolik nemocných a churavých a mnoho jich už umřelo.
+31 Kdybychom se sami správně posuzovali, nebyli bychom trestáni.
+32 Ale když nás Pán trestá, je to k naší nápravě, abychom nebyli odsouzeni s tímto světem.
+33 Proto, moji bratři, když se scházíte k jídlu, čekejte jedni na druhé.
+34 Má-li kdo hlad, ať se nají doma, abyste se nescházeli k potrestání. Ostatní věci pak zařídím, až přijdu.
 
 [Responsory9]
-R. The elders of the people consulted
-* That they might take Jesus by subtilty, and kill Him they came out, as against a thief, with swords and staves.
-V. The chief Priests and the Pharisees gathered a council.
-R. That they might take Jesus by subtilty, and kill Him: they came out, as against a thief, with swords and staves.
+R. Starší lidu se usnesli,
+* Že Ježíše lstí zajmou a zabijí; s meči a kyji pak vyšli jako na zločince.
+V. Vešli starší a Fariseové v radu.
+R. Že Ježíše lstí zajmou a zabijí; s meči a kyji pak vyšli jako na zločince.
 &Gloria
-R. The elders of the people consulted * That they might take Jesus by subtilty, and kill Him: they came out, as against a thief, with swords and staves.
+R. Že Ježíše lstí zajmou a zabijí; s meči a kyji pak vyšli jako na zločince.
 
 [Oratio Matutinum]
 v. Shlédni, prosíme, Pane, na tuto svou rodinu, pro niž náš Pán Ježíš Kristus neváhal vydat se v ruce zlých, a podstoupit kruté muky kříže.

--- a/web/www/horas/Bohemice/TemporaM/Pent01-4.txt
+++ b/web/www/horas/Bohemice/TemporaM/Pent01-4.txt
@@ -1,3 +1,114 @@
+[AntMatutinumM] (rubrica cisterciensis)
+Vezměte * oběti a vstupte do předsíně Hospodinovy, a klanějte se mu v jeho svatém chrámě.;;95
+Slitovník * a milosrdný Hospodin naplňuje dobrými věcmi tvou touhu.;;102
+Vyvádíš chléb * ze země, a víno rozradostňuje srdce lidské.;;103
+
+[Ant Matutinum 3N]
+Tělo mé * vpravdě je pokrm, a má krev vpravdě je nápoj. † Kdo jí mé tělo a pije mou krev, má život věčný, † praví Pán.
+(sed rubrica cisterciensis)
+Moudrost * zbudovala sobě dům, smísila víno, a prostřela stůl, alleluja.
+
+[Responsory2] (rubrica cisterciensis)
+R. Vyvedl vás Hospodin silnou rukou ze země egyptské;
+* Jenž vyvedl ze skály prameny vody, a živil vás manou na poušti.
+Nikoliv Mojžíš vám dal chléb z nebe, nýbrž můj Otec vám dává pravý chléb z nebe.
+R. Jenž vyvedl ze skály prameny vody, a živil vás manou na poušti.
+
+[Responsory3] (rubrica cisterciensis)
+R. Melchisedech, Král Salemu, Kněz Nejvyššího Boha, když přinesl chléb a víno, předznamenal tím Tělo Kristovo,
+* Svatou oběť, neposkvrněný obětní dar.
+V. Vstoupil Ježíš pro nás podle řádu Melchisedechova, a jednou obětoval sám sebe:
+R. Svatou oběť, neposkvrněný obětní dar.
+
+[Responsory4] (rubrica cisterciensis)
+@Tempora/Pent01-4:Responsory3
+
+[Lectio5]
+@Tempora/Pent01-4:Lectio4
+(sed rubrica cisterciensis)
+@Tempora/Pent01-4:Lectio4:s/Své tělo.*//
+
+[Lectio6]
+@Tempora/Pent01-4:Lectio5:s/Věřící .*//s
+(sed rubrica cisterciensis)
+@Tempora/Pent01-4:Lectio4:s/.* (Své tělo)/$1/
+
+[Lectio7]
+@Tempora/Pent01-4:Lectio5:s/.* (Věřící)/$1/s
+(sed rubrica cisterciensis)
+@Tempora/Pent01-4:Lectio5:s/Věřící .*//s
+
+[Lectio8]
+@Tempora/Pent01-4:Lectio6
+(sed rubrica cisterciensis)
+@Tempora/Pent01-4:Lectio5:s/.* (Věřící)/$1/s
+
+[Responsory5] (rubrica cisterciensis)
+R. Kdo jí mé Tělo a pije mou Krev, zůstává ve mně a já v něm;
+* Mé Tělo je totiž pravý pokrm, a má Krev je pravý nápoj.
+V. Jezte, přátelé, pijte a opíjejte se, nejdražší;
+R. Mé Tělo je totiž pravý pokrm, a má Krev je pravý nápoj.
+
+[Responsory6] (rubrica cisterciensis)
+@Tempora/Pent01-4:Responsory8:1-2
+V. Ve mně je milost každé cesty a pravdy, ve mně je každá naděje života a ctnosti.
+@Tempora/Pent01-4:Responsory8:4
+
+[Responsory7] (rubrica cisterciensis)
+R. Když ještě večeřeli, vzal Ježíš chléb, požehnal, a lámal, a dal svým učedníkům, a řekl: Vezměte a jezte:
+* Toto je mé tělo.
+V. Když viděli synové Israele manu na poušti, podivili se a říkali: Co je to?
+R. Toto je mé tělo.
+
+[Responsory8_]
+R. V jednom chlebu a jednom těle jsme mnozí;
+* Všichni máme účast na jednom chlebu a jednom kalichu.
+V. Připravil jsi to ve své sladkosti, Bože, chudákovi, jenž dáváš přebývat v jednom domě lidem stejné mysli.
+R. Všichni máme účast na jednom chlebu a jednom kalichu.
+
+[Responsory8C]
+@Tempora/Pent01-4:Responsory5:1-2
+V. Pojďte a jezte můj chléb, a pijte víno, které jsem vám smísil.
+@Tempora/Pent01-4:Responsory5:4
+
+[Responsory8]
+@:Responsory8_
+(sed rubrica cisterciensis)
+@:Responsory8C
+
+[Responsory10] (rubrica cisterciensis)
+R. Andělským pokrmem živíš svůj lid, Hospodine, a chléb z nebe nám dáváš, který má v sobě každé potěšení;
+* Ukazujíc tvou podstatu a sladkost, kterou chováš ke svým dětem;
+V. Hospodine, jenž dáváš život světu, vždy nám dávej svůj pravý chléb:
+R. Ukazujíc tvou podstatu a sladkost, kterou chováš ke svým dětem;
+
+[Lectio9]
+@Tempora/Pent01-4:Lectio7:s/A proto Pán .*//s
+
+[Lectio10]
+@Tempora/Pent01-4:Lectio7:s/.* (A proto Pán)/$1/s s/$/~/
+@Tempora/Pent01-4:Lectio8:s/A proto, pokud .*//s
+
+[Lectio11]
+@Tempora/Pent01-4:Lectio8:s/.* (A proto, pokud)/$1/s
+
+[Lectio12]
+@Tempora/Pent01-4:Lectio9
+(sed rubrica cisterciensis)
+@Tempora/Pent01-4:Lectio9:s/Pokud tedy.*//
+
+[Responsory11] (rubrica cisterciensis)
+R. Když uviděla Královna ze Sáby moudrost Šalamounovu, dům, který vystavěl, pokrmy jeho stolu, a jejich oděvy;
+* V údivu řekla: Blažení tvoji služebníci, neboť naslouchají tvé moudrosti.
+V. Královna Jihu přišla z konce země, aby naslouchala moudrosti Šalamounově.
+R. V údivu řekla: Blažení tvoji služebníci, neboť naslouchají tvé moudrosti.
+
+[Responsory12] (rubrica cisterciensis)
+R. Radujme se a jásejme, a vzdejme slávu Bohu, neboť přišla svatba Beránkova, a jeho manželka se připravila.
+* Blažení, kdo jsou pozváni na svatební hostinu.
+V. Xerxes před svatbou i zásnubami vystrojil Ester velkolepou hostinu.
+R. Blažení, kdo jsou pozváni na svatební hostinu.
+
 [Responsory TertiaM] (rubrica cisterciensis)
 V. Milosrdný a slitovný Hospodin.
 R. Pokrm dal těm, kdo se ho bojí.

--- a/web/www/horas/Latin/Commune/C10.txt
+++ b/web/www/horas/Latin/Commune/C10.txt
@@ -14,6 +14,7 @@ Special Benedictio
 Doxology=Nat
 Antiphonas horas
 (rubrica tridentina nisi rubrica cisterciensis) Psalmi Dominica
+(rubrica cisterciensis) 3 lectiones
 Gloria
 Suffr=Spiritu;Ecclesiæ,Papa;;
 Prefatio=Maria=veneratione;

--- a/web/www/horas/Latin/Commune/C11.txt
+++ b/web/www/horas/Latin/Commune/C11.txt
@@ -89,6 +89,8 @@ $Per Dominum
 
 [Invit]
 Sancta María, Dei Génetrix Virgo, * Intercéde pro nobis.
+(sed tempore paschali et rubrica cisterciensis)
+@Commune/C2p
 
 [Hymnus Matutinum]
 {:H-Quemterra:}v. Quem terra, pontus, sídera
@@ -200,7 +202,7 @@ R. Genuísti qui te fecit, et in ætérnum pérmanes Virgo.
 [Lectio4]
 Sermo sancti Joánnis Chrysóstomi
 !Apud Metaphrasten
-Dei Fílius non dívitem aut locupletem áliquam féminam sibi matrem elégit, sed beátam Vírginem illam, cujus ánima virtútibus ornáta erat. Cum enim beáta María supra omnem humánam natúram castitátem serváret, proptérea Christum Dóminum in ventre concépit. Ad hanc ígitur sanctíssimam Vírginem et Dei Matrem accurréntes, ejus patrocinii utilitátem assequamur. Itaque, quæcúmque estis vírgines, ad Matrem Dómini confúgite; illa enim pulchérrimam, pretiosíssimam et incorruptibilem possessiónem, patrocínio suo, vobis conservábit.
+Dei Fílius non dívitem aut locuplétem áliquam féminam sibi matrem elégit, sed beátam Vírginem illam, cujus ánima virtútibus ornáta erat. Cum enim beáta María supra omnem humánam natúram castitátem serváret, proptérea Christum Dóminum in ventre concépit. Ad hanc ígitur sanctíssimam Vírginem et Dei Matrem accurréntes, ejus patrocínii utilitátem assequámur. Itaque, quæcúmque estis vírgines, ad Matrem Dómini confúgite; illa enim pulchérrimam, pretiosíssimam et incorruptíbilem possessiónem, patrocínio suo, vobis conservábit.
 
 [Responsory4]
 R. Sicut cedrus exaltáta sum in Líbano, et sicut cypréssus in monte Sion: quasi myrrha elécta, 
@@ -209,7 +211,7 @@ V. Et sicut cinnamómum et bálsamum aromatízans.
 R. Dedi suavitátem odóris.
 
 [Lectio5]
-Magnum revera miraculum, fratres dilectíssimi, fuit beáta semper Virgo Maria. Quid namque illa majus aut illustrius ullo umquam témpore invéntum est, seu aliquándo inveníri póterit? Hæc sola cælum ac terram amplitúdine superávit. Quidnam illa sanctius? Non Prophétæ, non Apóstoli, non Mártyres, non Patriárchæ, non Angeli, non Throni, non Dominatiónes, non Séraphim, non Chérubim; non denique aliud quidpiam, inter creatas res visibiles aut invisibiles, majus aut excellentius inveníri potest. Eadem ancílla Dei est et mater; eadem Virgo et Génetrix.
+Magnum revéra miráculum, fratres dilectíssimi, fuit beáta semper Virgo María. Quid namque illa majus aut illústrius ullo umquam témpore invéntum est, seu aliquándo inveníri póterit? Hæc sola cælum ac terram amplitúdine superávit. Quidnam illa sánctius? Non Prophétæ, non Apóstoli, non Mártyres, non Patriárchæ, non Angeli, non Throni, non Dominatiónes, non Séraphim, non Chérubim; non deníque áliud quidpíam, inter creátas res visíbiles aut invisíbiles, majus aut excelléntius inveníri potest. Eádem ancílla Dei est et mater; eádem Virgo et Génetrix.
 
 [Responsory5]
 R. Quæ est ista quæ procéssit sicut sol, et formósa tamquam Jerúsalem? 
@@ -218,7 +220,7 @@ V. Et sicut dies verni circúmdabant eam flores rosárum et lília convállium.
 R. Vidérunt eam fíliæ Sion, et beátam dixérunt, et regínæ laudavérunt eam.
 
 [Lectio6]
-Hæc ejus mater est, qui a Patre ante omne principium génitus fuit; quem Angeli et hómines agnoscunt Dóminum rerum ómnium. Visne cognóscere quanto Virgo hæc præstantior sit cæléstibus Potentiis? Illæ cum timóre et tremóre assistunt, fáciem velántes suam: hæc humánum genus illi offert, quem génuit. Per hanc et peccatórum véniam conséquimur. Ave ígitur, mater, cælum, puella, virgo, thronus. Ecclésiæ nostræ decus, glória et firmaméntum: assidue pro nobis precare Jesum, Fílium tuum et Dóminum nostrum, ut per te misericórdiam inveníre in die judícii, et quæ repósita sunt iis qui díligunt Deum bona cónsequi possímus, grátia et benignitate Dómini nostri Jesu Christi: cum quo Patri simul et Sancto Spiritui gloria, et honor, et impérium, nunc et semper in sæcula sæculórum. Amen.
+Hæc ejus mater est, qui a Patre ante omne princípium génitus fuit; quem Angeli et hómines agnóscunt Dóminum rerum ómnium. Visne cognóscere quanto Virgo hæc præstántior sit cæléstibus Poténtiis? Illæ cum timóre et tremóre assístunt, fáciem velántes suam: hæc humánum genus illi offert, quem génuit. Per hanc et peccatórum véniam conséquimur. Ave ígitur, mater, cælum, puélla, virgo, thronus. Ecclésiæ nostræ decus, glória et firmaméntum: assídue pro nobis precáre Jesum, Fílium tuum et Dóminum nostrum, ut per te misericórdiam inveníre in die judícii, et quæ repósita sunt iis qui díligunt Deum bona cónsequi possímus, grátia et benignitáte Dómini nostri Jesu Christi: cum quo Patri simul et Sancto Spirítui glória, et honor, et impérium, nunc et semper in sǽcula sæculórum. Amen.
 
 [Responsory6]
 R. Ornátam monílibus fíliam Jerúsalem Dóminus concupívit: 
@@ -235,7 +237,7 @@ In illo témpore: Loquénte Jesu ad turbas, extóllens vocem quædam múlier de 
 _
 Homilía sancti Bedæ Venerábilis Presbýteri 
 !Lib 4. cap. 49. in Luc. 11.
-Magnæ devotiónis et fidei hæc mulier osténditur, quæ, scribis et pharisǽis Dóminum tentántibus simul et blasphemántibus, tanta ejus incarnatiónem præ ómnibus sinceritáte cognóscit, tanta fiducia confitétur, ut et præséntium prócerum calumniam, et futurórum confúndat hæreticórum perfidiam. Nam, sicut tunc Judǽi, Sancti Spíritus ópera blasphemándo, verum consubstantialémque Patri Dei Fílium negábant; sic hærétici póstea, negando Maríam semper Vírginem, Sancti Spíritus operante virtúte, nascitúro cum humanis membris Unigenito Dei, carnis suæ matériam ministrásse, verum consubstantialémque matri Fílium hóminis fatéri non debére dixérunt.
+Magnæ devotiónis et fídei hæc múlier osténditur, quæ, scribis et pharisǽis Dóminum tentántibus simul et blasphemántibus, tanta ejus incarnatiónem præ ómnibus sinceritáte cognóscit, tanta fidúcia confitétur, ut et præséntium prócerum calúmniam, et futurórum confúndat hæreticórum perfídiam. Nam, sicut tunc Judǽi, Sancti Spíritus ópera blasphemándo, verum consubstantialémque Patri Dei Fílium negábant; sic hærétici póstea, negándo Maríam semper Vírginem, Sancti Spíritus operánte virtúte, nascitúro cum humánis membris Unigénito Dei, carnis suæ matériam ministrásse, verum consubstantialémque matri Fílium hóminis fatéri non debére dixérunt.
 
 [Responsory7]
 R. Felix namque es, sacra Virgo María, et omni laude digníssima:
@@ -244,7 +246,7 @@ V. Ora pro pópulo, intérveni pro clero, intercéde pro devóto femíneo sexu: 
 R. Quia ex te ortus est sol justítiæ, Christus, Deus noster.
 
 [Lectio8]
-Sed, si caro Verbi Dei secúndum carnem nascentis a carne Vírginis matris pronuntiátur extranea, sine causa venter qui eam portasset, ubera quæ lactássent, beatificántur. Dicit autem Apóstolus: Quia misit Deus Fílium suum, factum ex mulíere, factum sub lege. Neque audiéndi sunt, qui legéndum putant: Natum ex mulíere, factum sub lege, sed Factum ex mulíere; quia concéptus ex útero virginali, carnem non de níhilo, non aliunde, sed materna traxit ex carne. Alioquin nec vere Fílius hóminis dicerétur, qui originem non haberet ex hómine. Et nos ígitur, his contra Eutychen dictis, extollámus vocem cum Ecclésia catholica, cujus hæc mulier typum gessit, extollámus et mentem de médio turbárum, dicamusque Salvatori: Beátus venter qui te portávit, et ubera quæ suxísti. Vere enim beáta parens, quæ, sicut quidam ait, Enixa est puérpera Regem, qui cælum terramque tenet per sæcula.
+Sed, si caro Verbi Dei secúndum carnem nascéntis a carne Vírginis matris pronuntiátur extránea, sine causa venter qui eam portásset, úbera quæ lactássent, beatificántur. Dicit autem Apóstolus: Quia misit Deus Fílium suum, factum ex mulíere, factum sub lege. Neque audiéndi sunt, qui legéndum putant: Natum ex mulíere, factum sub lege, sed Factum ex mulíere; quia concéptus ex útero virgináli, carnem non de níhilo, non aliúnde, sed matérna traxit ex carne. Alióquin nec vere Fílius hóminis dicerétur, qui oríginem non habéret ex hómine. Et nos ígitur, his contra Eutychen dictis, extollámus vocem cum Ecclésia cathólica, cujus hæc múlier typum gessit, extollámus et mentem de médio turbárum, dicamúsque Salvatóri: Beátus venter qui te portávit, et úbera quæ suxísti. Vere enim beáta parens, quæ, sicut quidam ait, Eníxa est puérpera Regem, qui cælum terrámque tenet per sǽcula.
 
 [Responsory8]
 R. Beátam me dicent omnes generatiónes, 

--- a/web/www/horas/Latin/CommuneM/C11.txt
+++ b/web/www/horas/Latin/CommuneM/C11.txt
@@ -32,11 +32,29 @@ Descéndi * in hortum nucum, ut vidérem poma convállium, † et inspícerem, s
 @:AntMatutinumM:3
 ;;249;250;251
 
+[Ant Matutinum] (rubrica cisterciensis)
+Ecce tu pulchra es, * amíca mea, ecce tu pulchra es; óculi tui columbárum.;;8
+Sicut lílium * inter spinas, sic amíca mea inter fílias.;;18
+Favus distíllans * lábia tua, Sponsa, et odor vestimentórum tuórum sicut odor thuris.;;23
+Emissiónes tuæ * paradísus malórum punicórum, cum pomórum frúctibus.;;44
+Fons hortórum, * púteus aquárum vivéntium, quæ fluunt ímpetu de Líbano.;;45
+Véniat * diléctus meus in hortum suum, et cómedat fructum pomórum suórum.;;47
+Veni * in hortum meum, soror mea sponsa, méssui myrrham meam cum aromátibus meis.;;84
+Comédi favum * cum melle meo, bibi vinum meum cum lacte meo.;;86
+Anima mea * liquefácta est, ut diléctus locútus est: quæsívi, et non invéni illum; vocávi, et non respóndit mihi: invenérunt me custódes civitátis, percussérunt me, et vulneravérunt me, tulérunt pállium meum custódes murórum: fíliæ Jerúsalem, nuntiáte dilécto, quia amóre lángueo.;;95
+Talis est * diléctus meus, et ipse est amícus meus, fíliæ Jerúsalem.;;96
+Descéndi * in hortum nucum, ut vidérem poma convállium, et inspícerem, si floruísset vínea, et germinássent mala púnica: revértere, tevértere, Sulamítis, revértere, revértere, ut intueámur te.;;97
+Hortus conclúsus es, * Dei Génitrix, hortus conclúsus, fons signátus: surge própera, amíca mea, et veni.;;98
+Regáli ex progénie * María exórta refúlget; cujus précibus nos adjuvári, mente et spíritu devotíssime póscimus.;;249;250;251
+
+[Ant Matutinum] (tempore paschali et rubrica cisterciensis)
+@CommuneM/C6
+
 [Lectio2]
 @Commune/C11:Lectio2:s/-25/-22/ :s/23 .*//s
 
 [Lectio3]
-@Commune/C11:Lectio2:s/18-25/23-25; 34/ :s/23 .*//s
+@Commune/C11:Lectio2:s/18-25/23-25; 34/ :s/.*23 /23 /s
 @Commune/C11:Lectio3:s/!.*// s/35 .*//s
 
 [Lectio4]
@@ -73,7 +91,7 @@ R. Et vidéntes eam fíliæ Sion, beatíssimam prædicavérunt, dicéntes: Ungu�
 [Responsory8]
 R. Diffúsa est grátia in lábiis tuis,
 * Proptérea benedíxit te Deus in ætérnum.
-V. Myrrha et gutta et cásia a vestiméntis tuis, a grádibus ebúrneis, ex quibus delectavérunt te fíliæ regum in hoóre tuo.
+V. Myrrha et gutta et cásia a vestiméntis tuis, a grádibus ebúrneis, ex quibus delectavérunt te fíliæ regum in honóre tuo.
 R. Proptérea benedíxit te Deus in ætérnum. 
 
 [Lectio9]

--- a/web/www/horas/Latin/SanctiM/07-16.txt
+++ b/web/www/horas/Latin/SanctiM/07-16.txt
@@ -14,6 +14,8 @@
 
 [Responsory7]
 @Commune/C11:Responsory6
+(sed rubrica cisterciensis)
+@CommuneM/C11
 
 [Lectio8]
 @Sancti/07-16:Lectio6
@@ -22,4 +24,23 @@
 @Sancti/09-08:Responsory5:s/Nativitátem/Commemoratiónem/
 
 [Responsory9]
-@Commune/C11:Responsory7:s/sanctam festivitátem/solemnem Commemoratiónem/
+@Commune/C11:Responsory7:s/sanctam festivitátem/solémnem Commemoratiónem/
+
+[Lectio9] (rubrica cisterciensis)
+Léctio sancti Evangélii secúndum Lucam. 
+!Luk. 11:27-28
+In illo témpore: Loquénte Jesu ad turbas; extóllens vocem quædam múlier de turba, dixit illi: Beátus venter, qui te portávit. Et réliqua.
+_
+Homilía sancti Bernárdi Abbátis.
+!Serm. 4. de Assumpt. B. M. V.
+Quaenam póterit lingua, etiámsi Angélica sit, dignis extóllere láudibus Vírginem Matrem; matrem autem non cujuscúmque, sed Dei? Duplex nóvitas‚ duplex prærogatíva: duplex miráculum, sed digne prorsus aptissiméque convéniens. Neque enim fílius álius vírginem‚ nec Deum décuit partus alter. Vide enim quam maniféste sibi cóncinant Vírginis nostræ cánticum‚ et nuptiále carmen: nimírum, cujus úterus, sponsi thálamus fuit. Audi Maríam in Evangélio: Respéxit, inquit, humilitátem ancíllæ suæ. Audi eámdem in epithalámio: Cum esset Rex, inquit, in accúbitu suo, nardus mea dedit odórem suum. Nardus quippe herba húmilis est, et pectus purgat: ut maniféstum sit, humilitátem nardi nómine designári, cujus odor et decor invénerit grátiam apud Deum.
+	
+[Lectio10] (rubrica cisterciensis)
+Síleat misericórdiam tuam, Virgo beáta‚ si quis est, qui invocátam te in necessitátibus suis sibi memínerit defuísse. Nos quidem sérvuli tui céteris in virtútibus congaudémus tibi, sed in hac pótius nobis ipsis. Laudámus virginitátem, humilitátem mirámur: sed misericórdia míseris sapit dúlcius, misericórdiam ampléctimur chárius‚ recordámur sæpius, crébrius invocámus. Hæc est enim quæ totíus mundi reparatiónem obtínuit, salútem ómnium impetrávit. Constat enim pro univérso génere humáno fuísse sollícitam, cui dictum est: Ne tímeas María, invenísti grátiam, útique quam quærébas. Quis ergo misericórdiæ tuæ, o Benedícta, longitúdinem et latitúdinem, sublimitátem et profúndum queat investigáre?
+	
+[Lectio11] (rubrica cisterciensis)
+Longitúdo misericórdiæ ejus usque in diem novíssimum invocántibus eam súbvenit univérsis. Latitúdo ejus replet orbem terrárum, ut tua quoque misericórdia plena sit omnis terra. Sic et sublímitas ejus civitátis supérnæ invénit restauratiónem, et profúndum ejus sedéntibus in ténebris et in umbra mortis obtínuit redemptiónem. Per te enim cœlum replétum, inférnus evacuátus est, instaurátæ ruínæ cœléstis Jerúsalem, expectántibus míseris vita pérdita data. Sic potentíssima et piíssima cháritas et afféctu compatiéndi, et subveniéndi abúndat efféctu, æque lócuples in utróque. Ad hunc ígitur fontem sitibúnda próperet ánima nostra: ad hunc misericórdiæ cúmulum tota sollicitúdine miséria nostra recúrrat.
+
+[Lectio12] (rubrica cisterciensis)
+!Serm. in Nativ. B. M. V.
+Sed quid de ejus supereminéntia loquar? Cui enim Angelórum aliquándo dictum est: Spíritus sanctus supervéniet in te, et virtus Altíssimi obumbrábit tibi: ideóque et quod nascétur ex te Sanctum vocábitur Fílius Dei? Dénique Véritas de terra orta est, non de Angélica creatúra: nec Angelos, sed semen Abrahæ apprehéndit. Magnum est Angelo ut miníster sit Dómini; sed Maria sublímius quiddam méruit, ut sit Mater. Fœcúnditas ítaque Vírginis superéminens glória est, tantóque excelléntior Angelis facta múnere singulári quanto differéntius præ minístris nomen Matris accépit. Hanc invénit grátiam plena jam grátia, ut charitáte férvida, virginitáte íntegra, humilitáte devóta, fíeret nihilóminus sine viri cognitióne grávida‚ sine muliébri dolóre puérpera; Parum est: Quod ex ea natum est, Sanctum vocátur, et est Fílius Dei.

--- a/web/www/horas/Latin/Tempora/Pent01-4.txt
+++ b/web/www/horas/Latin/Tempora/Pent01-4.txt
@@ -104,6 +104,8 @@ $Qui vivis
 
 [Invit]
 Christum Regem adorémus dominántem géntibus: * Qui se manducántibus dat spíritus pinguédinem.
+(sed rubrica cisterciensis)
+Veníte ad me, omnes qui laborátis, * Et ego refíciam vos.
 
 [Hymnus Matutinum]
 {:H-Sacrissolemnis:}v. Sacris solémniis juncta sint gáudia,

--- a/web/www/horas/Latin/TemporaM/Pent01-4.txt
+++ b/web/www/horas/Latin/TemporaM/Pent01-4.txt
@@ -11,6 +11,8 @@ Doxology=Nat
 
 [Ant Matutinum 3N]
 Caro mea * vere est cibus, et sanguis meus vere est potus. † Qui mandúcat carnem meam, et bibit sánguinem meum, habet vitam ætérnam, † dicit Dóminus.
+(sed rubrica cisterciensis)
+Sapiéntia * ædificávit sibi domum, míscuit vinum, et pósuit mensam, allelúia.
 
 [Ant Matutinum]
 @Tempora/Pent01-4::1-3
@@ -22,10 +24,25 @@ Caro mea * vere est cibus, et sanguis meus vere est potus. † Qui mandúcat car
 ;;272;214;273
 @Tempora/Pent01-4::14-15
 
+[Ant Matutinum] (rubrica cisterciensis)
+@Tempora/Pent01-4::1-3
+@Tempora/Pent01-4::6-8
+@:Responsory TertiaM
+@Tempora/Pent01-4::11-13
+@:AntMatutinumM
+@:Responsory SextaM
+;;272;214;273
+@:Responsory NonaM
+
 [AntMatutinumM]
 Benignitátem * fecit Dóminus, † et terra nostra dedit fructum suum.;;84
 Memor * Christus Dóminus sciéntium eum, † fruménto et vino stabilívit eos.;;86
 Dóminus * in Sion magnus: † Móyses et Aaron in sacerdótibus ejus.;;98
+
+[AntMatutinumM] (rubrica cisterciensis)
+Tóllite * hóstias, et introíte in átria Dómini, adorántes ipsum in templo sancto ejus.;;95
+Miserátor * et miséricors Dóminus replet in bonis desidérium tuum.;;102
+Edúcas panem * de terra, et vinum lætíficet cor hóminis.;;103
 
 [Lectio1]
 @Tempora/Pent01-4
@@ -40,44 +57,96 @@ Dóminus * in Sion magnus: † Móyses et Aaron in sacerdótibus ejus.;;98
 [Lectio4]
 @Tempora/Pent01-4:Lectio3:s/27-/28-/ s/27.*28/28/s
 
+[Responsory2] (rubrica cisterciensis)
+R. Edúxit vos Dóminus in manu forti de terra Ægypti:
+* Qui edúxit de petra rivos, et cibávit vos manna in solitúdine.
+V. Non Móyses dedit vobis panem de cælo, sed Pater meus dat vobis panem de cælo verum:
+R. Qui edúxit de petra rivos, et cibávit vos manna in solitúdine.
+
+[Responsory3] (rubrica cisterciensis)
+R. Melchísedech Rex Salem, Sacérdos Dei Altíssimi, próferens panem et vinum, præfigurávit Córporis Christi
+* Sanctum sacrifícium, immaculátam hóstiam.
+V. Introívit Jesus pro nobis secúndum órdinem Melchísedech, semel offeréndo seípsum:
+R. Sanctum sacrifícium, immaculátam hóstiam.
+
 [Responsory4]
 R. Panis, quem ego dabo caro mea est pro mundi vita. † Litigábant ergo Judǽi dicéntes:
 * Quómodo potest hic nobis dare carnem suam ad manducándum?
 V. Locútus est pópulus contra Dóminum: † Anima nostra náuseat super cibo isto levíssimo.
 R. Quómodo potest hic nobis dare carnem suam ad manducándum?
 
+[Responsory4] (rubrica cisterciensis)
+@Tempora/Pent01-4:Responsory3
+
 [Lectio5]
 @Tempora/Pent01-4:Lectio4
+(sed rubrica cisterciensis)
+@Tempora/Pent01-4:Lectio4:s/Corpus namque.*//
 
 [Responsory5]
 @Tempora/Pent01-4:Responsory4
 
 [Lectio6]
 @Tempora/Pent01-4:Lectio5:s/Manducátur .*//s
+(sed rubrica cisterciensis)
+@Tempora/Pent01-4:Lectio4:s/.* (Corpus namque)/$1/
 
 [Responsory6]
 @Tempora/Pent01-4:Responsory5
 
 [Lectio7]
 @Tempora/Pent01-4:Lectio5:s/.* (Manducátur)/$1/s
+(sed rubrica cisterciensis)
+@Tempora/Pent01-4:Lectio5:s/Manducátur .*//s
 
 [Responsory7]
 @Tempora/Pent01-4:Responsory6
 
 [Lectio8]
 @Tempora/Pent01-4:Lectio6
+(sed rubrica cisterciensis)
+@Tempora/Pent01-4:Lectio5:s/.* (Manducátur)/$1/s
 
-[Responsory8]
+[Responsory5] (rubrica cisterciensis)
+R. Qui mandúcat meam Carnem et bibit meum Sánguinem, in me manet, et ego in illo:
+* Caro enim mea vere est cibus, et Sanguis meus vere est potus.
+V. Comédite amíci, bíbite, et inebriámini, charíssimi:
+R. Caro enim mea vere est cibus, et Sanguis meus vere est potus.
+
+[Responsory6] (rubrica cisterciensis)
+@Tempora/Pent01-4:Responsory8:1-2:s/vivens Pater/Pater vivens/
+V. In me grátia omnis viæ et veritátis, in me omnis spes vitæ et virtútis.
+@Tempora/Pent01-4:Responsory8:4
+
+[Responsory7] (rubrica cisterciensis)
+R. Cœnántibus illis, accépit Jesus panem, et benedíxit, ac fregit, dedítque discípulis suis, dicens: Accípite et comédite:
+* Hoc est corpus meum.
+V. Vidéntes fílii Israël manna in desérto, admirántes dicébant: Quid est hoc?
+R. Hoc est corpus meum.
+
+[Responsory8_]
 R. Unus panis, et unum corpus multi sumus:
 * Omnes de uno pane, et de uno cálice participámus.
-V. Parásti in dulcédine tua páuperi, Deus qui habitáre facis unánimes in domo.
+V. Parásti in dulcédine tua páuperi, Deus, qui habitáre facis unánimes in domo.
 R. Omnes de uno pane, et de uno cálice participámus.
+
+[Responsory8C]
+@Tempora/Pent01-4:Responsory5:1-2:s/cenáv/cœnáv/
+V. Veníte et comédite panem meum, et bíbite vinum quod míscui vobis.
+@Tempora/Pent01-4:Responsory5:4
+
+[Responsory8]
+@:Responsory8_
+(sed rubrica cisterciensis)
+@:Responsory8C
 
 [Lectio9]
 @Tempora/Pent01-4:Lectio7:s/Dénique .*//s
 
 [Responsory9]
 @Tempora/Pent01-4:Responsory7
+(sed rubrica cisterciensis)
+@:Responsory8_
 
 [Lectio10]
 @Tempora/Pent01-4:Lectio7:s/.* (Dénique)/$1/s s/$/~/
@@ -85,6 +154,12 @@ R. Omnes de uno pane, et de uno cálice participámus.
 
 [Responsory10]
 @Tempora/Pent01-4:Responsory8
+
+[Responsory10] (rubrica cisterciensis)
+R. Angelórum esca nutris pópulum tuum, Dómine, et panem de cœlo dans nobis omne delectaméntum in se habéntem: 
+* Substántiam, et dulcédinem tuam quam habes in fílios ostendéndo:
+V. Dómine, qui das vitam mundo, semper da nobis panem verum:
+R. Substántiam, et dulcédinem tuam quam habes in fílios ostendéndo:
 
 [Lectio11]
 @Tempora/Pent01-4:Lectio8:s/.* (Ac per)/$1/s
@@ -95,14 +170,28 @@ R. Calix benedictiónis, cui benedícimus, † nonne communicátio sánguinis Ch
 V. Calix tuus inébrians, quam præclárus est, Dómine!
 R. Et panis, quem frángimus, † nonne participátio córporis Christi est?
 
+[Responsory11] (rubrica cisterciensis)
+R. Vidit Regína Saba sapiéntiam Salomónis, domum quam ædificáverat, cibos mensæ ejus, et vestiménta eórum:
+* Et admírans, dixit: Beáti servi tui, qui áudiunt sapiéntiam tuam.
+V. Regína Austri venit a fínibus terræ audíre sapiéntiam Salomónis.
+R. Et admírans, dixit: Beáti servi tui, qui áudiunt sapiéntiam tuam.
+
 [Lectio12]
 @Tempora/Pent01-4:Lectio9
+(sed rubrica cisterciensis)
+@Tempora/Pent01-4:Lectio9:s/Si autem.*//
 
 [Responsory12]
 R. Transitúrus de mundo ad Patrem Jesus, in mortis suæ memóriam
 * Instítuit sui córporis et sánguinis Sacraméntum.
 V. Corpus in cibum sánguinem in potum tríbuens: † Hoc, ait, fácite in meam commemoratiónem.
 R. Instítuit sui córporis et sánguinis Sacraméntum.
+
+[Responsory12] (rubrica cisterciensis)
+R. Gaudeámus et exultémus, et demus glóriam Deo, quia venérunt núptiæ Agni, et uxor ejus præparávit se.
+* Beáti qui cœnam nuptiárum ejus vocáti sunt.
+V. Assuérus pro conjunctióne, et núptiis Hester permagníficum convívium præparávit.
+R. Beáti qui cœnam nuptiárum ejus vocáti sunt.
 
 [Responsory TertiaM]
 @:Versum 1

--- a/web/www/missa/Bohemice/Tempora/Pent01-4.txt
+++ b/web/www/missa/Bohemice/Tempora/Pent01-4.txt
@@ -1,2 +1,7 @@
 [Officium]
 Festum Sanctissimi Corporis Christi
+
+[Evangelium]
+Pokračování svatého Evangelia podle Jana.
+!Jan 6:56-59
+Za onoho času řekl Ježíš zástupům Židů: „Mé tělo je skutečný pokrm a má krev je skutečný nápoj. Kdo jí mé tělo a pije mou krev, zůstává ve mně a já v něm. Jako mne poslal živý Otec a já žiji z Otce, tak i ten, kdo jí mne, bude žít ze mne. To je ten chléb, který sestoupil z nebe; ne takový, jaký jedli otcové a umřeli. Kdo jí tento chléb, bude žít navěky.“


### PR DESCRIPTION
Cistercian version Matins:
- added Commune de Beata 
- added Corpus Christi
- added Czech translation
- `specmatins.pl`: fixed the code adding _Pater noster_ to Matutinum parvum de Beata.
- `monastic.pl`: fixed the code replacing the standard ferial Antiphons with Allelúia in certain cases like Sabbato de Beata. This is wrong for the Cistercian rite.