### PR TITLE
Cist: Visitatio B.M.V. + Czech + bugfixes

### DIFF
--- a/web/cgi-bin/horas/specials/orationes.pl
+++ b/web/cgi-bin/horas/specials/orationes.pl
@@ -415,7 +415,7 @@ sub oratio {
 
           if ($cr[0] =~ /Vigilia Epi|$sundaystring/i) {
             $key =
-              ($version !~ /trident/i || $version =~ /altovadensis/i || ($version =~ /1906/ && $cr[2] > 5))
+              ($version !~ /trident/i || ($version =~ /1906/ && $cr[2] > 5))
               ? 7000
               : 2900;    # under DA, all Sundays, in 1906, priviliged Sundays, are all privilegded commemorations
           } else {

--- a/web/www/horas/Bohemice/Sancti/07-01.txt
+++ b/web/www/horas/Bohemice/Sancti/07-01.txt
@@ -313,7 +313,7 @@ Bude vám krev Beránkova * na znamení, praví Pán; a když uvidím krev, pře
 Thou, who redeemed us with your blood.
 
 [Lectio Prima]
-!Heb 9:19-20
+!Žid 9:19-20
 v. Neboť když Mojžíš ohlásil celému shromáždění všechna nařízení Zákona, vzal yzop se šarlatovou vlnou a pokropil jak knihu samu, tak všechen lid krví telat a kozlů smíchanou s vodou a řekl: 'Toto je krev smlouvy, kterou s vámi uzavřel Bůh'.
 
 [Responsory Tertia]
@@ -328,7 +328,7 @@ V. Krev Ježíše Krista, Syna Božího.
 R. Očistí nás od každého hříchu.
 
 [Capitulum Sexta]
-!Heb 9:13-14
+!Žid 9:13-14
 v. Jestliže už samo pokropení krví kozlů, býků a popel z jalovice posvěcuje ty, kteří jsou nečistí, k čistotě těla, čím spíše krev Krista, který skrze věčného Ducha sám sebe přinesl Bohu jako oběť bez poskvrny, očistí naše svědomí od mrtvých skutků, abychom mohli sloužit Bohu živému.
 $Deo gratias
 

--- a/web/www/horas/Bohemice/Sancti/07-02.txt
+++ b/web/www/horas/Bohemice/Sancti/07-02.txt
@@ -9,7 +9,8 @@ Požehnaná jsi * mezi ženami, a požehnaný plod života tvého.;;126
 Jakmile se ozval * hlas tvého pozdravení v mých uších, zajásalo nemluvně v mém lůně, alleluja.;;147
 
 [Responsory Vespera 1] (rubrica cisterciensis)
-Responsorium. Velebí duše má Hospodina a můj duch jásá v Bohu, mém spasiteli, * že se sklonil ke své služebnici v jejím ponížení. 
+R. Velebí duše má Hospodina a můj duch jásá v Bohu, mém spasiteli, 
+* že se sklonil ke své služebnici v jejím ponížení. 
 V. Hle, od této chvíle budou mne blahoslavit všechna pokolení.
 R. Že se sklonil ke své služebnici v jejím ponížení. 
 
@@ -32,7 +33,9 @@ Všemohoucí věčný Bože, jenž jsi z přemíry lásky blaženou Pannu Marii 
 $Per eumdem
 
 [Invit]
-Let us keep holiday for the Visitation of the Virgin Mary. * Let us worship Christ, her Son, and her Lord and ours.
+Navštívení Panny Marie oslavujme; * Klaňme se Kristu, jejímu Synu, Hospodinu.
+(sed rubrica cisterciensis)
+Zdrávas Maria, milostiplná, Pán s tebou. * Požehnaná jsi mezi ženami.
 
 [Lectio1]
 Z Písně Písní
@@ -77,29 +80,21 @@ R. A jak se to stalo, že matka mého Pána ke mě přišla?
 R. A jak se to stalo, že matka mého Pána ke mě přišla?
 
 [Lectio4]
-From the Sermons of St. John Chrysostom, Patriarch of Constantinople
-!In Metaphrast. July
-As soon as our Redeemer was come among us, He went with haste, while as yet He was in His mother's womb, to visit His friend John. And John, in the one womb, becoming conscious of the Presence of Jesus in the other womb, dashed himself impatiently against the narrow walls of his natural prison, as though crying out: I see the very Lord who hath given nature her bounds, and I wait not for the due season of my birth. There is no need for me to linger here till nine months are ended, for He That is Eternal is with me! I will break out of my dark cell; I will proclaim my full knowledge of many wonders. I am the sign. I will show that the Christ is here. I am the trumpet; let me peal forth the news that the Son of God is come in the flesh. Let me give my trumpet-note, let me bless my father's tongue, and make it to speak again. Let me give my trumpet-note, let me quicken my mother's womb.
+Řeč svatého Jana Zlatoústého.
+!U Metafrasí Měsíce července.
+Když k nám přicházel Spasitel lidského rodu, objevil se náhle u svého přítele Jana, když byl ještě v matčině lůně. Když jej ještě v děloze uviděl Jan, který byl také ještě v děloze, opřel se o stěny svého přirozeného žaláře a zvolal: „Vidím Pána, který dal přírodě její zákony a nemůžu se již dočkat času narození. Není třeba, abych zde byl devět měsíců, zde je se mnou ten, který je věčný. Chci vyjít z tohoto temného příbytku a provolávat všechno, co vím o těchto podivuhodných věcech.“ Jsem znamení: předznamenávám Kristův příchod. Jsem polnice: ohlašuji narození Syna Božího v těle. Nechte mě rozeznít polnici, abych jím samotným požehnal otcovské jazyky, a ji dlouze rozezněl, aby promluvila. Nechť zazní polnice, a oživím mateřské lůno.
 
 [Responsory4]
-R. Behold, he cometh leaping upon the mountains, skipping upon the hills;
-* My beloved is like a gazelle or a young roe-buck!
-V. He rejoiceth as a giant to run his course, his going-forth is from the end of the heavens.
-R. My beloved is like a gazelle or a young roe-buck!
+R. Hle, on přichází, a skáče přes hory, přeskakuje pahorky;
+* Podoben je můj miláček gazele, i mladému jelínku.
+V. Zajásal jako obr, když vybíhá na cestu, a vychází z nejvyššího nebe.
+R. Podoben je můj miláček gazele, i mladému jelínku.
 
 [Lectio5]
-Thou seest, O beloved, how new and how strange a mystery is here! John is not born, but by leaping he speaketh; he is yet unseen, and he giveth warning; he is not yet able to cry, but by his acts he is heard. He draweth not yet the breath of life, but he preacheth God. he seeth not yet the light, but he maketh known the Sun! He is not come out of the womb, but he hasteth to play the Fore-runner in the Presence of the Lord. He cannot restrain himself; he rebelleth against the bounds set by nature, and struggleth to break out of the prison of the belly. His longing is to herald the coming Saviour. He saith, as it were: Behold, the Deliverer cometh and am I to remain still bound to abide here? The Word cometh, that He may set right all things and am I still to tarry in prison? I will go forth. I will run before Him, and cry aloud to all men: “Behold the Lamb of God Which taketh away the sin of the world.”
-
-[Responsory5]
-R. Rejoice with me, rejoice with me, all ye that love the Lord, for, while I was~
-yet a little one, I pleased the Most High,
-* And I have brought forth from my bowels God and man.
-V. All generations shall call me blessed, for God hath regarded the low estate~
-of His hand-maiden.
-R. And I have brought forth from my bowels God and man.
+Vidíš, můj milovaný, jak nové a podivuhodné tajemství to je. Ještě se nenarodil a už kopáním mluví. Ještě se neobjevil a již varuje. Ještě mu není dovoleno křičet a již mluví svými skutky. Ještě nevstoupil do života a již káže o Bohu. Ještě neuzřel světlo a již poukazuje na slunce. Nedokáže se totiž udržet v Pánově přítomnosti, nedokáže již snést přirozené omezení matčina lůna, ale snaží se prolomit žalář jejího nitra a dělá vše pro to, aby poukázal na příchod Spasitele. He saith, as it were: Behold, the Deliverer cometh and am I to remain still bound to abide here? The Word cometh, that He may set right all things and am I still to tarry in prison? I will go forth. I will run before Him, and cry aloud to all men: “Behold the Lamb of God Which taketh away the sin of the world.”
 
 [Lectio6]
-But do thou tell us, O John, how it came to pass that while thou wast still in the darkness of thy mother's womb, thou didst see and hear? How didst thou behold the things of God? How didst thou leap and bound for joy? Great, saith John, is the mystery of that which taketh place here, far from the understanding of men are these doings. It is meet that I should do a new thing in nature for the sake of Him Who is making new things which are beyond nature. I see in the womb, because I see the Sun of righteousness in a womb. I hear, because I am coming as the herald of the Great Word. I cry out, because I espy the Only-begotten Son of the Father clad in Flesh. I bound for joy, because I see that He by Whom all things were made, hath taken upon Him the form of a servant. I leap, because I think of the Redeemer of the world being made Flesh. I run before His coming, and herald His approach unto you with this, as it were, my confession.
+Avšak řekni nám, Jane, když uzavřen jsi ještě v temné matčino lůno, jakpak můžeš vidět a slyšet? Jak můžeš nahlížet božské věci? Jak můžeš skákat a jásat? Veliké jest, praví, to tajemství, které se zde odehrává, a tyto skutky vzdáleny jsou lidskému chápání. Po zásluze dělám nové, avšak přirozené věci kvůli tomu, který také bude dělat nové věci, avšak nadpřirozené. Vidím, i když jsem ještě v děloze, neboť jsem v děloze jeho matky viděl, že nosí slunce spravedlnosti. Mé uši slyší, neboť se rodím jako hlas velikého Slova. Zvolal jsem, protože jsem hleděl na jednorozeného Syna Otce, oděného v těle. Jásám, neboť vidím stvořitele světa, kterak přijímá podobu člověka. Vyskakuji radostí, neboť poznávám vtěleného Spasitele světa. Přijdu ještě před jeho příchodem a svým způsobem jej ještě před vámi budu vyznávat.
 
 [Responsory6]
 R. Blessed art thou that hast believed, for there shall be a performance of those things which were told thee from the Lord. And Mary said:
@@ -110,13 +105,13 @@ R. My soul doth magnify the Lord.
 R. My soul doth magnify the Lord.
 
 [Lectio7]
-From the Holy Gospel according to Luke
-!Luke 1:39-47
-And Mary arose in those days and went into the hill-country with haste, into a city of Judah. And entered into the house of Zacharias, and saluted Elizabeth. And so on.
+Čtení svatého Evangelia podle Lukáše
+!Lukáš 1:39-47
+Za onoho času Maria vstala a ve spěchu odešla do hor, do města Judova. A vešla do domu Zachariášova a pozdravila Alžbětu. A ostatní.
 _
-Homily by St. Ambrose, Bishop of Milan
-!Bk. ii Comm. on Luke i
-We must here consider that the greater cometh unto the lesser, Mary unto Elizabeth, Christ unto John. And again afterwards, to hallow the baptism of John, the Lord came unto him to be baptized. It was soon that the blessings of the coming of Mary and of the Presence of God were made manifest. Have regard here to the distinction made, and to the special weight of every word. Elizabeth was the first to hear the voice of Mary's salutation, but John was the first to receive grace. She heard naturally, but he leaped mystically. She hailed the coming of Mary, he that of the Lord, Mary and Elizabeth spake words full of grace, but Jesus and John worked, and commenced their mystery of godliness from their mothers' beginnings, and so by twin miracles the mothers prophesied from the spirit of their unborn offspring. The babe leaped, and the mother was filled with the Holy Ghost. The mother was not filled before the son, but when the son was filled with the Holy Ghost, he filled his mother also.
+Homilie svatého Ambrože Biskupa.
+!Kniha 2. Komentářů na Lukáše.
+Je třeba, abychom si uvědomili, že větší přišli k menším, aby jim pomohli, Maria k Alžbětě a Kristus k Janovi. Zajisté také po nějakém čase přišel Pán k Janovu křtu, aby tento křest posvětil. Příchod Mariin a následná dobra spojená s božskou přítomností se tedy rychle ukázala. Pohleď tedy na ten rozdíl a vlastnosti jednotlivých slov. Alžběta nejprve uslyšela Mariin hlas, Jan však nejprve pocítil milost. Alžběta jej přirozeným způsobem uslyšela, Jan tajemným způsobem zajásal. Alžběta pocítila příchod Mariin, Jan příchod Páně. Alžběta s Marií mluví o milosti, Pán s Janem uvnitř působí a zbožné tajemství ozdobí mateřskými slovy. Ve dvojnásobném zázraku tak matky prorokují prorockým duchem svých synů. Zajásal syn, radostí byla naplněna matka. Matka však není naplněna radostí dříve než její syn. Když však byl syn naplněn Duchem svatým, ten pak naplnil i matku.
 
 [Responsory7]
 R. All generations shall call me blessed,
@@ -127,7 +122,7 @@ R. For the Lord, That is mighty, hath done to me great things, and holy is His~
 Name.
 
 [Lectio8]
-And whence is this to me, that the Mother of my Lord should come to me? That is to say, How cometh it to pass that so great a good should befall me, as that the Mother of my Lord should come to me I feel the miracle, I acknowledge the mystery: the Mother of my Lord, pregnant with the Word, is full of God. And Mary abode with her about three months, and returned to her own house. It is meet to record how Mary showed this kindness, and abode this mystic number of months.
+„A jak se mi to stalo, že Matka mého Pána přichází ke mně?“ To znamená: jak se stalo, že tak veliké dobro se mi přihodilo, že Matka mého Pána přichází ke mně? Vidím zázrak, cítím však tajemství. Matka Páně nosí Slovo, Bohem je naplněna. Maria s ní zůstala po tři měsíce a navrátila se do svého domu. Dobře je zde ukázáno, že svatá Maria splnila svou povinnost a zachovala tento tajemný počet měsíců.
 
 [Responsory8]
 R. O Holy Virgin Mary, happy indeed art thou, and right worthy of all praise,
@@ -138,7 +133,7 @@ R. For out of thee rose the Sun of righteousness.
 R. Even Christ our God.
 
 [Lectio9]
-She tarried long, not only for friendship's sake, but also for the good of the Great Prophet. For if the first coming of Mary so blessed him, that even as a babe in the womb he leapt for joy, and his mother was filled with the Holy Ghost, what blessedness must we not deem to have flowed upon him from so long neighbourhood of Mary. Thus was the Prophet anointed, and trained by exercise like a strong wrestler, in his mother's womb, for his sinews were being braced for a hard battle.
+To, jak dlouho zůstala, není pouze z důvodu jejich příbuznosti, ale také výrok velikého Věštce. Neboť pokud se hned při prvním setkání přihodil takový úkaz, že na pozdrav Mariin zajásalo nemluvně v lůně matky, a matka tohoto nemluvněte byla naplněna duchem svatým, jaký jiný důvod by pak měla mít právě taková doba Mariiny přítomnosti? Byl tedy pomazán, a jako dobrý atlet trénoval Prorok v lůně matky; jeho síla totiž byla připravena k té nejtěžší bitvě.
 &teDeum
 
 [Lectio93]
@@ -179,7 +174,7 @@ v. Hle, on přichází, běží po horách, skáče po pahorcích. Můj miláče
 $Deo gratias
 
 [Ant 2]
-When Elizabeth heard the salutation * of Mary, she spoke out with a loud voice and said: Whence is this to me, that the Mother of my Lord should come to me, alleluia.
+Když uslyšela * Alžběta Mariino pozdravení, zvolala hlasem velikým a řekla: Jak se mi to stalo, že přichází Matka mého Pána ke mně, alleluja.
 
 [Ant 2] (rubrica cisterciensis)
 Pochválen * buď Hospodin, Bůh Israele, protože navštívil a vykoupil svůj lid, jak mluvil ústy svatých.
@@ -198,7 +193,7 @@ $Deo gratias
 R.br. Navštívení tvé, * Boží Rodičko a Panno.
 R. Navštívení tvé, * Boží Rodičko a Panno.
 V. Radost zvěstovalo celému světu. 
-R.br. Boží Rodičko a Panno.
+R. Boží Rodičko a Panno.
 
 [Ant 3] (rubrica cisterciensis)
 Veleb * Pána celý rod věrných, zazni ladnou chválou zástupe Andělů na Mariinu radost.

--- a/web/www/horas/Bohemice/Sancti/11-23cc.txt
+++ b/web/www/horas/Bohemice/Sancti/11-23cc.txt
@@ -1,4 +1,4 @@
-[Rank]
+[Officium]
 sv. Felicity, Mučednice
 
 [Oratio]

--- a/web/www/horas/Bohemice/SanctiM/07-02.txt
+++ b/web/www/horas/Bohemice/SanctiM/07-02.txt
@@ -1,0 +1,142 @@
+[Ant Matutinum 3N]
+Nastalo totiž * Navštívení přesvaté Panny, jež zrozena z královského rodu zrodila Krista, Krále a Hospodina: † ona ať se přimlouvá za nás.
+(sed rubrica cisterciensis)
+Raduj se, * Matko Kristova, jež sis v jedinečné výsadě zasloužila nosit Krista Pána.
+
+[Responsory2] (rubrica cisterciensis)
+R. Hle, můj miláček ke mně mluví; 
+* Uvnitř mého srdce se ozývá jeho hlas.
+V. Jak sladké jsou mým ústům tvá slova, Hospodine, nad med v mých ústech.
+R. Uvnitř mého srdce se ozývá jeho hlas.
+
+[Responsory3] (rubrica cisterciensis)
+R. Pospíším si na horu myrrhy, a uzřím to slovo,
+* Jež zaznělo v mých uších od Anděla, který mě pozdravil.
+V. Běžela jsem po cestě tvých přikázání, vedle tvého slova.
+R. Jež zaznělo v mých uších od Anděla, který mě pozdravil.
+
+[Responsory4_]
+R. Velebí duše má Hospodina; a zajásal můj duch v Bohu, mém spasiteli,
+* Neboť shlédl na nepatrnost své služebnice.
+V. Ejhle, od této chvíle mě budou blahoslavit všechna pokolení.
+R. Neboť shlédl na nepatrnost své služebnice.
+
+[Responsory4C]
+R. Hlas hrdličky je slyšet, vstaň, pospěš, má přítelkyně, a přijď, má holubičko, ve skalním výklenku, v otvoru ve zdi.
+* Ukaž mi svou tvář, ať zazní tvůj hlas v mých uších.
+V. Tvůj hlas je totiž sladký, a tvá tvář krásná.
+R. Ukaž mi svou tvář, ať zazní tvůj hlas v mých uších.
+
+[Responsory4]
+@:Responsory4_
+(sed rubrica cisterciensis)
+@:Responsory4C
+
+[Lectio5]
+@Sancti/07-02:Lectio4
+(sed rubrica cisterciensis)
+@Sancti/07-02:Lectio4:s/Jsem znamení.*//
+
+[Lectio6]
+@Sancti/07-02:Lectio5
+(sed rubrica cisterciensis)
+@Sancti/07-02:Lectio5:s/(příchod Spasitele\.).*/$1/
+
+[Lectio7]
+@Sancti/07-02:Lectio6:s/Vidím, .*//s
+
+[Lectio8]
+@Sancti/07-02:Lectio6:s/.* Vidím, /Vidím, /s
+
+[Responsory6] (rubrica cisterciensis)
+R. Šťastné matky, ale děti jsou ještě šťastnější;
+* I ty, jež nosily štěstí, se staly šťastnými.
+V. Šťastný je dům, šťastná rodina, kterým se staly tak podivuhodné věci.
+R. I ty, jež nosily štěstí, se staly šťastnými.
+
+[Responsory7] (rubrica cisterciensis)
+R. Ó, dni hodný každého připomenutí! Ó, dni hodný nejvyšší úcty!
+* Neboť v tak ubohém dni zazářily radosti světu.
+V. Toto je den, který učinil Hospodin, jásejme a radujme se v něm.
+R. Neboť v tak ubohém dni zazářily radosti světu.
+
+[Responsory8]
+R. Hódie visitávit Elízabeth beáta Virgo María ex progénie David; † per quam salus mundi credéntibus appáruit,
+* Cujus vita gloriósa lucem dedit sǽculo.
+V. Beatíssimæ Vírginis Maríæ Visitatiónem devotíssime celebrémus.
+R. Cujus vita gloriósa lucem dedit sǽculo.
+
+[Responsory8] (rubrica cisterciensis)
+R. Ó, přejasná hvězdo mořská, Panno Matko jedinečná, jež's svou tetu navštívila, Jana sladce osvítila svým přejasným děťátkem;
+* Tě prosíme v tomto svátku, buď útěchou ve všem smutku, smrt odežeň a život dej nám v nebes věčné vlasti.
+V. K tobě lkají všichni hříšní, štědrá dárkyně nadějí, prameni, jenž nevyschne.
+R. Tě prosíme v tomto svátku, buď útěchou ve všem smutku, smrt odežeň a život dej nám v nebes věčné vlasti.
+
+[Lectio9]
+@Sancti/07-02:Lectio7:s/Alžběta jej.*//s
+(sed rubrica cisterciensis)
+@Sancti/07-02:Lectio7:s/Pohleď tedy.*//s
+
+[Responsory9]
+@Sancti/07-02:Responsory7
+
+[Lectio10]
+@Sancti/07-02:Lectio7:s/.* Alžběta jej/Alžběta jej/s
+(sed rubrica cisterciensis)
+@Sancti/07-02:Lectio7:s/.*(Pohleď tedy)/$1/s s/Zajásal syn.*//s
+
+[Responsory10]
+@Sancti/07-02:Responsory8
+
+[Lectio11]
+@Sancti/07-02:Lectio8
+
+[Lectio11] (rubrica cisterciensis)
+@Sancti/07-02:Lectio7:s/.*(Zajásal syn)/$1/s s/$/~/
+@Sancti/07-02:Lectio8:s/Maria s ní zůstala.*//s
+
+[Responsory11]
+R. S radostí oslavujme Navštívení svaté Panny Marie,
+* Aby se sama za nás přimlouvala u Pána Ježíše Krista.
+V. Navštívení slavné Panny Marie předůstojně připomínejmne.
+R. Aby se sama za nás přimlouvala u Pána Ježíše Krista.
+
+[Responsory11] (rubrica cisterciensis)
+@:Responsory4_
+
+[Lectio12]
+@Sancti/07-02:Lectio9
+
+[Lectio12] (rubrica cisterciensis)
+@Sancti/07-02:Lectio8:s/.*(Maria s ní zůstala)/$1/s s/$/~/
+@Sancti/07-02:Lectio9:s/Byl tedy pomazán.*//
+
+[Responsory9] (rubrica cisterciensis)
+R. Krásné dívky hromadící bohatství,
+* Pokladem těhotného lůna překonala Matka Páně.
+V. Jásejte a chvalte, obyvatelé Sionu, neboť ten veliký uprostřed vás je Svatý Israele.
+R. Pokladem těhotného lůna překonala Matka Páně.
+
+[Responsory10] (rubrica cisterciensis)
+R. Řekla však Maria: Veliké věci mi učinil ten, který je mocný. 
+* A svaté jest jeho jméno.
+V. A milosrdenství jeho od pokolení do pokolení k těm, kdo se ho bojí.
+R. A svaté jest jeho jméno.
+
+[Responsory12]
+R. Svaté a neposkvrněné Panenství, nevím, jaké ti mohu snést chvály! 
+* Neboť toho, jehož nebesa pojmouti nesmohla, jsi nosila ve svém klíně.
+V. Požehnaná ty mezi ženami, a požehnaný plod života tvého.
+R. Neboť toho, jehož nebesa pojmouti nesmohla, jsi nosila ve svém klíně.
+
+[Responsory12] (rubrica cisterciensis)
+R. Ujal se svého služebníka Israele, pamětliv svého milosrdenství,
+* Jež slíbil našim otcům, Abrahamovi a jeho potomkům navěky.
+V. Přísahal Hospodin Davidovi vpravdě, <i>Syna</i> z plodu tvého lůna posadím na tvůj trůn.
+R. Jež slíbil našim otcům, Abrahamovi a jeho potomkům navěky.
+
+[Commemoratio 2] (rubrica cisterciensis)
+@Sancti/07-02cc:Oratio
+
+[Commemoratio 3] (rubrica cisterciensis nisi rubrica altovadensis)
+@Sancti/07-02oct:Oratio

--- a/web/www/horas/Bohemice/SanctiM/11-22.txt
+++ b/web/www/horas/Bohemice/SanctiM/11-22.txt
@@ -1,0 +1,2 @@
+[Rank]
+sv. Cecilie, Panny a Mučednice

--- a/web/www/horas/Bohemice/Tempora/Pent02-5.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent02-5.txt
@@ -29,3 +29,7 @@ i Duchu, jenž nás miluje,
 jichž moc a vláda nej vyšší
 přes věky nad vším kraluje.
 Amen.
+
+[Oratio3]
+Ochránče těch, kteří v tebe doufají, Bože, bez nějž nic není platné, nic svaté; rozmnož nad námi své milosrdenství; abychom tebou řízeni a vedeni tak prošli skrze dobra časná, abychom neztratili ta věčná.
+$Per Dominum

--- a/web/www/horas/Latin/Sancti/07-01.txt
+++ b/web/www/horas/Latin/Sancti/07-01.txt
@@ -119,6 +119,50 @@ Qui tenes beáta regna
 Cum Parénte et Spíritu.
 Amen.
 
+[Hymnus Matutinum] (rubrica cisterciensis)
+v. Ira justa Conditóris,
+Imbr[e] aquárum víndice,
+Criminósum mersit orbem
+No<i>ë</i> in arca sóspite:
+Mira tandem vis amóris
+Lavit orbem sánguine.
+_
+Tam salúbri terra felix
+Irrigáta plúvia,
+Ante spinas quæ scatébat,
+Germinávit flósculos;
+Inque néctaris sapórem
+Transiér[e] absýnthia.
+_
+Triste prótinus venénum
+Dirus anguis pósuit,
+Et cruénta belluárum
+Désiit ferócia:
+Mitis Agni vulneráti
+Hæc fuit victória.
+_
+O sciéntiæ supérnæ
+Altitúd[o] impérvia!
+O suávitas benígni
+Prædicánda péctoris!
+Servus erat morte dignus,
+Rex luit pœn[am] óptimus.
+_
+Quando culpis provocámus
+Ultiónem júdicis,
+Tunc loquéntis protegámur
+Sánguinis præséntia;
+Ingruéntium malórum
+Tunc recédant ágmina.
+_
+Te redémptus laudet orbis
+Grata servans múnera,
+O salútis sempitérnæ
+Dux et Auctor ínclite,
+Qui tenes beáta regna
+Cum Parént[e] et Spíritu.
+Amen.
+
 [Ant Matutinum]
 Postquam consummáti sunt * dies octo, ut circumciderétur Puer, vocátum est nomen ejus Jesus.;;2
 Factus in agonía * prolíxius orábat, et factus est sudor ejus sicut guttæ sánguinis decurréntis in terram.;;3

--- a/web/www/horas/Latin/Sancti/07-02.txt
+++ b/web/www/horas/Latin/Sancti/07-02.txt
@@ -23,7 +23,8 @@ Benedícta * tu inter mulíeres, et benedíctus fructus ventris tui.;;126
 Ex quo facta est * vox salutatiónis tuæ in áuribus meis, exsultávit infans in útero meo, allelúja.;;147
 
 [Responsory Vespera 1] (rubrica cisterciensis)
-Responsorium.  Magníficat ánima mea Dóminum: et exsultávit spíritus meus in Deo, salutári meo. * Quia respéxit humilitátem ancíllæ suæ. 
+R.  Magníficat ánima mea Dóminum: et exsultávit spíritus meus in Deo, salutári meo. 
+* Quia respéxit humilitátem ancíllæ suæ. 
 V. Ecce enim ex hoc beátam me dicent omnes generatiónes.
 R. Quia respéxit humilitátem ancíllæ suæ. 
 
@@ -47,6 +48,8 @@ $Per eumdem
 
 [Invit]
 Visitatiónem Vírginis Maríæ celebrémus: * Christum ejus Fílium adorémus Dóminum.
+(sed rubrica cisterciensis)
+Ave María, grátia plena, Dóminus tecum. * Benedícta tu in muliéribus.
 
 [Lectio1]
 De Cánticis canticórum
@@ -159,7 +162,7 @@ Depósuit poténtes * de sede, et exaltávit húmiles.
 Esuriéntes implévit bonis * et dívites dimísit inánes.
 
 [Capitulum Laudes] (rubrica cisterciensis)
-!Cant. 2.
+!Cant. 2:8-9
 v. Ecce iste venit sáliens in móntibus, § transíliens colles: * símilis est diléctus meus cápreæ, hinnulóque cervórum.
 $Deo gratias
 
@@ -176,12 +179,12 @@ Benedíctus * Dóminus, Deus Israël, quia visitávit, et fecit redemptiónem pl
 @:Versum 1
 
 [Capitulum Sexta] (rubrica cisterciensis)
-!Cant. 2.
+!Cant. 2:10-12
 v. Surge, própera, amíca mea, colúmba mea, formósa mea, et veni. * Jam enim hiems tránsiit, § imber ábiit, et recéssit. * Flores apparuérunt in terra nostra, § tempus putatiónis advénit.
 $Deo gratias
 
 [Capitulum Nona] (rubrica cisterciensis)
-!Cant. 2.
+!Cant. 2:13
 v. Vox túrturis audíta est in terra nostra: § ficus prótulit grossos suos: * víneæ floréntes dedérunt odórem suum.
 $Deo gratias
 
@@ -189,7 +192,7 @@ $Deo gratias
 R.br. Visitátio tua, * Dei Génitrix Virgo.
 R. Visitátio tua, * Dei Génitrix Virgo.
 V. Gáudium annuntiávit univérso mundo. 
-R.br. Dei Génitrix Virgo.
+R. Dei Génitrix Virgo.
 
 [Ant 3] (rubrica cisterciensis)
 Magníficet * Dóminum totum genus fidélium, cóncrepet harmónica laude cohors Angélica in Maríæ gáudia.

--- a/web/www/horas/Latin/SanctiM/07-02.txt
+++ b/web/www/horas/Latin/SanctiM/07-02.txt
@@ -6,6 +6,8 @@ Doxology=Nat
 
 [Ant Matutinum 3N]
 Adest namque * Visitátio sacratíssime Vírginis, quæ ex regáli progénie génita génuit Christum Regem Dóminum: † ipsa intercédat pro peccátis nostris.
+(sed rubrica cisterciensis)
+Gaude María * Mater Christi, quæ singulári privilégio meruísti portáre Christum Dóminum.
 
 [Lectio1]
 @Sancti/07-02:Lectio1:1-7 s/-7/-5/
@@ -20,20 +22,47 @@ Adest namque * Visitátio sacratíssime Vírginis, quæ ex regáli progénie gé
 [Lectio4]
 @Sancti/07-02:Lectio3
 
-[Responsory4]
+[Responsory2] (rubrica cisterciensis)
+R. En diléctus meus lóquitur mihi: 
+* Intra præcórdia mea dat vocem suam.
+V. Quam dúlcia fáucibus meis elóquia tua, Dómine, super mel ori meo.
+R. Intra præcórdia mea dat vocem suam.
+
+[Responsory3] (rubrica cisterciensis)
+R. Ibo ad montem myrrhæ festinánter, et vidébo verbum hoc,
+* Quod factum est in áuribus meis ab Angelo salutánte.
+V. Viam mandatórum tuórum cucúrri, juxta verbum tuum.
+R. Quod factum est in áuribus meis ab Angelo salutánte.
+
+[Responsory4_]
 R. Magníficat ánima mea Dóminum: † et exsultávit spíritus meus in Deo, salutári meo,
 * Quia respéxit humilitátem ancíllæ suæ.
 V. Ecce enim ex hoc beátam me dicent omnes generatiónes.
 R. Quia respéxit humilitátem ancíllæ suæ.
 
+[Responsory4C]
+R. Vox túrturis audíta est, surge, própera, amíca mea, et veni, colúmba mea, in foramínibus petræ, in cavérna macériæ.
+* Osténde mihi fáciem tuam, sonet vox tua in áuribus meis.
+V. Vox enim tua dulcis, et fácies tua decóra.
+R. Osténde mihi fáciem tuam, sonet vox tua in áuribus meis.
+
+[Responsory4]
+@:Responsory4_
+(sed rubrica cisterciensis)
+@:Responsory4C
+
 [Lectio5]
 @Sancti/07-02:Lectio4
+(sed rubrica cisterciensis)
+@Sancti/07-02:Lectio4:s/prædicábo cognitiónem.*//
 
 [Responsory5]
 @Sancti/07-02:Responsory4
 
 [Lectio6]
 @Sancti/07-02:Lectio5
+(sed rubrica cisterciensis)
+@Sancti/07-02:Lectio5:s/Accéssit, inquit,.*//
 
 [Responsory6]
 @Sancti/07-02:Responsory5
@@ -47,26 +76,52 @@ R. Quia respéxit humilitátem ancíllæ suæ.
 [Lectio8]
 @Sancti/07-02:Lectio6:s/.* Vídeo, /Vídeo, /s
 
+[Responsory6] (rubrica cisterciensis)
+R. Felíces matres, sed et nati felicióres:
+* Et quæ géssere felícia facta fuére.
+V. Felix domus, felix família, quibus sunt visa tot mirabília.
+R. Et quæ géssere felícia facta fuére.
+
+[Responsory7] (rubrica cisterciensis)
+R. O dies omni voto recolénda! o dies omni stúdio veneránda!
+* In qua tot mísero fulsérunt gáudia mundo.
+V. Hæc dies quam fecit Dóminus, exultémus et lætémur in ea.
+R. In qua tot mísero fulsérunt gáudia mundo.
+
 [Responsory8]
 R. Hódie visitávit Elízabeth beáta Virgo María ex progénie David; † per quam salus mundi credéntibus appáruit,
 * Cujus vita gloriósa lucem dedit sǽculo.
 V. Beatíssimæ Vírginis Maríæ Visitatiónem devotíssime celebrémus.
 R. Cujus vita gloriósa lucem dedit sǽculo.
 
+[Responsory8] (rubrica cisterciensis)
+R. O præclára stella maris, Virgo Mater singuláris, quæ cognátam visitásti, Joánnem illuminásti prole præclaríssima:
+* Te præcámur in hoc festo, sis solámen omni mœsto, fuga mortem, confer sortem nobis in cœli pátria.
+V. Ad te clamant omnes rei, larga datrix sanctæ spei, o fons indefíciens.
+R. Te præcámur in hoc festo, sis solámen omni mœsto, fuga mortem, confer sortem nobis in cœli pátria.
+
 [Lectio9]
 @Sancti/07-02:Lectio7:s/Illa natúræ.*//s
+(sed rubrica cisterciensis)
+@Sancti/07-02:Lectio7:s/Vide distinctiónem.*//s
 
 [Responsory9]
 @Sancti/07-02:Responsory7
 
 [Lectio10]
 @Sancti/07-02:Lectio7:s/.* Illa natúræ/Illa natúræ/s
+(sed rubrica cisterciensis)
+@Sancti/07-02:Lectio7:s/.*(Vide distinctiónem)/$1/s s/Exsultávit infans.*//s
 
 [Responsory10]
 @Sancti/07-02:Responsory8
 
 [Lectio11]
 @Sancti/07-02:Lectio8
+
+[Lectio11] (rubrica cisterciensis)
+@Sancti/07-02:Lectio7:s/.*(Exsultávit infans)/$1/s s/$/~/
+@Sancti/07-02:Lectio8:s/Mansit autem.*//s
 
 [Responsory11]
 R. Cum jucunditáte Visitatiónem sanctæ Maríæ celebrémus,
@@ -77,11 +132,36 @@ R. Ut ipsa pro nobis intercédat ad Dóminum Jesum Christum.
 [Lectio12]
 @Sancti/07-02:Lectio9
 
+[Lectio12] (rubrica cisterciensis)
+@Sancti/07-02:Lectio8:s/.*(Mansit autem)/$1/s s/$/~/
+@Sancti/07-02:Lectio9:s/Ungebátur ítaque.*//
+
+[Responsory9] (rubrica cisterciensis)
+R. Speciósas fílias cumulántes divítias,
+* Thesáuro ventris grávidi transcéndit Mater Dómini.
+V. Exúlta, et lauda, habitátio Sion, quia magnus in médio tui Sanctus Israël.
+R. Thesáuro ventris grávidi transcéndit Mater Dómini.
+
+[Responsory10] (rubrica cisterciensis)
+R. Ait autem María: Fecit mihi magna qui potens est: 
+* Et sanctum nomen ejus.
+V. Et misericórdia ejus, a progénie in progénies timéntibus eum.
+R. Et sanctum nomen ejus.
+
+[Responsory11] (rubrica cisterciensis)
+@:Responsory4_
+
 [Responsory12]
 R. Sancta et immaculáta virgínitas, † quibus te láudibus éfferam, néscio: 
 * Quia quem cæli cápere non póterant, tuo grémio contulísti.
 V. Benedícta tu in muliéribus, † et benedíctus fructus ventris tui.
 R. Quia quem cæli cápere non póterant, tuo grémio contulísti.
+
+[Responsory12] (rubrica cisterciensis)
+R. Suscépit Israël púerum suum, recordátus misericórdiæ suæ.
+* Sicut locútus est Ábraham, et sémini ejus in sæcula.
+V. Jurávit Dóminus David veritátem, de fructu ventris tui ponam super sedem tuam.
+R. Sicut locútus est Ábraham, et sémini ejus in sæcula.
 
 [Commemoratio 2] (rubrica cisterciensis)
 @Sancti/07-02cc:Oratio


### PR DESCRIPTION
Cistercian version:
- added Visitation of Our Lady (feast only, not the Octave yet)
- added Czech translation 
- fixed a few small errors

Program changes: 
- in `orationes.pl`, removed an exception for the Altovadensis version, that caused an incorrect order of commemorations in Vespers on 01-25-2025 (e.g.), where the commemoration of a Sunday after Epiphany preceded the commemoration of St. Alberich (MM. maj.), which is incorrect.