### PR TITLE
Cist: Corrections and Dom. j. Augusti

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -1903,6 +1903,8 @@ sub spell_var {
   } else {
     $t =~ s/Génetrix/Génitrix/g;
     $t =~ s/Genetrí/Genitrí/g;
+    $t =~ s/(I|i)ntellég/$1ntellíg/g if $version =~ /cist/i;
+    $t =~ s/(I|i)ntélleg/$1ntéllig/g if $version =~ /cist/i;
     $t =~ s/\bco(t[ií]d[ií])/quo$1/g;
     $t =~ s/(allelú)ja/$1ia/gi if $version =~ /cist/i;
     $t =~ s/(c)(æ|ae)l/$1œl/gi if $version =~ /cist/i;

--- a/web/cgi-bin/horas/specials/hymni.pl
+++ b/web/cgi-bin/horas/specials/hymni.pl
@@ -102,7 +102,7 @@ sub hymnusmajor {
           || $dayname[0] =~ /Epi1/i && $version =~ /cist/i
           || $dayname[0] =~ /Quadp/i
           || $winner{Rank} =~ /Novembris/i
-          || (($month > 9 || $month < 5) && $version =~ /cist/i)
+          || ($month < 5 && $version =~ /cist/i)
           || ($winner{Rank} =~ /Octobris/i && $version !~ /cist/i))
       );
     setbuild1('Hymnus', $name);

--- a/web/www/horas/Bohemice/Sancti/10-07.txt
+++ b/web/www/horas/Bohemice/Sancti/10-07.txt
@@ -60,38 +60,38 @@ Bože, jehož Jednorozený svým životem, smrtí a zvmrtvýchvstáním nám př
 $Per eumdem
 
 [Invit]
-Let us keep the Feast of the Rose-garden of the Blessed Virgin Mary; * Let us worship Christ her Son, and her Lord and ours.
+Slavnost Růžence Panny Marie slavme; * Kristu Pánu, jejímu Synu, se klanějme.
 
 [Hymnus Matutinum]
-v. The Mount of Olives witnesseth
-The awful agony of God:
-His soul is sorrowful to death,
-His sweat of blood bedews the sod.
+v. Na hoře, kde olivy jsou,
+Spasitel v modlitbě leží,
+Mučí se, trápí, umdlévá,
+Krvavý pot jej oblévá.
 _
-And now the traitor's work is done:
-The clamorous crowds around him surge;
-Bound to pillar, God the Son
-Quivers beneath the blood-red scourge.
+Vydán již proradným zrádcem,
+K trestu již Bůh byl uchvácen,
+Svázán pevnými provazy,
+Důtkami krvavými zbit.
 _
-Lo! clad in purple soiled and worn,
-Meekly the Saviour waiteth now
-While wretches plait the cruel thorn
-To crown with shame his royal brow.
+Spletena z trnů přeostrých
+Koruna kruté pohany, 
+V nachovém plášti od bláta
+Korunuje krále slávy.
 _
-Sweating and sighing, faint with loss
-Of what hath flowed from life's red fount,
-He bears the exceeding heavy cross
-Up to the verge of Calvary's mount.
+Třikrát pod tíží kříže on,
+Potí se, zadýchá, padá,
+Až na vrcholek hory kříž,
+Jej silou donutili nést.
 _
-Nailed to the wood of ancient curse,
-Between two thieves the sinless one
-Still praying for his murderers,
-Breathes forth his soul, and all is done!
+Přibit na tento krutý kříž,
+Mezi zločinci nevinný,
+Když modlí se za trapiče,
+Bez sil vydechne naposled.
 _
-Glory to thee, and honour meet,
-Jesu, of Maiden-Mother born,
-And Father and the Paraclete,
-Through endless ages of the morn!
+Buď Trojici věčná sláva,
+Jež skrze svá svatá tajemství
+Modlícím se milost dává,
+Skrze niž slávu dostává.
 Amen.
 
 [Ant Matutinum]

--- a/web/www/horas/Bohemice/SanctiCist/09-16AV.txt
+++ b/web/www/horas/Bohemice/SanctiCist/09-16AV.txt
@@ -1,6 +1,9 @@
 [Officium]
 Sv. Ludmily, Vdovy, Mučednice a Patronky České země
 
+[Name]
+Ludmily
+
 [Oratio]
 Prosíme, nechť nám pomohou prosby i zásluhy svaté Ludmily, tvé Mučednice, Pane náš Bože; abychom následovali její stopy, a byli shledáni pevni ve víře, a plodní ve skutcích svatosti. 
 $Per Dominum 

--- a/web/www/horas/Bohemice/Tempora/081-0.txt
+++ b/web/www/horas/Bohemice/Tempora/081-0.txt
@@ -2,87 +2,121 @@
 Moudrost * si vybudovala dům, vysekala sedm sloupů, podmanila si národy, hrdla pyšných a nadutých vlastní mocí pošlapala.
 
 [Lectio1]
