### PR TITLE
CIST: Oratio de S. Lucia fixed

### DIFF
--- a/web/www/horas/Bohemice/SanctiM/12-13.txt
+++ b/web/www/horas/Bohemice/SanctiM/12-13.txt
@@ -1,0 +1,5 @@
+[Officium]
+S. Luciae Virginis et Martyris
+
+[Name]
+Lucie, panny a mučednice

--- a/web/www/horas/Latin/SanctiM/12-13.txt
+++ b/web/www/horas/Latin/SanctiM/12-13.txt
@@ -13,6 +13,9 @@ ex C6;
 Lectio1 tempora
 (rubrica 1951) Doxology=NatT
 
+[Name]
+Lúciæ Vírginis et Mártyris tuæ
+
 [Oratio] (rubrica cisterciensis)
 @Sancti/12-13
 


### PR DESCRIPTION
In the Cistercian rite, S. Lucia has a simple ordo _de Commune_, so the linking to the Roman file had to be excluded, but this excluded the N. replacement as well, which is needed in the Collect. Fixed.