### PR TITLE
Cist: error corrections

### DIFF
--- a/web/cgi-bin/horas/specials/orationes.pl
+++ b/web/cgi-bin/horas/specials/orationes.pl
@@ -725,7 +725,7 @@ sub vigilia_commemoratio {
   my %w = %{setupstring($lang, $fname)};
   my @wrank = split(';;', $w{Rank});
 
-  if ($w{Rank} =~ /Vigilia/i) {
+  if ($w{Rank} =~ /Vigili/i) {
     $w = $w{Oratio};
 
     if (!$w && $w{Rank} =~ /(?:ex|vide) C1v/) {
@@ -738,7 +738,7 @@ sub vigilia_commemoratio {
   }
   if (!$w) { return ''; }
   my $c = "!" . &translate('Commemoratio', $lang) . ": " . &translate("Vigilia", $lang) . "\n";
-  if ($w{Rank} =~ /Vigilia/i) { $c =~ s/\:.*/: $wrank[0]/; }
+  if ($w{Rank} =~ /Vigili/i) { $c =~ s/\:.*/: $wrank[0]/; }
   if ($w =~ /(\!.*?\n)(.*)/s) { $c = $1; $w = $2; }
   my %p = %{setupstring($lang, 'Psalterium/Special/Major Special.txt')};
   my $a = $p{"Feria Ant 2"};       #$p{"Day$dayofweek Ant 2"};

--- a/web/www/horas/Bohemice/Commune/C12.txt
+++ b/web/www/horas/Bohemice/Commune/C12.txt
@@ -42,8 +42,8 @@ Odpusť, prosíme, Pane, přestupky svých sluhů † abychom ježto se ti nedo
 $Qui tecum
 
 [Verse Nona]
-V. Požehnaná jsi mezi ženami.
-R. A požehnaný plod života tvého.
+V. Po porodu jsi, Panno, zůstala neporušená.
+R. Boží Rodičko, přimlouvej se za nás.
 
 [Hymnus Completorium_C]
 v. Zazářila ta rodička, 

--- a/web/www/horas/Bohemice/Psalterium/Special/Matutinum Special.txt
+++ b/web/www/horas/Bohemice/Psalterium/Special/Matutinum Special.txt
@@ -210,7 +210,8 @@ R. A vysvobodil je ode všech jejich těžkých neduhů.
 
 [MM Capitulum]
 @:MM Capitulum_
-(sed rubrica cisterciensis)
+
+[MM Capitulum] (rubrica cisterciensis)
 @:MM Capitulum_:1-4
 @Psalterium/Special/Minor Special:Versum Dominica Tertia
 (sed feria 3)

--- a/web/www/horas/Latin/Psalterium/Special/Matutinum Special.txt
+++ b/web/www/horas/Latin/Psalterium/Special/Matutinum Special.txt
@@ -802,7 +802,8 @@ R. Et erípuit eos de interitiónibus eórum.
 
 [MM Capitulum]
 @:MM Capitulum_
-(sed rubrica cisterciensis)
+
+[MM Capitulum] (rubrica cisterciensis)
 @:MM Capitulum_:1-4
 @Psalterium/Special/Minor Special:Versum Dominica Tertia
 (sed feria 3)
@@ -815,6 +816,8 @@ R. Et erípuit eos de interitiónibus eórum.
 @:Nocturn 2 Versum Feria6
 (sed feria 7)
 @:Nocturn 2 Versum Sabbato
+
+
 
 [MM Capitulum Adv_]
 !Titus 2:12-13


### PR DESCRIPTION
Error corrections:
- `orationes.pl`: In Czech, the word for Vigilia is usually "Vigilie", which was excluded by the original grep query `/Vigilia/i`, and the entire commemoration was lost. Corrected.
- Incorrect translation for verse for None in C12 corrected.
- `[MM Capitulum]` was corrected, so that it doesn't leak into other Monastic versions.