-Lesson from the book of Proverbs
-!Prov 1:1-6
-1 The parables of Solomon, the son of David, king of Israel.
-2 To know wisdom, and instruction:
-3 To understand the words of prudence: and to receive the instruction of doctrine, justice, and judgment, and equity:
-4 To give subtilty to little ones, to the young man knowledge and understanding.
-5 A wise man shall hear and shall be wiser: and he that understandeth, shall possess governments.
-6 He shall understand a parable, and the interpretation, the words of the wise, and their mysterious sayings.
+Začínají Šalamounova Přísloví
+!Přís. 1:1-6
+1 Přísloví Šalomouna, syna Davidova, krále Israele, 
+2 jak poznat moudrost a kázeň, jak pochopit výroky rozumnosti,
+3 jak si prozíravě osvojit kázeň, spravedlnost, právo a přímost, 
+4 aby prostoduší byli obdařeni chytrostí, mladík poznáním a důvtipem. 
+5 Bude-li naslouchat moudrý, přibude znalostí, a rozumný získá schopnost 
+6 porozumět přísloví a jinotaji, slovům mudrců i jejich hádankám.
 
 [Responsory1]
-R. God possessed me in the beginning, before He made the earth, before He created the depths, before He caused the fountains of water to spring.
-* Before the mountains were settled, before there were any hills, did the Lord beget me.
-V. When He prepared the heavens, I was there with Him, ordering all things.
-R. Before the mountains were settled, before there were any hills, did the Lord beget me.
+R. Na počátku Bůh - než stvořil zemi - dříve než ustanovil propasti, dříve než vyvedl ze země prameny vod,
+* Dříve než hory dostaly své místo, přede všemi pahorky mě zrodil Hospodin.
+V. Když připravoval nebesa, byla jsem, a vše s ním skládala.
+R. Dříve než hory dostaly své místo, přede všemi pahorky mě zrodil Hospodin.
+
+[Responsory1] (rubrica cisterciensis)
+R. Na počátku Bůh, než stvořil zemi, dříve než ustanovil propasti, dříve než vyvedl ze země prameny vod, dříve než hory dostaly své místo;
+* Přede všemi pahorky mě zrodil Hospodin.
+V. Já přebývám na výsostech, a můj trůn je v oblačném sloupu.
+R. Přede všemi pahorky mě zrodil Hospodin.
 
 [Lectio2]
-!Prov 1:7-14
-7 The fear of the Lord is the beginning of wisdom. Fools despise wisdom and instruction.
-8 My son, hear the instruction of thy father, and forsake not the law of thy mother:
-9 That grace may be added to thy head, and a chain of gold to thy neck.
-10 My son, if sinners shall entice thee, consent not to them.
-11 If they shall say: Come with us, let us lie in wait for blood, let us hide snares for the innocent without cause:
-12 Let us swallow him up alive like hell, and whole as one that goeth down into the pit.
-13 We shall find all precious substance, we shall fill our houses with spoils.
-14 Cast in thy lot with us, let us all have one purse.
+!Pís. 1:7-14
+7 Počátek poznání je bázeň Hospodinem, moudrostí a kázní pohrdají pošetilci. 
+8 Můj synu, poslouchej otcovo kárání a matčiným poučováním neopovrhuj. 
+9 Budou ti půvabným věncem na hlavě a náhrdelníkem na tvém hrdle. 
+10 Můj synu, kdyby tě lákali hříšníci, nepřivoluj! 
+11 Kdyby tě přemlouvali: „Pojď s námi, vražedné úklady nastrojíme, počíháme si na nevinného bez důvodu,
+12 pohltíme je, jako podsvětí živé, bezúhonní jako ti, kdo sestupují do jámy,
+13 přijdeme si na rozličný drahocenný majetek domy kořistí si naplníme,
+14 spoj svůj úděl s námi, budeme mít všichni jeden měšec.“
 
 [Responsory2]
-R. I alone compassed the circuit of heaven, and walked on the waves of the sea. In every nation and in every people, I held the first place.
-* In the greatness of my strength have I trodden under my feet the necks of such as be haughty and proud.
-V. I dwell in the highest places, and my throne is in a cloudy pillar.
-R. In the greatness of my strength have I trodden under my feet the necks of such as be haughty and proud.
+R. Okrsek nebeský jsem sama celý prochodila, i v mořských proudech jsem kráčela, a v každém národu i v každém lidu držela první místo;
+* Šíje pyšných a vznešených jsem svou mocí pošlapala.
+V. Já přebývám na výsostech, a můj trůn je v oblačném sloupu.
+R. Šíje pyšných a vznešených jsem svou mocí pošlapala.
+
+[Responsory2] (rubrica cisterciensis)
+R. Počátek moudrosti je bázeň před Hospodinem;
+* Dobré poznání mají všichni, kdo tak činí; jeho chvála zůstává na věky věkův.
+V. Láska k němu spočívá v zachovávání jeho zákonů; neboť veškerá moudrost je bázeň před Hospodinem.
+R. Dobré poznání mají všichni, kdo tak činí; jeho chvála zůstává na věky věkův.
 
 [Lectio3]
