### PR TITLE
Monastic 1617 / 1930; Fix Compline and add rubrics

### DIFF
--- a/web/www/horas/Bohemice/Psalterium/Common/Prayers.txt
+++ b/web/www/horas/Bohemice/Psalterium/Common/Prayers.txt
@@ -263,9 +263,7 @@ v. Tobě patří chvála, tobě patří chvalozpěv, tobě patří sláva Boha O
 v. Pane, smiluj se. Kriste, smiluj se. Pane, smiluj se.
 
 [Divinum auxilium]
-(rubrica Monastica)
-/:Pokud se odchází z Chóru, zakončí se takto.:/
-(sed rubrica cisterciensis omittitur)
+(rubrica 1963)/:Pokud se odchází z Chóru, zakončí se takto.:/
 Božská pomoc + ať s námi zůstává navždy.
 I s našimi bratry, kteří zde nejsou. Amen.
 (sed rubrica cisterciensis)

--- a/web/www/horas/Bohemice/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Bohemice/Psalterium/Common/Rubricae.txt
@@ -8,10 +8,10 @@
 [Credo secreto]
 /:«Credo» se říká potichu až do «Carnis resurrectiónem.»:/
 
-[Pater post]
+[Pater post_]
 /:Poté se říká pouze «Pater Noster» potichu, nenásleduje-li jiná Hodinka.:/
 
-[Pater post V]
+[Pater post V_]
 /:A pokud se takto zakončí Officium, řekne se pouze «Pater Noster» potichu.:/
 
 [Secreto_]

--- a/web/www/horas/Dansk/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Dansk/Psalterium/Common/Rubricae.txt
@@ -5,10 +5,10 @@
 [Pater totum secreto]
 /:«Fadervor» bedes stille.:/
 
-[Pater post]
+[Pater post_]
 /:Derefter siges kun «Fadervor» lydløst, medmindre der straks følger en anden Time.:/
 
-[Pater post V]
+[Pater post V_]
 /:Og er Embedet således afsluttet, siges kun «Fadervor» tavst.:/
 
 [Secreto_]

--- a/web/www/horas/Deutsch/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Deutsch/Psalterium/Common/Rubricae.txt
@@ -8,11 +8,14 @@
 [Credo secreto]
 /:Das « Credo » wird still gebetet bis « Auferstehung des Fleisches. »:/
 
-[Pater post]
+[Pater post_]
 /:Falls sich keine weitere Hore anschließt, ganz im Stillen::/
 
-[Pater post V]
+[Pater post V_]
 /:Falls hiermit das Officium endet, ganz im Stillen::/
+
+[Ant Maria post]
+/:Bei öffentlicher Rezitation, falls der Chor verlassen wird, schließt sich  « Dóminus det. » und die Marianische Schlußantiphon an. <i>(wie in den Laudes)</i>:/
 
 [Secreto_]
 /:still:/

--- a/web/www/horas/English/Psalterium/Common/Prayers.txt
+++ b/web/www/horas/English/Psalterium/Common/Prayers.txt
@@ -213,8 +213,7 @@ v. Thou art worthy of praise, thou art worthy of hymns, to Thee be glory: to God
 v. Lord have mercy upon us, Christ have mercy upon us, Lord have mercy upon us.
 
 [Divinum auxilium]
-(rubrica Monastica)
-/:Then, in the public recitation of the Office, if the Community is to leave the Choir, the following Versicle is said.:/
+(rubrica 1963)/:Then, in the public recitation of the Office, if the Community is to leave the Choir, the following Versicle is said.:/
 May the divine assistance + remain with us always.
 And with our brothers, who are absent. Amen.
 

--- a/web/www/horas/English/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/English/Psalterium/Common/Rubricae.txt
@@ -8,11 +8,14 @@
 [Credo secreto]
 /:«Credo» is said silently until «The resurrection of the body.»:/
 
-[Pater post]
+[Pater post_]
 /:Thereafter, only « Pater Noster » is said silently, unless another Hour follows immediately.:/
 
