### PR TITLE
correct translation errors in Spanish Ordo rubrics

### DIFF
--- a/web/www/missa/Espanol/Ordo/Ordo.txt
+++ b/web/www/missa/Espanol/Ordo/Ordo.txt
@@ -1,8 +1,8 @@
 &Vidiaquam
 
 # Incipit
-!El sacerdote, postrándose al pie del altar, se hace el Signo de la Cruz de la frente al pecho, y dice: 
-v. En el nombre del Padre, + del Hijo, y del Espíritu Santo. Amén.
+!El sacerdote al pie del altar, hecha la debida reverencia, se santigua con la señal de la cruz desde la frente hasta el pecho, y dice en voz clara:
+v. En el nombre del Padre, + y del Hijo, y del Espíritu Santo. Amén.
 
 !*D
 !En las Misas de Difuntos y desde el Domingo de Pasión hasta el Sábado Santo exclusivamente, este salmo se omite.
@@ -28,7 +28,7 @@ M. Al Dios que alegra mi juventud.
 !El sacerdote, haciendo sobre sí el Signo de la Cruz, dice:
 S. Nuestro auxilio + es el nombre del Señor.
 M. Que ha hecho el cielo y la tierra.
-!Ahora, uniendo las manos y postrándose con humildad, dice el Yo Confieso:
+!Seguidamente, uniendo las manos y profundamente inclinado, dice el Yo Confieso:
 S. Yo pecador me confieso a Dios todopoderoso, a la bienaventurada siempre Virgen María, al bienaventurado San Miguel Arcángel, al bienaventurado San Juan Bautista, a los santos Apóstoles San Pedro y San Pablo, a todos los Santos y a vos, Padre, que pequé mucho con el pensamiento, palabra y obra; (dándose en el pecho tres veces) por mi culpa, por mi culpa, por mi grandísima culpa. Por tanto, ruego a la bienaventurada siempre Virgen María, al bienaventurado San Miguel Arcángel, al bienaventurado San Juan Bautista, a los Santos Apóstoles San Pedro y San Pablo, a todos los Santos y a vos, Padre, que roguéis por mí a Dios Nuestro Señor.
 M. Dios Todopoderoso tenga misericordia de vosotros y, perdonados vuestros pecados, os lleve a la vida eterna. 		
 !El sacerdote contesta: 
@@ -42,7 +42,7 @@ M. Amén.
 S. El Señor omnipotente y misericordioso nos conceda el perdón, + la absolución y remisión de nuestros pecados.
 M. Amén. 	
 
-!Postrándose, sigue:
+!Inclinado, prosigue:
 S. Dios mío, volviéndoos a nosotros, nos daréis vida.
 M. Y vuestro pueblo se alegrará en Vos.
 S. Señor, muéstranos tu misericordia. 	
@@ -54,7 +54,7 @@ M. Y con tu espíritu.
 !Extendiendo y uniendo las manos, el sacerdote dice en alto: «Oremos». Ahora, al ascender al altar, dice en voz baja:
 v. Oremos
 v. Os rogamos, Señor, que apartéis de nosotros nuestras iniquidades, para que podamos entrar con pureza en el Santo de los santos. Por Jesucristo Nuestro Señor. Amén. 	
-!Con las manos unidas, y postrándose ante el altar, el sacerdote dice:
+!Inclinado y con las manos unidas sobre el altar, el sacerdote dice:
 v. Señor, os suplicamos por los méritos de vuestros Santos cuyas reliquias están aquí (besa el altar) y de todos los Santos, que os dignéis perdonarme todos mis pecados. Amén.
 
 !*S 	
@@ -70,7 +70,7 @@ Que te bendiga + Aquel en cuyo honor eres quemado. Amén.
 &introitus
 
 # Kyrie
-!El sacerdote, en medio del altar, dice, alternando con el ministro:
+!El sacerdote, en el centro del altar, dice, alternando con el ministro:
 S. Señor, ten piedad.
 M. Señor, ten piedad.
 S. Señor, ten piedad.
@@ -83,7 +83,7 @@ S. Señor, ten piedad.
 
 !! Gloria
 !*&GloriaM
-!Después, en medio del altar, extendiendo y uniendo las manos y postrándose ligeramente, el sacerdote dice -excepto en Cuaresma, Adviento y en las Misas de Difuntos- el Gloria. Cuando dice las palabras: «os adoramos», «os damos gracias», «Jesucristo» y «recibid nuestra súplica» se postra, y al final se hace el Signo de la Cruz de la frente al pecho:
+!Después, en el centro del altar, extendiendo y uniendo las manos e inclinando ligeramente la cabeza, el sacerdote dice -excepto en Cuaresma, Adviento y en las Misas de Difuntos- el Gloria. Cuando dice las palabras: «os adoramos», «os damos gracias», «Jesucristo» y «recibid nuestra súplica» inclina la cabeza, y al final se hace el Signo de la Cruz de la frente al pecho:
 v. Gloria a Dios en las alturas, y en la tierra paz a los hombres de buena voluntad. Os alabamos. Os bendecimos. Os adoramos. Os glorificamos. Os damos gracias por vuestra grande gloria. Señor, Dios, Rey de los cielos, Dios Padre omnipotente. Señor, Hijo Unigénito, Jesucristo. Señor Dios, Cordero de Dios, Hijo del Padre. Vos que quitáis los pecados del mundo, compadeceos de nosotros. Vos que quitáis los pecados del mundo, recibid nuestra súplica. Vos que estáis sentado a la diestra del Padre, compadeceos de nosotros. Porque Vos solo sois Santo. Vos solo sois el Señor. Vos solo sois el Altísimo, Jesucristo. Con el Espíritu Santo, + en la gloria de Dios Padre. Amén.	
 
 # Colecta