-!Prov 1:15-19
-15 My son, walk not thou with them, restrain thy foot from their paths.
-16 For their feet run to evil, and make haste to shed blood.
-17 But a net is spread in vain before the eyes of them that have wings.
-18 And they themselves lie in wait for their own blood, and practise deceits against their own souls.
-19 So the wage of every covetous man destroy the souls of the possessors.
+!Přís. 1:15-19
+15 Můj synu, nechoď s nimi cestou, zdržuj svou nohu od jejich stezky,
+16 neboť jejich nohy běží za zlem, pospíchají prolévat krev.
+17 Je zbytečné sypat pod síť, když každý okřídlenec vidí.
+18 Oni však strojí vražedné úklady proti sobě, číhají na vlastní duši.
+19 Takové jsou stezky všech, kdo za ziskem se honí; ten stojí své pány život.
 
 [Responsory3]
-R. O send out wisdom from the throne of thy glory, O Lord, to be with me, and to labour with me,
-* That I may know at all times what is pleasing unto thee.
-V. Give me wisdom, O Lord, that sitteth by thy throne.
-R. That I may know at all times what is pleasing unto thee.
+R. Sešli, Hospodine, moudrost z trůnu své velikosti, aby se mnou byla a se mnou působila;
+* Abych vždy věděl, co je tobě milé.
+V. Dej mi, Hospodine, pomoc moudrosti tvých příbytků.
+R. Abych vždy věděl, co je tobě milé.
 &Gloria
-R. That I may know at all times what is pleasing unto thee.
+R. Abych vždy věděl, co je tobě milé.
+
+[Responsory3] (rubrica cisterciensis)
+R. Sešli, Hospodine, moudrost z trůnu své velikosti; 
+* Aby se mnou byla a se mnou působila, abych vždy věděl, co je tobě milé.
+V. Dej mi, Hospodine, pomoc moudrosti tvých příbytků.
+R. Aby se mnou byla a se mnou působila, abych vždy věděl, co je tobě milé.
 
 [Lectio4]
-From the Treatise of St. Ambrose, Bishop of Milan, upon the 18-th Psalm.
-!Sermon v. 6
-The Prophet saith that „the fear of the Lord is the beginning of wisdom.“ And what is the first act of wisdom but to renounce the world since to love the things of the world is folly. So indeed saith the Apostle „The wisdom of this world is foolishness with God.“ (i Cor. iii. 19.) But the very fear of the Lord itself is useless, nay, harmful, if it be not according to knowledge. The Jews have a truly fervent zeal for God, but since they have not knowledge, their very zeal and fear do cause them to do things contrary to God's will. That they circumcise their children, that they keep holy the Sabbath-Day, showeth how they fear the Lord, but knowing not the spiritual meaning of the Law, they circumcise the body and not the heart.
+Z Pojednání svatého Ambrože Biskupa na Žalm sto osmnáctý.
+!Kniha 11 na Isajášovu kapitolu 38.
+Prorok říká, že bázeň před Hospodinem je počátkem moudrosti. Co je však pravým počátkem moudrosti, ne-li zřeknutí se tohoto světa? Neboť znát pouze světské věci je hloupost. Proto Apoštol říká, že moudrost tohoto světa je hloupost u Boha. Avšak i samotná bázeň před Hospodinem, pokud nepochází z poznání, ničemu neprospěje, dokonce je velikou přítěží. Přestože tedy Židé mají zápal pro Boha, avšak protože nepochází z poznání, takovým zápalem a bázní si získají akorát pohoršení Boží. Protože obřezávají svá nemluvňátka, protože zachovávají Den odpočinku, mají bázeň před Bohem. Protože však nevědí, že zákon je duchovní, obřezávají jen tělo, nikoliv však svá srdce.
+
 
 [Responsory4]
-R. Give me wisdom, O Lord, that sitteth by thy throne, and reject me not from among thy children.
-* For I am thy servant and son of thine handmaid.
-V. O send her out from the throne of thy glory, to be with me and to labour with me.
-R. For I am thy servant and son of thine handmaid.
+R. Dej mi, Hospodine, pomoc moudrosti tvých trůnů, a nezavrhuj mě od svých dětí.
+* Neboť tvůj služebník jsem já, a syn tvé služebnice.
+V. Sešli ji z trůnu své velikosti, aby se mnou byla a se mnou pracovala.
+R. Neboť tvůj služebník jsem já, a syn tvé služebnice.
+
+[Responsory4] (rubrica cisterciensis)
+R. Hospodine, Otče a Bože mého života, nezanechávej mě ve zlovolných myšlenkách; povýšenost mých očí mi nedávej, a zlovolné tužby ode mě zažeň, Hospodine; vzdal ode mě chtíč;
+* A duchu neuctivému a pošetilému neodevzdávej mě, Hospodine!
+V. Dvě věci jsem u tebe prosil, abys mi neodmítl, než zemřu: marnivost a lživé slovo ode mě vzdal.
+R. A duchu neuctivému a pošetilému neodevzdávej mě, Hospodine! 
 
 [Lectio5]