-[Pater post V]
+[Pater post V_]
 /:And if thus the Office is ended, only « Pater Noster » is said silently.:/
+
+[Ant Maria post]
+/:If the Choir is to be left: after its recitation, follows « Dóminus det. » and immediately, one of the Final Antiphones of Our Lady with its Versicle and Oration. <i>(cf. Laudes)</i>:/
 
 [Secreto_]
 /:silently:/

--- a/web/www/horas/Espanol/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Espanol/Psalterium/Common/Rubricae.txt
@@ -8,10 +8,10 @@
 [Credo secreto]
 /:El «Creo» en silencio hasta «La resurrección de la carne».:/
 
-[Pater post]
+[Pater post_]
 /:A partir de entonces sólo se dice «Padre nuestro» en silencio, a menos que siga inmediatamente otra Hora.:/
 
-[Pater post V]
+[Pater post V_]
 /:Y si así termina el Oficio, sólo se dice en silencio «Padre nuestro».:/
 
 [Secreto_]

--- a/web/www/horas/Francais/Psalterium/Common/Prayers.txt
+++ b/web/www/horas/Francais/Psalterium/Common/Prayers.txt
@@ -215,8 +215,7 @@ v. À vous revient la louange, à vous convient l'hymne ; à vous gloire, à Die
 v. Seigneur ayez pitié de nous. Christ ayez pitié de nous. Seigneur ayez pitié de nous.
 
 [Divinum auxilium]
-(rubrica Monastica)
-/:Puis, dans la récitation publique de l'Office, si la Communauté doit quitter le Chœur, on dit le verset suivant.:/
+(rubrica 1963)/:Puis, dans la récitation publique de l'Office, si la Communauté doit quitter le Chœur, on dit le verset suivant.:/
 Que le secours divin + demeure toujours avec nous.
 Et avec nos frères absents. Ainsi soit-il.
 

--- a/web/www/horas/Francais/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Francais/Psalterium/Common/Rubricae.txt
@@ -5,10 +5,10 @@
 [Pater totum secreto]
 /:« Notre Père » en silence.:/
 
-[Pater post]
+[Pater post_]
 /:Par la suite, seul « Notre Père » est prononcé silencieusement, à moins qu'une autre Heure ne suive immédiatement.:/
 
-[Pater post V]
+[Pater post V_]
 /:Et si ainsi l'Office est terminé, seul « Notre Père » est dit en silence.:/
 
 [Secreto_]

--- a/web/www/horas/Italiano/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Italiano/Psalterium/Common/Rubricae.txt
@@ -8,10 +8,10 @@
 [Credo secreto]
 /:Si dice il «Credo» sottovoce fino a «La risurrezione della carne».:/
 
-[Pater post]
+[Pater post_]
 /:Dopodiché si dice silenziosamente solo «Padre nostro», a meno che non segua immediatamente un'altra Ora.:/
 
-[Pater post V]
+[Pater post V_]
 /:E se così l'Ufficio è finito, si dice sottovoce solo «Padre nostro».:/
 
 [Secreto_]

--- a/web/www/horas/Latin/Psalterium/Common/Prayers.txt
+++ b/web/www/horas/Latin/Psalterium/Common/Prayers.txt
@@ -333,9 +333,7 @@ $Credo Carnis
 @:mLitany simplex
 
 [Divinum auxilium]
-(rubrica Monastica)
-/:Si descendendum sit a choro, concluditur dicendo.:/
-(sed rubrica cisterciensis omittitur)
+(rubrica 1963)/:Si descendendum sit a choro, concluditur dicendo.:/
 Divínum auxílium + máneat semper nobíscum.
 Et cum frátribus nostris abséntibus. Amen.
 (sed rubrica cisterciensis)

--- a/web/www/horas/Latin/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Latin/Psalterium/Common/Rubricae.txt
@@ -7,11 +7,23 @@
 [Credo secreto]
 /:« Credo » dicitur secreto usque ad « Carnis resurrectiónem. »:/
 
