### PR TITLE
Cist: Psalmi Dom. + Quicumque + calendar fix

### DIFF
--- a/web/cgi-bin/horas/specials/psalmi.pl
+++ b/web/cgi-bin/horas/specials/psalmi.pl
@@ -255,7 +255,8 @@ sub psalmi_minor {
     && $hora eq 'Prima'
     && ($dayname[0] =~ /(Epi|Pent)/i || $version !~ /Divino/i)
     && $dayofweek == 0
-    && ($dayname[0] =~ /(Adv|Pent01)/i || checksuffragium() || ($dayname[0] =~ /Pasc1/i && $version =~ /cist/i))
+    && ($dayname[0] =~ /(Adv|Pent01)/i || checksuffragium() 
+    || ($dayname[0] =~ /Adv|Epi|Quad|Pasc|Pent/i && $version =~ /cist/i))
     && ($winner =~ /Tempora/i || $version !~ /cist/i))
   {
     push(@psalm, 234);
@@ -408,7 +409,9 @@ sub psalmi_major {
   my @p;
 
   #Psalmi de dominica
-  if ( ($rule =~ /Psalmi Dominica/i || ($commune{Rule} && $commune{Rule} =~ /Psalmi Dominica/i))
+  if ( ($rule =~ /Psalmi Dominica/i
+    || ($version =~ /cist/i && $rank >= 2.2)
+    || ($commune{Rule} && $commune{Rule} =~ /Psalmi Dominica/i))
     && ($antiphones[0] !~ /\;\;\s*[0-9]+/)
     && ($rule !~ /Psalmi Feria/i))
   {

--- a/web/www/Tabulae/Kalendaria/CAV.txt
+++ b/web/www/Tabulae/Kalendaria/CAV.txt
@@ -204,7 +204,6 @@
 08-24=08-24=S. Bartholomaei, Apostoli=5=
 08-25=08-25=S. Ludovici, Confessoris=3=
 08-26=08-26=S. Zephirini, Papae et Martyris=1=
-08-27=08-27C=SS. Guarini et Amedei, Ep. et Conf. O.N. (1965)=2=
 08-28=08-28~08-28cc=S. Augustini Episcopi et Confessoris et Ecclesiae Doctoris=4=S. Hermetis=Mart=1=
 08-29=08-29~08-29cc=Decollatione S. Joannis Baptistae=4=S. Sabinae Mart=1=
 08-30=08-30o~08-30=SS. Felicis et Soc. Mart.=1.1=S. Rosæ a S. Maria Limanæ, Virginis (1965)=1=


### PR DESCRIPTION
Fixes for Cistercian version:
- Psalmi Dominica for everything above xij. Lect. et M. (rank 2.2)
- Fixed Quicumque for Sunday's Prime: currently it didn't show at all for the Cistercian versions
- Removed a feast of S. Guarinus and Amedeus, which are separately celebrated in January 