-But wherefore should I speak of Jews There are those among ourselves who have the fear of God, but not according to knowledge, and set up hard ordinances which the weakness of man is not able to bear. They fear God in this, that they seem to themselves to be looking to discipline, and to be enforcing the practice of godliness, but they lack knowledge, in that they feel not for the weakness of nature, nor consider whether a thing can, or cannot be done. Let not then the fear of God be unreasonable. True wisdom beginneth with the fear of God, neither is it spiritual wisdom without the fear of God, but neither ought the fear of God to be without wisdom.
+Co bych tedy vzkázal Židům? Jsou totiž mezi námi i tací, kteří sice mají bázeň před Bohem, avšak nikoliv podle poznání ustanovují tvrdá přikázání, která lidská přirozenost nedokáže snášet. Bázeň v tom je, neboť se zdá, že ve snaze o kázeň požadují ctnostné skutky. Avšak je v tom také neznalost, neboť neberou ohled na přirozenost, nezamýšlí se, zdali je to vůbec možné. Tato bázeň tedy nesmí býti nesmyslná. Pravá moudrost se zajisté zakládá na bázni před Bohem, zároveň však duchovní moudrost nemůže býti bez bázně Boží. Takže bázeň nesmí býti bez moudrost.  
 
 [Responsory5]
-R. The fear of the Lord is the beginning of wisdom.
-* A good understanding have all they that do His commandments. His praise endureth for ever.
-V. Love is the keeping of her laws, for all wisdom is the fear of the Lord.
-R. A good understanding have all they that do His commandments. His praise endureth for ever.
+R. Počátek moudrosti je bázeň před Hospodinem;
+* Dobré poznání mají všichni, kdo tak činí; jeho chvála zůstává na věky věkův.
+V. Láska k němu spočívá v zachovávání jeho zákonů; neboť veškerá moudrost je bázeň před Hospodinem.
+R. Dobré poznání mají všichni, kdo tak činí; jeho chvála zůstává na věky věkův.
+
+[Responsory5] (rubrica cisterciensis)
+R. Slovo nespravedlivé a lstivé ode mě vzdal, Hospodine; nedávej mi bohatství ani chudobu;
+* Ale jen k tomu, abych se najedl, mi dej vše potřebné.
+V. Abych snad nasycen vše nevyzvrátil, a nerouhal se jménu mého Boha.
+R. Ale jen k tomu, abych se najedl, mi dej vše potřebné.
 
 [Lectio6]
-Holy fear is the foundation of all good instruction. Just as a statue is set up upon a pedestal, and thereby receiveth both beauty and strength, even so doth it become the word of God to be set forth based upon an holy fear, and it is in the heart of him that feareth that it getteth the firmest root, even an home wherefrom it droppeth not, neither do the fowls of the air come and carry it away, as from the heart of him that is careless and deceiving.
+Základem každého slova je posvátná bázeň. Stejně jako modla bývá postavená na nějakém základu, a pak má větší cenu, když taková socha stojí na podstavci, neboť přijímá jeho pevnost. Takto i slovo Boží se lépe zakládá na posvátné bázni a silněji vyzařuje do srdcí těch, kteří se bojí Hospodina, aby nevyklouzlo slovo Boží ze srdce takového muže, aby pak nepřilétli ptáci a nesezobali je tak lhostejnému a nevědomému člověku.
 
 [Responsory6]
-R. Lord, remove far from me vanity and lies.
-* Give me neither poverty nor riches, but feed me with food convenient for me.
-V. Two things have I required of thee; deny me them not before I die.
-R. Give me neither poverty nor riches, but feed me with food convenient for me.
+R. Slovo nespravedlivé a lstivé ode mě vzdal, Hospodine;
+* Nedávej mi bohatství ani chudobu, ale jen k tomu, abych se najedl, mi dej vše potřebné.
+V. Dvě věci jsem u tebe prosil, abys mi neodmítl, než zemřu: marnivost a lživé slovo ode mě vzdal.
+R. Nedávej mi bohatství ani chudobu, ale jen k tomu, abych se najedl, mi dej vše potřebné.
 &Gloria
-R. Give me neither poverty nor riches, but feed me with food convenient for me.
+R. Nedávej mi bohatství ani chudobu, ale jen k tomu, abych se najedl, mi dej vše potřebné.
+
+[Responsory6] (rubrica cisterciensis)
+@TemporaOP/081-3:Responsory2
 
 [Responsory7]
-R. O Lord, Father and God of my life, leave me not to evil counsels; give me not a proud look, but turn away from me an haughty mind, O Lord turn away from me concupiscence,
-* And give me not over unto an impudent and froward mind, O Lord!
-V. Leave me not, O Lord, lest mine ignorance increase, and my sins abound.
-R. And give me not over unto an impudent and froward mind, O Lord.
+R. Hospodine, Otče a Bože mého života, nezanechávej mě ve zlovolných myšlenkách; povýšenost mých očí mi nedávej, a zlovolné tužby ode mě zažeň, Hospodine; vzdal ode mě chtíč;
+* A duchu neuctivému a pošetilému neodevzdávej mě, Hospodine!
+V. Neopouštěj mě, Hospodine, aby nerostla má nevědomost, a aby se nemnožily mé hříchy.
+R. A duchu neuctivému a pošetilému neodevzdávej mě, Hospodine!