-[Pater post]
+[Pater post_]
 /:Deinde dicitur tantum « Pater Noster » secreto, nisi sequatur alia Hora.:/
 
-[Pater post V]
+[Pater post V_]
 /:Et si tunc terminetur Officium, dicitur tantum « Pater Noster » secreto.:/
+
+[Ant Maria post]
+/:Si discedendum sit a Choro: eoque recitato, subjungitur « Dóminus det. » Et immediate dicitur, cum suis Versu et Oratione, una ex finalibus beatæ Mariæ Virginis Antiphonis. <i>(sicut ad Laudes)</i>:/
+
+[Pater post]
+(rubrica 1617 aut rubrica 1930)
+@:Pater post_
+(rubrica 1617 aut rubrica 1930)@:Ant Maria post
+
+[Pater post V]
+@:Pater post V_
+(rubrica 1617 aut rubrica 1930)@:Ant Maria post
 
 [Secreto_]
 /:secreto:/

--- a/web/www/horas/Magyar/Psalterium/Common/Prayers.txt
+++ b/web/www/horas/Magyar/Psalterium/Common/Prayers.txt
@@ -212,8 +212,7 @@ v. Téged illet a dicséret, + téged illet a himnusz, dicsőség az Atyaistenne
 v. Uram, irgalmazz nekünk! Krisztus, kegyelmezz nekünk! Uram, irgalmazz nekünk!
 
 [Divinum auxilium]
-(rubrica Monastica)
-/:Puis, dans la récitation publique de l'Office, si la Communauté doit quitter le Chœur, on dit le verset suivant.:/
+(rubrica 1963)/:Puis, dans la récitation publique de l'Office, si la Communauté doit quitter le Chœur, on dit le verset suivant.:/
 V. Az Isten áldása + maradjon mindig velünk.
 R. És távollévő testvéreinkkel. Ámen.
 

--- a/web/www/horas/Magyar/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Magyar/Psalterium/Common/Rubricae.txt
@@ -1,7 +1,7 @@
-[Pater post]
+[Pater post_]
 /:Ezután csak a «Pater Noster» szólal meg némán, hacsak nem következik azonnal újabb óra.:/
 
-[Pater post V]
+[Pater post V_]
 /:És ha így véget ér a Hivatal, csak a «Pater Noster» hangzik el némán.:/
 
 [Secreto_]

--- a/web/www/horas/Nederlands/Psalterium/Common/Prayers.txt
+++ b/web/www/horas/Nederlands/Psalterium/Common/Prayers.txt
@@ -219,9 +219,7 @@ v. Te decet laus, + te decet hymnus: tibi glória Deo Patri, et Fílio, cum Spí
 v. Heer, ontferm U over ons. Christus, ontferm U over ons. Heer, ontferm U over ons.
 
 [Divinum auxilium]
-(rubrica Monastica)
-/:Si descendendum sit a choro, concluditur dicendo.:/
-(sed rubrica cisterciensis omittitur)
+(rubrica 1963)/:Si descendendum sit a choro, concluditur dicendo.:/
 De hulp van God + blijve altijd met ons.
 En met onze afwezige broeders. Amen.
 (sed rubrica cisterciensis)

--- a/web/www/horas/Nederlands/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Nederlands/Psalterium/Common/Rubricae.txt
@@ -8,10 +8,10 @@
 [Credo secreto]
 /:«Credo» is said silently until «The resurrection of the body.»:/
 
-[Pater post]
+[Pater post_]
 /:Thereafter, only « Pater Noster » is said silently, unless another Hour follows immediately.:/
 
-[Pater post V]
+[Pater post V_]
 /:And if thus the Office is ended, only « Pater Noster » is said silently.:/
 
 [Secreto_]

--- a/web/www/horas/Ordinarium/Completorium.txt
+++ b/web/www/horas/Ordinarium/Completorium.txt
@@ -45,7 +45,7 @@ $Deus in adjutorium
 (sed rubrica 196 aut rubrica 1955 aut rubrica cisterciensis omittitur)
 
 #Oratio
