### PR TITLE
Epub language and debian

### DIFF
--- a/docker/generator/Dockerfile
+++ b/docker/generator/Dockerfile
@@ -3,6 +3,7 @@ FROM        perl:5.28-slim as final
 LABEL maintainer="Stepan Srubar <breviarium@srubarovi.cz>"
 
 # Install packages
+FROM debian:latest
 RUN apt-get update && apt-get install -y \
     libcgi-session-perl \
     bsdmainutils \

--- a/standalone/tools/epubgen2/epubgen2.sh
+++ b/standalone/tools/epubgen2/epubgen2.sh
@@ -47,7 +47,7 @@ OPTIONS:
 
    -o PATH     The output directory. Defaults to "output".
 
-   -l LANG     The language for the left side if required. Defaults to Latin.
+   -l LANG     The language for the right side if required. Defaults to Latin.
                 Valid Values: Bohemice Dansk Deutsch English Espanol Francais Italiano Latin Latin-Bea Magyar Polski Polski-Newer Portugues
 
    -b LANG     The base language in which to display the office. Defaults to Latin.


### PR DESCRIPTION
Second language appears to the right. Without debian version called out it will assume buster (debian 10) which reached EOL 30 June 2024.