### PR TITLE
Cist: bugfixes for Responsories after Pentecost etc.

### DIFF
--- a/web/www/horas/Bohemice/Sancti/01-25.txt
+++ b/web/www/horas/Bohemice/Sancti/01-25.txt
@@ -68,9 +68,6 @@ He went breathing out threatenings and slaughter, yea, truly, devouring the prey
 v. Šavel ještě soptil hrozbami a hořel touhou zabíjet učedníky Páně. Přišel k veleknězi a vyžádal si od něho pověřující listy na synagógy v Damašku: najde-li tam některé stoupence toho vyznání, muže i ženy, aby je mohl přivést v poutech do Jeruzaléma.
 $Deo gratias
 
-[Ant 2] (rubrica cisterciensis)
-Mé Evangelium, * které vám zvěstuji, nepochází ode mě, ani jsem je nepřijal od člověka, nýbrž skrze zjevení našeho Pána Ježíše Krista.
-
 [Lectio Prima]
 !Skutky 9:22
 v. Šavel však vystupoval s rozhodností stále větší a židy v Damašku přiváděl z míry, když dokazoval, že Ježíš je Mesiáš.

--- a/web/www/horas/Bohemice/Sancti/06-30.txt
+++ b/web/www/horas/Bohemice/Sancti/06-30.txt
@@ -179,9 +179,9 @@ Vy, kdo jste mě následovali, * zasednete na trůny a budete soudit dvanáct km
 Mé Evangelium, * které je zvěstováno, není ode mě, ani jsem je nepřijal od žádného člověka, nýbrž skrze zjevení našeho Pána Ježíše Krista.
 
 [Ant 2]
-@Ant 2_
+@:Ant 2_
 (sed rubrica cisterciensis)
-Ant 2C
+@:Ant 2C
 
 [Lectio Prima]
 !1 Kor 15:9-10

--- a/web/www/horas/English/Sancti/06-30.txt
+++ b/web/www/horas/English/Sancti/06-30.txt
@@ -166,8 +166,16 @@ If thou wilt see how these words were brought to the proof in very deed, read th
 v. I have fought a good fight, I have finished my course, I have kept the faith. Henceforth there is laid up for me a crown of righteousness, which the Lord, the righteous Judge, shall give me at that day.
 $Deo gratias
 
-[Ant 2]
+[Ant 2_]
 Thus saith the Lord: * Ye, which have followed Me, shall sit upon twelve thrones, judging the twelve tribes of Israel.
+
+[Ant 2C] 
+My Gospel, * which hath been preached, is not of me, neither did I receive it from any man, but by the revelation of our Lord Jesus Christ.
+
+[Ant 2]
+@:Ant 2_
+(sed rubrica cisterciensis)
+@:Ant 2C
 
 [Lectio Prima]
 !1 Cor 15:9-10

--- a/web/www/horas/Espanol/Tempora/Pent01-0.txt
+++ b/web/www/horas/Espanol/Tempora/Pent01-0.txt
@@ -207,6 +207,9 @@ R. Santo, Santo, Santo es el Señor Dios de las virtudes.
 &Gloria
 R. Llena está toda la tierra de su gloria.
 