-(si rubrica ^Monastic aut rubrica cisterciensis dicuntur)
+(deinde rubrica ^Monastic aut rubrica cisterciensis dicuntur)
 $Kyrie
 $rubrica Pater secreto
 $Pater noster Et

--- a/web/www/horas/Ordinarium/Minor.txt
+++ b/web/www/horas/Ordinarium/Minor.txt
@@ -33,7 +33,7 @@ $Deus in adjutorium
 (deinde dicitur)
 $Fidelium animae
 (sed rubrica cisterciensis omittitur)
-(rubrica Monastica) &Divinum_auxilium
+(rubrica cisterciensis aut rubrica 1963) &Divinum_auxilium
 (rubrica cisterciensis) $Fidelium animae
 
 (si rubrica 1951 dicuntur)

--- a/web/www/horas/Ordinarium/Vespera.txt
+++ b/web/www/horas/Ordinarium/Vespera.txt
@@ -38,7 +38,7 @@ $Deus in adjutorium
 (deinde dicitur)
 $Fidelium animae
 (sed rubrica cisterciensis omittitur)
-(rubrica Monastica) &Divinum_auxilium
+(rubrica cisterciensis aut rubrica 1963) &Divinum_auxilium
 (rubrica cisterciensis) $Fidelium animae
 
 (si rubrica 1951 dicuntur)

--- a/web/www/horas/Polski/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Polski/Psalterium/Common/Rubricae.txt
@@ -8,10 +8,10 @@
 [Credo secreto]
 /:«Wierzę» cicho do «Ciała zmartwychwstanie».:/
 
-[Pater post]
+[Pater post_]
 /:Odtąd po cichu odmawia się tylko «Ojcze nasz», chyba że natychmiast nastąpi następna Godzina.:/
 
-[Pater post V]
+[Pater post V_]
 /:A jeśli w ten sposób zakończy się Oficjum, odmawia się po cichu tylko «Ojcze nasz».:/
 
 [Secreto_]

--- a/web/www/horas/Portugues/Psalterium/Common/Prayers.txt
+++ b/web/www/horas/Portugues/Psalterium/Common/Prayers.txt
@@ -191,8 +191,7 @@ v. Oremos
 v. Senhor, tem piedade de nós. Cristo, tem piedade de nós. Senhor, tem piedade de nós.
 
 [Divinum auxilium]
-(rubrica Monastica)
-/:Ao se retirar do côro, depois da última hora:/
+(rubrica 1963)/:Ao se retirar do côro, depois da última hora:/
 O auxílio divino + permaneça sempre conosco.
 E com nossos irmãos ausentes. Amém.
 

--- a/web/www/horas/Portugues/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Portugues/Psalterium/Common/Rubricae.txt
@@ -5,10 +5,10 @@
 [Credo secreto]
 /:«Credo» é dito silenciosamente até «Na ressurreição da carne.»:/
 
-[Pater post]
+[Pater post_]
 /:Depois disso, apenas «Pai Nosso» é dito silenciosamente, a menos que outra Hora se siga imediatamente.:/
 
-[Pater post V]
+[Pater post V_]
 /:E se assim o Ofício termina, apenas «Pai Nosso» é dito silenciosamente.:/
 
 [Secreto_]


### PR DESCRIPTION
- Fixed Compline when Preces Dominicales are not to be said
- corrected the conclusion of the minor hours (no Divinum auxilium)
- added rubric before final Pater noster

The rubrics pointed out for Monastic 1930 are actually the same as in the Tridentine books. DO, however, presumes that the recitation is done in private and that there is a break after Lauds: therefore, the only two places to show the Final Antiphone are Lauds and Compline. — If someone is to join Prime and more hours after Matins and lauds, technically, he should postpone the Antiphone until he stops—but then that is "expert mode" which goes beyond the purpose of the website IMHO.

@mbab Please double check if I have overlooked something. I think just today's Feast of the Apostles is sufficient to have a look at all the hours conclusions.