--- a/web/www/horas/Bohemice/Tempora/081-1.txt
+++ b/web/www/horas/Bohemice/Tempora/081-1.txt
@@ -1,0 +1,17 @@
+[Responsory1] (rubrica cisterciensis)
+R. Dej mi, Hospodine, pomoc moudrosti tvých trůnů, a nezavrhuj mě od svých dětí.
+* Neboť tvůj služebník jsem já, a syn tvé služebnice.
+V. Hospodine, Otče, a Bože mého života, nezanechávej mě ve zlověstných myšlenkách;
+R. Neboť tvůj služebník jsem já, a syn tvé služebnice.
+
+[Responsory2]
+R. Veliké jsou totiž tvé soudy, Hospodine, a nevýslovná tvá slova;
+* Vyvýšil jsi svůj lid a poctil jej.
+V. Přenesl jsi je přes Rudé Moře a převedl je přes množství vod.
+R. Vyvýšil jsi svůj lid a poctil jej.
+
+[Responsory2] (rubrica cisterciensis)
+R. Neopouštěj mě, Hospodine Otče, a panovníku mého života, abych nebyl raněn před zraky svých nepřátel;
+* Aby se nade mnou neradoval můj nepřítel.
+V. Chop se zbroje a štítu, a povstaň mi na pomoc;
+R. Aby se nade mnou neradoval můj nepřítel.

--- a/web/www/horas/Bohemice/Tempora/Pent12-0.txt
+++ b/web/www/horas/Bohemice/Tempora/Pent12-0.txt
@@ -6,19 +6,19 @@ Všemohoucí a milosrdný Bože, z jehož daru vychází, aby tobě tvoji věrn�
 $Per Dominum
 
 [Lectio7]
-From the Holy Gospel according to Luke
-!Luke 10:23-37
-At that time, Jesus said unto His disciples: Blessed are the eyes which see the things that ye see. For I tell you that many prophets and kings have desired to see those things which ye see, and have not seen them. And so on.
+Čtení svatého Evangelia podle Lukáše
+!Lukáš 10:23-37
+Za onoho času řekl Ježíš svým učedníkům: „Blahoslavené oči, které vidí, co vy vidíte. Říkám vám totiž, že mnozí Proroci a králové chtěli vidět to, co vidíte vy, ale neviděli.“ A ostatní.
 _
-Homily by the Venerable Bede, Priest (at Jarrow.)
-!Bk. iii. ch. 43 on Luke x.
-Blessed were the eyes not of Scribes and Pharisees, which saw but the Body of the Lord, but those eyes, eyes blessed indeed, which were able to see those things whereof it is written „Thou hast hid these things from the wise and prudent, and hast revealed them unto babes.“ Blessed are the eyes of those little ones unto whom it seemeth good in the eyes of the Son to reveal Himself and the Father also. Abraham rejoiced to see the day of Christ and he saw it, and was glad. (John viii. 56.) Isaiah, and Micah, and many among the Prophets, saw the glory of the Lord, wherefore also they be called Seers, but all they beheld it and hailed it afar off, seeing but as through a glass, darkly. (1 Cor. xiii. 12.)
+Homilie ctihodného Bédy Kněze.
+!Kniha 3, kapitola 43 na Lukáše, kapitolu 10.
+Pán nemluvil o očích Zákoníků a Farizeů, které viděly pouze Pánovo tělo, ale naopak o těch blahoslavených očích, které dokázaly poznat jeho tajemství, pravil: „A odhalil jsi je maličkým.“ Blažené oči maličkých, kterým Syn sebe i Otce ráčil odhalit. Abrahám zajásal, když uzřel den Kristův: „a viděl, a zaradoval se.“ (Jan 8, 56) Isajáš, Micheáš a mnozí jiní Proroci uzřeli slávu Páně. I proto bývají nazýváni „Vidoucí.“ Avšak všichni tito Proroci se dívali zdaleka, a třebaže s radosti, vše viděli jen jakoby v zrcadle, zahalené tajemstvím. (1 Kor. 13, 12)
 
 [Lectio8]
-Otherwise were the Apostles, who saw the Lord face to Face, eating with Him, and learning from Him by asking whatsoever they listed. For them there was no need to be taught by Angels, or the shifting fabric of visions. They whom Luke doth call Prophets and kings, Matthew nameth as „Prophets and righteous men“ (xiii. 17.) Righteous men are indeed mighty kings, who know how to lord it over their own rebellious temptations, instead of falling under them to become their slaves.
+Apoštolové však měli Pána přímo před očima, jedli s ním, a mohli se jej na cokoliv zeptat a poučit se. Neměli tedy potřebu poučení skrze Anděly nebo různé druhy vidění. Zatímco Lukáš nazývá mnohé Proroky i králi, Matouš otevřeně nazývá Proroky také spravedlivými (13, 17). Proroci jsou totiž opravdu velcí králové, neboť pohnutkám svých pokušení nesvolili a nepodlehli, ale naučili se být jim jako králové nadřazeni.
 
 [Lectio9]