@@ -114,7 +114,7 @@ M. Y con tu espíritu.
 
 !*RnD
 # Evangelio
-!El Misal es trasladado al otro lado del altar. En las Misas Ordinarias, el sacerdote, postrándose en medio del altar, con las manos unidas, dice:
+!El Misal es trasladado al otro lado del altar. En las Misas Ordinarias, el sacerdote, inclinándose en el centro del altar, con las manos unidas, dice:
 v. Purificad mi corazón y mis labios, Dios omnipotente, que purificasteis los labios del Profeta Isaías con un carbón encendido, dignaos por vuestra bondad purificarme, a fin de que pueda dignamente anunciar vuestro Santo Evangelio. Por Jesucristo Nuestro Señor. Amén. 	
 v. Bendecidme, Señor. El Señor esté en mi corazón y en mis labios para anunciar dignamente y como es debido su santo Evangelio. Amén. 	
 !  
@@ -195,7 +195,7 @@ v. Lavaré mis manos entre los inocentes y estaré, oh Señor, alrededor de vues
 !*nD
 &Gloria
 
-!Postrándose en medio del altar, el sacerdote, con las manos unidas, dice:
+!En el centro del altar, el sacerdote, ligeramente inclinado y con las manos unidas, dice:
 v. Recibid, oh Santa Trinidad, esta oblación que os ofrecemos en memoria de la Pasión, Resurrección y Ascensión de nuestro Señor Jesucristo; y en honor de la Bienaventurada siempre Virgen María y de San Juan Bautista y de los Santos Apóstoles Pedro y pablo, y de éstos y de todos los Santos, para que a ellos les ceda en honor y a nosotros en salud, y ellos en los cielos se dignen interceder por nosotros que celebramos su memoria en la tierra. Por el mismo Jesucristo nuestro Señor. Amén.
 
 !El sacerdote besa el altar y, volviéndose al pueblo, le invita a orar extendiendo y uniendo sus manos, diciendo:
@@ -210,7 +210,7 @@ _
 &secreta
 
 # Prefacio
-!El sacerdote comienza el prefacio, una llamada de acción de gracias a Dios Padre por Jesucristo, en unión con todos los espíritus celestiales. La oración de acción de gracias difiere para las Fiestas importantes. El sacerdote comienza el prefacio poniendo las manos sobre el altar:
+!El sacerdote comienza el prefacio, una llamada de acción de gracias a Dios Padre por Jesucristo, en unión con todos los espíritus celestiales. La oración de acción de gracias difiere para las Fiestas importantes. El sacerdote comienza el prefacio poniendo las manos sobre el altar. Las eleva ligeramente al decir «Arriba los corazones». Une las manos ante el pecho e inclina la cabeza al decir «Demos gracias al Señor, Dios nuestro». Luego separa las manos y las mantiene separadas hasta el final del prefacio. Terminado este, las junta de nuevo e inclinado dice «Santo». Y cuando dice «Bendito el que viene», hace sobre sí el Signo de la Cruz.
 S. El Señor esté con vosotros. 	
 M. Y con tu espíritu. 	
 S. Arriba los corazones. 	
@@ -367,13 +367,13 @@ v. Vuestro Cuerpo, Señor, que acabo de recibir y vuestra Sangre, que acabo de b
 &communio
 
 # Poscomunión
-!Volviendo al medio del altar y al pueblo, el Sacerdote dice:
+!Volviendo al centro del altar y al pueblo, el Sacerdote dice:
 S. El Señor esté con vosotros.
 M. Y con tu espíritu.
 &postcommunio
 
 # Conclusión
-!Inclinado el Sacerdote en medio del altar, dice:
+!Inclinado el Sacerdote en el centro del altar, dice:
 S. El Señor esté con vosotros.
 M. Y con tu espíritu.	
 


### PR DESCRIPTION
The Spanish translation of the Ordo rubrics contains some elements that could be improved:

- The expressions "facta illi debita reverentia", "profunde inclinatus", "inclinatus", and "inclinat caput" are translated as "postrándose" ("prostrating"), which is incorrect.
- The phrase "en medio del altar" would be clearer if rendered as "en el centro del altar" ("in the center of the altar").
- The rubric for the Preface is not fully translated.