### PR TITLE
'Act 7:55; 7:58; 7:59' → 'Act 7:55; 7:58-59'; removed spurious newline; added some accent marks to words with ≥3 syllables.

### DIFF
--- a/web/www/missa/Francais/Sancti/08-03.txt
+++ b/web/www/missa/Francais/Sancti/08-03.txt
@@ -40,7 +40,7 @@ Seigneur, acceptez ces offrandes en mémoire de vos saints : comme le martyre le
 $Per Dominum
 
 [Communio]
-!Act 7:55; 7:58; 7:59
+!Act 7:55; 7:58-59
 Je vois les cieux ouverts et Jésus debout à la droite du Dieu tout puissant : Seigneur Jésus, accueillez mon âme et ne leur tenez pas rigueur de ce péché.
 
 [Postcommunio]

--- a/web/www/missa/Francais/Sancti/12-26.txt
+++ b/web/www/missa/Francais/Sancti/12-26.txt
@@ -65,7 +65,7 @@ $Per Dominum
 @Sancti/12-25m3:Secreta
 
 [Communio]
-!Act 7:55; 7:58; 7:59
+!Act 7:55; 7:58-59
 Je vois les cieux ouverts et Jésus debout à la droite du Dieu tout puissant : Seigneur Jésus, accueille mon âme et ne leur tient pas rigueur de ce péché.
 
 [Postcommunio]

--- a/web/www/missa/Italiano/Sancti/08-03.txt
+++ b/web/www/missa/Italiano/Sancti/08-03.txt
@@ -39,7 +39,7 @@ Ricevi, o Signore, i doni per la commemorazione dei tuoi Santi: affinché, come 
 $Per Dominum
 
 [Communio]
-!Act 7:55; 7:58; 7:59
+!Act 7:55; 7:58-59
 Vedo i cieli aperti, e Gesù ritto alla destra della potenza di Dio. Signore Gesù, ricevi il mio spirito e  non imputar loro questo a peccato.
 
 [Postcommunio]

--- a/web/www/missa/Italiano/Sancti/12-26.txt
+++ b/web/www/missa/Italiano/Sancti/12-26.txt
@@ -65,7 +65,7 @@ $Per Dominum
 @Sancti/12-25m3:Secreta
 
 [Communio]
-!Act 7:55; 7:58; 7:59
+!Act 7:55; 7:58-59
 Vedo i cieli aperti e Gesù stare alla destra di Dio. Signore Gesù, accogli il mio spirito, e non imputare loro questo peccato.
 
 [Postcommunio]

--- a/web/www/missa/Latin/Sancti/08-03.txt
+++ b/web/www/missa/Latin/Sancti/08-03.txt
@@ -48,7 +48,7 @@ Súscipe, Dómine, múnera pro tuórum commemoratióne Sanctórum: ut, sicut ill
 $Per Dominum
 
 [Communio]
-!Act 7:55; 7:58; 7:59
+!Act 7:55; 7:58-59
 Vídeo cœlos apértos, et Jesum stantem a dextris virtútis Dei: Dómine Jesu, accipe spíritum meum, et ne státuas illis hoc peccátum.
 
 [Postcommunio]

--- a/web/www/missa/Latin/Tempora/093-6.txt
+++ b/web/www/missa/Latin/Tempora/093-6.txt
@@ -90,8 +90,7 @@ Benedíctus es in templo sancto glóriæ tuæ. Et laudábilis et gloriósus in s
 Benedíctus es super thronum sanctum regni tui. Et laudábilis et gloriósus in sǽcula.
 Benedíctus es super sceptrum divinitátis tuæ. Et laudábilis et gloriósus in sǽcula.
 Benedíctus es, qui sedes super Chérubim, íntuens abýssos. Et laudábilis et gloriósus in sǽcula.
-Benedíctus es, qui ámbulas super pennas ventórum et super undas maris. Et laudábilis
-et gloriósus in sǽcula.
+Benedíctus es, qui ámbulas super pennas ventórum et super undas maris. Et laudábilis et gloriósus in sǽcula.
 Benedícant te omnes Angeli et Sancti tui. Et laudent te et gloríficent in sǽcula.
 Benedícant te coeli, terra, mare, et ómnia quæ in eis sunt. Et laudent te et gloríficent in sǽcula.
 Glória Patri, et Fílio, et Spirítui Sancto. Et laudábili et glorióso in sǽcula.

--- a/web/www/missa/Latin/Tempora/Adv4-0.txt
+++ b/web/www/missa/Latin/Tempora/Adv4-0.txt
@@ -30,7 +30,7 @@ $Qui vivis
 [Lectio]
 Léctio Epístolæ beáti Pauli Apóstoli ad Corínthios
 !1 Cor 4:1-5
-Fratres: Sic nos exístimet homo ut minístros Christi, et dispensatóres mysteriórum Dei. Hic jam quǽritur inter dispensatóres, ut fidélis quis inveniátur. Mihi autem pro mínimo est, ut a vobis júdicer aut ab humano die: sed neque meípsum judico. Nihil enim mihi cónscius sum: sed non in hoc justificátus sum: qui autem júdicat me, Dóminus est. Itaque nolíte ante tempus judicáre, quoadúsque véniat Dóminus: qui et illuminábit abscóndita tenebrárum, et manifestábit consília córdium: et tunc laus erit unicuique a Deo.
+Fratres: Sic nos exístimet homo ut minístros Christi, et dispensatóres mysteriórum Dei. Hic jam quǽritur inter dispensatóres, ut fidélis quis inveniátur. Mihi autem pro mínimo est, ut a vobis júdicer aut ab humáno die: sed neque meípsum júdico. Nihil enim mihi cónscius sum: sed non in hoc justificátus sum: qui autem júdicat me, Dóminus est. Ítaque nolíte ante tempus judicáre, quoadúsque véniat Dóminus: qui et illuminábit abscóndita tenebrárum, et manifestábit consília córdium: et tunc laus erit unicúique a Deo.
 
 [Graduale]
 !Ps 144:18; 144:21

--- a/web/www/missa/Nederlands/Sancti/08-03.txt
+++ b/web/www/missa/Nederlands/Sancti/08-03.txt
@@ -41,7 +41,7 @@ Aanvaard, Heer, de gaven bij de gedachtenis van uw heiligen, opdat onze godsvruc
 $Per Dominum
 
 [Communio]
-!Act 7:55; 7:58; 7:59
+!Act 7:55; 7:58-59
 Ik zie de hemel geopend, en Jezus staande aan de rechterhand van de kracht Gods. Heer Jezus, ontvang mijn geest en reken hun deze zonde niet toe.
 
 [Postcommunio]

--- a/web/www/missa/Portugues/Sancti/12-26.txt
+++ b/web/www/missa/Portugues/Sancti/12-26.txt
@@ -69,7 +69,7 @@ Santificai, Senhor, pelo novo Nascimento do vosso Filho Unigénito, as oblatas q
 $Per eundem
 
 [Communio]
-!Act 7:55; 7:58; 7:59
+!Act 7:55; 7:58-59
 Vejo os céus abertos e Jesus, de pé, à dextra de Deus omnipotente. Ó Senhor Jesus, recebei o meu espírito e lhes não imputeis este pecado.
 
 [Postcommunio]


### PR DESCRIPTION
felicem novum annum lætum 😃🎆