-„And, behold, a certain lawyer stood up, and tempted Him, saying Master, what shall I do to inherit eternal life?“ This lawyer, who stood up to ask the Lord a tempting question touching eternal life, took the subject of his asking, as I think, from the words which the Lord had just uttered, when He said „Rejoice, because your names are written in heaven“. But his attempt was a proof of the truth of that which the Lord immediately added „I thank thee, O Father, Lord of heaven and earth, that Thou hast hid these things from the wise and prudent, and hast revealed them unto babes!“
+ A hle, jeden ze Znalců zákona vstal a pokoušel jej slovy: „Mistře, co mám učinit, abych získal život věčný?“ Znalec zákona, který se ptá Pána ve snaze jej pokoušet, tuto příležitost k pokušení, jak se domnívám, vzal ze samotných slov Páně, který pravil: „Radujte se, že vaše jména jsou zapsána v nebesích.“ Avšak zákoník samotným tímto svým pokoušením dokazuje, jak pravdivé je Pánovo vyznání, když Otci pravil: „Žes tyto věci skryl před moudrými a rozumnými a zjevil jsi je maličkým.“	
 &teDeum
 
 [Ant 2_]

--- a/web/www/horas/Bohemice/TemporaM/081-0.txt
+++ b/web/www/horas/Bohemice/TemporaM/081-0.txt
@@ -1,0 +1,11 @@
+[Lectio4]
+@Tempora/081-0:Lectio3:s/15/17/ s/19/22/ s/15 .*17/17/s
+20 Moudrost pronikavě volá na ulici, na náměstích vydává svůj hlas. 
+21 Volá na nároží plném hluku, pronáší své výroky u vchodů do městských bran:
+22 „Dokdy budete, prostoduší, milovat prostoduchost, posměvači budou mít zálibu v posmívání, hlupáci poznání nenávidět? 
+
+[Lectio5]
+@Tempora/081-0:Lectio4:s/ Přestože.*//s
+
+[Lectio6]
+@Tempora/081-0:Lectio4:s/.* Přestože/Přestože/s

--- a/web/www/horas/Bohemice/TemporaM/Pent12-0.txt
+++ b/web/www/horas/Bohemice/TemporaM/Pent12-0.txt
@@ -1,0 +1,13 @@
+[Lectio9]
+@Tempora/Pent12-0:Lectio7:s/Isajáš,.*//s
+
+[Lectio10]
+@Tempora/Pent12-0:Lectio7:s/.* Isajáš,/Isajáš,/s s/$/~/
+@Tempora/Pent12-0:Lectio8:s/Zatímco.*//s
+
+[Lectio11]
+@Tempora/Pent12-0:Lectio8:s/.* Zatímco/Zatímco/s s/$/~/
+@Tempora/Pent12-0:Lectio9:s/Znalec.*//s
+
+[Lectio12]
+@Tempora/Pent12-0:Lectio9:s/.* Znalec/Znalec/s

--- a/web/www/horas/Bohemice/TemporaOP/081-3.txt
+++ b/web/www/horas/Bohemice/TemporaOP/081-3.txt
@@ -1,0 +1,5 @@
+[Responsory2]
+R. Veliké jsou totiž tvé soudy, Hospodine, a nevýslovná tvá slova;
+* Vyvýšil jsi svůj lid a poctil jej.
+V. Vyvedl jsi jako ovce svůj lid v područí Mojžíše a Aarona.
+R. Vyvýšil jsi svůj lid a poctil jej.

--- a/web/www/horas/Latin/Sancti/10-DP.txt
+++ b/web/www/horas/Latin/Sancti/10-DP.txt
@@ -1,4 +1,3 @@
-(nisi rubrica cisterciensis)
 @Sancti/10-07
 
 [Rank] (rubrica Trident)

