### PR TITLE
Upgrade Docker Base Image to perl:5.42-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/alpine:latest as gitinfo
+FROM public.ecr.aws/docker/library/alpine:latest AS gitinfo
 
 RUN apk add git
 COPY .git /build/
@@ -13,15 +13,15 @@ RUN echo "  \"branch\": \"`git rev-parse --abbrev-ref HEAD`\"" >> /build/buildin
 RUN echo "}" >> /build/buildinfo
 
 # Final container (copies in /out/buildinfo when done)
-FROM public.ecr.aws/docker/library/perl:5.28-slim as final
+FROM public.ecr.aws/docker/library/perl:5.42-slim AS final
 
 # Set envs
-ENV APACHE_RUN_USER www-data \
-    APACHE_RUN_GROUP www-data \
-    APACHE_LOCK_DIR /var/lock/apache2 \
-    APACHE_LOG_DIR /var/log/apache2 \
-    APACHE_PID_FILE /var/run/apache2/apache2.pid \
-    APACHE_SERVER_NAME localhost
+ENV APACHE_RUN_USER=www-data \
+    APACHE_RUN_GROUP=www-data \
+    APACHE_LOCK_DIR=/var/lock/apache2 \
+    APACHE_LOG_DIR=/var/log/apache2 \
+    APACHE_PID_FILE=/var/run/apache2/apache2.pid \
+    APACHE_SERVER_NAME=localhost
 
 # Install packages
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Also, fix a few linter errors in the `Dockerfile` around token case (`as` vs `AS`, etc) and setting env vars (`key var` vs `key=var`).

The key change of this PR is line 16, the rest are trivial linter errors.

Not ready for merge, needs further testing.