### PR TITLE
Make viewport meta tag conditional for mobile version only

### DIFF
--- a/web/cgi-bin/horas/webdia.pl
+++ b/web/cgi-bin/horas/webdia.pl
@@ -17,12 +17,15 @@ sub htmlHead {
   my ($horasjs) = "<SCRIPT TYPE='text/JavaScript' LANGUAGE='JavaScript1.2'>\n" . horasjs() . '</SCRIPT>';
   $onload && ($onload = " onload=\"$onload\";");
 
+  my $is_mobile = ($officium eq 'Pofficium.pl');
+  my $viewport_tag = $is_mobile ? '  <META NAME="viewport" CONTENT="width=device-width, initial-scale=1.0">' : '';
+
   print <<"PrintTag";
 Content-type: text/html; charset=utf-8
 
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <HTML><HEAD>
-  <META NAME="viewport" CONTENT="width=device-width, initial-scale=1.0">
+$viewport_tag
   <META NAME="Resource-type" CONTENT="Document">
   <META NAME="description" CONTENT="Divine Office">
   <META NAME="keywords" CONTENT="Divine Office, Breviarium, Liturgy, Traditional, Zsolozsma">


### PR DESCRIPTION
When viewed on mobile devices, some users found the text size too large with the viewport tag.

This change applies the viewport tag only to the mobile version (Pofficium.pl), allowing users to choose the desktop version for smaller text if preferred.

Fixes issue raised by Augustinus-Altovadensis on commit 9b263cf.