### PR TITLE
Cist: Epi1-0 (partially) et bugfixes

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -876,7 +876,7 @@ sub concurrence {
     || ($cwinner{Rank} =~ /C10/i && $winner{Rank} =~ /C1[01]/i)
 
     # no 1st Vespers of Easter after 1955
-    || ($version =~ /19(?:55|6)|altovadensis/i && $cwinner{Rank} =~ /Dominica Resurrectionis|Patrocinii S. Joseph/i)
+    || ($version =~ /19(?:55|6)/i && $cwinner{Rank} =~ /Dominica Resurrectionis|Patrocinii S. Joseph/i)
 
     # TODO: last condition should be made obsolete and handled via database
     || ($version =~ /19(?:55|6)/

--- a/web/www/horas/Bohemice/Sancti/01-06.txt
+++ b/web/www/horas/Bohemice/Sancti/01-06.txt
@@ -1,5 +1,5 @@
-[Rank]
-Epiphany of the Lord;;Duplex I classis;;7
+[Officium]
+Zjevení Páně
 
 [Ant Vespera]
 Před východem slunce zrozen, * a před věky, Pán náš Spasitel se dnes zjevil světu.

--- a/web/www/horas/Bohemice/Sancti/07-20o.txt
+++ b/web/www/horas/Bohemice/Sancti/07-20o.txt
@@ -1,5 +1,5 @@
-[Rank]
+[Officium]
 sv. Markéty, Panny a Mučednice
 
-[Oratio]
-@Commune/C6:Oratio1:s/N\./Markéta/
+[Name]
+Markéta

--- a/web/www/horas/Bohemice/TemporaM/Pent08-0.txt
+++ b/web/www/horas/Bohemice/TemporaM/Pent08-0.txt
@@ -1,0 +1,66 @@
+@Tempora/Pent08-0
+
+[Rule]
+12 lectiones
+
+[Lectio2]
+@Tempora/Pent08-0::1-3 s/-9/-7/
+
+[Lectio3]
+@Tempora/Pent08-0:Lectio2:1 s/6/8/
+@Tempora/Pent08-0:Lectio2:4-5 s/\p{Letter}/\u$&/
+
+[Lectio4]
+@Tempora/Pent08-0:Lectio3
+
+[Responsory4]
+@Tempora/Pent03-1Feria:Responsory1
+
+[Lectio5]
+@Tempora/Pent08-0:Lectio4:s/ Unde .*//s
+
+[Responsory5]
+@Tempora/Pent08-0:Responsory4
+
+[Lectio6]
+@Tempora/Pent08-0:Lectio4:s/.* Unde/Unde/s s/$/~/
+@Tempora/Pent08-0:Lectio5:s/ In quo.*//s
+
+[Responsory6]
+@Tempora/Pent08-0:Responsory5
+
+[Lectio7]
+@Tempora/Pent08-0:Lectio5:s/.* In quo/In quo/s
+
+[Responsory7]
+@Tempora/Pent08-0:Responsory6
+
+[Lectio8]
+@Tempora/Pent08-0:Lectio6
+
+[Responsory8]
+@Tempora/Pent01-3:Responsory2
+
+[Lectio9]
+@Tempora/Pent08-0:Lectio7
+
+[Responsory9]
+@Tempora/Pent01-3:Responsory1
+
+[Lectio10]
+@Tempora/Pent08-0:Lectio8
+
+[Responsory10]
+@Tempora/Pent01-3:Responsory3
+
+[Lectio11]
+@Tempora/Pent08-0:Lectio9
+
+[Responsory11]
+@Tempora/Pent03-2Feria:Responsory1
+
+[Lectio12]
+Sin autem, inquit, carnáles divítias, quæ labúntur, non bene dispensétis; veras æternásque divítias doctrínæ Dei quis credet vobis? Et si in his, aliéna quæ sunt (aliénum est autem nobis omne quod sǽculi est), infidels fuístis; ea, quæ vestra sunt, et próprie hómini deputáta, quis vobis crédere póterit?
+
+[Responsory12]
+@Tempora/Pent01-0:Responsory8

--- a/web/www/horas/Latin/Tempora/Epi1-0.txt
+++ b/web/www/horas/Latin/Tempora/Epi1-0.txt
@@ -77,6 +77,8 @@ $Qui vivis
 
 [Commemoratio]
 @Tempora/Epi1-0a:Oratio:s/V\. .*/V. Omnes de Saba vénient, allelúja./ s/R\. .*/R. Aurum et thus deferéntes, allelúja./
+(sed rubrica cisterciensis)
+@Tempora/Epi1-0a:Oratio
 
 [Invit]
 Christum Dei Fílium, Maríæ et Joseph súbditum, * Veníte, adorémus.
@@ -383,3 +385,6 @@ Et dicébant: * Unde huic sapiéntia hæc, et virtútes? Nonne hic est fabri fí
 
 [Ant 3]
 María autem * conservábat ómnia verba hæc, cónferens in corde suo.
+
+[Commemoratio 3] (rubrica cisterciensis)
+@Tempora/Epi1-0a:Oratio

--- a/web/www/horas/Latin/Tempora/Epi1-0a.txt
+++ b/web/www/horas/Latin/Tempora/Epi1-0a.txt
@@ -13,6 +13,10 @@ Initia cum responsory
 [Versum 1]
 @Sancti/01-06
 
+[Versum 1] (rubrica cisterciensis)
+V. Adoráte Deum.
+R. Omnes Angeli ejus.
+
 [Versum Commemoratio]
 @Sancti/01-06:Versum Tertia
 
@@ -89,6 +93,9 @@ $Deo gratias
 
 [Versum 2]
 @Sancti/01-06
+
+[Versum 2] (rubrica cisterciensis)
+@:Versum 1
 
 [Ant 2]
 @:Ant 1


### PR DESCRIPTION
Cistercian version:
- repaired Sunday within Epiphany Octave (Commemorations and Versicles)
- repaired First Vespers in Resurrectione (in both Cistercian versions should be the short ones)
- some bugfixes

@FAJ-Munich 
Could you please fix the Commemorations on Sunday 01-12-2025 in Vespers, so that first is the Commemoration of the Holy Family, then of the Sunday and not vice versa, for the Altovadensis version? Sunday within an Octave cannot trump MM. maj., and also cannot just lose a Commemoration...
Thank you!