--- a/web/www/horas/Latin/SanctiCist/09-16AV.txt
+++ b/web/www/horas/Latin/SanctiCist/09-16AV.txt
@@ -8,6 +8,9 @@ S. Ludmillæ, Viduæ, Martyris et Patronæ Regni Bohemiæ (Propria Bohemiæ et L
 Psalmi Dominica
 Antiphonas horas
 
+[Name]
+Ludmillæ
+
 [Oratio]
 Ajuvent nos, quæsumus, preces et mérita sanctæ Ludmíllæ Mártyris tuæ, Dómine Deus noster: * ut ejus vestígiis inhæréntes, in fide inveniámur stábiles, § et in sanctis opéribus efficáces. 
 $Per Dominum 

--- a/web/www/horas/Latin/Tempora/081-0.txt
+++ b/web/www/horas/Latin/Tempora/081-0.txt
@@ -20,6 +20,12 @@ R. In princípio Deus ántequam terram fáceret, priúsquam abýssos constitúer
 V. Quando præparábat cælos, áderam, cum eo cuncta compónens.
 R. Antequam montes collocaréntur, ante omnes colles generávit me Dóminus.
 
+[Responsory1] (rubrica cisterciensis)
+R. In princípio Deus ántequam terram fáceret, priúsquam abýssos constitúeret, priúsquam prodúceret fontes aquárum, antequam montes collocaréntur:
+* Ante omnes colles generávit me Dóminus.
+V. Ego in altíssimis hábito, et thronus meus in colúmna nubis.
+R. Ante omnes colles generávit me Dóminus.
+
 [Lectio2]
 !Prov 1:7-14
 7 Timor Dómini princípium sapiéntiæ. Sapiéntiam atque doctrínam stulti despíciunt. 
@@ -37,6 +43,12 @@ R. Gyrum cæli circuívi sola, et in flúctibus maris ambulávi, in omni gente e
 V. Ego in altíssimis hábito, et thronus meus in colúmna nubis.
 R. Superbórum et sublímium colla própria virtúte calcávi.
 
+[Responsory2] (rubrica cisterciensis)
+R. Inítium sapiéntiæ timor Dómini: 
+* Intelléctus bonus ómnibus faciéntibus eum: laudátio ejus manet in sǽculum sǽculi.
+V. Diléctio illíus custódia legum est: quia omnis sapiéntia timor Dómini.
+R. Intelléctus bonus ómnibus faciéntibus eum: laudátio ejus manet in sǽculum sǽculi.
+
 [Lectio3]
 !Prov 1:15-19
 15 Fili mi, ne ámbules cum eis: próhibe pedem tuum a sémitis eórum; 
@@ -53,10 +65,16 @@ R. Ut sciam quid accéptum sit coram te omni témpore.
 &Gloria
 R. Ut sciam quid accéptum sit coram te omni témpore.
 
+[Responsory3] (rubrica cisterciensis)
+R. Emítte, Dómine, sapiéntiam de sede magnitúdinis tuæ:  
+* Ut mecum sit, et mecum labóret, ut sciam quid accéptum sit coram te omni témpore.
+V. Da mihi, Dómine, sédium tuárum assistrícem sapiéntiam.
+R. Ut mecum sit, et mecum labóret, ut sciam quid accéptum sit coram te omni témpore.
+
 [Lectio4]
 Ex Tractatu sancti Ambrósii Epíscopi in Psalmum centésimum décimum octavum
 !Sermo 5, n. 36-37
-Initium esse sapiéntiæ timórem Dómini, dicit prophéta. Quid est autem initium sapiéntiæ, nisi sæculo renuntiáre? Quia sápere sæcularia, stultítia est. Dénique sapiéntiam hujus mundi, stultítiam esse apud Deum, Apóstolus dicit. Sed et ipse timor Dómini, nisi secúndum sciéntiam sit, nihil prodest, immo obest plurimum. Síquidem Judæi habent zelum Dei; sed quia non habent secúndum sciéntiam, in ipso zelo et timóre majórem cóntrahunt divinitátis offensam. Quod circumcídunt infántulos suos, quod sábbata custódiunt, timórem Dei habent; sed quia nesciunt legem spiritalem esse, circumcídunt corpus, non cor suum.
+Inítium esse sapiéntiæ timórem Dómini, dicit prophéta. Quid est autem inítium sapiéntiæ, nisi sǽculo renuntiáre? Quia sápere sæculária, stultítia est. Dénique sapiéntiam hujus mundi, stultítiam esse apud Deum, Apóstolus dicit. Sed et ipse timor Dómini, nisi secúndum sciéntiam sit, nihil prodest, immo obest plúrimum. Síquidem Judǽi habent zelum Dei; sed quia non habent secúndum sciéntiam, in ipso zelo et timóre majórem cóntrahunt divinitátis offénsam. Quod circumcídunt infántulos suos, quod sábbata custódiunt, timórem Dei habent; sed quia nesciunt legem spiritálem esse, circumcídunt corpus, non cor suum.
 
 [Responsory4]
 R. Da mihi, Dómine, sédium tuárum assistrícem sapiéntiam, et noli me reprobáre a púeris tuis: 
@@ -64,8 +82,14 @@ R. Da mihi, Dómine, sédium tuárum assistrícem sapiéntiam, et noli me reprob
 V. Mitte illam de sede magnitúdinis tuæ, ut mecum sit et mecum labóret.
 R. Quóniam servus tuus sum ego, et fílius ancíllæ tuæ.
 
+[Responsory4] (rubrica cisterciensis)
+R. Dómine Pater, et Deus vitæ meæ, ne derelínquas me in cogitátu malígno: extolléntiam oculórum meórum ne déderis mihi, et desidérium malígnum avérte a me, Dómine; aufer a me concupiscéntiam: 
+* Et ánimo irreverénti et infruníto ne tradas me, Dómine.
+V. Duo rogáví te, ne déneges mihi ántequam móriar: vanitátem, et verbum mendácii longe fac a me:
+R. Et ánimo irreverénti et infruníto ne tradas me, Dómine.
+
 [Lectio5]
-Et quid de Judǽis dico? Sunt étiam in nobis qui habent timórem Dei, sed non secúndum sciéntiam, statuéntes durióra præcepta, quæ non possit humana condítio sustinére. Timor in eo est, quia vidéntur sibi consúlere disciplinæ, opus virtútis exígere; sed inscítia in eo est, quia non compatiúntur natúræ, non æstimant possibilitátem. Non sit ergo irrationábilis timor. Etenim vera sapiéntia a timóre Dei íncipit, nec est sapiéntia spiritalis sine timóre Dei; ita timor sine sapiéntia esse non debet.
+Et quid de Judǽis dico? Sunt étiam in nobis qui habent timórem Dei, sed non secúndum sciéntiam, statuéntes durióra præcépta, quæ non possit humána condítio sustinére. Timor in eo est, quia vidéntur sibi consúlere disciplínæ, opus virtútis exígere; sed inscítia in eo est, quia non compatiúntur natúræ, non ǽstimant possibilitátem. Non sit ergo irrationábilis timor. Etenim vera sapiéntia a timóre Dei íncipit, nec est sapiéntia spiritális sine timóre Dei; ita timor sine sapiéntia esse non debet.
 
 [Responsory5]
 R. Inítium sapiéntiæ timor Dómini: 
@@ -73,8 +97,14 @@ R. Inítium sapiéntiæ timor Dómini:
 V. Diléctio illíus custódia legum est: quia omnis sapiéntia timor Dómini.
 R. Intelléctus bonus ómnibus faciéntibus eum: laudátio ejus manet in sǽculum sǽculi.
 
+[Responsory5] (rubrica cisterciensis)
+R. Verbum iníquum et dolósum longe fac a me, Dómine: divítias et paupertátem ne déderis mihi:
+* Sed tantum víctui meo tríbue necessária.
+V. Ne forte satiátus évomam illud, et perjúrem nomen Dei mei.
+R. Sed tantum víctui meo tríbue necessária.
+
 [Lectio6]
-Basis quædam verbi est timor sanctus. Sicut enim simulacrum aliquod in basi statúitur, et tunc majórem habet grátiam, cum in basi státua fúerit collocata, standíque áccipit firmitátem: ita verbum Dei in timóre sancto mélius statúitur, fortius radicátur in péctore timéntis Dóminum; ne labátur verbum de corde viri, ne veniant vólucres et áuferant illud de incuriosi et dissimulántis afféctu.
+Basis quædam verbi est timor sanctus. Sicut enim simulácrum áliquod in basi statúitur, et tunc majórem habet grátiam, cum in basi státua fúerit collocáta, standíque áccipit firmitátem: ita verbum Dei in timóre sancto mélius statúitur, fórtius radicátur in péctore timéntis Dóminum; ne labátur verbum de corde viri, ne véniant vólucres et áuferant illud de incuriósi et dissimulántis afféctu.
 
 [Responsory6]
 R. Verbum iníquum et dolósum longe fac a me, Dómine: 
@@ -83,6 +113,9 @@ V. Duo rogávi te, ne déneges mihi ántequam móriar.
 R. Divítias et paupertátem ne déderis mihi, sed tantum víctui meo tríbue necessária.
 &Gloria
 R. Divítias et paupertátem ne déderis mihi, sed tantum víctui meo tríbue necessária.
+
+[Responsory6] (rubrica cisterciensis)
+@TemporaOP/081-3:Responsory2
 
 [Responsory7]
 R. Dómine, Pater et Deus vitæ meæ, ne derelínquas me in cogitátu malígno: extolléntiam oculórum meórum ne déderis mihi, et desidérium malígnum avérte a me, Dómine; aufer a me concupiscéntiam, 

--- a/web/www/horas/Latin/Tempora/081-1.txt
+++ b/web/www/horas/Latin/Tempora/081-1.txt
@@ -14,6 +14,12 @@ R. Ne derelínquas me, Dómine, pater et dominátor vitæ meæ, ut non córruam 
 V. Apprehénde arma et scutum et exsúrge in adjutórium mihi.
 R. Ne gáudeat de me inimícus meus.
 
+[Responsory1] (rubrica cisterciensis)
+R. Da mihi, Dómine, sédium tuárum assistrícem sapiéntiam, et noli me reprobáre a púeris tuis: 
+* Quóniam servus tuus sum ego, et fílius ancíllæ tuæ.
+V. Dómine Pater, et Deus vitæ meæ, ne derelínquas me in cogitátu malígno:
+R. Quóniam servus tuus sum ego, et fílius ancíllæ tuæ.
+
 [Lectio2]
 !Prov 3:7-10
 7 Ne sis sápiens apud temetípsum, time Deum et recéde a malo;
@@ -26,6 +32,12 @@ R. Magna enim sunt judícia tua, Dómine, et inenarrabília verba tua:
 * Magnificásti pópulum tuum et honorásti.
 V. Transtulísti illos per Mare Rubrum et transvexísti eos per aquam nímiam.
 R. Magnificásti pópulum tuum et honorásti.
+
+[Responsory2] (rubrica cisterciensis)
+R. Ne derelínquas me, Dómine Pater, et dominátor vitæ meæ, ut non córruam in conspéctu adversariórum meórum:
+* Ne gáudeat de me inimícus meus.
+V. Apprehénde arma et scutum, et exúrge in adjutórium mihi:
+R. Ne gáudeat de me inimícus meus.
 
 [Lectio3]
 !Prov 3:11-15


### PR DESCRIPTION
changes in code:
- `horascommon.pl`: fixed "modern" Latin orthography - intell-i-gentia (correct for older versions) vs. intell-e-gentia (correct for 1960+). So far I have done this only for Cistercian version, but I guess this should be for all versions with the exception of 196*.
- `hymni.pl`: the program incorrectly displayed winter Hymns already now, should be on the first Sunday in November. Fixed.