### PR TITLE
Cist: bugfixes

### DIFF
--- a/web/www/horas/Bohemice/SanctiM/03-21C.txt
+++ b/web/www/horas/Bohemice/SanctiM/03-21C.txt
@@ -49,7 +49,7 @@ Duchu vznešený, jeden Bože, po vše
 Amen.
 
 [Ant 1]
-Přesvatý * Vyznavači Páně, otče a vůcče Mnichů, Benedikte, přimlouvej se za naši spásu i za spásu všech.
+Přesvatý * Vyznavači Páně, otče a vůdče Mnichů, Benedikte, přimlouvej se za naši spásu i za spásu všech.
 
 [Oratio]
 Vzbuď, Pane, ve své Církvi Ducha, jemuž svatý Benedikt, Opat, sloužil: abychom, jím také naplněni, snažili se milovat, co on miloval, a skutky vykonávat to, co vyučoval.
@@ -74,7 +74,7 @@ Vznešený řádů našich Patriarcha,
 Isáka, Mojžíše i Abraháma, 
 V srdci svém spojil.
 _
-On sám ty, které světa bouře smetly,
+On sám ty, které bouře světa smetly,
 Zde zbožným pláčem k životu navrátil, 
 Mír pak z místa, kde strach býti nemůže,
 V pokoji přines'.
@@ -87,7 +87,7 @@ Amen.
 
 [Ant Matutinum] (nisi tempore paschali)
 Byl to muž ctihodného života, * milostí požehnaný <i>(Benedictus)</i> i jménem.;;1
-Od samého svého dětství * měl srdce starce, svůj věk převyšoval svým chováním, a nepodvolil svého ducha žádným potěšením.;;2
+Od samého svého dětství * měl srdce zkušené, svůj věk převyšoval svým chováním, a nepodvolil svého ducha žádným potěšením.;;2
 Dokud byl ještě na této zemi, * i na to, co ještě svobodně mohl používat, již shlížel jako na vyprahlý svět s květy.;;4
 Vzešel * z provincie Nursie, a v Římě, kam jej rodiče poslali, obdržel klasické vzdělání.;;5
 Opustil dům * i majetek otce, a v touze zalíbit se pouze Bohu, hledal hábit svatého obracení.;;8

--- a/web/www/horas/Latin/Sancti/01-15.txt
+++ b/web/www/horas/Latin/Sancti/01-15.txt
@@ -5,7 +5,7 @@ S. Pauli Primi Eremitæ et Confessoris
 ;;Duplex;;3;;vide C5
 (sed rubrica 1570 aut rubrica 1617)
 ;;Semiduplex;;2.2;;vide C5
-(sed rubrica 1930 aut rubrica 1963)
+(sed rubrica 1930 aut rubrica 1963 aut rubrica cisterciensis)
 ;;Memoria;;1.1;;vide C5
 
 [Rule]

--- a/web/www/horas/Latin/SanctiM/01-11.txt
+++ b/web/www/horas/Latin/SanctiM/01-11.txt
@@ -2,7 +2,7 @@
 
 [Rule]
 @SanctiM/01-07
-(die Baptismatis Domini)No secunda vespera
+(die Baptismatis Domini aut feria 7) No secunda vespera
 
 [Ant Matutinum]
 @Sancti/01-06:Ant Matutinum:8 s/;;\d+//

--- a/web/www/horas/Latin/SanctiM/03-21C.txt
+++ b/web/www/horas/Latin/SanctiM/03-21C.txt
@@ -101,7 +101,7 @@ Relícta domo * rebúsque patris, soli Deo placére cúpiens, † sanctæ conver
 Recéssit ígitur * sciénter nésciens, et sapiénter indóctus.;;10
 Hic ítaque * cum jam relíctis litterárum stúdiis pétere desérta decrevísset, nutrix quæ hunc árctius amábat, secúta est.;;14
 Prædícta * nutrix illíus ad purgándum tríticum a vicínis muliéribus præstári sibi capistérium pétiit, quod casu accidénte fractum est.;;20
-Compássus * nutríci oratiónem fudit Benedíctus puer cum láctymis, et capistérium reparávit.;;23
+Compássus * nutríci oratiónem fudit Benedíctus puer cum lácrymis, et capistérium reparávit.;;23
 Benedíctus Dei fámulus * magnum fecit miráculum, fudit preces ad Dóminum, et rejúnxit capistérium.;;63
 Huic, dum erémum péteret, * Románus mónarchus obviávit: cujus cum desidérium cognovísset, et secrétum ténuit, et adjutórium impéndit.;;64
 Cumque * in specu pósito submítti panem diábolus conspíceret, jactávit lápidem, et tintinábulum fregit.;;91

--- a/web/www/horas/Latin/SanctiM/07-13AV.txt
+++ b/web/www/horas/Latin/SanctiM/07-13AV.txt
@@ -2,7 +2,7 @@
 Beatarum Virginum et Martyrum Arausicanarum (1965)
 
 [Rank]
-;;Commemoratio;;1;;vide C6a
+;;Commemoratio;;1;;vide C6b
 
 [Oratio]
-@Commune/C6a:Oratio:s/N\. (et|a) N\.//
+@Commune/C6b:Oratio:s/N\. .* N\.//


### PR DESCRIPTION
Correction of typos and missed things.

@FAJ-Munich 
Could you please check, whether on Saturday January 11 in any monastic rite, the day within Epiphany Octave should have second Vespers? I trust you still have the rubrics fresh in mind... I checked the last week's changes and found that in Vespers on 1-11-2025 for the Altovadense version, the Commemoration of the Octave appears twice, and once (from the `SanctiM/01-11.txt` file) without the translation. This PR correct this, but it might introduce another problem...

BTW, for this day in the 1951 version, it doesn't show the commemoration of the Octave, which is in the `TemporaM?` file, which it should... In Vespers nor in Lauds.

Thank you, God bless!