### PR TITLE
Cist: Code changes for Matins in Oct./Vigils

### DIFF
--- a/web/cgi-bin/horas/horasscripts.pl
+++ b/web/cgi-bin/horas/horasscripts.pl
@@ -257,6 +257,7 @@ sub psalm : ScriptFunc {
   $output .= "\n" . join("\n", @lines) . "\n";
   $output .= "\&Gloria\n" unless $psnum == 210 || $nogloria;
   $output =~ s/\$ant/Ant. $antline/g if $psnum == 94;
+  $output =~ s/94C/94/ if $psnum == "94C";
   $output;
 }
 

--- a/web/cgi-bin/horas/monastic.pl
+++ b/web/cgi-bin/horas/monastic.pl
@@ -229,12 +229,24 @@ sub psalmi_matutinum_monastic {
       brevis_monastic($lang);
 
       # on a ferial day in "Summer", we have just a Lectio brevis
+ 
     } elsif (exists($winner{Lectio94}) || exists($winner{Lectio4})) {
       legend_monastic($lang);
 
       # on a III. class feast in "Summer", we have the contracted Saint's legend
     }
     push(@s, "\n");
+   } elsif ($dayname[0] =~ /(Pasc[1-6]|Pent)/i
+    && $winner{Rank} !~ /quat(t?)uor|Dominica/i
+    && $rule !~ /(3|12) lectiones/
+    && $version =~ /Cist/i)
+  {
+    # CIST: days within Octaves and Vigils need Lectio brevis + R.br. as well
+
+    if ($winner =~ /Tempora/i || $winner{Rank} =~ /Vigil/i) { 
+      brevis_monastic($lang);
+      push(@s, "\n");
+    }
   } else {
     lectiones(0, $lang);
 
@@ -409,8 +421,11 @@ sub brevis_monastic {
   my $lang = shift;
   absolutio_benedictio($lang);
   my $lectio;
+  my %w = columnsel($lang) ? %winner : %winner2;
 
-  if ($commune =~ /C10/) {
+  if ($version =~ /Cist/i && $w{"MM LB"}) {
+    $lectio = $w{"MM LB"};
+  } elsif ($commune =~ /C10/) {
     my %c = (columnsel($lang)) ? %commune : %commune2;
     my $name = getC10readingname();
     my @resp = split(/\n/, $c{'Responsory3'});

--- a/web/cgi-bin/horas/specials.pl
+++ b/web/cgi-bin/horas/specials.pl
@@ -162,7 +162,15 @@ sub specials {
     }
 
     if ($item =~ /invitatorium/i) {
-      invitatorium($lang);
+      # CIST: between Most Holy Trinity and All Saints, Psalm 94 is prayed instead of Invitatory on Ferias incl. in Octaves
+      if ($version =~ /Cist/i 
+        && $winner{Rank} =~ /Feria|Vigilia/i
+        && $dayname[0] =~ /Pent|Epi/i
+        && $month > 5 && $month < 11 ) 
+        {
+          push(@s, "\&psalm('94C')", "\n");
+        }
+      else { invitatorium($lang); }
       next;
     }
 

--- a/web/www/horas/Bohemice/Psalterium/Common/Prayers.txt
+++ b/web/www/horas/Bohemice/Psalterium/Common/Prayers.txt
@@ -136,15 +136,15 @@ Skrze téhož Krista, našeho Pána.
 Který s tebou žije a kraluje po všechny věky věkův.
 
 [Per Dominum]
-r. Skrze našeho Pána Ježíše Krista, tvého Syna, jenž s tebou žije a kraluje v jednotě Ducha Svatého Bůh, po všecky věky věkův.
+r. Skrze našeho Pána Ježíše Krista, tvého Syna, jenž s tebou žije a kraluje v jednotě Ducha Svatého Bůh, po všechny věky věkův.
 R. Amen.
 
 [Per Dominum eiusdem]
-r. Skrze našeho Pána Ježíše Krista, tvého Syna, jenž s tebou žije a kraluje v jednotě téhož Ducha Svatého Bůh, po všecky věky věkův.
+r. Skrze našeho Pána Ježíše Krista, tvého Syna, jenž s tebou žije a kraluje v jednotě téhož Ducha Svatého Bůh, po všechny věky věkův.
 R. Amen.
 
 [Qui cum Patre]
-r. Jenž s Otcem a Duchem Svatým žiješ a kraluješ Bůh, po všecky věky věkův. 
+r. Jenž s Otcem a Duchem Svatým žiješ a kraluješ Bůh, po všechny věky věkův. 
 R. Amen.
 
 [Per eumdem]
@@ -152,15 +152,15 @@ r. Skrze téhož Pána našeho Ježíše Krista, tvého Syna, jenž s tebou žij
 R. Amen.
 
 [Qui vivis]
-r. Jenž žiješ a kraluješ s Bohem Otcem v jednotě Ducha Svatého jeden Bůh, svět navěky.
+r. Jenž žiješ a kraluješ s Bohem Otcem v jednotě Ducha Svatého, Bůh, po všechny věky věkův.
 R. Amen.
 
 [Qui tecum]
-r. Který s tebou žije a kraluje, v jednotě s Duchem svatým, jeden Bůh, po všechny věky věkův.
+r. Jenž s tebou žije a kraluje, v jednotě s Duchem svatým, Bůh, po všechny věky věkův.
 R. Amen.
 
 [Qui tecum eiusdem]
-r. Který s tebou žije a kraluje, v jednotě s týmž Duchem svatým, jeden Bůh, po všechny věky věkův.
+r. Jenž s tebou žije a kraluje, v jednotě s týmž Duchem svatým, Bůh, po všechny věky věkův.
 R. Amen.
 
 [Te Deum]

--- a/web/www/horas/Bohemice/Psalterium/Psalmi/Psalmi matutinum.txt
+++ b/web/www/horas/Bohemice/Psalterium/Psalmi/Psalmi matutinum.txt
@@ -602,10 +602,10 @@ Jásejte * Bohu, celá země.;;99!Dobré je * chválit Pána.;;91
 ;;100
 
 [Daym5C]
-@:Daym5_:1-6
+@:Daym5_:1-6:s/92.*/92/
 V. Blažen je člověk, kterého ty vzděláváš, Hospodine.
 R. A o svém zákoně jej učíš.
-@:Daym5_:9-14
+@:Daym5_:9-14:s/99.*/99/
 
 [Daym5]
 @:Daym5_

--- a/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm85.txt
+++ b/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm85.txt
@@ -1,4 +1,4 @@
-85:1 Modlitba. Od Davida. Nakloň, Hospodine, svůj sluch a vyslyš mě, vždyť jsem ubohý a chudý.
+85:1 Nakloň, Hospodine, svůj sluch a vyslyš mě, vždyť jsem ubohý a chudý.
 85:2 Zachovej mou duši, neboť jsem ti oddán, pomoz svému služebníku, který v tebe doufá.
 85:3 Ty jsi můj Bůh, smiluj se nade mnou, Pane, neboť stále k tobě volám. Obvesel život svého služebníka, neboť k tobě, Pane, pozvedám svou duši.
 85:5 Tys totiž, Pane, dobrý a shovívavý, nejvýš milosrdný ke všem, kdo volají k tobě.

--- a/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm94C.txt
+++ b/web/www/horas/Bohemice/Psalterium/Psalmorum/Psalm94C.txt
@@ -1,0 +1,10 @@
+94:1 Pojďme, jásejme Hospodinu, oslavujme Skálu své spásy,
+94:2 předstupme před něho s chvalozpěvy a písněmi mu zajásejme!
+94:3 Neboť veliký Bůh je Hospodin a veliký Král nade všemi bohy.
+94:4 V jeho ruce jsou hlubiny země a jemu patří výšiny hor.
+94:5 Jeho je moře, vždyť on je učinil, i souš, kterou zhnětly jeho ruce.
+94:6 Pojďme, padněme, klaňme se, a plačme před svým tvůrcem, Hospodinem! Neboť on je náš Pán a Bůh.
+94:7 A my jsme lid, který pase, stádce vedené jeho rukou. Kéž byste dnes uposlechli jeho hlasu: „Nezatvrzujte svá srdce
+94:8 jako v Meribě, jako tehdy v Masse na poušti, kde mě dráždili vaši otcové, zkoušeli mě, ač viděli mé činy.
+94:10 Čtyřicet let mi bylo protivné ono pokolení; řekl jsem: Je to lid, který bloudí v srdci, nepoznali mé cesty.
+94:11 Proto jsem přísahal ve svém hněvu: Nepřijdou na místo mého klidu!“

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm94C.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm94C.txt
@@ -1,0 +1,10 @@
+94:1 O kommt doch, laßt uns vor dem Herrn frohlocken, laßt jubeln uns vor Gott, dem Urquell unseres Segens.
+94:2 Laßt uns vor ihm mit Lobgesang erscheinen, mit Psalmen ihn umjubeln.
+94:3 Fürwahr, ein großer Gott ist unser Herrgott, ein König hoch erhaben über alle Mächte:
+94:4 und doch, der Herr weist nicht von sich sein Volk; denn seine Hand hält alle Erdengründe, und als sein Eigentum bewacht er auch der Berge Höhen.
+94:5 Sogar das Meer gehört ihm, weil er es geschaffen, und auch die Erde, die gebildet haben seine Hände.
+94:6 Drum kommet, lasset uns ihm huldigen, und laßt vor Gott uns niederwerfen, laßt Dankestränen weinen uns vor unserem Herrn, der uns erschaffen. Ja, er ist unser Herrgott;
+94:7 Wir aber sind sein Volk, von ihm genährte Schäflein. Besonders heut, wollt' ja den Ruf des Herrn beachten: Seid nicht verstockt in eurem Herzen,
+94:8 wie einst bei der Empörung an dem Tage, da man mir nicht glaubte in der Wüste; da eure Väter mir nicht glaubten, mich erst prüfen wollten, obgleich sie doch gesehen hatten meine Werke.
+94:9 Durch vierzig Jahre mußt ich ärgern mich mit dieser Rotte und mir sagen: Sie bleiben stets verkehrten Sinnes.
+94:10 Sie aber wollten nicht auf meine Pläne achten, so daß ich nun schwur in meinem Zorne: Sie sollen nicht das Land betreten, das ich ihnen geben wollt' als Wohnung.

--- a/web/www/horas/English/Psalterium/Psalmorum/Psalm94C.txt
+++ b/web/www/horas/English/Psalterium/Psalmorum/Psalm94C.txt
@@ -1,0 +1,10 @@
+94:1 O come, let us sing unto the Lord : let us make a joyful noise to the God of our salvation.
+94:2 Let us come before His presence with thanksgiving, and make a joyful noise unto Him with psalms.
+94:3 For the Lord is a great God, and a great King above all gods.
+94:4 In His hand are the inmost depths of the earth : and the heights of the hills are His also.
+94:5 For the sea is His, and He made it, and His hands formed the dry land.
+94:6 Come let us adore and fall down: and weep before the Lord that made us: For he is the Lord our God:
+94:7 And we are the people of His pasture, and the sheep of His hand. Today if ye will hear His voice, harden not your heart.
+94:8 As in the Provocation, and as in the day of Temptation in the wilderness, when your fathers tempted Me, and proved Me, and saw My works.
+94:9 Forty years long was I grieved with that generation, and said: It is a people that do alway err in their heart.
+94:10 And they have not known My ways; unto whom I sware in My wrath that they should not enter into My rest.

--- a/web/www/horas/Espanol/Psalterium/Psalmorum/Psalm94C.txt
+++ b/web/www/horas/Espanol/Psalterium/Psalmorum/Psalm94C.txt
@@ -1,0 +1,10 @@
+94:1 Venid, regocijémonos en el Señor; * cantemos con júbilo las alabanzas de Dios, Salvador nuestro. 
+94:2 Corramos a presentarnos ante su acatamiento, * dándole gracias, y entonándole himnos con júbilo.
+94:3 Porque el Señor es el Dios grande, * y un rey más grande que todos los dioses. 
+94:4 Porque en su mano tiene toda la extensión de la tierra, * y suyos son los más encumbrados montes.
+94:5 Suyo es el mar, y obra es de sus manos; * y hechura de sus manos es la tierra. 
+94:6 Venid, pues, adorémosle, postrémonos: derramando lágrimas en la presencia del Señor que nos ha creado: Pues Él es el Señor Dios nuestro:
+94:7 Y nosotros el pueblo a quien Él apacienta, y ovejas de su grey. * Hoy mismo, si oyereis su voz, * guardaos de endurecer vuestros corazones, 
+94:8 Como sucedió, dice el Señor, cuando provocaron mi ira, poniéndome a prueba en el desierto, * en donde vuestros padres me tentaron, me probaron, y vieron mis obras.
+94:9 Por espacio de cuarenta años estuve irritado contra esta generación, * y dije: Siempre está descarriado el corazón de este pueblo. 
+94:10 Ellos no conocieron mis caminos; por lo que juré airado * que no entrarían en mi reposo.

--- a/web/www/horas/Francais/Psalterium/Psalmorum/Psalm94C.txt
+++ b/web/www/horas/Francais/Psalterium/Psalmorum/Psalm94C.txt
@@ -1,0 +1,10 @@
+94:1 Venez, réjouissons-nous devant le Seigneur ; * poussons des cris de joie vers Dieu, notre Sauveur.
+94:2 Allons au-devant de Lui avec des louanges, * et chantons des cantiques à Sa gloire.
+94:3 Car le Seigneur est le grand Dieu, * et le grand Roi au-dessus de tous les dieux.
+94:4 Dans Sa main sont tous les confins de la terre, * et les sommets des montagnes Lui appartiennent.
+94:5 A Lui est la mer, et c'est Lui qui l'a faite, * et Ses mains ont formé le continent.
+94:6 Venez, adorons, prosternons-nous devant Dieu, et pleurons devant le Seigneur qui nous a faits, parce que Lui-même est le Seigneur notre Dieu;
+94:7 Et nous, nous sommes le peuple de Son pâturage, et les brebis de Sa main. * Aujourd'hui, si vous entendez Sa voix, * gardez-vous d'endurcir vos cœurs,
+94:8 comme lorsqu'ils excitèrent Ma colère, au jour de la tentation dans le désert, * où vos pères M'ont tenté, M'ont mis à l'épreuve, et ont vu Mes œuvres.
+94:9 Pendant quarante ans Je fus irrité contre cette génération ; * et Je dis : Leur cœur ne cesse de s'égarer.
+94:10 Et ils n'ont point connu Mes voies ; * de sorte que J'ai juré dans Ma colère : Ils n'entreront point dans Mon repos.

--- a/web/www/horas/Italiano/Psalterium/Psalmorum/Psalm94C.txt
+++ b/web/www/horas/Italiano/Psalterium/Psalmorum/Psalm94C.txt
@@ -1,0 +1,10 @@
+94:1 Venite, esultiamo davanti al Signore, * con giubilo acclamiamo a Dio, nostro salvatore:
+94:2 presentiamoci a lui con inni di lode, * e con salmi di gioia onoriamolo.
+94:3 Poiché un Dio grande è il Signore, * e un Re grande sopra tutti gli dei: 
+94:4 poiché nella sua mano sono tutti i confini della terra, * e le sommità dei monti gli appartengono.
+94:5 Poiché suo è il mare, ed egli l'ha fatto, * e le sue mani hanno formato i continenti:
+94:6 Venite, adoriamo, e prostriamoci in faccia a Dio: piangiamo davanti al Signore che ci ha creati, perché egli è il Signore nostro Dio;
+94:7 E noi siamo il suo popolo, e le pecorelle del suo pascolo. * Oggi, se udirete la sua voce, non vogliate indurire i vostri cuori,
+94:8 come allorché fui provocato a sdegno nel giorno della tentazione nel deserto: * dove i padri vostri mi tentarono, mi misero alla prova e videro le opere mie.
+94:9 Per quarant'anni fui vicino a questa generazione [per punirla] * e dissi; costoro sono sempre perversi di cuore;
+94:10 essi non hanno conosciuto le mie vie: ond'io giurai nell'ira mia: * essi più non entreranno nel mio riposo.

--- a/web/www/horas/Latin/Psalterium/Psalmi/Psalmi matutinum.txt
+++ b/web/www/horas/Latin/Psalterium/Psalmi/Psalmi matutinum.txt
@@ -602,10 +602,10 @@ Jubiláte * Deo omnis terra;;99!Bonum est * confitéri Dómino;;91
 ;;100
 
 [Daym5C]
-@:Daym5_:1-6
+@:Daym5_:1-6:s/92.*/92/
 V. Beátus homo, quem tu erudíeris Dómine.
 R. Et de lege tua docúeris eum.
-@:Daym5_:9-14
+@:Daym5_:9-14:s/99.*/99/
 
 [Daym5]
 @:Daym5_

--- a/web/www/horas/Latin/Psalterium/Psalmorum/Psalm94C.txt
+++ b/web/www/horas/Latin/Psalterium/Psalmorum/Psalm94C.txt
@@ -1,0 +1,10 @@
+94:1 Veníte, exsultémus Dómino: * jubilémus Deo salutári nostro:
+94:2 Præoccupémus fáciem ejus in confessióne: * et in psalmis jubilémus ei.
+94:3 Quóniam Deus magnus Dóminus: * et Rex magnus super omnes deos.
+94:4 Quia in manu ejus sunt omnes fines terræ: * et altitúdines móntium ipsíus sunt.
+94:5 Quóniam ipsíus est mare, et ipse fecit illud: * et siccam manus ejus formavérunt.
+94:6 Veníte adorémus, et procidámus: et plorémus ante Dóminum, qui fecit nos. * Quia ipse est Dóminus Deus noster:
+94:7 Et nos pópulus páscuæ ejus, et oves manus ejus. * Hódie si vocem ejus audiéritis, nolíte obduráre corda vestra:
+94:8 Sicut in irritatióne secúndum diem tentatiónis in desérto: * ubi tentavérunt me patres vestri, probavérunt me, et vidérunt ópera mea.
+94:9 Quadragínta annis offénsus fui generatióni illi, * et dixi: Semper hi errant corde.
+94:10 Et isti non cognovérunt vias meas, ut jurávi in ira mea: * Si introíbunt in réquiem meam.

--- a/web/www/horas/Latin/Tempora/Pent01-5.txt
+++ b/web/www/horas/Latin/Tempora/Pent01-5.txt
@@ -8,6 +8,8 @@ Feria VI infra Hebdomadam I post Octavam Pentecostes
 ;;Semiduplex II class;;5.6;;ex Tempora/Pent01-4
 (sed rubrica tridentina nisi rubrica cisterciensis)
 ;;Semiduplex IIS class;;2.9;;ex Tempora/Pent01-4
+(sed rubrica cisterciensis)
+;;Semiduplex;;2.1;;ex Tempora/Pent01-4
 (sed rubrica 196 aut rubrica 1955)
 ;;Feria;;1
 

--- a/web/www/horas/Latin/TemporaM/Pent01-5.txt
+++ b/web/www/horas/Latin/TemporaM/Pent01-5.txt
@@ -2,13 +2,12 @@
 
 [Rule]
 ex TemporaM/Pent01-4;
-3 Lectiones
+3 Lectiones (nisi rubrica cisterciensis)
 Doxology=Corp
 Feria Te Deum
 Psalmi Feria (rubrica cisterciensis)
 
 [Rule] (rubrica 196)
- 
 
 [Ant Vespera]  (rubrica tridentina aut rubrica divino)
 @Tempora/Pent01-4::1-4
@@ -28,7 +27,32 @@ Psalmi Feria (rubrica cisterciensis)
 ;;
 ;;
 
-[Lectio1]
+[Ant Matutinum] (rubrica cisterciensis)
+Novus Abel, * Christus, hóstiam gratam pro nobis ófferens Deo Patri, novum dedicávit in suo Sánguine testaméntum.;;85
+;;86
+Ædificávit Noë * altáre Dómino, ófferens super illud holocáusta: odoratúsque Dóminus odórem suavitátis, benedíxit ei.;;88(2-19)
+;;88(20-53)
+Introdúcens Joseph fratres suos, instrúxit convívium, et appósito pane comédit, et bibit cum eis.;;92
+;;93
+@TemporaM/Pent01-4:Responsory TertiaM
+Allelúia, * allelúia, allelúia.
+;;
+;;
+;;
+;;
+;;
+
+[MM LB] (rubrica cisterciensis)
+!Psalm 77:23-25
+v. Mandávit Dóminus núbibus désuper: * et jánuas cæli apéruit. Et pluit illis manna ad manducándum: * et panem cæli dedit eis. Panem Angelórum manducávit homo, * cibária misit eis in abundántia.
+$Tu autem
+_
+R.br. Panis iste verus est, * Qui de cælo descéndit.
+R. Panis iste verus est, * Qui de cælo descéndit.
+V. Et dat vitam mundo.
+R. Qui de cælo descéndit.
+
+[Lectio1] 
 @Tempora/Pent01-5:Lectio7
 
 [Responsory1]
@@ -52,3 +76,5 @@ Psalmi Feria (rubrica cisterciensis)
 $Deo gratias
 _
 @Tempora/Pent01-4:Versum 2
+(sed rubrica cisterciensis)
+@TemporaM/Pent01-4:Responsory SextaM

--- a/web/www/horas/Polski-Newer/Psalterium/Psalmorum/Psalm94C.txt
+++ b/web/www/horas/Polski-Newer/Psalterium/Psalmorum/Psalm94C.txt
@@ -1,0 +1,11 @@
+94:1 Pójdźcie, śpiewajmy z radością Panu: * śpiewajmy Bogu, zbawicielowi naszemu.
+94:2 Uprzedzajmy oblicze Jego z wychwalaniem * i psalmy śpiewajmy Mu.
+94:3 Albowiem Bogiem wielkim Pan * i królem wielkim ponad wszystkie bogi.
+94:4 Bo w ręce Jego wszystkie krańce ziemi * i gór wysokości Jego są.
+94:5 Bo Jego jest morze, i On je uczynił, * i lądy utworzyły ręce Jego.
+94:6 Pójdźcie, pokłońmy się, i upadajmy przed Bogiem: płaczmy przed Panem, który nas stworzył, albowiem on jest Panem, Bogiem naszym;
+94:7 A my ludem pastwiska Jego i owcami ręki Jego. * Dziś, jeśli głos Jego usłyszycie, * nie zatwardzajcie serc waszych:
+94:9 Jak w rozdrażnieniu, jak w dzień kuszenia na puszczy, * kędy mię kusili ojcowie wasi, doświadczyli mię, a widzieli uczynki moje.
+94:10 Czterdzieści lat gniewałem się na ten naród, * i rzekłem: Zawsze ci błądzą sercem.
+94:11 A oni nie poznali dróg moich, jak zaprzysiągłem w gniewie moim: * że nie wnijdą do pokoju mego.
+$ant

--- a/web/www/horas/Polski/Psalterium/Psalmorum/Psalm94C.txt
+++ b/web/www/horas/Polski/Psalterium/Psalmorum/Psalm94C.txt
@@ -1,0 +1,10 @@
+94:1 Pójdźcie, radujmy się Panu: * śpiewajmy Bogu, zbawicielowi naszemu:
+94:2 Uprzedźmy oblicze jego z wyznawaniem: * a psalmami śpiewajmy mu.
+94:3 Albowiem Bóg wielki Pan: * i król wielki nade wszymi bogi.
+94:4 Bo w ręce jego są wszystkie kraje ziemie: * i gór wysokości jego są.
+94:5 Bo jego jest morze, a on je uczynił: * a suchą utworzyły ręce jego.
+94:6 Pójdźcie, pokłońmy się, i upadajmy przed Bogiem: płaczmy przed Panem, który nas stworzył, albowiem on jest Panem, Bogiem naszym;
+94:7 A my ludem pastwiska jego, i owcami ręki jego. * Dziś, jeźli głos jego usłyszycie, nie zatwardzajcież serc waszych:
+94:8 Jako w draźnieniu wedle dnia kuszenia na puszczy: * kędy mię kusili ojcowie wasi; doświadczali mię, i ujrzeli uczynki moje.
+94:9 Czterdzieści lat gniewałem się na ten naród, * i rzekłem: Zawsze ci błądzą sercem.
+94:10 A ci nie poznali dróg moich, jakom przysiągł w gniewie moim: * jeźli wnidą do pokoju mego.


### PR DESCRIPTION
Changes in code for the Cistercian rite:
- `horasscripts.pl`: cosmetics (see further)
- `specials.pl`: Implemented change from discussion #4555 (in Cistercian rite, in Summer, the Invitatory is not said on Ferias or Vigils)
- `monastic.pl`: MM LB (Lectio Brevis in Matins) is needed not only on Ferias, but also on Ferias within Octaves and Vigils. Therefore this has been introduced, and will be adapted as needed.

Other changes:
- unified the Czech translation of collect endings
- added Friday in Octava Corporis Christi