### PR TITLE
Cist: Upd. Matins of Sunday 2 till 5 post Pentecosten + Czech

### DIFF
--- a/web/cgi-bin/DivinumOfficium/LanguageTextTools.pm
+++ b/web/cgi-bin/DivinumOfficium/LanguageTextTools.pm
@@ -62,7 +62,7 @@ sub ensure_single_alleluia {
   my ($text_ref, $lang) = @_;
 
   # Add a single 'alleluia', unless it's already there.
-  $$text_ref =~ s/\p{P}?\s*$/ ", " . lc(alleluia($lang)) . '.'/e unless $$text_ref =~ /$alleluia_regexp\p{P}?\)?\s*$/;
+  $$text_ref =~ s/\p{P}?\s*$/ ", " . lc(alleluia($lang)) . '.'/e unless $$text_ref =~ /$alleluia_regexp\p{P}?\)?\s*$/ || !$$text_ref;
 }
 
 #*** ensure_double_alleluia($text, $lang)

--- a/web/www/horas/Bohemice/Tempora/Pent01-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent01-0.txt
@@ -198,6 +198,9 @@ R. Holy, Holy, Holy is the Lord God of hosts.
 &Gloria
 R. The whole earth is full of His glory.
 
+[Responsory8] (rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory2
+
 [Lectio9]
 !Commemoration for the First Sunday after Pentecost
 From the Holy Gospel according to Luke

--- a/web/www/horas/Bohemice/Tempora/Pent01-1.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent01-1.txt
@@ -8,10 +8,12 @@ Začíná první kniha Samuelova
 2 Měl dvě ženy. Jedna se jmenovala Anna a druhá Peninna. Peninna měla děti, ale Anna děti neměla.
 3 Ten muž putoval každý rok ze svého města, aby se poklonil Hospodinu zástupů a přinesl mu oběť v Šilo. Tam byli Hospodinovými kněžími dva Eliho synové, Chofni a Pinchas.
 
-[Responsory1]
+[Responsory1_]
 R. Připravte svá srdce Hospodinu, a služte pouze jemu; 
 * A on vás vysvobodí z rukou vašich nepřátel.
 V. Obraťte se k němu celým svým srdcem, a odstraňte cizí bohy z vašeho středu.
+(sed rubrica cisterciensis)
+V. Odstraňte cizí bohy z vašeho středu.
 R. A on vás vysvobodí z rukou vašich nepřátel.
 
 [Lectio2]
@@ -22,11 +24,11 @@ R. A on vás vysvobodí z rukou vašich nepřátel.
 7 Tak tomu bývalo rok co rok. Kdykoli Anna putovala do Hospodinova domu, Pennina ji takto popouzela. Anna plakala a nejedla.
 8 Její muž Elkana jí ale řekl: „Anno, proč pláčeš, proč nejíš a proč se tak trápíš? Nejsem pro tebe lepší než deset synů?“
 
-[Responsory2]
-R. Deus ómnium exaudítor est: ipse misit Angelum suum, et tulit me de óvibus patris mei:
-* Et unxit me unctióne misericórdiæ suæ.
-V. Dóminus, qui erípuit me de ore leónis, et de manu béstiæ liberávit me.
-R. Et unxit me unctióne misericórdiæ suæ.
+[Responsory2_]
+R. Bůh vyslyší každého: on poslal svého Anděla, a vzal mě od ovcí mého otce;
+* A pomazal mě mastí svého milosrdenství.
+V. Hospodin, jenž mě vytrhl ze lví tlamy, a ze spárů divoké zvěře mě osvobodil.
+R. A pomazal mě mastí svého milosrdenství.
 
 [Lectio3]
 !1 Sam. 1:9-11
@@ -34,10 +36,33 @@ R. Et unxit me unctióne misericórdiæ suæ.
 10 Ona měla v duši hořkost, modlila se k Hospodinu a nepřestávala plakat.
 11 Zavázala se slibem a řekla: „Hospodine zástupů, jestliže skutečně shlédneš na ponížení své služebnice a rozpomeneš se na mě, jestliže na svou služebnici nezapomeneš a dáš své služebnici mužského potomka, tak ho na všechny dny jeho života dám Hospodinu a břitva se nedotkne jeho hlavy.“
 
-[Responsory3]
-R. Dóminus, qui erípuit me de ore leónis, et de manu béstiæ liberávit me, 
-* Ipse me erípiet de mánibus inimicórum meórum.
-V. Misit Deus misericórdiam suam et veritátem suam: ánimam meam erípuit de médio catulórum leónum.
-R. Ipse me erípiet de mánibus inimicórum meórum.
+[Responsory3_]
+R. Hospodin, jenž mě vytrhl ze lví tlamy, a ze spárů divoké zvěře mě osvobodil, 
+* On mě vytrhne z rukou mých nepřátel.
+V. Seslal Bůh své milosrdenství a svou pravdu; mou duši vytrhl ze středu lvíčat.
+R. On mě vytrhne z rukou mých nepřátel.
 &Gloria
-R. Ipse me erípiet de mánibus inimicórum meórum.
+R. On mě vytrhne z rukou mých nepřátel.
+
+[Responsory3C]
+R. Já jsem tě vzal z domu tvého otce, praví Hospodin, a postavil tě, abys pásl stádce mého lidu, a byl jsem s tebou všude, kam jsi šel,
+* A posiloval tvou vládu navždy.
+V. Zjednal jsem ti velké jméno, vedle jmen velkých mužů, jež žijí na zemi.
+R. A posiloval tvou vládu navždy.
+&Gloria
+R. A posiloval tvou vládu navždy.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@:Responsory3C

--- a/web/www/horas/Bohemice/Tempora/Pent01-2.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent01-2.txt
@@ -1,0 +1,65 @@
+[Officium]
+úterý v prvním týdnu po Svatodušním Oktávu
+
+[Lectio1]
+Čtení z první knihy Samuelovy
+!1 Sam 1:12-18
+12 A stalo se, že když Anna pokračovala v modlitbě před Hospodinem, Eli pozoroval její ústa.
+13 Anna totiž mluvila ve svém srdci, pouze rty se jí pohybovaly, ale hlas nebylo slyšet, takže ji Eli považoval za opilou.
+14 Eli jí řekl: „Jak dlouho se budeš opíjet? Přestaň s tím vínem!“
+15 Anna odpověděla a řekla: „Ne, můj pane, jsem žena s bolestí v duši. Víno ani jiný opojný nápoj jsem nepila, jen jsem vylévala své srdce před Hospodinem.
+16 Nepovažuj svou služebnici za ničemnou ženu, vždyť až dosud jsem mluvila z velkého žalu a soužení.“
+17 Eli jí odpověděl a řekl: „Jdi v pokoji a Izraelův Bůh ať ti dopřeje, jak sis od něho přála.“
+18 Ona řekla: „Kéž u tebe tvá služebnice nalezne milost.“ 
+
+[Responsory1_]
+R. Saul pobil tisíc, David však deset tisíc; 
+* Neboť ruka Hospodinova byla s ním; zabil Filištína a sňal pohanu z Israele.
+V. Není to snad David, o němž zpívali jako jeden muž, a říkali: Saul pobil tisíc, David však deset tisíc?
+R. Neboť ruka Hospodinova byla s ním; zabil Filištína a sňal pohanu z Israele.
+
+[Lectio2]
+!1 Sam 1:18-22
+18 Žena pak odešla svou cestou. Jedla a její tvář nebyla už jako dříve.
+19 Ráno vstali a poklonili se před Hospodinem. Navrátili se pak do svého domu v Ramatě. Poznal pak Elkana Annu, svou manželku, a Hospodin se na něj rozpomněl.
+20 V průběhu roku Anna počala, porodila syna a dala mu jméno Samuel. Řekla: „Od Hospodina jsem si ho vyprosila.“
+21 Pak ten muž Elkana s celým svým domem putoval, aby obětoval Hospodinu výroční oběť a splnil svůj slib.
+22 Ale Anna neputovala. Řekla totiž svému muži: „Až bude chlapec odstaven, přivedu ho, ukáže se před Hospodinem a zůstane tam navždy.“
+
+[Responsory2_]
+R. Hory Gilboa, ať rosa ani déšť nezkropí vaše svahy, 
+* Kde padli silní Israele.
+V. Všechny hory, jež jste v jejich okolí, nechť navštíví Hospodin, Gilboa však ať přejde.
+R. Kde padli silní Israele.
+
+[Lectio3]
+!1 Sam 1:23-28
+23 Její muž Elkana jí řekl: „Udělej, co považuješ za dobré. Zůstaň doma, dokud ho neodstavíš. Hospodin své slovo jistě splní.“ Žena zůstala doma a kojila svého syna, dokud ho neodstavila.
+24 A když ho odstavila, vzala ho s sebou na pouť, s tříročním býčkem, s jednou efou mouky a s měchem vína. Přivedla ho do Hospodinova domu do Šilo. Chlapec byl ještě velmi malý.
+25 Porazili býčka a přivedli chlapce k Elimu.
+26 Anna řekla: „Prosím, můj pane, jako že žiješ, můj pane, já jsem ta žena, která stála tady u tebe a modlila se k Hospodinu.
+27 Za tohoto chlapce jsem se modlila a Hospodin mi dal, o co jsem ve své prosbě žádala.
+28 Tak jsem ho i já odevzdala Hospodinu. Po všechny dny, po které bude živ, ať patříHospodinu. A klaněli se tam Hospodinu.
+
+[Responsory3_]
+R. Já jsem tě vzal z domu tvého otce, praví Hospodin, a postavil tě, abys pásl stádce mého lidu;
+* A byl jsem s tebou všude, kam jsi šel, a posiloval tvou vládu navždy.
+V. Zjednal jsem ti velké jméno, vedle jmen velkých mužů, jež žijí na zemi; a odpočinout jsem ti dal od všech tvých nepřátel.
+R. A byl jsem s tebou všude, kam jsi šel, a posiloval tvou vládu navždy.
+&Gloria
+R. A byl jsem s tebou všude, kam jsi šel, a posiloval tvou vládu navždy.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-3:Responsory2_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory1_

--- a/web/www/horas/Bohemice/Tempora/Pent01-3.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent01-3.txt
@@ -20,11 +20,16 @@ R. A co je před tebou zlé, jsem spáchal.
 16 A ten člověk mu řekl: „Nejprve se musí obrátit tuk v kouř z oběti jako obvykle, pak si vezmi, po čem tvá duše touží.“ Řekl: „Ne, ale teď dáš. Pokud ne, vezmu si násilím.“
 17 Hřích knězových pomocníků byl před Hospodinem velmi veliký, protože ti muži znevažovali oběť přinášenou Hospodinu.
 
-[Responsory2]
+[Responsory2_]
 R. Vyslyšel jsi, Hospodine, prosbu svého služebníka, abych mohl vybudovat chrám tvému jménu; 
 * Dobrořeč tomuto domu a posvěť jej navěky, Bože Israele.
 V. Hospodine, jenž chráníš smlouvu se svými služebníky, jež kráčejí před tebou v upřímnosti svého srdce.
 R. Dobrořeč tomuto domu a posvěť jej navěky, Bože Israele.
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3_
 
 [Lectio3]
 !1 Král. 2:18-21
@@ -33,10 +38,15 @@ R. Dobrořeč tomuto domu a posvěť jej navěky, Bože Israele.
 20 Elkanovi a jeho ženě Eli požehnal: „Kéž ti Hospodin dá potomstvo z této ženy namísto toho, který jí byl dopřán a kterého ona dopřála Hospodinu.“ A odešli domů.
 21 Hospodin se Anny ujal. Počala a porodila tři syny a dvě dcery. Chlapec Samuel však vyrůstal v Hospodinově přítomnosti.
 
-[Responsory3]
+[Responsory3_]
 R. Slyš, Hospodine, chvalozpěv i prosbu, které tvj služebník před tebou dnes přednáší, aby tvé oči byly otevřeny, a tvé uši pozorně nakloněny; 
 * K tomuto domu ve dne i v noci.
 V. Shlédni, Hospodine, ze své svatyně, a ze svého vznešeného nebeského příbytku.
 R. K tomuto domu ve dne i v noci.
 &Gloria
 R. K tomuto domu ve dne i v noci.
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-1:Responsory1_

--- a/web/www/horas/Bohemice/Tempora/Pent03-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent03-0.txt
@@ -16,25 +16,25 @@ Zvítězil David * nad Filištínem jen prakem a kamenem, ve jménu Páně.
 @Tempora/Pent02-5:Oratio
 
 [Lectio1]
-Lesson from the first book of Samuel
+Čtení z první knihy Samuelovy
 !1 Sam 9:18-21
-18 And Saul came to Samuel in the midst of the gate and said: Tell me, I pray thee, where is the house of the seer?
-19 And Samuel answered Saul, saying: I am the seer, go up before me to the high place, that you may eat with me today, and I will let thee go in the morning: and tell thee all that is in thy heart.
-20 And as for the asses, which were lost three days ago, be not solicitous, because they are found. And for whom shall be all the best things of Israel? Shall they not be for thee and for all thy father's house?
-21 And Saul answering, said: Am not I a son of Jemini of the least tribe of Israel, and my kindred the last among all the families of the tribe of Benjamin? Why then hast thou spoken this word to me?
+18 Saul přistoupil k Samuelovi v městské bráně a řekl: „Pověz mi, prosím, kde je tady dům vidoucího.“
+19 Samuel Saulovi odpověděl: „Já jsem vidoucí. Vystup přede mnou na výšinu. Dnes budete jíst se mnou. Ráno tě propustím a oznámím ti všechno, co máš na srdci.
+20 Co se týče oslic, které se ti ztratily před třemi dny, nevěnuj jim už pozornost, protože se našly. Ke komu se upíná touha celého Israele? Copak ne na tebe a celý dům tvého otce?“
+21 Saul odpověděl: „Nejsem snad Benjaminovec — z nejmenšího kmene Israele? A není snad můj rod nejmenší ze všech rodů v kmeni Benjamin? Proč mi říkáš tato slova?“
 
 [Lectio2]
 !1 Sam 9:22-25
-22 Then Samuel taking Saul and his servant, brought them into the parlour, and gave them a place at the head of them that were invited. For there were about thirty men.
-23 And Samuel said to the cook: Bring the portion, which I gave thee, and commanded thee to set it apart by thee.
-24 And the cook took up the shoulder, and set it before Saul. And Samuel said: Behold what is left, set it before thee, and eat: because it was kept of purpose for thee, when I invited the people. And Saul ate with Samuel that day.
-25 And they went down from the high place into the town, and he spoke with Saul upon the top of the house: and he prepared a bed for Saul on the top of the house, and he slept.
+22 Samuel vzal Saula a jeho mládence, přivedl je do místnosti a přidělil jim místo v čele pozvaných. Bylo jich tam zhruba třicet mužů.
+23 Samuel řekl kuchaři: „Podávej podíl, který jsem ti dal, o kterém jsem ti řekl: ‚Ponech ho u sebe.‘“
+24 Kuchař vzal kýtu i to, co bylo na ní, a položil to před Saula. Samuel řekl: „Pohleď, toto zbylo. Polož to před sebe a jez, protože je to pro tebe uchováno na předem stanovenou dobu, kdy řeknu: ‚Pozval jsem lid.‘“ Toho dne jedl Saul se Samuelem.
+25 Sestoupili z výšiny do města a rozprostřeli Saulovi lože na střeše a on se uložil k spánku.
 
 [Lectio3]
 !1 Sam 9:26-27;10:1
-26 And when they were risen in the morning, and it began now to be light, Samuel called Saul on the top of the house, saying: Arise, that I may let thee go. And Saul arose: and they went out both of them, to wit, he and Samuel.
-27 And as they were going down in the end of the city, Samuel said to Saul: Speak to the servant to go before us, and pass on: but stand thou still a while, that I may tell thee the word of the Lord.
-1 And Samuel took a little vial of oil and poured it upon his head, and kissed him, and said: Behold, the Lord hath anointed thee to be prince over his inheritance, and thou shalt deliver his people out of the hands of their enemies, that are round about them. And this shall be a sign unto thee, that God hath anointed thee to be prince.
+26 Když vyšla jitřenka, zavolal Samuel na Saula na střeše: „Vstaň, chci tě propustit.“ Saul vstal a oba, on i Samuel, vyšli ven.
+27 Sestupovali k okraji města. Samuel řekl Saulovi: „Řekni mládenci, ať od nás odejde.“ A on odešel. „Ty se teď zastav, oznámím ti Boží slovo.“
+1 Samuel vzal nádobku s olejem, vylil mu ho na hlavu, políbil ho a řekl: „Nepomazal tě snad Hospodin za vévodu nad svým lidem, Izraelem? Budeš vládnout nad Hospodinovým lidem a zachráníš ho z rukou jeho okolních nepřátel. Toto ti bude znamením, že tě Hospodin pomazal za vévodu nad svým dědictvím:
 
 [Lectio4]
 !From the Encyclical Letter of Pope Pius XI
@@ -47,19 +47,19 @@ If we are, for the aforesaid reasons, to undertake both of those practices, we m
 All men are under obligation to make reparation; for our souls are disfigured as the Christian faith teacheth by original sin as a result of the pitiable fall of Adam. We are also subject to passions, whereby we are corrupted in a truly sad state, and have thus made ourselves worthy of everlasting condemnation. It is true that the proud philosophers of this world deny the aforesaid verities, and in their place do raise up again the ancient heresy of Pelagius: which taught that in human nature there is a certain innate goodness wherewith, by our own powers, we are raised up to ever higher levels of perfection; but such false theories, born of human pride, have been condemned by the Apostle in his saying that all men are by nature the children of wrath. As a matter of fact, from the very beginning of the creation of the world, mankind recognized, in one way or another, the obligation of making reparation, impelled thereto, as by a natural instinct, in an endeavour to placate God by offering public sacrifices unto him.
 
 [Lectio7]
-From the Holy Gospel according to Luke
-!Luke 15:1-5
-At that time: the publicans and sinners drew near unto him to hear him. And so on.
+Čtení svatého Evangelia podle Lukáše
+!Lukáš 15:1-5
+Za onoho času přicházeli k Ježíšovi celníci a hříšníci, aby jej poslouchali. A ostatní.
 _
-Homily by Pope St. Gregory (the Great)
-!34th on the Gospels
-Ye have heard, my brethren, from the Gospel which hath but now been read, how that the publicans and sinners drew near unto our Redeemer, and how that He received them, not only to converse, but also to eat with Him. And when the Pharisees and Scribes saw it, they murmured. From this learn ye, that true righteousness is merciful, and false righteousness is contemptuous, albeit that the righteous also oft-times feel moved with just indignation at sinners. But it is one thing to feel thus indignant through pride, and another to feel so through love of law.
+Homilie svatého Řehoře Papeže.
+!Homilie 34 na Evangelia.
+Bratři moji, ve čtení z Evan­gelia jste slyšeli, že hříšníci a celníci přistupovali k našemu Spasiteli. A on s nimi nejen mluvil, ale také jedl. Když to uviděli Fariseové, pohoršili se. Z tohoto příběhu pochopte, že pravá spravedlnost zná slitování, falešná však spravedlnost jen pohoršení. Přesto i spravedliví mívají ve zvyku pohoršovat se nad hříšníky, a to zcela po právu. Avšak něco jiného způsobuje ztělesnění pýchy a něco jiného zápal pro kázeň.
 
 [Lectio8]
-The righteous indeed look down upon sinners, and yet, as not despising them; they abandon them, and yet, as not without hope; they fight against them, and yet, as loving them all the while; for if they be behoven to chasten them grievously as touching the outer man, yet is it through charity which offereth sweetness to their inner man. In their hearts they prefer before themselves them whom they are correcting; they hold as better than themselves them whom they judge. And thus doing, they watch by carefulness over them, which are committed unto their charge, and, by lowly-mindedness, over themselves.
+Takoví lidé se sice pohoršují se, ale nejsou pohoršeni, zoufají si, ale nejsou zoufalí, bojují proti hříchům, ale v lásce, neboť i když navenek přehánějí něčí nedostatky skrze učení, uvnitř si zachovávají sladkost lásky. V duchu totiž většinou dávají přednost těm, které kárají, považují za lepší ty, které soudí. Když však toto činí, v pokoře jsou si dobře vědomi, že i oni sami podléhají učení. 
 
 [Lectio9]
-On the other hand, they whose exaltation cometh of a false righteousness, look down upon their neighbour, but are softened by no mercy toward his misery, and are all the more sinful, because they perceive not that they themselves are sinners. Of such were those Pharisees who judged the Lord because He received sinners, and, in the dryness of their own heart, rebuked the very Fountain of mercy. They were sick of so desperate a sickness that they knew not of themselves that they were sick; but, that they might know that they were so, the Heavenly Physician applied to them His tender ointments, and, by means of a gracious parable, lanced the boil of their pride of heart.
+A naopak, ti, kteří mají ve zvyku pyšnit se falešnou spravedlností, ty ani nenapadne slitovat se nad slabostí těch, které nenávidí. A tím, že sami sebe nepovažují za hříšníky, stávají se hříšníky o to horšími. Mezi takovými se našli i Fariseové, kteří odsuzovali a kritizovali Pána za to, že přijímal hříšníky, neboť pramen milosrdenství v jejich srdci již vyschl. Byli totiž nemocní. A přestože o své nemoci nevěděli, jakmile však uznají, co jsou, tedy přiznají svou nemoc, nebeský lékař je vyléčí něžnými obklady, předejde dobrým vzorem a zatlačí otok rány v jejich srdcích.
 &teDeum
 
 [Capitulum Laudes]

--- a/web/www/horas/Bohemice/Tempora/Pent03-0o.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent03-0o.txt
@@ -2,15 +2,15 @@
 Neděle 3. po Svatém Duchu
 
 [Lectio4]
-From the Exposition [attributed to] of blessed Gregory, Pope, on the book of Kings
-!Lib. 4, cap. 5 in I Reg. c. 10
-Then Samuel took a vial of oil, and poured it over his head. Clearly this anointing expresses what has become a custom in Holy Church: for he who is made one of her princes receives the sacrament of anointing. Now, since this anointing is a sacrament, he who is thus promoted is well anointed outwardly, if he is inwardly strengthened by sacramental power. First, then, let us consider the virtues of oil. Oil is superior to other liquids, in that it feeds flame and is wont to heal wounds. It therefore signifies mercy, as it is written of the Lord, his mercy is over all his works. In that it feeds flame, it signifies preaching which enlightens the mind of the elect.
+Z Výkladu svatého Řehoře Papeže na knihy Královské.
+!Kniha 4, kapitola 5 na 1. knihu královskou, kapitola 10.
+Pak vzal Samuel nádobku s olejem a vylil mu ji na hlavu. Toto zajisté popisuje to pomazání, které se nyní v Církvi svaté provádí i skutečně: tedy že ten, kdo je dosazen na vrcholnou pozici, přijme svátostné pomazání. Neboť takové pomazání je vskutku svátost. Ten, kdo je povýšen, je řádně pomazán zvenku, aby zevnitř byl posílen silou svátosti. Zaměřme se však nejdříve na dobré vlastnosti oleje. Olej je totiž nadřazen jiným tekutinám: olej živí oheň a bývá zvykem olejem uzdravovat rány. Jím je tedy vyjádřeno dobro milosrdenství, neboť o Pánu je psáno: „Dobrotivý je Hospodin ke všem, soucit má se všemi svými tvory.“ Protože olej živí oheň, označuje i milost kázání, která ozařuje mysli vyvolených
 
 [Lectio5]
-But in that wounds are healed by oil, it is clearly shown that the wounds of sin are to be wiped out. Let the head of the King be anointed then, that his mind may be filled with the spiritual grace of a teacher. Let him have oil through his anointing, let him have abundant mercy, which he should prefer to all other virtues. Let him have oil, so that while he kindles within himself the flame of the Holy Spirit, he may enlighten others by the Word. Likewise let him have the oil of healing, that he may dispense wisdom, and by it wipe out the stains of sins, and restore the sick in mind to health.
+Protože olejem se také uzdravují rány, toto zajisté naznačuje, že rány hříšníků se mají čistit. Pomazává se tedy hlava krále, neboť mysl učitele se má naplnit duchovní milostí. Má-li král při svém pomazání olej, má i dostatek milosrdenství, kterému dává přednost před ostatními ctnostmi. Nechť má olej, aby, zatímco v sobě živí oheň Ducha svatého, mohl skrze své slovo zářit ostatním. Nechť však má také uzdravující olej, aby ve své moudrosti vždy věděl, jak se zbavit zápachu hříchů a nemocné mysli opět uzdravil.
 
 [Lectio6]
-But Saul was anointed from a vial, not to signify teaching, but to indicate his future. For a vial is a very small vessel. Why was it that Saul was anointed from a vial of oil, if not because he was eventually to be cast out? For after he had refused to obey God, he heard from Samuel, because you have rejected the word of the Lord, he has also rejected you from being king. As the vial held but little oil, so he was to be cast away received but little spiritual grace. This may be taken to be the rulers of the holy Church. For many of them receive the high dignity of the prelacy who are not perfect in their love of God and of their neighbors.
+Saul byl však pomazán z misky. A sice ne proto, aby se předznamenalo učení, ale aby se ukázala jeho budoucnost. Miska je totiž malá nádoba. Co tedy znamená, že byl pomazán z misky, ne-li to, že pak nechtěl uposlechnout Boha a proto od Samuela uslyšel: „Protože jsi zavrhl Hospodinovo slovo, zavrhl Hospodin tebe, abys již nebyl králem nad Israelem.“ Stejně jako miska pojme jen málo oleje, tak i on, když měl být zavržen, obdržel jen málo duchovní milosti. Což se snadno může stát i vůdcům svaté Církve. Většinou totiž vrcholné pozice přijímají ti, kteří v lásce k Bohu a bližnímu nejsou dokonalí. 
 
 [Lectio7]
 @Tempora/Pent03-0:Lectio7

--- a/web/www/horas/Bohemice/Tempora/Pent03-1Feria.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent03-1Feria.txt
@@ -1,0 +1,21 @@
+[Officium]
+pondělí v třetím týdnu po Svatodušním Oktávu
+
+[Responsory1_]
+R. Rozpomeň se, Hospodine, na svou smlouvu, a řekni svému Andělu mstiteli: Zadrž již svou ruku, 
+* Aby neosiřela země, abys nezahubil každou živou duši.
+V. Já jsem ten, kdo zhřešil, já jsem konal nepravosti: oni jsou jen ovce, co učinili? Odvrať, prosím, svůj hněv, Hospodine, od svého lidu.
+(sed rubrica cisterciensis)
+V. Utichniž, Hospodine, tvůj hněv nad tvým lidem, a nad tvým svatým městem.
+R. Aby neosiřela země, abys nezahubil každou živou duši.
+
+[Responsory1C] 
+R. Zaplakal pak David převelice hořce nad Saulem, a jeho syny, a řekl: Jak jen mohli padnout siláci ve válce,
+* A otupět jejich zbraně ve válce; slavní Israele, plačte.
+V. Hory Gilboa, ani rosa, ani déšť nechť nesvlaží vaše svahy, kde padli mnozí ranění;
+R. A otupěly jejich zbraně ve válce; slavní Israele, plačte.
+
+[Responsory1] 
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory1C

--- a/web/www/horas/Bohemice/Tempora/Pent03-2Feria.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent03-2Feria.txt
@@ -1,11 +1,16 @@
 [Officium]
 úterý v třetím týdnu po Svatodušním Oktávu
 
-[Responsory1]
+[Responsory1_]
 R. Hospodine, pokud se obrátí tvůj lid, a bude se modlit ve tvém svatostánku;
 * Ty jej vyslyš z nebe, Hospodine, a vysvoboď je z rukou jejich nepřátel.
 V. Pokud proti tobě zhřešil tvůj lid, a obrátí se a bude konat pokání, přijde a bude se modlit na tomto místě.
 R. Ty jej vyslyš z nebe, Hospodine, a vysvoboď je z rukou jejich nepřátel.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-1Feria:Responsory1_
 
 [Lectio2]
 @Tempora/Pent03-2
@@ -15,6 +20,12 @@ R. Stalo se, když Hospodin uchvátil Eliáše ve vichru do nebe;
 * Eliseus volal a pravil: Otče můj, otče můj, vůz Israele, a jeho vozataj.
 V. Když vyšli a začali spolu mluvit, hle, ohnivý vůz a ohniví koně je navzájem rozdělili, a Eliáš ve vichřici vystoupil do nebe.
 R. Eliseus volal a pravil: Otče můj, otče můj, vůz Israele, a jeho vozataj.
+
+[Responsory2] (rubrica cisterciensis)
+R. Stalo se, když Hospodin uchvátil Eliáše ve vichru do nebe, Eliseus zvolal a pravil: 
+* Otče můj, otče můj, vůz Israele, a jeho vozataj.
+V. Když spolu vyšli a začali rozmlouvat, hle, ohnivý vůz a ohniví koně je navzájem rozdělili, a Eliseus zvolal:
+R. Otče můj, otče můj, vůz Israele, a jeho vozataj.
 
 [Lectio3]
 @Tempora/Pent03-2

--- a/web/www/horas/Bohemice/Tempora/Pent04-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent04-0.txt
@@ -12,56 +12,56 @@ Dej nám, prosíme, Pane, aby běh světa nám byl v míru dle tvého řádu sm�
 $Per Dominum.
 
 [Lectio1]
-Lesson from the first book of Samuel
+Čtení z první knihy Samuelovy
 !1 Sam 17:1-7
-1 Now the Philistines gathering together their troops to battle, assembled at Socho of Juda, and camped between Socho and Azeca in the borders of Dommim.
-2 And Saul and the children of Israel being gathered together came to the valley of Terebinth, and they set the army in array to fight against the Philistines.
-3 And the Philistines stood on a mountain on the one side, and Israel stood on a mountain on the other side: and there was a valley between them.
-4 And there went out a man baseborn from the camp of the Philistines named Goliath, of Geth, whose height was six cubits and a span:
-5 And he had a helmet of brass upon his head, and he was clothed with a coat of mail with scales, and the weight of his coat of mail was five thousand sicles of brass:
-6 And he had greaves of brass on his legs, and a buckler of brass covered his shoulders. 
-7 And the staff of his spear was like a weaver's beam, and the head of his spear weighed six hundred sicles of iron: and his armourbearer went before him.
+1 Pelištejci shromáždili svá vojska k boji. Shromáždili se do Soka v Judsku a utábořili se mezi Sokem a Azekou v Efes-dammimu.
+2 Saul a izraelští muži se shromáždili a utábořili se v údolí Ela, aby se s Pelištejci utkali.
+3 Pelištejci zaujímali postavení na hoře z jedné strany, Izraelité zaujímali postavení na hoře z druhé strany. Mezi nimi bylo údolí.
+4 Z pelištejského tábora vycházel zápasník jménem Goliáš z Gatu. Byl vysoký šest loket a jednu píď.
+5 Na hlavě měl bronzovou helmici a byl oděn do šupinatého pancíře. Jeho pancíř vážil pět tisíc šekelů bronzu.
+6 Na nohou měl bronzové holeně a na ramenou bronzový oštěp.
+7 Násada jeho kopí byla jako tkalcovské vratidlo, hrot jeho kopí vážil šest set šekelů železa, před ním chodil štítonoš.
 
 [Lectio2]
 !1 Sam 17:8-11
-8 And standing he cried out to the bands of Israel, and said to them: Why are you come out prepared to fight? am not I a Philistine, and you the servants of Saul? Choose out a man of you, and let him come down and fight hand to hand.
-9 If he be able to fight with me, and kill me, we will be servants to you: but if I prevail against him, and kill him, you shall be servants, and shall serve us.
-10 And the Philistine said: I have defied the bands of Israel this day: Give me a man, and let him fight with me hand to hand.
-11 And Saul and all the Israelites hearing these words of the Philistine were dismayed, and greatly afraid.
+8 Postavil se a volal do izraelských řad. Říkal jim: „Proč jste vytáhli a seřadili se k bitvě? Nejsem snad Pelištejec a vy Saulovi služebníci? Vyberte si muže a ten ať ke mně sestoupí.
+9 Dokáže-li mě přemoci v boji a zabije mě, budeme my vašimi služebníky. Přemohu-li ho já a zabiju ho, budete vy našimi služebníky a budete nám sloužit.“
+10 Ten Pelištejec říkal: „Copak já nejsem Pelištejec? Dnes jsem potupil israelské řady. Dejte mi muže, budeme spolu bojovat.“
+11 Když uslyšel Saul a všechen Izrael tato Pelištejcova slova, zděsili se a velmi se báli.
 
 [Lectio3]
 !1 Sam 17:12-16
-12 Now David was the son of that Ephrathite of Bethlehem Juda before mentioned, whose name was Isai, who had eight sons, and was an old man in the days of Saul, and of great age among men.
-13 And his three eldest sons followed Saul to the battle: and the names of his three sons that went to the battle, were Eliab the firstborn, and the second Abinadab, and the third Samma.
-14 But David was the youngest. So the three eldest having followed Saul,
-15 David went, and returned from Saul, to feed his father's flock at Bethlehem.
-16 Now the Philistine came out morning and evening, and presented himself forty days.
+12 David byl synem toho Efratejce z judského Betléma, který se jmenoval Jesse. Měl osm synů. Ten muž byl v Saulově době už starý, byl pokročilého věku.
+13 Tři starší Jesseovi synové odešli a následovali Saula do války. Toto jsou jména tří jeho synů, kteří odešli do války: prvorozený Eliab, druhorozený Abinadab a třetí Šamma.
+14 David byl nejmladší, tři starší následovali Saula.
+15 David odešel, vrátil se od Saula, aby pásl ovce svého otce v Betlémě.
+16 Ten Pelištejec se přibližoval ráno a večer. Předváděl se čtyřicet dní.
 
 [Lectio4]
-from the Sermons of St. Augustine, Bishop (of Hippo.)
-!Serm. 197. de Temp. circa med.
-The children of Israel faced their enemies for forty days. These forty days, by reason of the four Seasons of the year, and of the four Continents of the globe, are a figure of this present life, during which the Christian world ceaseth not to be arrayed in battle against the devil and his angels, as it were against Goliath and the army of the Philistines. Neither can they hope to overcome him, were it not for the true David, that is, Christ, with His staff, that is, with the Mystery of His Cross. For before Christ came, my dearly beloved brethren, the devil was at large. But when Christ came, He did to him what is written in the Gospel, where it is said „How can one enter into a strong man's house, and spoil his goods, except he first bind the strong man?” Christ therefore came, and bound the devil.
+Řeč svatého Augustina Biskupa.
+!Řeč 197 během roku.
+Synové israelští stáli proti nepřátelům čtyřicet dnů. Čtyřicet dnů, tedy proto také čtyři roční období a čtyři světové strany označují tento život, v němž křesťanský lid nepřestává bojovati proti Goliášovi či jeho vojsku, tedy proti ďáblovi a jeho andělům. Nemohl by však zvítězit, pokud by k němu nesestoupil pravý David, Kristus s pastýřskou holí, tedy s tajemstvím kříže. Totiž před příchodem Kristovým, nejdražší bratři, byl ďábel svobodný. Když však přišel Kristus, učinil s ním podle toho, jak se říká v Evangeliu: „Nikdo nemůže vstoupit do domu silákova a uloupit jeho věci, dokud siláka nejprve nesváže.“ Přišel tedy Kristus a svázal ďábla.
 
 [Lectio5]
-But some man will say: If he is bound, why is he still so powerful? It is quite true, my dearly beloved brethren, that he is very powerful but his lordship is over the lukewarm and the careless, and such as fear not God in truth. He is chained up like a dog, and can only bite those who are such suicidal fools as to go within the length of his tether. Look you, my brethren, what a dolt a man must be who getteth himself bitten by a dog that is chained up. Let not the desires and lusts of the world draw thee within reach of him, and he will not be able to get at thee. He can bark, he can whine but he can only bite those who are willing to be bitten. He assaileth us, not by violence, but by persuasion he asketh, not seizeth, our consent.
+Někdo by snad mohl říct: Pokud je svázaný, jak to, že tak mnoho vítězí? Je pravda, nejdražší bratři, že v mnohém vítězí. Avšak pouze nad těmi, kteří jsou vlažní, lhostejní a Boha se ve skutečnosti nebojí. Ďábel je tedy svázán řetězy, jako se uvazuje pes, aby nemohl nikoho pokousat, pouze pak toho, kdo se k němu smrtonosnou lhostejností připoutá. Pohleďte tedy, bratři, jak hloupý je takový člověk, který se nechá pokousat od psa vsazeného do řetězů.  Ty se však k ďáblu skrze svou vůli a touhu nepoutej, a on se neodváží k tobě přistoupit. Může štěkat, může tě lákat, avšak pokousat může pouze toho, kdo k tomu svolí. On neškodí tím, že by nás nutil, ale přesvědčuje. Ani z nás mučením nedostává náš souhlas, pouze o něj požádá.
 
 [Lectio6]
-David, then, came, and found the Jewish people set in battle array against the devil and since there was no one who dared to go to single combat, he, who was a type of Christ, sallied out to the battle, took his staff in his hand, and went forth against Goliath. In him was a shadow of a substance which is in Christ. Christ, the true David, when He went forth to fight against the spiritual Goliath, that is to say, against the devil, went forth bearing His Cross. Ye see, my brethren, in what part it was that David smote Goliath it was upon that forehead whereon the Cross had never been traced. And as the staff of David was a figure of the Cross of Christ, so was the stone wherewith the giant was smitten a figure of the Lord Himself.
+Přišel tedy David a nalezl lid židovský, kterak bojuje proti ďáblu. A i když se nenašel žádný, kdo by se odvážil přistoupit k souboji muže proti muži, ten, který ztělesňuje postavu Krista, vyšel k souboji, měl v ruce pouze pastýřskou hůl a takto vyšel bojovat proti Goliášovi. V něm je tedy zpodobněno, co v Ježíši Kristu bylo dokonáno. Přišel tedy pravý David, Kristus, který v boji proti duchovnímu Goliášovi, tedy proti ďáblovi, sám nesl svůj kříž. Všimněte si, bratři, kam David Goliáše udeřil: totiž do čela, kde neměl znamení kříže. Tak jako jeho pastýřská hůl byla předzvěstí kříže, stejně i ten kámen, kterým byl zasažen, předznamenal Krista Pána. 	
 
 [Lectio7]
-From the Holy Gospel according to Luke
-!Luke 5:1-11
-At that time: As the people pressed upon Jesus, to hear the word of God, He stood by the lake of Gennesareth. And so on.
+Čtení svatého Evangelia podle Lukáše.
+!Lukáš 5:1-11
+Za onoho času, když se tlačily davy k Ježíšovi, aby slyšely slovo Boží, a on stál na břehu Genezaretského jezera. A ostatní.
 _
-Homily by St. Ambrose, Bishop of Milan.
-!Bk. iv. on Luke v.
-When the Lord wrought so many works of healing, neither time nor place could restrain the people from seeking health. Evening came, and they still followed Him He went down to the lake, and they still pressed upon Him and therefore He entered into Peter's ship. This is that ship, which spiritually up to this very hour, according to the expression of Matthew, is buffeted by tempests, but still, according to Luke, is filled with fishes, this signifying, that, for a while, to labour is present to the Church, but, hereafter, it shall be to rejoice. The fishes are they which swim in the troublous waters of human life. In this ship also spiritually doth Christ, for His disciples, still sleep, and still command; for He sleepeth for the lukewarm, and watcheth for the perfect.
+Homilie svatého Ambrože Biskupa.
+!Kniha 4 na 5. kapitolu Lukáše.
+Jakmile začal Pán mnohé lidi uzdravovat z různých druhů nemocí, nemohli od něj dostat davy lidí, kteří za ním neustále a všude přicházeli, aby je uzdravil. Když večer usedl ke stolu, přišli za ním, když přišel k jezeru, tlačili se na něj, tak tedy nastoupil na Petrovu loď. To je tedy ta loď, která se ještě podle Matouše zmítala ve vlnách, a podle Lukáše pak byla plná ryb. Zde poznáváme svou Církev, která se na svém počátku zmítala ve vlnách, pak se ale hojně rozrostla. Ryby jsou tedy ti, kteří plují tímto životem. Tam tedy pro učedníky Kristus ještě spí, zde je nabádá. Spí totiž pro vlažné, pro dokonalé bdí. 
 
 [Lectio8]
-O fear, then, for the ship where wisdom steereth, false teaching is not known, and faith swelleth the sails. How shall she be troubled, whose Lord is Himself the Church's sure Foundation It is where faith is weak that there is fear where love is perfect, there there is safety. To many it is commanded to loose their nets, but to Peter only to „Launch out into the deep,“ that is, into the depths of doctrine. What indeed is there so deep, as to gaze upon the depth of all riches, to recognise the Son of God, and to take up the confession of His Divine generation This is a thing which the mind is not able to grasp by the searchings of man's reason, but which is embraced by an hearty faith.
+Ve vlnách se pak nezmítá pouze taková loď, kterou řídí moudrost, která nezná proradnost, a vítr víry jí duje do plachet. Jak by se jen mohla zmítat, když jejím kapitánem je ten, v němž je samotný základ Církve? Nepokoje jsou pouze tam, kde je malá víra. Bezpečí pak vládne tam, kde je dokonalá láska. A i když je ostatním přikázáno, aby spustili své sítě, pouze Petrovi Pán řekl: „Zajeď na hlubinu,“ tedy do hloubky učení Církve. Co totiž může být hlubšího, než uzřít hlubinu Božího bohatství, poznat Syna Božího a přijmout utvrzení o Božím narození? To sice lidská mysl nemůže plně pochopit zkoumáním svého rozumu, plnost víry to však pojmout dokáže.
 
 [Lectio9]
-Nor albeit, it is not given unto me to know how He was born, yet that born He was, I may not be ignorant. What the order of His generation was, I know not, but the Source of His generation I acknowledge. None hath beheld the Begetting of the Son of God by the Father, but the Church hath stood by to hear the Father testify that this is His beloved Son. (Luke iii. 22.) If we believe not God, whom shall we believe? For whatsoever we believe cometh either by sight or by hearing; sight is oftentimes deceived, but „faith cometh by hearing.“ (Rom. x. 17.)
+Neboť, přestože mi není dáno vědět, jak se Bůh narodil, nelze, abych nevěděl, že se narodil. Postup tohoto narození neznám, původce tohoto narození však znám. Nebyli jsme sice přítomni, když se Boží Syn zrodil z Otce, avšak byli jsme přítomni, když jej Otec prohlásil za Božího Syna (Lukáš iii. 22). Pakliže nevěříme Bohu, komu máme věřit? Totiž vše, čemu věříme, jsme buď viděli, nebo slyšeli. Zrak se dá snadno ošálit, víra je tedy ze zvěstování. (Řím. x. 17)
 &teDeum
 
 [Ant 2]

--- a/web/www/horas/Bohemice/Tempora/Pent05-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent05-0.txt
@@ -12,55 +12,55 @@ Bože, jenž jsi těm, kteří tě milují, připravil neviditelná dobra; vlej 
 $Per Dominum
 
 [Lectio1]
-Lesson from the second book of Samuel
+Začíná druhá kniha Samuelova
 !2 Sam 1:1-4
-1 Now it came to pass, after Saul was dead, that David returned from the slaughter of the Amalecites, and abode two days in Siceleg.
-2 And on the third day, there appeared a man who came out of Saul's camp, with his garments rent, and dust strewed on his head: and when he came to David, he fell upon his face, and adored.
-3 And David said to him: From whence comest thou? And he said to him: I am fled out of the camp of Israel.
-4 And David said unto him: What is the matter that is come to pass? tell me. He said: The people are fled from the battle, and many of the people are fallen and dead: moreover Saul and Jonathan his son are slain.
+1 Stalo se tedy, že po Saulově smrti se David vrátil z bitvy s Amalekity. David zůstal dva dny v Siklagu.
+2 Třetího dne náhle přišel nějaký muž z tábora od Saula, měl roztržené šaty a hlínu na hlavě. Když vcházel k Davidovi, padl k zemi a klaněl se.
+3 David mu řekl: „Odkud přicházíš?“ A on mu řekl: „Unikl jsem z izraelského tábora.“
+4 David mu řekl: „Co se stalo? Podej mi zprávu!“ A on řekl: „Lid utekl z bitvy a mnoho jich padlo a zemřelo; a také Saul a jeho syn Jonatan zemřeli.“
 
 [Lectio2]
 !2 Sam 1:5-10
-5 And David said to the young man that told him: How knowest thou that Saul and Jonathan his son, are dead?
-6 And the young man that told him, said: I came by chance upon mount Gelboe, and Saul leaned upon his spear: and the chariots and horsemen drew nigh unto him,
-7 And looking behind him, and seeing me, he called me. And I answered, Here am I.
-8 And he said to me: Who art thou? And I said to him: I am an Amalecite.
-9 And he said to me: Stand over me, and kill me: for anguish is come upon me, and as yet my whole life is in me.
-10 So standing over him, I killed him: for I knew that he could not live after the fall: and I took the diadem that was on his head, and the bracelet that was on his arm and have brought them hither to thee, my lord.
+5 Tomu mládenci, který mu podával zprávu, David řekl: „Jak víš, že zemřel Saul i jeho syn Jonatan?“
+6 Mládenec, který mu podával zprávu, řekl: „Zrovna jsem byl v pohoří Gilboa. A hle, Saul se opíral o své kopí. Vozy a jezdci se na něho zaměřili.
+7 Obrátil se, uviděl mě a zavolal na mě: Řekl jsem: Tady jsem.
+8 Řekl mi: ‚Kdo jsi?‘ Řekl jsem mu: Já jsem Amalekita.
+9 Řekl mi: ‚Postav se proti mně a usmrť mě, protože mě sice svírá smrtelná křeč, ale stále ještě žiju.‘
+10 Postavil jsem se proti němu a usmrtil ho. Poznal jsem totiž, že by nepřežil svůj pád. Vzal jsem čelenku z jeho hlavy a náramek z jeho paže a přinesl jsem je svému pánu.“
 
 [Lectio3]
 !2 Sam 1:11-15
-11 Then David took hold of his garments and rent them, and likewise all the men that were with him.
-12 And they mourned, and wept, and fasted until evening for Saul, and for Jonathan his son, and for the people of the Lord, and for the house of Israel, because they were fallen by the sword.
-13 And David said to the young man that told him: Whence art thou? He answered: I am the son of a stranger of Amalee.
-14 David said to him: Why didst thou not fear to put out thy hand to kill the Lord's anointed?
-15 And David calling one of his servants, said: Go near and fall upon him. And he struck him so that he died.
+11 David uchopil své šaty a roztrhl je. Totéž udělali i všichni muži, kteří byli s ním.
+12 Až do večera naříkali, plakali a postili se pro Saula, pro jeho syna Jonatana, pro Hospodinův lid a pro izraelský dům, protože padli mečem.
+13 Mládenci, který mu to oznámil, David řekl: „Odkud jsi?“ Odpověděl: „Jsem syn cizince, Amalekity.“
+14 David mu řekl: „Jak to, že ses nebál vztáhnout svou ruku a zabít Hospodinova pomazaného?“
+15 David zavolal jednoho z mládenců a řekl: „Pojď sem a sraz ho!“ Ten ho udeřil a on zemřel.
 
 [Lectio4]
-From the Book of Moral (Reflections upon Job), written by Pope St. Gregory the Great.
-!Bk. iv. ch. 3, 4
-Thus was it that David, who rewarded no evil to them that did evil to him (Ps. vii. 5), when Saul and Jonathan had fallen in battle, cursed the mountains of Gilboa, saying Ye mountains of Gilboa, let there be no dew, neither let there be rain upon you, nor fields of offerings; for there the shield of the mighty is vilely cast away, the shield of Saul, as though he had not been anointed with oil. Why was it that Jeremiah, when he saw that his preaching was thrown away upon his hearers, cursed and said Cursed be the man who brought tidings to my father, saying: A man-child is born unto thee? (xx. 15.)
+Z knihy Morálií svatého Řehoře Papeže.
+!Kniha 4., Kapitola 3. a 4.
+Copak učinil David, který neodplácel zlem těm, kteří mu působili příkoří, když Saul a Jonathan padli ve válce? Proklel pohoří Gelboe těmito slovy: „Pohoří Gelboe, ať na vás nesestoupí rosa ani déšť, ať zde nejsou ani pole prvních obětin! Neboť tam je odhozen štít silných, štít Saulův, jako by ani nebyl pomazán olejem. Pročpak Jeremiáš, když shledal, že jeho promluvy jsou stiženy nepochopením posluchačů, pronesl tuto kletbu: „Proklet buď muž, který mému otci oznámil: ‚Narodil se ti chlapec‘“? (xx. 15.)
 
 [Lectio5]
-He had the mountains of Gilboa to do with the death of Saul, that they should be condemned to have dew fall on them no more, neither rain, but should wither away, barren of the green glory of the springtime? But this word Gilboa signified bubbling fountain, and the death of Saul the Anointed of God is a type of the death of our Anointed Mediator. Thus we find in the mountains of Gilboa no unfit image of the proud hearts of the Jews, which had their spring in earthly desires, and took part in the death of the Anointed Saviour. And since among them their Anointed Monarch met His death, the dew of grace is upon them no more.
+Co tedy pohoří Gelboe provedlo tak zlého, když Saul zemřel, že na ně neměla padnout ani rosa, ani déšť, a od veškerých zárodků zeleně je tato věta měla vysušit? Avšak protože slovo Gelboe se překládá jako bystřina, právě skrze Saula, pomazaného a mrtvého, je vyjádřena smrt našeho prostředníka. Není tedy náhodou, že právě pohoří Gelboe znázorňuje pyšná srdce Židů, která, zatímco oplývají touhami tohoto světa, mají prsty ve smrti Krista, tedy pomazaného. A protože v nich pomazaný král umírá, oni sami jsou zbaveni rosy každé milosti.
 
 [Lectio6]
-And well is it said of them Let there be upon you no fields of offerings. The proud minds of the Hebrews bear yet no offering. Since the coming of their Redeemer, the most part of them remain still without belief in Him, and refuse to follow the promise of their ancient faith. The Holy Church hath borne for her first-born, holy unto the Lord, a multitude of the Gentiles, and will, but in the end of the world, embrace such Jews as she then shall find, and present them as the last gatherings of her harvest.
+O nich je také správně řečeno, že nemohou být pole prvních obětin. Pyšné mysli Židů totiž žádné plody prvních obětin nenesou, neboť při příchodu Spasitele jejich největší část zůstala v proradnosti a nechtěli následovat první znamení víry. Avšak svatá Církev ve svých počátcích byla obohacena zástupy pohanských Národů, takže na konci časů jen posbírá těch pár Židů, které najde. A když sebere i toho posledního, odevzdá je jako zbytky své úrody.
 
 [Lectio7]
-From the Holy Gospel according to Matthew
-!Matt 5:20-24
-At that time, Jesus said unto His disciples: Unless your righteousness shall exceed the righteousness of the Scribes and Pharisees, ye shall in no case enter into the kingdom of heaven. And so on.
+Čtení svatého Evangelia podle Matouše
+!Mat. 5:20-24
+Za onoho času řekl Ježíš svým učedníkům: „Pokud nebudete mít více spravedlnosti než Zákoníci a Fariseové, nevejdete do království nebeského.“ A ostatní.
 _
-Homily by St. Augustine, Bishop of Hippo
-!Bk. I on the Lord's Sermon on the Mount, ch. 9
-Thou shalt not kill, is of the righteousness of the Pharisees; Thou shalt not be angry with thy brother without a cause, is of the righteousness of them which shall enter into the kingdom of heaven. The least therefore is: “Thou shalt not kill, and whosoever shall break this commandment, he shall be called the least in the kingdom of heaven.” (v. 19.) But whosoever shall do it, and not kill, he is not therefore great, and meet for the kingdom of heaven; albeit, he hath risen a step; but he will have gotten farther, if he be not angry with his brother without a cause, which, if he do, he will be the farther off from manslaughter. Wherefore, He Which teacheth us that we are not to be angry without a cause, destroyeth not the law, Thou shalt not kill, but rather fulfilleth and increaseth it, making us not only to be free of the sin of outward killing, but also clean of anger within.
+Homilie svatého Augustina Biskupa.
+!Kniha 1. o Horském kázání. Kap. 9.
+Spravedlnost Fariseů spočívá v přikázání „Nezabiješ,“ spra­vedlnost těch, kteří vejdou v nebeské království už v tom, že se bezdůvodně nehněvají. Nezabíjet je tedy to nejmenší, a kdo i to poruší, bude v království nebeském nazván nejmenším. Kdo však toto přikázání naplní a nebude zabíjet, nebude hned velikým a hodným království nebeského, avšak postoupí pouze o určitý stupeň. Dokonalý pak bude ten, kdo se ani nehněvá bez vhodné příčiny. Kdo toto dokáže, bude od vraždy již velmi vzdálen. Proto tedy ten, kdo učí, abychom se nehněvali, neporušuje přikázání „Nezabiješ,“ ale spíše je naplňuje: tak si tedy zachováme nevinnost jak vnější, když nezabíjíme, tak i ve svém srdci, když se nehněváme.
 
 [Lectio8]
-On sins of this kind there are diverse steps. First, there is the swelling feeling of anger. When this feeling appeareth in a man's heart, he keepeth it. Then the inward disturbance wringeth forth words of indignation, not themselves meaning aught, but showing the trouble of him who is provoked. And this is something more than anger kept covered under silence. Next, this audible outburst of indignation may contain direct and open reviling of him who hath roused it. And it cannot be doubted that this is something more than an empty cry of anger.
+U tohoto hříchu tedy existují stupně: nejprve se člověk rozhněvá a tuto pohnutku uchová ve svém srdci. Nyní, pokud tato pohnutka vynutí nějaký zlostný zvuk, zpravidla to moc neznamená, takový výbuch však svědčí o takovém hnutí mysli, které zraňuje nahněvaného: je to však už více, než když člověk svůj sílící hněv jen dusí v tichosti. Pokud však slyšíme nejen zlostné zvuky, ale i slova, která ukazují a vyjadřují jistou urážku toho, vůči komu jsou zaměřena, kdopak by pochyboval, že toto je ještě více, než když slyšíme pouhé zlostné zvuky? 
 
 [Lectio9]
-Behold here the three degrees of guilt open respectively to the judgment, to the council, and to hellfire. In the judgment, there is still place for defence. In the council, albeit this also is in a sense a judgment, yet we may suppose this distinction from the judgment proper, that the council pronounceth sentence, not as the result of a trial whereat the accused is present, but as the result of a consultation among the judges, to what punishment he is to be sentenced of whom it is already established that he is guilty. When we get to hell-fire, there remaineth no longer any doubt about condemnation, as in the judgment, and no longer any doubt about sentence, as in the council. In hellfire the condemnation and the pain of him that is condemned are alike certain.
+Podívejme se nyní také na tři stupně obžaloby: soud, soudní tribunál a pekelný oheň. Před soudcem je ještě dán prostor obhajobě. U soudního tribunálu však vidíme, že ačkoliv zde také bývá zvykem soudit, na tomto místě se zajisté nabízí, abychom vyložili rozdíl mezi nimi. Úkolem soudního tribunálu je totiž vynést rozsudek. Když už se s obžalovaným samotným neprobírá, zda má být odsouzen, radí se tribunál mezi sebou, a usnese se, k jakému trestu má být odsouzen. U pekelného ohně pak není pochyb ani o odsouzení, jako před soudcem, ani o výši trestu, jako před soudním tribunálem. V pekelném ohni je zcela jisté zavržení i trest odsouzeného.
 &teDeum
 
 [Ant 2]

--- a/web/www/horas/Bohemice/TemporaM/Pent03-0o.txt
+++ b/web/www/horas/Bohemice/TemporaM/Pent03-0o.txt
@@ -1,0 +1,34 @@
+[Lectio3]
+@Tempora/Pent03-0:Lectio2:s/22-/23-/ s/22 .*23 /23 /s
+
+[Lectio3] (rubrica cisterciensis)
+@Tempora/Pent03-0:Lectio2:s/22-25/24-26/ s/22 .* Toho dne /24 Toho dne /s
+@Tempora/Pent03-0:Lectio3:2
+
+[Lectio5]
+@Tempora/Pent03-0o:Lectio4:s/ Olej .*//
+
+[Lectio6]
+@Tempora/Pent03-0o:Lectio4:s/.* (?=Olej)//s s/$/~/
+@Tempora/Pent03-0o:Lectio5:s/ Pomazává .*//
+
+[Lectio7]
+@Tempora/Pent03-0o:Lectio5:s/.* (?=Pomazává)//
+
+[Lectio9]
+@Tempora/Pent03-0:Lectio7:s/Přesto .*//s
+(sed rubrica cisterciensis)
+@Tempora/Pent03-0:Lectio7:s/Avšak .*//s
+
+[Lectio10]
+@Tempora/Pent03-0:Lectio7:s/.* Přesto /Přesto /s s/$/~/
+(sed rubrica cisterciensis)
+@Tempora/Pent03-0:Lectio7:s/.* Avšak /Avšak /s s/$/~/
+@Tempora/Pent03-0:Lectio8:s/V duchu .*//s
+
+[Lectio11]
+@Tempora/Pent03-0:Lectio8:s/.* V duchu /V duchu /s s/$/~/
+@Tempora/Pent03-0:Lectio9:s/Mezi .*//s
+
+[Lectio12]
+@Tempora/Pent03-0:Lectio9:s/.* Mezi /Mezi /s

--- a/web/www/horas/Bohemice/TemporaM/Pent04-0.txt
+++ b/web/www/horas/Bohemice/TemporaM/Pent04-0.txt
@@ -1,0 +1,41 @@
+[Lectio2]
+@Tempora/Pent04-0:Lectio1:2 s/1-/4-/
+(sed rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio1:2 s/1-7/3-5/
+@Tempora/Pent04-0:Lectio1:6-9
+(sed rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio1:5-7:s/Jeho pancíř.*//
+
+[Lectio3] (rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio1:2 s/1-7/5-7/
+@Tempora/Pent04-0:Lectio1:7-9:s/.* Jeho /5 Jeho /
+
+[Lectio5]
+@Tempora/Pent04-0:Lectio4:s/Totiž .*//s
+
+[Lectio6]
+@Tempora/Pent04-0:Lectio4:s/.* Totiž /Totiž /s s/$/~/
+@Tempora/Pent04-0:Lectio5:s/Ďábel .*//s
+
+[Lectio7]
+@Tempora/Pent04-0:Lectio5:s/.* Ďábel /Ďábel /s
+
+[Lectio8]
+@Tempora/Pent04-0:Lectio6
+
+[Lectio9]
+@Tempora/Pent04-0:Lectio7:s/Tam tedy .*//s
+(sed rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio7:s/Ryby .*//s
+
+[Lectio10]
+@Tempora/Pent04-0:Lectio7:s/.* Tam tedy /Tam tedy /s s/$/~/
+(sed rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio7:s/.* Ryby /Ryby /s s/$/~/
+@Tempora/Pent04-0:Lectio8:s/A i když .*//s
+
+[Lectio11]
+@Tempora/Pent04-0:Lectio8:s/.* A i když /A i když /s
+
+[Lectio12]
+@Tempora/Pent04-0:Lectio9

--- a/web/www/horas/Bohemice/TemporaM/Pent05-0.txt
+++ b/web/www/horas/Bohemice/TemporaM/Pent05-0.txt
@@ -1,0 +1,41 @@
+[Lectio3]
+@Tempora/Pent05-0::1-3 s/15/12/
+
+[Lectio3] (rubrica cisterciensis)
+@Tempora/Pent05-0:Lectio2:1 s/5-/6-/
+@Tempora/Pent05-0:Lectio2:3-7:s/Vzal jsem.*//
+
+[Lectio4]
+@Tempora/Pent05-0:Lectio3:s/11/13/ s/11 .*13/13/s
+
+[Lectio4] (rubrica cisterciensis)
+@Tempora/Pent05-0:Lectio2:1 s/5-10/10-12/
+@Tempora/Pent05-0:Lectio2:7:s/.* Vzal jsem/10 Vzal jsem/
+@Tempora/Pent05-0:Lectio3:2-3
+
+[Lectio5]
+@Tempora/Pent05-0:Lectio4:s/ Pročpak .*//s
+
+[Lectio6]
+@Tempora/Pent05-0:Lectio4:s/.*(Pročpak)/$1/s s/$/~/
+@Tempora/Pent05-0:Lectio5:s/ Avšak.*//s
+
+[Lectio7]
+@Tempora/Pent05-0:Lectio5:s/.*(Avšak)/$1/s
+
+[Lectio8]
+@Tempora/Pent05-0:Lectio6
+
+[Lectio9]
+@Tempora/Pent05-0:Lectio7:s/Proto tedy.*//s
+
+[Lectio10]
+@Tempora/Pent05-0:Lectio7:s/.* Proto tedy/Proto tedy/s s/$/~/
+@Tempora/Pent05-0:Lectio8:s/ Pokud však.*//s
+
+[Lectio11]
+@Tempora/Pent05-0:Lectio8:s/.* Pokud však/Pokud však/s s/$/~/
+@Tempora/Pent05-0:Lectio9:s/ U soudního.*//s
+
+[Lectio12]
+@Tempora/Pent05-0:Lectio9:s/.* U soudního/U soudního/s

--- a/web/www/horas/English/Tempora/Pent01-0.txt
+++ b/web/www/horas/English/Tempora/Pent01-0.txt
@@ -207,6 +207,9 @@ R. Holy, Holy, Holy is the Lord God of hosts.
 &Gloria
 R. The whole earth is full of His glory.
 
+[Responsory8] (rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory2
+
 [Lectio9]
 !Commemoration for the First Sunday after Pentecost
 From the Holy Gospel according to Luke

--- a/web/www/horas/English/Tempora/Pent01-1.txt
+++ b/web/www/horas/English/Tempora/Pent01-1.txt
@@ -8,10 +8,12 @@ Lesson from the first book of Samuel
 2 And he had two wives, the name of one was Anna, and the name of the other Phenenna. Phenenna had children: but Anna had no children.
 3 And this man went up out of his city upon the appointed days, to adore and to offer sacrifice to the Lord of hosts in Silo. And the two sons of Heli, Ophni and Phinees, were there priests of the Lord.
 
-[Responsory1]
+[Responsory1_]
 R. Prepare your hearts unto the Lord, and serve Him Only
 * And He will deliver you out of the hand of your enemies.
 V. Return unto Him with all your hearts, and put away the strange gods from among you.
+(sed rubrica cisterciensis)
+V. Put away the strange gods from among you.
 R. And He will deliver you out of the hand of your enemies.
 
 [Lectio2]
@@ -22,7 +24,7 @@ R. And He will deliver you out of the hand of your enemies.
 7 And thus she did every year, when the time returned that they went up to the temple of the Lord: and thus she provoked her: but Anna wept, and did not eat.
 8 Then Elcana her husband said to her: Anna, why weepest thou? and why dost thou not eat? And why dost thou afflict thy heart? Am not I better to thee than ten children?
 
-[Responsory2]
+[Responsory2_]
 R. God, Which heareth all, even He sent His Angel, and took me from keeping my father's sheep, and
 * Anointed me with the oil of His mercy.
 V. The Lord That delivered me out of the mouth of the lion, and out of the paw of the bear
@@ -34,10 +36,33 @@ R. And anointed me with the oil of His mercy.
 10 As Anna had her heart full of grief, she prayed to the Lord, shedding many tears,
 11 And she made a vow, saying: O Lord, of hosts, if thou wilt look down on the affliction of thy servant, and wilt be mindful of me, and not forget thy handmaid, and wilt give to thy servant a man child: I will give him to the Lord all the days of his life, and no razor shall come upon his head.
 
-[Responsory3]
+[Responsory3_]
 R. The Lord That delivered me out of the mouth of the lion, and out of the paw of the bear 
 * He will deliver me out of the hand of mine enemies.
 V. God hath sent forth His mercy and His truth, and delivered my soul from among the lion's whelps.
 R. He will deliver me out of the hand of mine enemies.
 &Gloria
 R. He will deliver me out of the hand of mine enemies.
+
+[Responsory3C]
+R. Thus saith the Lord: I took thee out of thy father's house, and appointed thee to be ruler over My people, over Israel, and I was with thee whithersoever thou wentest;
+* To establish thy kingdom for ever.
+V. And I have made thee a great name, like unto the name of the great men that are in the earth.
+R. To establish thy kingdom for ever.
+&Gloria
+R. To establish thy kingdom for ever.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@:Responsory3C

--- a/web/www/horas/English/Tempora/Pent01-2.txt
+++ b/web/www/horas/English/Tempora/Pent01-2.txt
@@ -12,7 +12,7 @@ Lesson from the first book of Samuel
 17 Then Heli said to her: Go in peace: and the God of Israel grant thee thy petition, which thou hast asked of him.
 18 And she said: Would to God thy handmaid may find grace in thy eyes.
 
-[Responsory1]
+[Responsory1_]
 R. Saul hath slain his thousands, and David his ten thousands.
 * Because the hand of the Lord was with him, he smote the Philistine, and took away the reproach from Israel.
 V. Is not this David? Did they not sing one to another of him in dances, saying: Saul hath slain his thousands, and David his ten thousands?
@@ -26,7 +26,7 @@ R. Because the hand of the Lord was with him, he smote the Philistine, and took 
 21 And Elcana her husband went up, and all his house, to offer to the Lord the solemn sacrifice, and his vow.
 22 But Anna went not up: for she said to her husband: I will not go till the child be weaned, and till I may carry him, that he may appear before the Lord, and may abide always there.
 
-[Responsory2]
+[Responsory2_]
 R. Ye mountains of Gilboa, let there be no dew, neither let there be rain upon you
 * For there are the mighty of Israel fallen.
 V. All ye mountains that stand round about, the Lord look upon you but let Him pass by Gilboa
@@ -41,10 +41,25 @@ R. For there are the mighty of Israel fallen.
 27 For this child did I pray, and the Lord hath granted me my petition, which I asked of him.
 28 Therefore I also have lent him to the Lord all the days of his life, he shall be lent to the Lord. And they adored the Lord there.
 
-[Responsory3]
+[Responsory3_]
 R. Thus saith the Lord: I took thee out of thy father's house, and appointed thee to be ruler over My people, over Israel.
 * And I was with thee whithersoever thou wentest, to establish thy kingdom for ever.
 V. And I have made thee a great name, like unto the name of the great men that are in the earth, and have caused thee to rest from all thine enemies.
 R. And I was with thee whithersoever thou wentest, to establish thy kingdom for ever.
 &Gloria
 R. And I was with thee whithersoever thou wentest, to establish thy kingdom for ever.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-3:Responsory2_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory1_

--- a/web/www/horas/English/Tempora/Pent01-3.txt
+++ b/web/www/horas/English/Tempora/Pent01-3.txt
@@ -20,11 +20,16 @@ R. And done evil in thy sight.
 16 And he that sacrificed said to him: Let the fat first be burnt today according to the custom, and then take as much as thy soul desireth. But he answered and said to him: Not so: but thou shalt give it me now, or else I will take it by force.
 17 Wherefore the sin of the young men was exceeding great before the Lord: because they withdrew men from the sacrifice of the Lord.
 
-[Responsory2]
+[Responsory2_]
 R. O Lord, Thou hast hearkened unto the prayer of thy servant, that I might build a temple unto thy Name,
 * O God of Israel, bless Thou, and hallow this house for ever.
 V. O Lord, Who keepest covenant with thy servants that walk before thee in all their heart.
 R. O God of Israel, bless Thou, and hallow this house for ever.
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3_
 
 [Lectio3]
 !1 Sam 2:18-21
@@ -33,10 +38,16 @@ R. O God of Israel, bless Thou, and hallow this house for ever.
 20 And Heli blessed Elcana and his wife: and he said to him: The Lord give thee seed of this woman, for the loan thou hast lent to the Lord. And they went to their own home.
 21 And the Lord visited Anna, and she conceived, and bore three sons and two daughters: and the child Samuel became great before the Lord.
 
-[Responsory3]
+[Responsory3_]
 R. Hearken, O Lord, unto the cry and to the prayer which thy servant prayeth before thee today, that thine eyes may be open and thine ears attend;
 * Toward this house day and night.
 V. Look down from thine high and holy place, O Lord, even from heaven thy dwelling.
 R. Toward this house, day and night.
 &Gloria
 R. Toward this house, day and night.
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-1:Responsory1_
+

--- a/web/www/horas/English/Tempora/Pent03-1Feria.txt
+++ b/web/www/horas/English/Tempora/Pent03-1Feria.txt
@@ -1,11 +1,14 @@
 [Officium]
 Feria secunda infra Hebdomadam III post Octavam Pentecostes
 
-[Responsory1]
+[Responsory1_]
 R. Remember, O Lord, thy covenant, and say unto the destroying Angel: Stay now thine hand;
 * That the land be not utterly laid waste, and that thou destroy not every living soul.
 V. Even I it is that have sinned, and done evil indeed; but these sheep, what have they done? Let thine anger, I pray thee, O Lord, be turned away from thy people.
 R. That the land be not utterly laid waste, and that Thou destroy not every living soul.
+
+[Responsory1] 
+@:Responsory1_
 
 [Responsory2]
 R. O Lord, Thou hast hearkened unto the prayer of thy servant, that I might build a temple unto thy Name,

--- a/web/www/horas/English/Tempora/Pent03-2Feria.txt
+++ b/web/www/horas/English/Tempora/Pent03-2Feria.txt
@@ -1,17 +1,28 @@
 [Officium]
 Feria teria infra Hebdomadam III post Octavam Pentecostes
 
-[Responsory1]
+[Responsory1_]
 R. Lord, when thy people shall turn again to thee, and shall pray unto thee in this house;
 * Then hear Thou in heaven, O Lord, and deliver them out of the hand of their enemies.
 V. If thy people sin against thee, and turn again, and repent, and come and pray unto thee in this house.
 R. Then hear Thou in heaven, O Lord, and deliver them out of the hand of their enemies.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-1Feria:Responsory1_
 
 [Responsory2]
 R. And it came to pass when the Lord would take up Elijah into heaven by a whirlwind
 * Elisha cried, and said: My father, my father, the chariot of Israel, and the horsemen thereof.
 V. And as they still went on, and talked, behold, there appeared a chariot of fire, and horses of fire, and parted them both asunder, and Elijah went up by a whirlwind into heaven.
 R. Elisha cried, and said: My father, my father, the chariot of Israel, and the horsemen thereof.
+
+[Responsory2] (rubrica cisterciensis)
+R. And it came to pass when the Lord would take up Elijah into heaven by a whirlwind, Elisha cried, and said: 
+* My father, my father, the chariot of Israel, and the horsemen thereof.
+V. And as they still went on, and talked, behold, there appeared a chariot of fire, and horses of fire, and Elisha cried, and said: 
+R. My father, my father, the chariot of Israel, and the horsemen thereof.
 
 [Responsory3]
 R. Thus saith the Lord: I took thee out of thy father's house, and appointed thee to be ruler over My people, over Israel.

--- a/web/www/horas/Espanol/Tempora/Pent01-1.txt
+++ b/web/www/horas/Espanol/Tempora/Pent01-1.txt
@@ -11,10 +11,12 @@ Empieza el Libro de los Reyes
 2 Tenía dos mujeres, de nombre una Ana y otra Penena. Penena tenía hijos, pero Ana era estéril. 
 3 Subía de su ciudad este hombre de año en año para adorar a Yahvé Sebaot y ofrecerle sacrificios en Silo. Estaban allí los dos hijos de Helí, Ofni y Finés, sacerdotes de Yahvé.
 
-[Responsory1]
+[Responsory1_]
 R. Preparad vuestros corazones para el Señor, y servidle a Él solo: 
 * Y Él os libertará de las manos de vuestros enemigos. 
 V. Convertíos a Él con todo vuestro corazón, y arrojad de en medio de vosotros los falsos dioses. 
+(sed rubrica cisterciensis)
+V. Arrojad de en medio de vosotros los falsos dioses. 
 R. Y Él os libertará de las manos de vuestros enemigos.
 
 [Lectio2]
@@ -25,7 +27,7 @@ R. Y Él os libertará de las manos de vuestros enemigos.
 7 Así hacía cada año cuando subían a la casa de Yahvé, y siempre la mortificaba del mismo modo. Ana lloraba y no comía.  
 8 Elcana, su marido, le decía: “Ana, ¿por qué lloras y no comes? ¿Por qué está triste tu corazón? ¿No soy yo para ti mejor que diez hijos?”
 
-[Responsory2]
+[Responsory2_]
 R. Dios escucha a todos los hombres; Él envió a su Ángel, y me sacó de en medio de las ovejas de mi padre; 
 * Y me ungió con la unción de su misericordia. 
 V. Es el Señor quien me arrancó de las fauces del león, y de las garras de la bestia feroz. 
@@ -37,10 +39,33 @@ R. Y me ungió con la unción de su misericordia.
 10 vino Anna con su corazón lleno de amargura, y oró al Señor derramando copiosas lágrimas. 
 11 E hizo un voto diciendo: Señor Dios de los ejércitos, si te dignares volver los ojos para mirar la aflicción de tu sierva, y te acordares de mí, y no olvidándote de tu esclava, dieres a tu sierva un hijo varón, le consagraré al Señor por todos los días de su vida, y no pasará jamás navaja por su cabeza.
 
-[Responsory3]
+[Responsory3_]
 R. El Señor que me arrancó de las fauces del león y de las garras de la bestia feroz, 
 * Él mismo me librará de las manos de mis enemigos. 
 V. Dios ha hecho brillar su misericordia y fidelidad; ha arrancado mi alma de en medio de los cachorros de los leones.  
 R. Él mismo me librará de las manos de mis enemigos. 
 &Gloria
 R. Él mismo me librará de las manos de mis enemigos. 
+
+[Responsory3C]
+R. He aquí que Yo te saqué de la casa de tu padre, dice el Señor, y te constituí pastor del rebaño de mi pueblo, por todas partes donde has andado he estado contigo,
+* Asegurando tu reino para siempre.  
+V. He hecho tu nombre tan célebre como el de los grandes de la tierra. 
+R. Asegurando tu reino para siempre. 
+&Gloria
+R. Asegurando tu reino para siempre.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@:Responsory3C

--- a/web/www/horas/Espanol/Tempora/Pent01-2.txt
+++ b/web/www/horas/Espanol/Tempora/Pent01-2.txt
@@ -15,7 +15,7 @@ Empieza el Libro Primero de los Reyes
 17 Díjole entonces Helí: “Vete en paz y que el Dios de Israel te otorgue lo que tanto le has pedido.” 
 18 “Que halle gracia a tus ojos tu sierva.”
 
-[Responsory1]
+[Responsory1_]
 R. Saúl ha muerto a mil, y David a diez mil: 
 * Porque la mano del Señor estaba con él; ha herido al Filisteo y librado de oprobio a Israel. 
 V. ¿Por ventura no es este David, de quien cantaban a coro diciendo: Saúl ha muerto a mil, y David a diez mil? 
@@ -29,7 +29,7 @@ R. Porque la mano del Señor estaba con él; ha herido al Filisteo y librado de 
 21 y subió Elcana con toda su casa a sacrificar a Yahvé el sacrificio anual y cumplir su voto. 
 22 Ana no subió, sino que dijo a su marido: “Cuando el niño se haya destetado, yo le llevaré para presentárselo a Yahvé y para que se quede ya allí para siempre.”
 
-[Responsory2]
+[Responsory2_]
 R. Montes de Gelboé, ni el rocío ni la lluvia caigan ya sobre vosotros, 
 * En donde murieron los valerosos de Israel. 
 V. Visite el Señor todos los montes que están alrededor, pero pase de largo ante Gelboé. 
@@ -44,10 +44,25 @@ R. En donde murieron los valerosos de Israel.
 27 Este niño le pedía yo, y Yahvé me ha concedido lo que pedí; 
 28 también ahora quiero yo dárselo a Yahvé por todos los días de su vida, para que sea siempre donado a Yahvé.” Y adoraron allí a Yahvé.
 
-[Responsory3]
+[Responsory3_]
 R. He aquí que Yo te saqué de la casa de tu padre, dice el Señor, y te constituí pastor del rebaño de mi pueblo. 
 * Por todas partes donde has andado he estado contigo, asegurando tu reino para siempre.  
 V. He hecho tu nombre tan célebre como el de los grandes de la tierra, y te he librado de todos tus enemigos. 
 R. Por todas partes donde has andado he estado contigo, asegurando tu reino para siempre. 
 &Gloria
 R. Por todas partes donde has andado he estado contigo, asegurando tu reino para siempre. 
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-3:Responsory2_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory1

--- a/web/www/horas/Espanol/Tempora/Pent01-3.txt
+++ b/web/www/horas/Espanol/Tempora/Pent01-3.txt
@@ -23,11 +23,16 @@ R. Y he cometido la maldad en tu presencia.
 16 Y si el hombre le decía: “Espera a que se queme el sebo, como siempre, y luego cogerás lo que tú quieras,” le respondía el criado: “No; tienes que dármela ahora mismo, y si no, la cojo yo por la fuerza.” 
 17 Muy grande era el pecado de aquellos jóvenes ante Yahvé, pues hacían odioso a los hombres el ofrecer ante Yahvé.
 
-[Responsory2]
+[Responsory2_]
 R. Oíste, oh Señor, la oración de tu siervo, permitiéndome que edificara un templo para gloria de tu nombre: 
 * Bendice y santifica para siempre esta casa, oh Dios de Israel, 
 V. Señor, que guardas el pacto con tus siervos, que andan en tu presencia con todo su corazón. 
 R. Bendice y santifica para siempre esta casa, oh Dios de Israel.
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3
 
 [Lectio3]
 !1 Sam 2:18-21

--- a/web/www/horas/Francais/Tempora/Pent01-1.txt
+++ b/web/www/horas/Francais/Tempora/Pent01-1.txt
@@ -11,10 +11,12 @@ Commencement du Premier Livre de Samuel
 2 Il avait deux femmes, dont l'une s'appelait Anne, et la seconde Phénenna. Phénenna avait des enfants et Anne n'en avait pas.
 3 Cet homme allait de sa ville à Silo aux jours ordonnés, pour adorer le Seigneur des armées, et pour Lui offrir des sacrifices. Les deux fils d'Héli, Ophni et Phinées, y faisaient la fonction de prêtres du Seigneur.
 
-[Responsory1]
+[Responsory1_]
 R. Préparez vos cœurs pour le Seigneur, et ne servez que lui seul :
 * Et il vous délivrera des mains de vos ennemis,
 V. Convertissez- vous à lui de tout votre cœur, et ôtez les dieux étrangers d’au milieu de vous.
+(sed rubrica cisterciensis)
+V. Ôtez les dieux étrangers d’au milieu de vous.
 R. Et il vous délivrera des mains de vos ennemis.
 
 [Lectio2]
@@ -25,7 +27,7 @@ R. Et il vous délivrera des mains de vos ennemis.
 7 Elle la traitait ainsi tous les ans lorsque le temps était venu de monter au temple du Seigneur ; et Anne se mettait à pleurer, et ne mangeait point.
 8 Elcana, son mari, lui dit donc : Anne, pourquoi pleurez-vous ? Pourquoi ne mangez-vous pas et pourquoi votre cœur s'afflige-t-il ? Ne suis-je pas pour vous plus que ne vous seraient dix enfants ?
 
-[Responsory2]
+[Responsory2_]
 R. Dieu exauce les prières de tous ; lui-même a envoyé son Ange et il m’a pris aux brebis de mon père;
 * Et il m’a oint de l’onction de sa miséricorde,
 V. C’est le Seigneur qui m’a arraché de la gueule du lion, et qui m’a délivré des griffes de la bête féroce.
@@ -37,10 +39,33 @@ R. Et il m’a oint de l’onction de sa miséricorde.
 10 Anne, qui avait le cœur plein d'amertume, pria le Seigneur en répandant beaucoup de larmes,
 11 et elle fit un vœu en ces termes : Seigneur des armées, si Vous daignez regarder l'affliction de Votre servante, si Vous Vous souvenez de moi, si Vous n'oubliez point Votre servante, et, si Vous donnez à Votre esclave un enfant mâle, je le donnerai à mon Seigneur pour tous les jours de sa vie, et le rasoir ne passera point sur sa tête.
 
-[Responsory3]
+[Responsory3_]
 R. Le Seigneur, qui m’a arraché de la gueule du lion, et qui m’a délivré des griffes de la bête féroce,
 * Lui-même m’arrachera des mains de mes ennemis.
 V. Dieu a envoyé sa miséricorde et sa vérité ; il a arraché mon âme du milieu des lionceaux.
 R. Lui-même m’arrachera des mains de mes ennemis.
 &Gloria
 R. Lui-même m’arrachera des mains de mes ennemis.
+
+[Responsory3C]
+R. Je t’ai tiré de la maison de ton père, dit le Seigneur, et je t’ai établi pour paître le troupeau de mon peuple, at j’ai été avec toi dans tous les lieux où tu as marché,
+* Affermissant ton royaume pour toujours.
+V. Je t’ai fait un nom puissant auprès du nom des grands qui sont sur la terre.
+R. Affermissant ton royaume pour toujours.
+&Gloria
+R. Affermissant ton royaume pour toujours.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@:Responsory3C

--- a/web/www/horas/Francais/Tempora/Pent01-2.txt
+++ b/web/www/horas/Francais/Tempora/Pent01-2.txt
@@ -15,7 +15,7 @@ Du Premier Livre de Samuel
 17 Alors Héli lui dit : Allez en paix ; et que le Dieu d'Israël vous accorde la demande que vous Lui avez faite.
 18 Anne lui répondit : Plaise à Dieu que votre servante trouve grâce devant vos yeux ! Elle s'en alla ensuite, elle mangea, et elle ne changea plus de visage comme auparavant.
 
-[Responsory1]
+[Responsory1_]
 R. Saül en a tué mille et David dix mille :
 * Parce que la main du Seigneur était avec lui ; il a frappé le Philistin et ôté l’opprobre d’Israël.
 V. N’est-ce pas là ce David, pour qui on chantait en dansant : Saul en a tué mille et David dix mille ?
@@ -29,7 +29,7 @@ R. Parce que la main du Seigneur était avec lui ; il a frappé le Philistin et 
 21 Elcana son mari vint ensuite avec toute sa maison, pour immoler au Seigneur la victime accoutumée, et pour Lui rendre son vœu.
 22 Mais Anne n'y alla point, et elle dit à son mari : Je n'irai pas au sanctuaire jusqu'à ce que l'enfant soit sevré, et je le mènerai afin qu'il soit présenté au Seigneur, et qu'il demeure toujours devant Lui.
 
-[Responsory2]
+[Responsory2_]
 R. Montagnes de Gelboé, que la rosée et la pluie ne tombent plus sur vous.
 * Là où sont tombés les héros d’Israël.
 V. Que le Seigneur visite toutes les montagnes qui sont alentour ; mais qu’il passe loin de Gelboé.
@@ -44,10 +44,25 @@ R. Là où sont tombés les héros d’Israël.
 27 Je Le suppliais pour cet enfant, et le Seigneur m'a accordé la demande que je Lui ai faite.
 28 C'est pourquoi je le Lui prête pour tous les jours où il sera prêté au Seigneur. Ils adorèrent donc le Seigneur en ce lieu.
 
-[Responsory3]
+[Responsory3_]
 R. Je t’ai tiré de la maison de ton père, dit le Seigneur, et je t’ai établi pour paître le troupeau de mon peuple :
 * Et j’ai été avec toi dans tous les lieux où tu as marché, affermissant ton royaume pour toujours.
 V. Je t’ai fait un nom puissant auprès du nom des grands qui sont sur la terre, et je t’ai donné un repos, à l’abri de tous tes ennemis.
 R. Et j’ai été avec toi dans tous les lieux où tu as marché, affermissant ton royaume pour toujours.
 &Gloria
 R. Et j’ai été avec toi dans tous les lieux où tu as marché, affermissant ton royaume pour toujours.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-3:Responsory2_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory1

--- a/web/www/horas/Francais/Tempora/Pent01-3.txt
+++ b/web/www/horas/Francais/Tempora/Pent01-3.txt
@@ -23,11 +23,16 @@ R. Et j'ai fait le mal en votre présence.
 16 Celui qui immolait lui disait : Qu'on fasse auparavant brûler la graisse selon la coutume, et après cela prenez de la chair autant que vous en voudrez. Mais le serviteur lui répondait : Non ; vous en donnerez immédiatement, ou j'en prendrai par force.
 17 Et ainsi le péché de ces fils d'Héli était très grand devant le Seigneur, parce qu'ils détournaient les hommes du sacrifice du Seigneur.
 
-[Responsory2]
+[Responsory2_]
 R. Seigneur, vous avez exaucé la prière de votre serviteur, pour que je bâtisse un temple à votre nom :
 * Bénissez et sanctifiez cette demeure pour toujours, ô Dieu d’Israël,
 V. Seigneur, qui gardez l’alliance avec vos serviteurs qui marchent devant vous selon tout leur cœur.
 R. Bénissez et sanctifiez cette demeure pour toujours, ô Dieu d’Israël,
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3
 
 [Lectio3]
 !1 Reg 2:18-21

--- a/web/www/horas/Italiano/Tempora/Pent01-1.txt
+++ b/web/www/horas/Italiano/Tempora/Pent01-1.txt
@@ -12,10 +12,12 @@ Incomincia il primo libro dei Re
 2 Ed ebbe due mogli, una chiamata Anna e l'altra Fenenna. Fenenna poi ebbe dei figli, ma Anna non ne aveva. 
 3 Or quest'uomo nei giorni stabiliti, dalla sua città saliva a Silo per adorare e sacrificare al Signore degli eserciti. E là c'erano i due figli di Eli, Ofni e Finees sacerdoti del Signore.
 
-[Responsory1]
+[Responsory1_]
 R. Preparate i vostri cuori al Signore, e servite a lui solo; 
 * Ed egli vi libererà dalle mani dei vostri nemici.
 V. Convertitevi a lui con tutto il vostro cuore, e togliete di mezzo a voi gli dèi stranieri.
+(sed rubrica cisterciensis)
+V. Togliete di mezzo a voi gli dèi stranieri.
 R. Ed egli vi libererà dalle mani dei vostri nemici.
 
 [Lectio2]
@@ -26,7 +28,7 @@ R. Ed egli vi libererà dalle mani dei vostri nemici.
 7 E faceva così tutti gli anni, allorché, ritornato il tempo, salivano al tempio del Signore, e così la provocava. Ed ella piangeva e non prendeva cibo. 
 8 Onde Elcana suo marito le disse; Anna, perché piangi? perché non mangi? e perché è afflitto il tuo cuore? Non ti son io qualcosa di meglio di dieci figli?
 
-[Responsory2]
+[Responsory2_]
 R. Iddio ascolta tutti; egli mandò il suo Angelo, e mi tolse dalle pecore di mio padre; 
 * E mi unse coll'unzione della sua misericordia.
 V. Il Signore, che mi strappò dalla bocca del leone, mi liberò anche dagli artigli della bestia. 
@@ -38,10 +40,33 @@ R. E mi unse coll'unzione della sua misericordia.
 10 Anna, avendo il cuore amareggiato, pregò il Signore piangendo dirottamente, 
 11 e fece voto, dicendo; Signore degli eserciti, se ti volgerai a mirare l'afflizione della tua serva, e ti ricorderai di me, e non ti dimenticherai della tua serva, ma darai ad essa tua serva un figlio maschio, io lo consacrerò al Signore per tutti i giorni della sua vita, e il rasoio non toccherà la sua testa.
 
-[Responsory3]
+[Responsory3_]
 R. Il Signore, che mi strappò dalla bocca del leone e mi liberò dagli artigli della bestia, 
 * Egli mi strapperà pure dalle mani dei miei nemici.
 V. Iddio mandò la sua misericordia e la sua verità; strappò l'anima mia di mezzo ai giovani leoni.
 R. Egli mi strapperà pure dalle mani dei miei nemici.
 &Gloria
 R. Egli mi strapperà pure dalle mani dei miei nemici.
+
+[Responsory3C]
+R. Io ti tolsi dalla casa di tuo padre, dice il Signore, e ti scelsi per pascolare il gregge del mio popolo, a fui con te in ogni cosa ovunque andasti,
+* Rafforzando per sempre il tuo regno.
+V. E ho reso grande il tuo nome, come quello dei grandi che sono sulla terra. 
+R. Rafforzando per sempre il tuo regno.
+&Gloria
+R. Rafforzando per sempre il tuo regno.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@:Responsory3C

--- a/web/www/horas/Italiano/Tempora/Pent01-2.txt
+++ b/web/www/horas/Italiano/Tempora/Pent01-2.txt
@@ -16,7 +16,7 @@ Dal primo libro dei Re
 17 Allora Eli le disse; Va in pace, e il Dio di Israele ti accordi la domanda che gli hai fatta. 
 18 Ed ella rispose; Voglia il cielo che la sua serva trovi grazia negli occhi tuoi.
 
-[Responsory1]
+[Responsory1_]
 R. Saul ne uccise mille, e David diecimila; 
 * Perché la mano del Signore era con lui; uccise il Filisteo, e cancellò la vergogna di Israele.
 V. Questi non è forse David, del quale cantavano in coro dicendo; Saul ne uccise mille, e David diecimila? 
@@ -30,7 +30,7 @@ R. Perché la mano del Signore era con lui; uccise il Filisteo, e cancellò la v
 21 Poi Elcana suo marito salì con tutta la sua famiglia per immolare al Signore l'ostia solenne 
 22 e Anna non vi salì, dicendo a suo marito; Non verrò finché il bimbo sia slattato, allora lo condurrò affinché si presenti dinanzi al Signore, e vi rimanga poi per sempre.
 
-[Responsory2]
+[Responsory2_]
 R. Monti di Gelboe, non cada più su di voi né rugiada né pioggia, 
 * Là dove son caduti i forti d'Israele.
 V. Il Signore visiti tutti i monti che sono all'intorno, ma oltrepassi Gelboe.
@@ -45,10 +45,25 @@ R. Là dove son caduti i forti d'Israele.
 27 Pregavo per (avere) questo bambino, e il Signore ha esaudito la grazia che gli domandai. 
 28 Perciò io pure l'ho donato al Signore per tutti i giorni che egli sarà consacrato al Signore. E adorarono ivi il Signore.
 
-[Responsory3]
+[Responsory3_]
 R. Io ti tolsi dalla casa di tuo padre, dice il Signore, e ti scelsi per pascolare il gregge del mio popolo; 
 * E fui con te in ogni cosa ovunque andasti, rafforzando per sempre il tuo regno.
 V. E ho reso grande il tuo nome, come quello dei grandi che sono sulla terra; e t'ho data la pace con tutti i tuoi nemici. 
 R. E fui con te in ogni cosa ovunque andasti, rafforzando per sempre il tuo regno.
 &Gloria
 R. E fui con te in ogni cosa ovunque andasti, rafforzando per sempre il tuo regno.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-3:Responsory2_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory1

--- a/web/www/horas/Italiano/Tempora/Pent01-3.txt
+++ b/web/www/horas/Italiano/Tempora/Pent01-3.txt
@@ -24,11 +24,16 @@ R. E ho fatto ciò ch'è male dinanzi a te.
 16 E colui che faceva l'immolazione gli diceva; Si faccia oggi prima bruciare il grasso secondo il costume, e poi prendine quanto l'anima tua desidera. Ma quello rispondeva: No; me ne devi dare adesso, altrimenti me la prenderò per forza. 
 17 Il peccato dunque di quei giovani era troppo grande davanti al Signore, perché distoglievano la gente dal far sacrificio al Signore.
 
-[Responsory2]
+[Responsory2_]
 R. Hai ascoltato, o Signore, la preghiera del tuo servo di edificare un tempio al tuo nome; 
 * Benedici e santifica per sempre questa casa, o Dio d'Israele.
 V. Signore, che osservi il patto coi tuoi servi che camminano dinanzi a te nella sincerità del loro cuore.
 R. Benedici e santifica per sempre questa casa, o Dio d'Israele.
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3
 
 [Lectio3]
 !1 Sam 2:18-21

--- a/web/www/horas/Latin/Tempora/Pent01-0.txt
+++ b/web/www/horas/Latin/Tempora/Pent01-0.txt
@@ -254,6 +254,9 @@ R. Sanctus, sanctus, sanctus Dóminus Deus Sábaoth.
 &Gloria
 R. Plena est omnis terra glória ejus.
 
+[Responsory8] (rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory2
+
 [Lectio9]
 !Commemoratio Dominicæ
 Léctio sancti Evangélii secúndum Lucam

--- a/web/www/horas/Latin/Tempora/Pent01-1.txt
+++ b/web/www/horas/Latin/Tempora/Pent01-1.txt
@@ -17,10 +17,12 @@ Incipit liber primus Regum
 2 et hábuit duas uxóres, nomen uni Anna, et nomen secúndæ Phenénna. Fuerúntque Phenénnæ fílii: Annæ autem non erant líberi.
 3 Et ascendébat vir ille de civitáte sua statútis diébus, ut adoráret et sacrificáret Dómino exercítuum in Silo. Erant autem ibi duo fílii Heli, Ophni et Phínees, sacerdótes Dómini.
 
-[Responsory1]
+[Responsory1_]
 R. Præparáte corda vestra Dómino, et servíte illi soli: 
 * Et liberábit vos de mánibus inimicórum vestrórum.
 V. Convertímini ad eum in toto corde vestro, et auférte deos aliénos de médio vestri.
+(sed rubrica cisterciensis)
+V. Auférte deos aliénos de médio vestri.
 R. Et liberábit vos de mánibus inimicórum vestrórum.
 
 [Lectio2]
@@ -31,7 +33,7 @@ R. Et liberábit vos de mánibus inimicórum vestrórum.
 7 sicque faciébat per síngulos annos: cum redeúnte témpore ascénderent ad templum Dómini, et sic provocábat eam: porro illa flebat, et non capiébat cibum.
 8 Dixit ergo ei Elcana vir suus: Anna, cur fles? et quare non cómedis? et quam ob rem afflígitur cor tuum? numquid non ego mélior tibi sum, quam decem fílii?
 
-[Responsory2]
+[Responsory2_]
 R. Deus ómnium exaudítor est: ipse misit Angelum suum, et tulit me de óvibus patris mei:
 * Et unxit me unctióne misericórdiæ suæ.
 V. Dóminus, qui erípuit me de ore leónis, et de manu béstiæ liberávit me.
@@ -43,10 +45,33 @@ R. Et unxit me unctióne misericórdiæ suæ.
 10 cum esset Anna amáro ánimo, orávit ad Dóminum, flens lárgiter,
 11 et votum vovit, dicens: Dómine exercítuum, si respíciens víderis afflictiónem fámulæ tuæ, et recordátus mei fúeris, nec oblítus ancíllæ tuæ, dederísque servæ tuæ sexum virílem: dabo eum Dómino ómnibus diébus vitæ ejus, et novácula non ascéndet super caput ejus.
 
-[Responsory3]
+[Responsory3_]
 R. Dóminus, qui erípuit me de ore leónis, et de manu béstiæ liberávit me, 
 * Ipse me erípiet de mánibus inimicórum meórum.
 V. Misit Deus misericórdiam suam et veritátem suam: ánimam meam erípuit de médio catulórum leónum.
 R. Ipse me erípiet de mánibus inimicórum meórum.
 &Gloria
 R. Ipse me erípiet de mánibus inimicórum meórum.
+
+[Responsory3C]
+R. Ego te tuli de domo patris tui, dicit Dóminus, et pósui te páscere gregem pópuli mei, et fui tecum in ómnibus ubicúmque ambulásti,
+* Firmans regnum tuum in ætérnum.
+V. Fecíque tibi nomen grande, juxta nomen magnórum, qui sunt in terris.
+R. Firmans regnum tuum in ætérnum.
+&Gloria
+R. Firmans regnum tuum in ætérnum.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@:Responsory3C

--- a/web/www/horas/Latin/Tempora/Pent01-2.txt
+++ b/web/www/horas/Latin/Tempora/Pent01-2.txt
@@ -18,7 +18,7 @@ De libro primo Regum
 17 Tunc Heli ait ei: Vade in pace: et Deus Israël det tibi petitiónem tuam quam rogásti eum.
 18 Et illa dixit: Utinam invéniat ancílla tua grátiam in óculis tuis.
 
-[Responsory1]
+[Responsory1_]
 R. Percússit Saul mille, et David decem míllia: 
 * Quia manus Dómini erat cum illo: percússit Philisthǽum, et ábstulit oppróbrium ex Israël.
 V. Nonne iste est David, de quo canébant in choro, dicéntes: Saul percússit mille, et David decem míllia?
@@ -32,7 +32,7 @@ R. Quia manus Dómini erat cum illo: percússit Philisthǽum, et ábstulit oppr�
 21 Ascéndit autem vir ejus Elcana, et omnis domus ejus, ut immoláret Dómino hóstiam solémnem, et votum suum.
 22 Et Anna non ascéndit: dixit enim viro suo: Non vadam donec ablactétur infans, et ducam eum, ut appáreat ante conspéctum Dómini, et máneat ibi júgiter.
 
-[Responsory2]
+[Responsory2_]
 R. Montes Gélboë, nec ros nec plúvia véniant super vos, 
 * Ubi cecidérunt fortes Israël.
 V. Omnes montes, qui estis in circúitu ejus, vísitet Dóminus: a Gélboë autem tránseat.
@@ -47,10 +47,25 @@ R. Ubi cecidérunt fortes Israël.
 27 Pro púero isto orávi, et dedit mihi Dóminus petitiónem meam quam postulávi eum.
 28 Idcírco et ego commodávi eum Dómino cunctis diébus quibus fúerit commodátus Dómino. Et adoravérunt ibi Dóminum.
 
-[Responsory3]
+[Responsory3_]
 R. Ego te tuli de domo patris tui, dicit Dóminus, et pósui te páscere gregem pópuli mei:
 * Et fui tecum in ómnibus ubicúmque ambulásti, firmans regnum tuum in ætérnum.
 V. Fecíque tibi nomen grande, juxta nomen magnórum, qui sunt in terra: et réquiem dedi tibi ab ómnibus inimícis tuis.
 R. Et fui tecum in ómnibus ubicúmque ambulásti, firmans regnum tuum in ætérnum.
 &Gloria
 R. Et fui tecum in ómnibus ubicúmque ambulásti, firmans regnum tuum in ætérnum.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-3:Responsory2_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory1_:s/de cælo/in cælo/ s/suórum/eórum/ s/isto loco/loco isto/

--- a/web/www/horas/Latin/Tempora/Pent01-3.txt
+++ b/web/www/horas/Latin/Tempora/Pent01-3.txt
@@ -26,11 +26,16 @@ R. Et malum coram te feci.
 16 Dicebátque illi ímmolans: Incendátur primum juxta morem hódie adeps, et tolle tibi quantumcúmque desíderat ánima tua. Qui respóndens ajébat ei: Nequáquam: nunc enim dabis, alióquin tollam vi.
 17 Erat ergo peccátum puerórum grande nimis coram Dómino: quia retrahébant hómines a sacrifício Dómini.
 
-[Responsory2]
+[Responsory2_]
 R. Exaudísti, Dómine, oratiónem servi tui, ut ædificárem templum nómini tuo: 
 * Bénedic et sanctífica domum istam in sempitérnum, Deus Israël.
 V. Dómine, qui custódis pactum cum servis tuis, qui ámbulant coram te in toto corde suo.
 R. Bénedic et sanctífica domum istam in sempitérnum, Deus Israël.
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3_
 
 [Lectio3]
 !1 Reg 2:18-21
@@ -39,10 +44,15 @@ R. Bénedic et sanctífica domum istam in sempitérnum, Deus Israël.
 20 Et benedíxit Heli Elcanæ et uxóri ejus: dixítque ei: Reddat tibi Dóminus semen de mulíere hac, pro fœ́nore quod commodásti Dómino. Et abiérunt in locum suum.
 21 Visitávit ergo Dóminus Annam, et concépit, et péperit tres fílios, et duas fílias: et magnificátus est puer Sámuel apud Dóminum.
 
-[Responsory3]
+[Responsory3_]
 R. Audi, Dómine, hymnum et oratiónem, quam servus tuus orat coram te hódie, ut sint óculi tui apérti, et aures tuæ inténtæ, 
 * Super domum istam die ac nocte.
 V. Réspice, Dómine, de sanctuário tuo, et de excélso cælórum habitáculo.
 R. Super domum istam die ac nocte.
 &Gloria
 R. Super domum istam die ac nocte.
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-1:Responsory1_

--- a/web/www/horas/Latin/Tempora/Pent03-1Feria.txt
+++ b/web/www/horas/Latin/Tempora/Pent03-1Feria.txt
@@ -10,11 +10,24 @@ Oratio Dominica
 [Lectio1]
 @Tempora/Pent03-1
 
-[Responsory1]
+[Responsory1_]
 R. Recordáre, Dómine, testaménti tui, et dic Angelo percutiénti: Cesset jam manus tua, 
 * Ut non desolétur terra, et ne perdas omnem ánimam vivam.
 V. Ego sum qui peccávi, ego qui iníque egi: isti qui oves sunt, quid fecérunt? Avertátur, óbsecro, furor tuus, Dómine, a pópulo tuo.
+(sed rubrica cisterciensis)
+V. Quiéscat, Dómine, ira tua a pópulo tuo, et a civitáte sancta tua:
 R. Ut non desolétur terra, et ne perdas omnem ánimam vivam.
+
+[Responsory1C]
+R. Planxit autem David planctu magno super Saül, et fílios ejus, et dixit: Quómodo cecidérunt fortes in bello,
+* Et periérunt arma béllica; ínclyti Israël, flete.
+V. Montes Gélboë, nec ros nec plúvia super vos descéndant, ubi cecidérunt vulneráti multi:
+R. Et periérunt arma béllica; ínclyti Israël, flete.
+
+[Responsory1] 
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory1C
 
 [Lectio2]
 @Tempora/Pent03-1

--- a/web/www/horas/Latin/Tempora/Pent03-2Feria.txt
+++ b/web/www/horas/Latin/Tempora/Pent03-2Feria.txt
@@ -10,11 +10,16 @@ Oratio Dominica
 [Lectio1]
 @Tempora/Pent03-2
 
-[Responsory1]
+[Responsory1_]
 R. Dómine, si convérsus fúerit pópulus tuus, et oráverit ad sanctuárium tuum:
 * Tu exáudies de cælo, Dómine, et líbera eos de mánibus inimicórum suórum.
 V. Si peccáverit in te pópulus tuus, et convérsus égerit pœniténtiam, veniénsque oráverit in isto loco.
 R. Tu exáudies de cælo, Dómine, et líbera eos de mánibus inimicórum suórum.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-1Feria:Responsory1_
 
 [Lectio2]
 @Tempora/Pent03-2
@@ -24,6 +29,12 @@ R. Factum est, dum tólleret Dóminus Elíam per túrbinem in cælum,
 * Eliséus clamábat, dicens: Pater mi, pater mi, currus Israël, et auríga ejus.
 V. Cumque pérgerent, et incedéntes sermocinaréntur, ecce currus ígneus et equi ígnei divisérunt utrúmque, et ascéndit Elías per túrbinem in cælum.
 R. Eliséus clamábat, dicens: Pater mi, pater mi, currus Israël, et auríga ejus.
+
+[Responsory2] (rubrica cisterciensis)
+R. Factum est, dum tólleret Dóminus Elíam per túrbinem in cælum, Eliséus clamábat, dicens: 
+* Pater mi, pater mi, currus Israël, et auríga ejus.
+V. Cumque simul pérgerent, et incedéntes sermocinaréntur, ecce currus ígneus, et equi ígnei divisérunt utrúmque, et clamábat Eliséus:
+R. Pater mi, pater mi, currus Israël, et auríga ejus.
 
 [Lectio3]
 @Tempora/Pent03-2

--- a/web/www/horas/Latin/Tempora/Pent04-0.txt
+++ b/web/www/horas/Latin/Tempora/Pent04-0.txt
@@ -58,19 +58,19 @@ De libro primo Regum
 [Lectio4]
 Sermo sancti Augustíni Epíscopi
 !Sermo 197 de Temp. circa med.
-Stabant fílii Israël contra adversarios quadragínta diébus. Quadragínta dies, propter quatuor témpora et quatuor partes orbis terræ, vitam præséntem significant, in qua contra Góliath vel exercitum ejus, id est, contra diabolum et ángelos ejus, Christianórum pópulus pugnare non désinit. Nec tamen vincere posset, nisi verus David Christus cum báculo, id est, cum crucis mysterio descendísset. Ante advéntum enim Christi, fratres caríssimi, solutus erat diabolus; veniens Christus fecit de eo, quod in Evangelio dictum est: Nemo potest intrare in domum fortis et vasa ejus dirípere, nisi prius alligáverit fortem. Venit ergo Christus et alligávit diabolum.
+Stabant fílii Israël contra adversários quadragínta diébus. Quadragínta dies, propter quátuor témpora et quátuor partes orbis terræ, vitam præséntem signíficant, in qua contra Góliath vel exércitum ejus, id est, contra diábolum et ángelos ejus, Christianórum pópulus pugnáre non désinit. Nec tamen víncere posset, nisi verus David Christus cum báculo, id est, cum crucis mystério descendísset. Ante advéntum enim Christi, fratres caríssimi, solútus erat diábolus; véniens Christus fecit de eo, quod in Evangélio dictum est: Nemo potest intráre in domum fortis et vasa ejus dirípere, nisi prius alligáverit fortem. Venit ergo Christus et alligávit diábolum.
 
 [Responsory4]
 @Tempora/Pent01-2:Responsory1
 
 [Lectio5]
-Sed dicit áliquis: Si alligátus est, quare adhuc tantum prævalet? Verum est, fratres caríssimi, quia multum prævalet: sed tépidis, et negligéntibus, et Deum in veritáte non timéntibus dominátur. Alligátus est enim tamquam innexus canis caténis et neminem potest mordére, nisi eum qui se illi mortifera securitate conjúnxerit. Jam vidéte, fratres, quam stultus est homo ille, quem canis in caténa positus mordet. Tu te illi per voluntátes et cupiditates sæculi noli conjúngere, et ille ad te non præsumit accédere. Latrare potest, sollicitare potest; mordére omnino non potest, nisi voléntem. Non enim cogendo, sed suadéndo nocet; nec extorquet a nobis consénsum, sed petit.
+Sed dicit áliquis: Si alligátus est, quare adhuc tantum prǽvalet? Verum est, fratres caríssimi, quia multum prǽvalet: sed tépidis, et negligéntibus, et Deum in veritáte non timéntibus dominátur. Alligátus est enim tamquam innéxus canis caténis et néminem potest mordére, nisi eum qui se illi mortífera securitáte conjúnxerit. Jam vidéte, fratres, quam stultus est homo ille, quem canis in caténa pósitus mordet. Tu te illi per voluntátes et cupiditátes sǽculi noli conjúngere, et ille ad te non præsúmit accédere. Latráre potest, sollicitáre potest; mordére omníno non potest, nisi voléntem. Non enim cogéndo, sed suadéndo nocet; nec extórquet a nobis consénsum, sed petit.
 
 [Responsory5]
 @Tempora/Pent01-2:Responsory2
 
 [Lectio6]
-Venit ergo David et invénit Judæórum pópulum contra diabolum præliántem; et cum nullus esset qui præsumeret ad singulare certámen accédere, ille qui figuram Christi gerebat, processit ad prælium, tulit báculum in manu sua et éxiit contra Góliath. Et in illo quidem tunc figurátum est, quod in Dómino Jesu Christo completum est. Venit enim verus David Christus, qui contra spiritalem Góliath, id est, contra diabolum pugnatúrus crucem suam ipse portávit. Vidéte, fratres, ubi David Góliath percusserit: in fronte útique, ubi crucis signaculum non habebat. Sicut enim báculus crucis typum hábuit, ita étiam et lapis ille, de quo percússus est, Christum Dóminum figurabat.
+Venit ergo David et invénit Judæórum pópulum contra diábolum præliántem; et cum nullus esset qui præsúmeret ad singuláre certámen accédere, ille qui figúram Christi gerébat, procéssit ad prǽlium, tulit báculum in manu sua et éxiit contra Góliath. Et in illo quidem tunc figurátum est, quod in Dómino Jesu Christo complétum est. Venit enim verus David Christus, qui contra spiritálem Góliath, id est, contra diábolum pugnatúrus crucem suam ipse portávit. Vidéte, fratres, ubi David Góliath percússerit: in fronte útique, ubi crucis signáculum non habébat. Sicut enim báculus crucis typum hábuit, ita étiam et lapis ille, de quo percússus est, Christum Dóminum figurábat.
 
 [Responsory6]
 @Tempora/Pent01-2:Responsory3

--- a/web/www/horas/Latin/TemporaM/Pent03-0o.txt
+++ b/web/www/horas/Latin/TemporaM/Pent03-0o.txt
@@ -19,11 +19,17 @@
 [Lectio3]
 @Tempora/Pent03-0:Lectio2:s/22-/23-/ s/22 .*23 /23 /s
 
+[Lectio3] (rubrica cisterciensis)
+@Tempora/Pent03-0:Lectio2:s/22-25/24-26/ s/22 .* Et comédit /24 Et comédit /s
+@Tempora/Pent03-0:Lectio3:2
+
 [Responsory3]
 @Tempora/Pent01-1:Responsory3
 
 [Lectio4]
 @Tempora/Pent03-0:Lectio3
+(sed rubrica cisterciensis)
+@Tempora/Pent03-0:Lectio3:s/26-// s/26 .*//
 
 [Responsory4]
 @Tempora/Pent03-1Feria:Responsory1
@@ -55,12 +61,16 @@
 
 [Lectio9]
 @Tempora/Pent03-0:Lectio7:s/Quamvis .*//s
+(sed rubrica cisterciensis)
+@Tempora/Pent03-0:Lectio7:s/dedignári:.*/dedignári./s
 
 [Responsory9]
 @Tempora/Pent01-3:Responsory1
 
 [Lectio10]
 @Tempora/Pent03-0:Lectio7:s/.* Quamvis /Quamvis /s s/$/~/
+(sed rubrica cisterciensis)
+@Tempora/Pent03-0:Lectio7:s/.* sed áliud/Sed áliud/s s/$/~/
 @Tempora/Pent03-0:Lectio8:s/Præpónunt .*//s
 
 [Responsory10]

--- a/web/www/horas/Latin/TemporaM/Pent04-0.txt
+++ b/web/www/horas/Latin/TemporaM/Pent04-0.txt
@@ -5,25 +5,37 @@
 
 [Lectio1]
 @Tempora/Pent04-0:Lectio1:s/-7/-3/ s/4 .*//s
+(sed rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio1:s/-7/-2/ s/3 .*//s
 
 [Responsory1]
 @Tempora/Pent01-1:Responsory1
 
 [Lectio2]
 @Tempora/Pent04-0:Lectio1:2 s/1-/4-/
+(sed rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio1:2 s/1-7/3-5/
 @Tempora/Pent04-0:Lectio1:6-9
+(sed rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio1:5-7:s/; porro.*/./
 
 [Responsory2]
 @Tempora/Pent01-1:Responsory2
 
 [Lectio3]
-@Tempora/Pent04-0:Lectio2:
+@Tempora/Pent04-0:Lectio2
+
+[Lectio3] (rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio1:2 s/1-7/5-7/
+@Tempora/Pent04-0:Lectio1:7-9:s/.* porro/5 Porro/
 
 [Responsory3]
 @Tempora/Pent01-1:Responsory3
 
 [Lectio4]
 @Tempora/Pent04-0:Lectio3
+(sed rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio2:1-4:s/-11/-10/
 
 [Responsory4]
 @Tempora/Pent03-1Feria:Responsory1
@@ -55,12 +67,16 @@
 
 [Lectio9]
 @Tempora/Pent04-0:Lectio7:s/Ibi adhuc .*//s
+(sed rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio7:s/Pisces .*//s
 
 [Responsory9]
 @Tempora/Pent01-3:Responsory1
 
 [Lectio10]
 @Tempora/Pent04-0:Lectio7:s/.* Ibi adhuc /Ibi adhuc /s s/$/~/
+(sed rubrica cisterciensis)
+@Tempora/Pent04-0:Lectio7:s/.* Pisces /Pisces /s s/$/~/
 @Tempora/Pent04-0:Lectio8:s/Et si .*//s
 
 [Responsory10]

--- a/web/www/horas/Latin/TemporaM/Pent05-0.txt
+++ b/web/www/horas/Latin/TemporaM/Pent05-0.txt
@@ -9,14 +9,31 @@
 [Responsory2]
 @Tempora/Pent01-1:Responsory2
 
+[Lectio1] (rubrica cisterciensis)
+@Tempora/Pent05-0::1-5 s/-4/-3/
+
+[Lectio2] (rubrica cisterciensis)
+@Tempora/Pent05-0:Lectio1:2 s/1-4/4-5/
+@Tempora/Pent05-0:Lectio1:6
+@Tempora/Pent05-0:Lectio2:2
+
 [Lectio3]
 @Tempora/Pent05-0::1-3 s/15/12/
+
+[Lectio3] (rubrica cisterciensis)
+@Tempora/Pent05-0:Lectio2:1 s/5-/6-/
+@Tempora/Pent05-0:Lectio2:3-7:s/ruínam;.*/ruínam./
 
 [Responsory3]
 @Tempora/Pent01-1:Responsory3
 
 [Lectio4]
 @Tempora/Pent05-0:Lectio3:s/11/13/ s/11 .*13/13/s
+
+[Lectio4] (rubrica cisterciensis)
+@Tempora/Pent05-0:Lectio2:1 s/5-10/10-12/
+@Tempora/Pent05-0:Lectio2:7:s/.* et tuli/10 Et tuli/
+@Tempora/Pent05-0:Lectio3:2-3
 
 [Responsory4]
 @Tempora/Pent03-1Feria:Responsory1

--- a/web/www/horas/Polski/Tempora/Pent01-1.txt
+++ b/web/www/horas/Polski/Tempora/Pent01-1.txt
@@ -8,10 +8,12 @@ Początek Pierwszej Księgi Królewskiej
 2 I miał dwie żony, imię jednéj Anna, a imię drugiéj Phenenna. I miała Phenenna syny; ale Anna nie miała dziatek.
 3 I chadzał on mąż z miasta swego na dni ustawione, aby się kłaniał i ofiarował Panu zastępów, do Sylo. A tam byli dwaj synowie Heli, Ophni i Phinees, kapłani Pańscy.
 
-[Responsory1]
+[Responsory1_]
 R. Przygotujcie serca wasze Panu, a służcie jemu samemu:
 * I uwolni was z rąk nieprzyjaciół waszych.
 V. Nawróćcie się do mnie ze wszystkiego serca waszego, wyrzućcież bogi cudze z pośrodku was.
+(sed rubrica cisterciensis)
+V. Wyrzućcież bogi cudze z pośrodku was.
 R. I uwolni was z rąk nieprzyjaciół waszych.
 
 [Lectio2]
@@ -22,7 +24,7 @@ R. I uwolni was z rąk nieprzyjaciół waszych.
 7 I tak czynił na każdy rok, kiedy, gdy czas nadszedł, chodzili do kościoła Pańskiego: i tak ją draźniła, a ona płakała, i nie jadła.
 8 Rzekł tedy jéj Elkana, mąż jéj: Anno, czemu płaczesz? a przecz nie jesz? a przez co się frasuje serce twoje? azam ja nie lepszy tobie, niźli dziesięć synów?
 
-[Responsory2]
+[Responsory2_]
 R. Pan wysłuchujący wszystkich: On posłał swego anioła i zabrał mnie od owiec mego ojca:
 * I namaścił mnie olejem miłosierdzia swego.
 V. Pan, który uratował mię z lwiej paszczęki, i z rąk bestii uwolnił mię.
@@ -34,10 +36,33 @@ R. I namaścił mnie olejem miłosierdzia swego.
 10 będąc Anna gorzkiego serca, modliła się do Pana, płacząc hojnie:
 11 I ślubiła ślub mówiąc: Panie zastępów, jeźli wejrzawszy wejrzysz na utrapienie służebnice twojéj, a wspomnisz na mię, a nie zapamiętasz służebnice twojéj, a dasz słudze twojéj płeć męzką, dam go Panu przez wszystkie dni żywota jego, a brzytwa nie postoi na głowie jego.
 
-[Responsory3]
+[Responsory3_]
 R. Pan, który uratował mię z lwiej paszczęki, i z rąk bestii uwolnił mię.
 * Ten wyrwie mnie z rąk nieprzyjaciół moich.
 V. Zesłał Bóg miłosierdzie swoje, i prawdę swoję, i wyrwał duszę moję z pośrodku szczeniąt lwich.
 R. Ten wyrwie mnie z rąk nieprzyjaciół moich.
 &Gloria
 R. Ten wyrwie mnie z rąk nieprzyjaciół moich.
+
+[Responsory3C]
+R. Zabrałem cię z domu ojca twego, mówi Pan, i postawiłem cię, byś pasł stado ludu mego, i byłem z tobą, gdziekolwiek poszedłeś,
+* Utwierdzając królestwo twoje na wieki.
+V. I uczyniłem ci imię wielkie, wedle imienia wielkich, którzy są na ziemi.
+R. Utwierdzając królestwo twoje na wieki.
+&Gloria
+R. Utwierdzając królestwo twoje na wieki.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@:Responsory3_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@:Responsory3C

--- a/web/www/horas/Polski/Tempora/Pent01-2.txt
+++ b/web/www/horas/Polski/Tempora/Pent01-2.txt
@@ -12,7 +12,7 @@ Z Pierwszej Księgi Królewskiej
 17 Rzekł tedy Heli: Idź w pokoju, a Bóg Izrael niech ci da prośbę twoję, o którąś go prosiła.
 18 A ona rzekła: Oby nalazła służebnica twoja łaskę w oczach twoich.
 
-[Responsory1]
+[Responsory1_]
 R. Poraził Saul tysiąc, a Dawid dziesięć tysięcy:
 * Albowiem była z nim ręka Pańska: zabił Philistyna, i usunął hańbę z Izraela.
 V. Aza to nie on Dawid, któremu śpiewano w tańcach, mówiąc: Zabił Saul w tysiącach swych, a Dawid w dziesiąci tysięcy swoich?
@@ -26,7 +26,7 @@ R. Albowiem była z nim ręka Pańska: zabił Philistyna, i usunął hańbę z I
 21 I szedł mąż jej Elkana i wszystek dom jego, aby ofiarował Panu ofiarę uroczystą, i ślub swój.
 22 Lecz Anna nie szła; bo mówiła mężowi swemu: Nie pójdę, aż się ostawi dziecię i zawiodę je, że się ukaże przed obliczem Pańskiem, i zostanie tam ustawicznie.
 
-[Responsory2]
+[Responsory2_]
 R. Góry Gelboe, ani rosa ani deszcz niech nie padają na was,
 * Gdzie polegli mocarze Izraela.
 V. Wszystkie góry, które są wokół, nawiedzi Pan: od Gelboe zaś odejdzie.
@@ -41,10 +41,25 @@ R. Gdzie polegli mocarze Izraela.
 27 O tom dziecię prosiła, i dał mi Pan prośbę moję, któréjem u niego prosiła.
 28 Przetóż i ja pożyczyłam go Panu na wszystkie dni, których będzie pożyczony Panu. I pokłonili się tam Panu.
 
-[Responsory3]
+[Responsory3_]
 R. Zabrałem cię z domu ojca twego, mówi Pan, i postawiłem cię, byś pasł stado ludu mego.
 * I byłem z tobą, gdziekolwiek poszedłeś, utwierdzając królestwo twoje na wieki.
 V. I uczyniłem ci imię wielkie, wedle imienia wielkich, którzy są na ziemi: i odpoczynek ci dałem od wszystkich przeciwników twoich.
 R. I byłem z tobą, gdziekolwiek poszedłeś, utwierdzając królestwo twoje na wieki.
 &Gloria
 R. I byłem z tobą, gdziekolwiek poszedłeś, utwierdzając królestwo twoje na wieki.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@:Responsory2_
+
+[Responsory2]
+@:Responsory2_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-3:Responsory2_
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory1

--- a/web/www/missa/Bohemice/Tempora/Pent03-0r.txt
+++ b/web/www/missa/Bohemice/Tempora/Pent03-0r.txt
@@ -1,0 +1,47 @@
+[Officium]
+3. neděle po Svatém Duchu
+
+[Introitus]
+!Ps. 24:16, 18
+v. Look toward me, and have pity on me, O Lord, for I am alone and afflicted. Put an end to my affliction and my suffering, and take away all my sins, O my God.
+!Ps. 24:1-2
+To You, I lift up my soul, O Lord. In You, O my God, I trust; let me not be put to shame.
+&Gloria
+v. Look toward me, and have pity on me, O Lord, for I am alone and afflicted. Put an end to my affliction and my suffering, and take away all my sins, O my God.
+
+[Oratio]
+O God, protector of all who hope in You, without Whom nothing is strong, nothing is holy, increase Your mercy toward us, that, with Your guidance and direction we may so pass through the things of this temporal life as not to lose those of life eternal.
+$Per Dominum
+
+[Lectio]
+Čtení z prvního listu svatého Apoštola Petra
+!1 Petr 5:6-11
+Milovaní, pokorně se skloňte pod mocnou rukou Boží, a on vás povýší, až k tomu přijde čas. 'Na něj hoďte všechnu svou starost,' vždyť jemu na vás záleží. Buďte střízliví a bděte, protože váš protivník ďábel jako řvoucí lev obchází a hledá, koho by mohl zhltnout. Postavte se proti němu, silní vírou. Víte přece, že vaši bratři po (celém) světě musejí také tak trpět. Když teď nakrátko snesete utrpení, Bůh, dárce veškeré milosti, který vás pro (zásluhy) Krista Ježíše povolal ke své věčné slávě, sám vás zdokonalí, utuží, utvrdí a upevní. Jemu patří vláda na věčné věky. Amen.
+
+[Graduale]
+!Ps. 54:23, 17, 19
+Cast your care upon the Lord, and He will support you.
+V. When I called upon the Lord, He heard my voice from those who war against me. Alleluia, alleluia.
+!Ps 7:12
+A just judge is God, strong and patient; is He angry every day? Alleluia.
+
+[Evangelium]
+Pokračování + svatého Evangelia podle Lukáše
+!Lukáš 15:1-10
+Za onoho času k němu přicházeli samí celníci a hříšníci, aby ho slyšeli. Farizeové a učitelé Zákona mezi sebou reptali: „Přijímá hříšníky a jí s nimi!“ Pověděl jim tedy toto podobenství: „Kdo z vás, když má sto ovcí a jednu z nich ztratí, nenechá těch devětadevadesát v pustině a nepůjde za tou ztracenou, dokud ji nenajde? A když ji najde, s radostí si ji vloží na ramena. Až přijde domů, svolá své přátele i sousedy a řekne jim: 'Radujte se se mnou, protože jsem našel svou ztracenou ovci.' Říkám vám, že právě tak bude v nebi větší radost nad jedním hříšníkem, který se obrátí, než nad devětadevadesáti spravedlivými, kteří obrácení nepotřebují. Nebo která žena, když má deset stříbrných mincí a jednu z nich ztratí, nerozsvítí svítilnu, nevymete dům a nehledá pečlivě, dokud ji nenajde? A když ji najde, svolá své přítelkyně i sousedky a řekne jim: 'Radujte se se mnou, protože jsem našla stříbrnou minci, kterou jsem ztratila.' Právě tak, říkám vám, mají radost Boží andělé nad jedním hříšníkem, který se obrátil.“
+
+[Offertorium]
+!Ps. 9:11-13
+They trust in You who cherish Your name, O Lord, for You forsake not those who seek You. Sing praise to the Lord enthroned in Sion, for He has not forgotten the cry of the afflicted.
+
+[Secreta]
+Look favorably, O Lord, upon the offerings of Your prayerful Church and grant that those who believe may, in continual holiness, partake of them for their salvation.
+$Per Dominum
+
+[Communio]
+!Luke 15:10
+I say to you: there is joy among the angels of God over one sinner who repents.
+
+[Postcommunio]
+May the holy things of which we have partaken bring us to life and prepare for Your everlasting mercy those whom You have cleansed from sin.
+$Per Dominum

--- a/web/www/missa/Bohemice/Tempora/Pent04-0.txt
+++ b/web/www/missa/Bohemice/Tempora/Pent04-0.txt
@@ -1,0 +1,47 @@
+[Officium]
+4. neděle po Svatém Duchu
+
+[Introitus]
+!Ps. 26:1-2
+v. The Lord is my light and my salvation; whom should I fear? The Lord is my life’s refuge; of whom should I be afraid? My enemies that trouble me, themselves stumble and fall.
+!Ps 26:3
+Though an army encamp against me, my heart will not fear.
+&Gloria
+v. The Lord is my light and my salvation; whom should I fear? The Lord is my life’s refuge; of whom should I be afraid? My enemies that trouble me, themselves stumble and fall.
+
+[Oratio]
+Grant us, we beseech You, O Lord, that the course of the world may be directed according to Your rule in peace and that Your Church may have the joy of serving You undisturbed.
+$Per Dominum
+
+[Lectio]
+Lesson from the letter of St. Paul the Apostle to the Romans
+!Rom 8:18-23
+Brethren: I reckon that the sufferings of the present time are not worthy to be compared with the glory to come that will be revealed in us. For the eager longing of creation awaits the revelation of the sons of God. For creation was made subject to vanity - not by its own will but by reason of Him Who made it subject - in hope, because creation itself also will be delivered from its slavery to corruption into the freedom of the glory of the sons of God. For we know that all creation groans and travails in pain until now. And not only it, but we ourselves also who have the first-fruits of the Spirit - we ourselves groan within ourselves, waiting for the adoption as sons of God, the redemption of our body, in Christ Jesus our Lord.
+
+[Graduale]
+!Ps. 78:9-10
+Pardon our sins, O Lord; why should the nations say, Where is their God?
+V. Help us, O God our Saviour; because of the glory of Your name, O Lord, deliver us. Alleluia, alleluia.
+!Ps. 9:5; 9:10
+O God, seated on Your throne, judging justly: be a stronghold for the oppressed in times of distress. Alleluia.
+
+[Evangelium]
+Pokračování + svatého Evangelia podle Lukáše
+!Lukáš 5:1-11
+Za onoho času, Ježíš stál u Genezaretského jezera, lidé se na něho tlačili, aby slyšeli Boží slovo. Tu spatřil u břehu stát dvě lodě. Rybáři z nich vystoupili a prali sítě. Vstoupil na jednu z těch lodí, která patřila Šimonovi, a požádal ho, aby trochu odrazil od břehu. Posadil se a z lodi učil zástupy. Když přestal mluvit, řekl Šimonovi: „Zajeď na hlubinu a spusťte sítě k lovení!“ Šimon mu odpověděl: „Mistře, celou noc jsme se lopotili, a nic jsme nechytili. Ale na tvé slovo spustím sítě.“ Když to udělali, zahrnuli veliké množství ryb, že se jim sítě téměř trhaly. Dali znamení společníkům v druhé lodi, aby jim přišli na pomoc, a ti přijeli. Naplnili obě lodě, až se potápěly. Když to Šimon Petr viděl, padl Ježíšovi k nohám a řekl: „Pane, odejdi ode mě: jsem člověk hříšný!“ Zmocnil se ho totiž úžas, a také všech jeho společníků, nad tím lovem ryb, které chytili; stejně i Zebedeových synů Jakuba a Jana, kteří byli Šimonovými druhy. Ježíš řekl Šimonovi: „Neboj se! Od nynějška budeš lovit lidi.“ Přirazili s loďmi k zemi, nechali všeho a šli za ním.
+
+[Offertorium]
+!Ps. 12:4-5
+Give light to my eyes that I may never sleep in death, lest my enemy say, I have overcome him.
+
+[Secreta]
+Be appeased, we beseech You, O Lord, by accepting our offerings, and in Your kindness make even our rebellious wills turn to You.
+$Per Dominum
+
+[Communio]
+!Ps. 17:3
+O Lord, my rock, my fortress, my deliverer: my God, my rock of refuge!
+
+[Postcommunio]
+May the sacrament we have received cleanse us, we beseech You, O Lord, and by its grace protect us.
+$Per Dominum

--- a/web/www/missa/Bohemice/Tempora/Pent05-0.txt
+++ b/web/www/missa/Bohemice/Tempora/Pent05-0.txt
@@ -1,0 +1,53 @@
+[Officium]
+5. neděle po Svatém Duchu
+
+[Rule]
+Gloria
+Credo
+Prefatio=Trinitate
+Suffr=Sanctorum;Maria3,Ecclesiae,Papa;;
+
+[Introitus]
+!Ps. 26:7, 9
+v. Hear, O Lord, the sound of my call; be my helper: forsake me not: despise me not, O God my Saviour.
+!Ps 26:1
+The Lord is my light and my salvation; whom should I fear?
+&Gloria
+v. Hear, O Lord, the sound of my call; be my helper: forsake me not: despise me not, O God my Saviour.
+
+[Oratio]
+O God, You Who have prepared good things as yet unseen for those who love You, pour a burning love into our hearts, so that we, loving You in and above all things, may obtain Your promises which surpass all desire.
+$Per Dominum
+
+[Lectio]
+Lesson from the first letter of St. Peter the Apostle
+!1 Pet 3:8-15.
+Beloved: Be all like-minded in prayer, compassionate, lovers of the brethren, merciful, reserved, humble; not rendering evil for evil, or abuse for abuse, but contrariwise, blessing; for unto this were you called that you might inherit a blessing. For, 'He who would love life, and see good days, let him refrain his tongue from evil, and his lips that they speak no deceit. Let him turn away from evil and do good, let him seek after peace and pursue it. For the eyes of the Lord are upon the just, and His ears unto their prayers; but the face of the Lord is against those who do evil.' And who is there to harm you, if you are zealous for what is good? But even if you suffer anything for justice’ sake, blessed are you. So have no fear of their fear and do not be troubled. But hallow the Lord Christ in your hearts.
+
+[Graduale]
+!Ps. 83:10, 9
+Behold, O God, our protector, and look on Your servants.
+V. O Lord God of Hosts, hear the prayers of Your servants. Alleluia, alleluia.
+!Ps. 20:1
+V. O Lord, in Your strength the king is glad; in Your victory how greatly he rejoices! Alleluia.
+
+[Evangelium]
+Pokračování + svatého Evangelia podle Matouše
+!Mat. 5:20-24.
+Za onoho času, řekl Ježíš svým učedníkům: Nebude-li vaše spravedlnost mnohem dokonalejší než spravedlnost učitelů Zákona a farizeů, do nebeského království nevejdete. Slyšeli jste, že bylo řečeno předkům: 'Nezabiješ.' Kdo by zabil, propadne soudu. Ale já vám říkám: Každý, kdo se na svého bratra hněvá, propadne soudu; kdo svého bratra tupí, propadne veleradě; a kdo ho zatracuje, propadne pekelnému ohni. Přinášíš-li tedy svůj dar k oltáři a tam si vzpomeneš, že tvůj bratr má něco proti tobě, nech tam svůj dar před oltářem a jdi se napřed smířit se svým bratrem, teprve potom přijď a obětuj svůj dar.
+
+[Offertorium]
+!Ps. 15:7-8.
+I bless the Lord Who counsels me; I set God ever before me; with Him at my right hand I shall not be disturbed.
+
+[Secreta]
+Be propitious to our supplications, O Lord, and graciously receive these oblations of Your servants and handmaids, that what each one offered to the glory of Your name, may profit all to salvation.
+$Per Dominum
+
+[Communio]
+!Ps. 26:4.
+One thing I ask of the Lord; this I seek: to dwell in the house of the Lord all the days of my life.
+
+[Postcommunio]
+Grant us, we beseech You, O Lord, that we whom You have filled with the heavenly gift may be cleansed of our hidden sins and delivered from the snares of our enemies.
+$Per Dominum


### PR DESCRIPTION
Changes in code: discussion #4575 (`sub ensure_single_alleluia()` to doesn't add alleluia to an empty string)

As the Responsories for green Sunday's Matins are always the same and somehow shifted from the Roman version, (hopefully) non-invasive changes were done to all datafiles, where these common texts are present.