+[Responsory8] (rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory2
+
 [Lectio9]
 !Conmemoración del Domingo
 Lección del Santo Evangelio según San Lucas

--- a/web/www/horas/Espanol/Tempora/Pent01-2.txt
+++ b/web/www/horas/Espanol/Tempora/Pent01-2.txt
@@ -65,4 +65,4 @@ R. Por todas partes donde has andado he estado contigo, asegurando tu reino para
 [Responsory3]
 @:Responsory3_
 (sed rubrica cisterciensis)
-@Tempora/Pent03-2Feria:Responsory1
+@Tempora/Pent03-2Feria:Responsory1_

--- a/web/www/horas/Espanol/Tempora/Pent01-3.txt
+++ b/web/www/horas/Espanol/Tempora/Pent01-3.txt
@@ -32,7 +32,7 @@ R. Bendice y santifica para siempre esta casa, oh Dios de Israel.
 [Responsory2]
 @:Responsory2_
 (sed rubrica cisterciensis)
-@:Responsory3
+@:Responsory3_
 
 [Lectio3]
 !1 Sam 2:18-21
@@ -41,10 +41,15 @@ R. Bendice y santifica para siempre esta casa, oh Dios de Israel.
 20 Helí bendijo a Elcana y a su mujer, diciendo: “Que te dé Yahvé hijos de esta mujer por el que le prestaste.” Volviéronse ellos a su casa, 
 21 y Yahvé visitó a Ana, que concibió y parió tres hijos y dos hijas. El joven Samuel iba creciendo en la presencia de Yahvé.
 
-[Responsory3]
+[Responsory3_]
 R. Escucha, Señor, los himnos y las plegarias que tu siervo pronuncia hoy en tu presencia, para que estén tus ojos abiertos, 
 * Hacia esta casa de día y de noche. 
 V. Óyeles, Señor, desde tu santuario y desde tu excelsa mansión de los cielos. 
 R. Hacia esta casa de día y de noche. 
 &Gloria
 R. Hacia esta casa de día y de noche. 
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-1:Responsory1_

--- a/web/www/horas/Espanol/Tempora/Pent03-1Feria.txt
+++ b/web/www/horas/Espanol/Tempora/Pent03-1Feria.txt
@@ -1,11 +1,14 @@
 [Officium]
 Feria secunda infra Hebdomadam III post Octavam Pentecostes
 
-[Responsory1]
+[Responsory1_]
 R. Acuérdate, Señor, de tu alianza, y di al Ángel exterminador: Cesa ya en tus castigos, 
 * Para que no quede la tierra aterrorizada, y no hagas perecer a toda alma viviente. 
 V. Yo soy quien ha pecado, y quien ha obrado la iniquidad: pero estas ovejas ¿qué han hecho? Aparta, Señor, te ruego tu furor de tu pueblo. 
 R. Para que no quede la tierra aterrorizada, y no hagas perecer a toda alma viviente.
+
+[Responsory1] 
+@:Responsory1_
 
 [Responsory2]
 R. Oíste, oh Señor, la oración de tu siervo, permitiéndome que edificara un templo para gloria de tu nombre: 

--- a/web/www/horas/Espanol/Tempora/Pent03-2Feria.txt
+++ b/web/www/horas/Espanol/Tempora/Pent03-2Feria.txt
@@ -1,17 +1,28 @@
 [Officium]
 Feria teria infra Hebdomadam III post Octavam Pentecostes
 
-[Responsory1]
+[Responsory1_]
 R. Señor, si tu pueblo se arrepintiere, y orare en tu santuario; 
 * Tú le oirás, Señor, desde el cielo, y le librarás de las manos de sus enemigos. 
 V. Si tu pueblo pecare contra ti, y convirtiéndose, hiciere penitencia, y viniere a orar en este lugar. 
 R. Tú le oirás, Señor, desde el cielo, y le librarás de las manos de sus enemigos.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-1Feria:Responsory1_
 
 [Responsory2]
 R. Y sucedió que mientras el Señor arrebataba al cielo a Elías en un torbellino de fuego, 
 * Eliseo clamaba, diciendo: Padre mío, Padre mío, verdadero carro de Israel y su conductor. 
 V. Mientras proseguían su camino andando y hablando entre sí, he aquí que un carro de fuego con caballos también de fuego, separaron a entrambos, y Elías subió al cielo en el torbellino. 
 R. Eliseo clamaba, diciendo: Padre mío, Padre mío, verdadero carro de Israel y su conductor.
+
+[Responsory2] (rubrica cisterciensis)
+R. Y sucedió que mientras el Señor arrebataba al cielo a Elías en un torbellino de fuego, Eliseo clamaba, diciendo: 
+* Padre mío, Padre mío, verdadero carro de Israel y su conductor. 
+V. Mientras proseguían su camino andando y hablando entre sí, he aquí que un carro de fuego con caballos también de fuego, Eliseo clamaba, diciendo: 
+R. Padre mío, Padre mío, verdadero carro de Israel y su conductor.
 
 [Responsory3]
 R. He aquí que Yo te saqué de la casa de tu padre, dice el Señor, y te constituí pastor del rebaño de mi pueblo. 

--- a/web/www/horas/Francais/Tempora/Pent01-0.txt
+++ b/web/www/horas/Francais/Tempora/Pent01-0.txt
@@ -207,6 +207,9 @@ R. Saint, saint, saint est le Seigneur Dieu des armées :
 &Gloria
 R. Toute la terre est pleine de sa gloire.
 
+[Responsory8] (rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory2
+
 [Lectio9]
 !Commémoraison du dimanche
 Lecture du saint Évangile selon saint Luc.

--- a/web/www/horas/Francais/Tempora/Pent01-2.txt
+++ b/web/www/horas/Francais/Tempora/Pent01-2.txt
@@ -65,4 +65,4 @@ R. Et j’ai été avec toi dans tous les lieux où tu as marché, affermissant 
 [Responsory3]
 @:Responsory3_
 (sed rubrica cisterciensis)
-@Tempora/Pent03-2Feria:Responsory1
+@Tempora/Pent03-2Feria:Responsory1_

--- a/web/www/horas/Francais/Tempora/Pent01-3.txt
+++ b/web/www/horas/Francais/Tempora/Pent01-3.txt
@@ -32,7 +32,7 @@ R. Bénissez et sanctifiez cette demeure pour toujours, ô Dieu d’Israël,
 [Responsory2]
 @:Responsory2_
 (sed rubrica cisterciensis)
-@:Responsory3
+@:Responsory3_
 
 [Lectio3]
 !1 Reg 2:18-21
@@ -41,10 +41,15 @@ R. Bénissez et sanctifiez cette demeure pour toujours, ô Dieu d’Israël,
 20 Et Héli bénit Elcana et sa femme, et il dit à Elcana : Que le Seigneur vous rende des enfants de cette femme pour le dépôt que vous avez mis entre les mains du Seigneur. Et ils s'en retournèrent chez eux.
 21 Le Seigneur visita donc Anne ; et elle conçut, et enfanta trois fils et deux filles ; et l'enfant Samuel grandit devant le Seigneur.
 
-[Responsory3]
+[Responsory3_]
 R. Écoutez, Seigneur, l’hymne et l’oraison que votre serviteur profère devant vous aujourd’hui, afin que vos yeux soient ouverts et vos oreilles attentives,
 * Sur cette maison, jour et nuit.
 V. Regardez, Seigneur, de votre sanctuaire et du haut de votre habitation des cieux.
 R. Sur cette maison, jour et nuit.
 &Gloria
 R. Sur cette maison, jour et nuit.
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-1:Responsory1_

--- a/web/www/horas/Francais/Tempora/Pent03-1Feria.txt
+++ b/web/www/horas/Francais/Tempora/Pent03-1Feria.txt
@@ -1,11 +1,14 @@
 [Officium]
 Feria secunda infra Hebdomadam III post Octavam Pentecostes
 
-[Responsory1]
+[Responsory1_]
 R. Souvenez-vous, Seigneur, de votre alliance, et dites à l’Ange exterminateur : “Que ta main s’arrête désormais”, 
 * Afin que la terre ne soit pas dévastée, et que vous ne causiez la perte de toute âme vivante.
 V. C’est moi qui ai péché, moi qui ai agi de façon inique ; ceux-là sont des brebis, qu’ont-ils fait ? Que s’éloigne votre fureur, Seigneur, de votre peuple,
 R. Afin que la terre ne soit pas dévastée, et que vous ne causiez la perte de toute âme vivante.
+
+[Responsory1] 
+@:Responsory1_
 
 [Responsory2]
 R. Vous avez exaucé, Seigneur, la prière de votre serviteur : ainsi ai-je bâti un temple à votre nom :

--- a/web/www/horas/Francais/Tempora/Pent03-2Feria.txt
+++ b/web/www/horas/Francais/Tempora/Pent03-2Feria.txt
@@ -1,17 +1,28 @@
 [Officium]
 Feria tertia infra Hebdomadam III post Octavam Pentecostes
 
-[Responsory1]
+[Responsory1_]
 R. Seigneur, si votre peuple se tourne et prie du côté de ce sanctuaire :
 * Vous l’exaucerez du haut du ciel, et libérez-le des mains de ses ennemis. 
 V. Si votre peuple a péché contre vous et que, converti, il fasse pénitence et vienne prier en ce lieu.
 R. Vous l’exaucerez du haut du ciel, et libérez-le des mains de ses ennemis.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-1Feria:Responsory1_
 
 [Responsory2]
 R. Et il arriva qu’au moment où le Seigneur emportait Élie dans un tourbillon vers le ciel, 
 * Élisée criait en disant : Mon père, mon père, char d’Israël et son conducteur. 
 V. Tandis qu’ils cheminaient et tout en marchant parlaient ensemble, voici qu’un char de feu et des chevaux de feu les séparèrent, et Élie monta dans un tourbillon vers le ciel. 
 R. Élisée criait en disant : Mon père, mon père, char d’Israël et son conducteur. 
+
+[Responsory2] (rubrica cisterciensis)
+R. Et il arriva qu’au moment où le Seigneur emportait Élie dans un tourbillon vers le ciel, Élisée criait en disant : 
+* Mon père, mon père, char d’Israël et son conducteur. 
+V. Tandis qu’ils cheminaient et tout en marchant parlaient ensemble, voici qu’un char de feu et des chevaux de feu les séparèrent, Élisée criait en disant :  
+R. Mon père, mon père, char d’Israël et son conducteur. 
 
 [Responsory3]
 R. C’est moi qui t’ai pris à la maison de ton père, dit le Seigneur, et t’ai mis pasteur du troupeau de mon peuple : 

--- a/web/www/horas/Italiano/Tempora/Pent01-0.txt
+++ b/web/www/horas/Italiano/Tempora/Pent01-0.txt
@@ -207,6 +207,9 @@ R. Santo, santo, santo è il Signore Dio degli eserciti:
 &Gloria
 R. Piena è tutta la terra della sua gloria.
 
+[Responsory8] (rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory2
+
 [Lectio9]
 !Commemorazione della  Domenica
 Lettura del santo Vangelo secondo Luca

--- a/web/www/horas/Italiano/Tempora/Pent01-2.txt
+++ b/web/www/horas/Italiano/Tempora/Pent01-2.txt
@@ -66,4 +66,4 @@ R. E fui con te in ogni cosa ovunque andasti, rafforzando per sempre il tuo regn
 [Responsory3]
 @:Responsory3_
 (sed rubrica cisterciensis)
-@Tempora/Pent03-2Feria:Responsory1
+@Tempora/Pent03-2Feria:Responsory1_

--- a/web/www/horas/Italiano/Tempora/Pent01-3.txt
+++ b/web/www/horas/Italiano/Tempora/Pent01-3.txt
@@ -33,7 +33,7 @@ R. Benedici e santifica per sempre questa casa, o Dio d'Israele.
 [Responsory2]
 @:Responsory2_
 (sed rubrica cisterciensis)
-@:Responsory3
+@:Responsory3_
 
 [Lectio3]
 !1 Sam 2:18-21
@@ -42,10 +42,15 @@ R. Benedici e santifica per sempre questa casa, o Dio d'Israele.
 20 Ed Eli benedisse Elcana e sua moglie dicendogli; Il Signore ti dia prole da questa donna in ricompensa di quello che hai donato al Signore. Ed essi se ne ritornarono a casa loro. 
 21 Il Signore adunque visitò Anna, che divenne madre e diede alla luce tre figli e due figlie. E il fanciullo Samuele si faceva grande presso il Signore.
 
-[Responsory3]
+[Responsory3_]
 R. Ascolta, o Signore, l'inno e la preghiera che oggi il tuo servo innalza al tuo cospetto, affinché i tuoi occhi siano rivolti e le tue orecchie aperte, 
 * Sopra questa casa giorno e notte.
 V. Rimira, o Signore, dal tuo santuario e dall'eccelsa abitazione dei cieli.
 R. Sopra questa casa giorno e notte.
 &Gloria
 R. Sopra questa casa giorno e notte.
+
+[Responsory3]
+@:Responsory3_
+(sed rubrica cisterciensis)
+@Tempora/Pent01-1:Responsory1_

--- a/web/www/horas/Italiano/Tempora/Pent03-1Feria.txt
+++ b/web/www/horas/Italiano/Tempora/Pent03-1Feria.txt
@@ -1,11 +1,14 @@
 [Officium]
 Feria secunda infra Hebdomadam III post Octavam Pentecostes
 
-[Responsory1]
+[Responsory1_]
 R. Ricordati, o Signore, del tuo testamento, e di all'Angelo persecutore: si fermi ormai la tua mano,
 * Perché non sia desolata la terra, e non distrugga ogni anima vivente.
 V. Sono io che ho peccato, sono io che ho agito male: questi che sono pecore, che hanno fatto? Sia distolto, ti prego o Signore, il tuo furore dal tuo popolo.
 R. Perché non sia desolata la terra, e non distrugga ogni anima vivente.
+
+[Responsory1]
+@:Responsory1_
 
 [Responsory2]
 @Tempora/Pent01-3:Responsory2

--- a/web/www/horas/Italiano/Tempora/Pent03-2Feria.txt
+++ b/web/www/horas/Italiano/Tempora/Pent03-2Feria.txt
@@ -1,17 +1,28 @@
 [Officium]
 Feria tertia infra Hebdomadam III post Octavam Pentecostes
 
-[Responsory1]
+[Responsory1_]
 R. Signore, se il tuo popolo si sarà convertito e avrà pregato nel tuo santuario:
 * Tu lo esaudirai dal cielo, o Signore, e liberali dalle mani dei loro nemici.
 V. Se il tuo popolo avrà peccato contro di te, e convertitosi avrà fatto penitenza, e sarà venuto a pregare in codesto loco.
 R. Tu lo esaudirai dal cielo, o Signore, e liberali dalle mani dei loro nemici.
+
+[Responsory1]
+@:Responsory1_
+(sed rubrica cisterciensis)
+@Tempora/Pent03-1Feria:Responsory1_
 
 [Responsory2]
 R. Ed avvenne che, mentre il Signore trasportava Elia in cielo per mezzo del turbine,
 * Eliseo esclamava dicendo: Padre mio, padre mio, cocchio di Israele e sua auriga.
 V. E mentre avanzavano e parlavano camminando, ecco il cocchio di fuoco e i cavalli di fuoco li separarono l'uno dall'altro, ed Elio salì in cielo per mezzo del turbine.
 R. Eliseo esclamava dicendo: Padre mio, padre mio, cocchio di Israele e sua auriga.
+
+[Responsory2] (rubrica cisterciensis)
+R. Ed avvenne che, mentre il Signore trasportava Elia in cielo per mezzo del turbine, Eliseo esclamava dicendo: 
+* Padre mio, padre mio, cocchio di Israele e sua auriga.
+V. E mentre avanzavano e parlavano camminando, ecco il cocchio di fuoco e i cavalli di fuoco li separarono l'uno dall'altro, Eliseo esclamava dicendo: 
+R. Padre mio, padre mio, cocchio di Israele e sua auriga.
 
 [Responsory3]
 @Tempora/Pent01-2:Responsory3

--- a/web/www/horas/Latin/Sancti/01-25.txt
+++ b/web/www/horas/Latin/Sancti/01-25.txt
@@ -114,9 +114,6 @@ $Deo gratias
 [Ant 2]
 @Sancti/06-30:Ant 2
 
-[Ant 2] (rubrica cisterciensis)
-Evangélium meum, * quod evangelizátum est, non est a me, neque ab hómine accépi illud, sed per revelatiónem Dómini nostri Jesu Christi.
-
 [Lectio Prima]
 !Act 9:22
 v. Saulus autem multo magis convalescébat, et confundébat Judǽos qui habitábant Damásci, affírmans quóniam hic est Christus.

--- a/web/www/horas/Latin/Sancti/06-30.txt
+++ b/web/www/horas/Latin/Sancti/06-30.txt
@@ -211,11 +211,16 @@ $Deo gratias
 [Versum 2]
 @:Versum 1
 
-[Ant 2]
+[Ant 2_]
 Vos qui secúti estis me, * sedébitis super sedes, judicántes duódecim tribus Israël, dicit Dóminus.
 
-[Ant 2](rubrica cisterciensis)
+[Ant 2C]
 Evangélium meum, * quod evangelizátum est, non est a me, neque ab hómine accépi illud, sed per revelatiónem Dómini nostri Jesu Christi.
+
+[Ant 2]
+@:Ant 2_
+(sed rubrica cisterciensis)
+@:Ant 2C
 
 [Lectio Prima]
 !1 Cor 15:9-10

--- a/web/www/horas/Polski/Tempora/Pent01-0.txt
+++ b/web/www/horas/Polski/Tempora/Pent01-0.txt
@@ -176,6 +176,9 @@ R. Święty, Święty, Święty, Pan Bóg Zastępów.
 &Gloria
 R. Cała ziemia pełna jest Jego chwały. 
 
+[Responsory8] (rubrica cisterciensis)
+@Tempora/Pent03-2Feria:Responsory2
+
 [Lectio9] (rubrica 1960)
 @:Lectio8a:s/.*(Wreszcie)/$1/s
 &teDeum

--- a/web/www/horas/Polski/Tempora/Pent01-2.txt
+++ b/web/www/horas/Polski/Tempora/Pent01-2.txt
@@ -62,4 +62,4 @@ R. I byłem z tobą, gdziekolwiek poszedłeś, utwierdzając królestwo twoje na
 [Responsory3]
 @:Responsory3_
 (sed rubrica cisterciensis)
-@Tempora/Pent03-2Feria:Responsory1
+@Tempora/Pent03-2Feria:Responsory1_


### PR DESCRIPTION
- Fixed the issue with 01-25/06-30 and their common [Ant 2]. Here, both versions of the Antiphon are needed - the Roman version is used in Cistercian Matins, that's why I divided the [Ant 2], but I messed up the cross-links before. Sorry for that!
- finished adding cross-links from yesterday's PR