### PR TITLE
Fix and complete German translations for Psalms split for the hours

### DIFF
--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm101.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm101.txt
@@ -1,29 +1,29 @@
-101:2 Dómine, exáudi oratiónem meam: * et clamor meus ad te véniat.
-101:3 Non avértas fáciem tuam a me: * in quacúmque die tríbulor, inclína ad me aurem tuam.
-101:3 In quacúmque die invocávero te, * velóciter exáudi me.
-101:4 Quia defecérunt sicut fumus dies mei: * et ossa mea sicut crémium aruérunt.
-101:5 Percússus sum ut fœnum, et áruit cor meum: * quia oblítus sum comédere panem meum.
-101:6 A voce gémitus mei * adhæsit os meum carni meæ.
-101:7 Símilis factus sum pellicáno solitúdinis: * factus sum sicut nyctícorax in domicílio.
-101:8 Vigilávi, * et factus sum sicut passer solitárius in tecto.
-101:9 Tota die exprobrábant mihi inimíci mei: * et qui laudábant me, advérsum me jurábant.
-101:10 Quia cínerem tamquam panem manducábam, * et potum meum cum fletu miscébam.
-101:11 A fácie iræ et indignatiónis tuæ: * quia élevans allisísti me.
-101:12 Dies mei sicut umbra declinavérunt: * et ego sicut fœnum árui.
-101:13 Tu autem, Dómine, in ætérnum pérmanes: * et memoriále tuum in generatiónem et generatiónem.
-101:14 Tu exsúrgens miseréberis Sion: * quia tempus miseréndi ejus, quia venit tempus.
-101:15 Quóniam placuérunt servis tuis lápides ejus: * et terræ ejus miserebúntur.
-101:16 Et timébunt gentes nomen tuum, Dómine, * et omnes reges terræ glóriam tuam.
-101:17 Quia ædificávit Dóminus Sion: * et vidébitur in glória sua.
-101:18 Respéxit in oratiónem humílium: * et non sprevit precem eórum.
-101:19 Scribántur hæc in generatióne áltera: * et pópulus, qui creábitur, laudábit Dóminum:
-101:20 Quia prospéxit de excélso sancto suo: * Dóminus de cælo in terram aspéxit:
-101:21 Ut audíret gémitus compeditórum: * ut sólveret fílios interemptórum:
-101:22 Ut annúntient in Sion nomen Dómini: * et laudem ejus in Jerúsalem.
-101:23 In conveniéndo pópulos in unum, * et reges ut sérviant Dómino.
-101:24 Respóndit ei in via virtútis suæ: * Paucitátem diérum meórum núntia mihi.
-101:25 Ne révoces me in dimídio diérum meórum: * in generatiónem et generatiónem anni tui.
-101:26 Inítio tu, Dómine, terram fundásti: * et ópera mánuum tuárum sunt cæli.
-101:27 Ipsi períbunt, tu autem pérmanes: * et omnes sicut vestiméntum veteráscent.
-101:28 Et sicut opertórium mutábis eos, et mutabúntur: * tu autem idem ipse es, et anni tui non defícient.
-101:29 Fílii servórum tuórum habitábunt: * et semen eórum in sæculum dirigétur.
+101:2 Herr, erhöre mein Gebet, * und mein rufen gelange zu Dir.
+101:3 Wende Dein Angesicht nicht ab von mir; * an welchem Tag auch immer ich bedrängt werde, neige zu mir Dein Ohr.
+101:3 An welchem Tag auch immer ich Dich anrufe, * erhöre mich schnell.
+101:4 Denn hingeschwunden wie rauch sind meine Tage, * und meine Gebeine verdorrt wie brennholz.
+101:5 ich wurde geschlagen wie Gras, und es verdorrte mein Herz, * denn ich vergaß, mein brot zu essen.
+101:6 Vom laut meines Seufzens * klebt mein Gebein an meinem Fleisch.
+101:7 ich gleiche dem Pelikan der Wüste, * bin geworden wie eine nachteule in ihrer behausung.
+101:8 ich habe gewacht * und bin geworden wie ein einsamer Sperling auf dem Dach.
+101:9 Den ganzen Tag verhöhnten mich meine Feinde, * und die mich lobten, verschworen sich gegen mich.
+101:10 Denn Asche aß ich wie brot, * und meinen Trank mischte ich mit Tränen,
+101:11 vor dem Angesicht Deines zornes und Deiner Empörung, * denn Du hobst mich empor und schmettertest mich nieder.
+101:12 meine Tage neigen sich wie Schatten, * und ich verdorre wie Gras.
+101:13 Du aber, Herr, bleibst in Ewigkeit * und Dein Gedenken von Geschlecht zu Geschlecht.
+101:14 Du wirst Dich erheben und Dich Sions erbarmen, * denn es ist zeit, sich seiner zu erbarmen, ja, gekommen ist die zeit.
+101:15 Denn seine Steine gefallen Deinen Knechten, * und sie fühlen Erbarmen mit seiner Erde.
+101:16 und die Völker werden Deinen namen fürchten, o Herr, * und alle Könige der Erde Deine Herrlichkeit.
+101:17 Denn der Herr hat Sion erbaut, * und er wird in seiner Herrlichkeit erscheinen.
+101:18 Er sah auf das Gebet der Demütigen, * und er verschmähte nicht ihre bitte.
+101:19 man schreibe dies für ein kommendes Geschlecht; * und ein Volk, das einst geschaffen wird, wird loben den Herrn.
+101:20 Denn er schaute herab von seiner heiligen Höhe, * der Herr blickte vom Himmel auf die Erde,
+101:21 auf dass er höre das Seufzen der Gefesselten * und die Söhne der Getöteten erlöse,
+101:22 damit sie in Sion den namen des Herrn verkünden * und sein lob in Jerusalem,
+101:23 wenn die Völker sich allzumal versammeln * und die Könige, um dem Herrn zu dienen.
+101:24 Es antwortete ihm [das geprüfte Volk] auf dem Weg seiner Stärke: * Die geringe zahl meiner Tage tue mir kund!
+101:25 berufe mich nicht ab in der Hälfte meiner Tage; * von Geschlecht zu Geschlecht währen Deine Jahre.
+101:26 im Anbeginn hast Du, o Herr, die Erde begründet, * und Werke Deiner Hände sind die Himmel.
+101:27 Sie werden vergehen, Du aber bleibst, * und sie alle werden altern wie ein Kleid.
+101:28 und wie ein Gewand wirst Du sie wechseln, und sie werden getauscht, * Du aber bist immer derselbe, und Deine Jahre enden nie.
+101:29 Die Söhne Deiner Knechte werden Wohnung nehmen, * und ihre nachkommen werden bleiben in Ewigkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm102.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm102.txt
@@ -1,22 +1,22 @@
-102:1 Bénedic, ánima mea, Dómino: * et ómnia, quæ intra me sunt, nómini sancto ejus.
-102:2 Bénedic, ánima mea, Dómino: * et noli oblivísci omnes retributiónes ejus.
-102:3 Qui propitiátur ómnibus iniquitátibus tuis: * qui sanat omnes infirmitátes tuas.
-102:4 Qui rédimit de intéritu vitam tuam: * qui corónat te in misericórdia et miseratiónibus.
-102:5 Qui replet in bonis desidérium tuum: * renovábitur ut áquilæ juvéntus tua:
-102:6 Fáciens misericórdias Dóminus: * et judícium ómnibus injúriam patiéntibus.
-102:7 Notas fecit vias suas Móysi, * fíliis Israël voluntátes suas.
-102:8 Miserátor, et miséricors Dóminus: * longánimis, et multum miséricors.
-102:9 Non in perpétuum irascétur: * neque in ætérnum comminábitur.
-102:10 Non secúndum peccáta nostra fecit nobis: * neque secúndum iniquitátes nostras retríbuit nobis.
-102:11 Quóniam secúndum altitúdinem cæli a terra: * corroborávit misericórdiam suam super timéntes se.
-102:12 Quantum distat ortus ab occidénte: * longe fecit a nobis iniquitátes nostras.
-102:13 Quómodo miserétur pater filiórum, misértus est Dóminus timéntibus se: * quóniam ipse cognóvit figméntum nostrum.
-102:14 Recordátus est quóniam pulvis sumus: * homo, sicut fœnum dies ejus, tamquam flos agri sic efflorébit.
-102:16 Quóniam spíritus pertransíbit in illo, et non subsístet: * et non cognóscet ámplius locum suum.
-102:17 Misericórdia autem Dómini ab ætérno, * et usque in ætérnum super timéntes eum.
-102:17 Et justítia illíus in fílios filiórum, * his qui servant testaméntum ejus:
-102:18 Et mémores sunt mandatórum ipsíus, * ad faciéndum ea.
-102:19 Dóminus in cælo parávit sedem suam: * et regnum ipsíus ómnibus dominábitur.
-102:20 Benedícite Dómino, omnes Ángeli ejus: * poténtes virtúte, faciéntes verbum illíus, ad audiéndam vocem sermónum ejus.
-102:21 Benedícite Dómino, omnes virtútes ejus: * minístri ejus, qui fácitis voluntátem ejus.
-102:22 Benedícite Dómino, ómnia ópera ejus: * in omni loco dominatiónis ejus, bénedic, ánima mea, Dómino.
+102:1 Preise, meine Seele, den Herrn, * und alles, was in mir ist, seinen heiligen namen!
+102:2 Preise, meine Seele, den Herrn, * und vergiss nicht all seine Wohltaten.
+102:3 Er ist es, der dir alle Sünden vergibt * und der all deine Gebrechen heilt,
+102:4 der dein leben vom untergang erlöst, * der dich krönt mit barmherzigkeit und Erbarmen,
+102:5 der dein Sehnen mit Gütern erfüllt. * Deine Jugend wird sich erneuern wie die des Adlers.
+102:6 Der Herr übt barmherzigkeit * und schafft recht allen, die unrecht leiden.
+102:7 Er tat moses seine Wege kund * und den Söhnen israels seinen Willen.
+102:8 Ein Erbarmer und barmherzig ist der Herr, * langmütig und sehr barmherzig.
+102:9 nicht für immer wird er zürnen * und nicht auf ewig drohen.
+102:10 nicht nach unseren Sünden verfuhr er mit uns, * noch hat er uns nach unseren Vergehen vergolten.
+102:11 Denn gemäß der Höhe des Himmels über der Erde, * hat er stark gemacht seine barmherzigkeit über denen, die ihn fürchten.
+102:12 So weit der Aufgang entfernt ist vom untergang, * ließ er fern sein von uns all unsere missetaten.
+102:13 Wie ein Vater sich seiner Kinder erbarmt, so hat sich der Herr erbarmt über alle, die ihn fürchten, * denn er weiß, was wir für ein Gebilde sind.
+102:14 Er denkt daran, dass wir Staub sind; * der mensch, wie Gras sind seine Tage, wie eine blume des Feldes, so wird er erblühen.
+102:16 Denn der Geist wird vorübergehn in ihm, und er wird nicht bestehen, * und seinen Ort wird er nicht mehr kennen.
+102:17 Die barmherzigkeit des Herrn aber währt seit ewig * und bis in Ewigkeit über denen, die ihn fürchten,
+102:17 und seine Gerechtigkeit über den Kindeskindern, * über jenen, die bewahren seinen bund,
+102:18 und die denken an seine Gebote, * um sie zu erfüllen.
+102:19 Der Herr hat im Himmel seinen Thron bereitet, * und sein Königtum herrscht über alles.
+102:20 Preiset den Herrn, all seine Engel, * die ihr, gewaltig an Kraft, sein Wort vollbringt, bereit, zu hören auf die Stimme seiner reden.
+102:21 Preiset den Herrn, all seine Heerscharen, * seine Diener, die ihr seinen Willen tut.
+102:22 Preiset den Herrn, all seine Werke, * an jedem Ort seiner Herrschaft, preise, meine Seele, den Herrn!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm103.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm103.txt
@@ -1,36 +1,36 @@
-103:1 Bénedic, ánima mea, Dómino: * Dómine, Deus meus, magnificátus es veheménter.
-103:1 Confessiónem, et decórem induísti: * amíctus lúmine sicut vestiménto:
-103:2 Exténdens cælum sicut pellem: * qui tegis aquis superióra ejus.
-103:3 Qui ponis nubem ascénsum tuum: * qui ámbulas super pennas ventórum.
-103:4 Qui facis ángelos tuos, spíritus: * et minístros tuos ignem uréntem.
-103:5 Qui fundásti terram super stabilitátem suam: * non inclinábitur in sæculum sæculi.
-103:6 Abýssus, sicut vestiméntum, amíctus ejus: * super montes stabunt aquæ.
-103:7 Ab increpatióne tua fúgient: * a voce tonítrui tui formidábunt.
-103:8 Ascéndunt montes: et descéndunt campi * in locum, quem fundásti eis.
-103:9 Términum posuísti, quem non transgrediéntur: * neque converténtur operíre terram.
-103:10 Qui emíttis fontes in convállibus: * inter médium móntium pertransíbunt aquæ.
-103:11 Potábunt omnes béstiæ agri: * exspectábunt ónagri in siti sua.
-103:12 Super ea vólucres cæli habitábunt: * de médio petrárum dabunt voces.
-103:13 Rigans montes de superióribus suis: * de fructu óperum tuórum satiábitur terra:
-103:14 Prodúcens fœnum juméntis, * et herbam servitúti hóminum:
-103:14 Ut edúcas panem de terra: * et vinum lætíficet cor hóminis:
-103:15 Ut exhílaret fáciem in óleo: * et panis cor hóminis confírmet.
-103:16 Saturabúntur ligna campi, et cedri Líbani, quas plantávit: * illic pásseres nidificábunt.
-103:17 Heródii domus dux est eórum: * montes excélsi cervis: petra refúgium herináciis.
-103:19 Fecit lunam in témpora: * sol cognóvit occásum suum.
-103:20 Posuísti ténebras, et facta est nox: * in ipsa pertransíbunt omnes béstiæ silvæ.
-103:21 Cátuli leónum rugiéntes, ut rápiant, * et quærant a Deo escam sibi.
-103:22 Ortus est sol, et congregáti sunt: * et in cubílibus suis collocabúntur.
-103:23 Exíbit homo ad opus suum: * et ad operatiónem suam usque ad vésperum.
-103:24 Quam magnificáta sunt ópera tua, Dómine! * ómnia in sapiéntia fecísti: impléta est terra possessióne tua.
-103:25 Hoc mare magnum, et spatiósum mánibus: * illic reptília, quorum non est númerus.
-103:26 Animália pusílla cum magnis: * illic naves pertransíbunt.
-103:27 Draco iste, quem formásti ad illudéndum ei: * ómnia a te exspéctant ut des illis escam in témpore.
-103:28 Dante te illis, cólligent: * aperiénte te manum tuam, ómnia implebúntur bonitáte.
-103:29 Averténte autem te fáciem, turbabúntur: * áuferes spíritum eórum, et defícient, et in púlverem suum reverténtur.
-103:30 Emíttes spíritum tuum, et creabúntur: * et renovábis fáciem terræ.
-103:31 Sit glória Dómini in sæculum: * lætábitur Dóminus in opéribus suis:
-103:32 Qui réspicit terram, et facit eam trémere: * qui tangit montes, et fúmigant.
-103:33 Cantábo Dómino in vita mea: * psallam Deo meo, quámdiu sum.
-103:34 Jucúndum sit ei elóquium meum: * ego vero delectábor in Dómino.
-103:35 Defíciant peccatóres a terra, et iníqui ita ut non sint: * bénedic, ánima mea, Dómino.
+103:1 lobpreise, meine Seele, den Herrn; * Herr, mein Gott, Du bist gar hoch gepriesen!
+103:1 lobpreis und Pracht hast Du angetan, * bist umhüllt mit licht wie mit einem Gewand,
+103:2 der Du ausspannst den Himmel wie ein Fell, * der Du mit Wassern seine oberen räume bedeckst,
+103:3 der Du Gewölk zu Deinem Aufstieg machst, * der Du wandelst auf den Flügeln der Winde,
+103:4 der Du zu Deinen boten die Geister machst * und Deine Diener zu loderndem Feuer,
+103:5 der Du die Erde begründet hast auf ihrem festen Fundament; * sie wird nicht wanken in alle Ewigkeit.
+103:6 Der Abgrund ist, gleich einem Kleid, ihre umhüllung, * hoch auf den bergen werden Wasser stehen.
+103:7 Vor Deiner Schelte werden sie fliehen, * vor der Stimme Deines Donners erschrecken.
+103:8 Es erheben sich die berge und senken sich die Felder, * hin zu dem Ort, den Du für sie begründet hast.
+103:9 Eine Grenze hast Du gesetzt, die sie nicht überschreiten, * und sie werden nicht zurückkehren, die Erde zu be decken.
+103:10 Der Du Quellen hervorsprudeln lässt in den Tälern: * zwischen den bergen werden Wasser hindurchgehen.
+103:11 Es werden trinken alle Tiere des Feldes, * danach verlangen die Wildesel in ihrem Durst.
+103:12 Über ihnen werden die Vögel des Himmels wohnen, * mitten aus den Felsen lassen sie ihre Stimmen hören.
+103:13 Du bist es, der die berge tränkt von seinen oberen räumen aus, * von der Frucht Deiner Werke wird gesättigt die Erde.
+103:14 Du lässt Gras wachsen für das Vieh * und Kraut zum Dienst für die menschen,
+103:14 um brot hervorzubringen aus der Erde, * und dass Wein des menschen Herz erfreue,
+103:15 um das Gesicht zu erheitern mit Öl, * und dass brot des menschen Herz stärke.
+103:16 Gesättigt werden die bäume des Feldes und die zedern des libanon, die er gepflanzt hat, * dort werden Sperlinge nisten.
+103:17 Das nest des reihers ist ihr Führer, * die hohen berge sind für die Hirsche, die Felsen eine zuflucht für igel.
+103:19 Er hat den mond gemacht für die zeiten, * die Sonne kennt ihren untergang.
+103:20 Du hast Finsternis gesetzt, und es ward nacht; * in ihr schweifen umher alle Tiere des Waldes,
+103:21 die Jungen der löwen, die brüllen um zu reißen * und die von Gott ihre nahrung verlangen.
+103:22 Aufgegangen ist die Sonne und sie versammelten sich, * und auf ihren lagern werden sie sich niederlassen.
+103:23 Hinausgehen wird der mensch zu seinem Werk * und an seine Arbeit bis zum Abend.
+103:24 Wie groß sind Deine Werke, o Herr! * Alles hast Du in Weisheit gemacht, erfüllt ist die Erde mit Deinem Eigentum.
+103:25 Dies große und weite meer mit seinen Armen, * dort sind Kriechtiere, die ohne zahl sind,
+103:26 lebewesen, kleine mit großen, * dort ziehen Schiffe dahin,
+103:27 dieser Drache, den Du geformt hast, um darin zu spielen, * sie alle erwarten von Dir, dass Du ihnen nahrung gibst zur rechten zeit.
+103:28 Gibst Du ihnen, werden sie sammeln, * öffnest Du Deine Hand, werden sie alle erfüllt mit Gutem.
+103:29 Wendest Du aber Dein Angesicht ab, werden sie verwirrt, * nimmst Du ihren Geist hinweg, schwinden sie dahin und kehren zurück zum Staub.
+103:30 Aussenden wirst Du Deinen Geist, und sie werden erschaffen, * und Du wirst das Angesicht der Erde erneuern.
+103:31 Es sei die Herrlichkeit des Herrn in Ewigkeit, * freuen wird sich der Herr an seinen Werken,
+103:32 der auf die Erde blickt und sie erbeben lässt, * der die berge berührt, und sie rauchen.
+103:33 Singen will ich dem Herrn in meinem leben, * spielen meinem Gott, solange ich bin.
+103:34 Angenehm sei ihm mein Ausspruch, * ich aber will mich freuen im Herrn.
+103:35 Dahinschwinden mögen die Sünder von der Erde und die Frevler, so dass sie nicht mehr sind. * lobpreise, meine Seele, den Herrn!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm104.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm104.txt
@@ -1,44 +1,44 @@
-104:1 Confitémini Dómino, et invocáte nomen ejus: * annuntiáte inter Gentes ópera ejus.
-104:2 Cantáte ei, et psállite ei: * narráte ómnia mirabília ejus.
-104:3 Laudámini in nómine sancto ejus: * lætétur cor quæréntium Dóminum.
-104:4 Quærite Dóminum, et confirmámini: * quærite fáciem ejus semper.
-104:5 Mementóte mirabílium ejus, quæ fecit: * prodígia ejus, et judícia oris ejus.
-104:6 Semen Ábraham, servi ejus: * fílii Jacob, elécti ejus.
-104:7 Ipse Dóminus Deus noster: * in univérsa terra judícia ejus.
-104:8 Memor fuit in sæculum testaménti sui: * verbi, quod mandávit in mille generatiónes:
-104:9 Quod dispósuit ad Ábraham: * et juraménti sui ad Isaac:
-104:10 Et státuit illud Jacob in præcéptum: * et Israël in testaméntum ætérnum:
-104:11 Dicens: Tibi dabo terram Chánaan, * funículum hereditátis vestræ.
-104:12 Cum essent número brevi, * paucíssimi et íncolæ ejus:
-104:13 Et pertransiérunt de gente in gentem, * et de regno ad pópulum álterum.
-104:14 Non relíquit hóminem nocére eis: * et corrípuit pro eis reges.
-104:15 Nolíte tángere christos meos: * et in prophétis meis nolíte malignári.
-104:16 Et vocávit famem super terram: * et omne firmaméntum panis contrívit.
-104:17 Misit ante eos virum: * in servum venúmdatus est Joseph.
-104:18 Humiliavérunt in compédibus pedes ejus, ferrum pertránsiit ánimam ejus * donec veníret verbum ejus.
-104:19 Elóquium Dómini inflammávit eum: * misit rex, et solvit eum; princeps populórum, et dimísit eum.
-104:21 Constítuit eum dóminum domus suæ: * et príncipem omnis possessiónis suæ:
-104:22 Ut erudíret príncipes ejus sicut semetípsum: * et senes ejus prudéntiam docéret.
-104:23 Et intrávit Israël in Ægýptum: * et Jacob áccola fuit in terra Cham.
-104:24 Et auxit pópulum suum veheménter: * et firmávit eum super inimícos ejus.
-104:25 Convértit cor eórum ut odírent pópulum ejus: * et dolum fácerent in servos ejus.
-104:26 Misit Móysen, servum suum: * Aaron, quem elégit ipsum.
-104:27 Pósuit in eis verba signórum suórum: * et prodigiórum in terra Cham.
-104:28 Misit ténebras, et obscurávit: * et non exacerbávit sermónes suos.
-104:29 Convértit aquas eórum in sánguinem: * et occídit pisces eórum.
-104:30 Édidit terra eórum ranas: * in penetrálibus regum ipsórum.
-104:31 Dixit, et venit cœnomyía: * et cínifes in ómnibus fínibus eórum.
-104:32 Pósuit plúvias eórum grándinem: * ignem comburéntem in terra ipsórum.
-104:33 Et percússit víneas eórum, et ficúlneas eórum: * et contrívit lignum fínium eórum.
-104:34 Dixit, et venit locústa, et bruchus, * cujus non erat númerus:
-104:35 Et comédit omne fœnum in terra eórum: * et comédit omnem fructum terræ eórum.
-104:36 Et percússit omne primogénitum in terra eórum: * primítias omnis labóris eórum.
-104:37 Et edúxit eos cum argénto et auro: * et non erat in tríbubus eórum infírmus.
-104:38 Lætáta est Ægýptus in profectióne eórum: * quia incúbuit timor eórum super eos.
-104:39 Expándit nubem in protectiónem eórum: * et ignem ut lucéret eis per noctem.
-104:40 Petiérunt, et venit cotúrnix: * et pane cæli saturávit eos.
-104:41 Dirúpit petram et fluxérunt aquæ: * abiérunt in sicco flúmina;
-104:42 Quóniam memor fuit verbi sancti sui: * quod hábuit ad Ábraham, púerum suum.
-104:43 Et edúxit pópulum suum in exsultatióne, * et eléctos suos in lætítia.
-104:44 Et dedit illis regiónes Géntium: * et labóres populórum possedérunt:
-104:45 Ut custódiant justificatiónes ejus, * et legem ejus requírant.
+104:1 Preiset den Herrn und ruft seinen namen an, * verkündet bei den Völkern seine Werke.
+104:2 Singt ihm und spielt ihm, * erzählt all seine Wunder.
+104:3 rühmt euch seines heiligen namens, * es freue sich das Herz derer, die den Herrn suchen.
+104:4 Suchet den Herrn, und ihr werdet gestärkt, * suchet sein Angesicht immerdar.
+104:5 Gedenkt seiner Wunder, die er getan, * seiner zeichen und der Urteile seines Mundes,
+104:6 ihr nachkommen Abrahams, seine Knechte, * ihr Söhne Jakobs, seine Erwählten.
+104:7 Er ist der Herr, unser Gott, * auf der ganzen Erde gelten seine Urteile.
+104:8 Eingedenk war er auf ewig seines bundes, * des Wortes, das er entboten auf tausend Geschlechter hin,
+104:9 den er angeordnet für Abraham, * und seines Eides an isaak.
+104:10 Und er gab ihn Jakob als Gebot * und für israel als ewigen bund,
+104:11 da er sprach: Dir will ich das Land Kanaan geben * als das zugemessene Land eures Erbes.
+104:12 Als sie an zahl gering waren, * sehr wenige und Fremdlinge in ihm,
+104:13 und da sie zogen von Volk zu Volk, * und von einem reich zu einem anderen Volk,
+104:14 ließ er keinen Menschen, der ihnen schade, * und ihret wegen strafte er Könige.
+104:15 Tastet nicht an meine Gesalbten, * und an meinen Propheten handelt nicht schlecht!
+104:16 Und er rief Hungersnot über das Land, * und jegliche Stütze an brot zerbrach er.
+104:17 Er sandte einen Mann vor ihnen her: * Als Sklave wurde Joseph verkauft.
+104:18 Sie erniedrigten mit Fesseln sei ne Füße, Eisen durchdrang seine Seele, * bis eintraf sein Wort.
+104:19 Der Spruch des Herrn hat ihn entflammt; * der König sandte hin und befreite ihn, der Fürst der Völker, und er ließ ihn heraus.
+104:21 Er machte ihn zum Herrn seines Hauses * und zum Herrscher über seinen ganzen besitz,
+104:22 dass er seine Fürsten bilde wie sich selbst * und seine Greise Klugheit lehre.
+104:23 Und israel zog nach ägypten, * und Jakob wurde Anwohner im Lande Chams.
+104:24 Und vermehrt hat er sein Volk gar sehr * und es stärker gemacht als seine Feinde.
+104:25 Deren Herz verkehrte er, sodass sie hassten sein Volk, * und List gebrauchten gegen seine Diener.
+104:26 Er sandte Moses, seinen Knecht, * Aaron, den er selbst erwählt hat.
+104:27 Durch sie richtete er die Worte seiner zeichen auf * und der Wundertaten im Lande Chams.
+104:28 Er sandte Finsternis, und es wurde dunkel, * und ließ seine Worte nicht zunichte werden.
+104:29 Er verwandelte ihre Gewässer in blut * und tötete ihre Fische.
+104:30 ihr Land brachte Frösche hervor * (selbst) in den Gemächern ihrer Könige.
+104:31 Er sprach, und es kam die Fliege, * und die Stechmücke in ihrem ganzen Gebiet.
+104:32 ihren regen machte er zu Hagel, * gab verzehrendes Feuer in ihr Land.
+104:33 Und er zerschlug ihre Weinstöcke und ihre Feigenbäume * und zerbrach das Gehölz ihres Gebietes.
+104:34 Er sprach, und es kam die Heuschrecke und die Grille, * die zahllos war.
+104:35 Und sie fraß alles Gras in ihrem Land, * und sie fraß alle Frucht ihres Landes.
+104:36 Und er schlug alle Erstgeburt in ihrem Land, * die Erstlinge all ihrer Wehen.
+104:37 Und er führte sie heraus mit Silber und Gold, * und in all ihren Stämmen war kein Schwacher.
+104:38 ägypten freute sich bei ihrem Auszug, * denn ihr Schrecken war auf sie gefallen.
+104:39 Er breitete eine Wolke aus zu ihrem Schutz * und Feuer, um ihnen zu leuchten in der nacht.
+104:40 Sie baten, und es kam die Wachtel, * und mit dem brot des Himmels hat er sie gesättigt.
+104:41 Er ließ bersten den Felsen und es flossen Wasser, * im dürren Land flossen Ströme dahin.
+104:42 Denn er war eingedenk seines heiligen Wortes, * das er gerichtet an Abraham, seinen Knecht.
+104:43 Und er führte sein Volk heraus in Jubel * und seine Auserwählen in Freude.
+104:44 Und er gab ihnen die Länder der Heiden, * und worum die Völker sich abgemüht, das nahmen sie in besitz,
+104:45 auf dass sie seine Satzungen bewahren * und sein Gesetz eifrig beobachten.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm105.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm105.txt
@@ -1,47 +1,47 @@
-105:1 Confitémini Dómino, quóniam bonus: * quóniam in sæculum misericórdia ejus.
-105:2 Quis loquétur poténtias Dómini, * audítas fáciet omnes laudes ejus?
-105:3 Beáti, qui custódiunt judícium, * et fáciunt justítiam in omni témpore.
-105:4 Meménto nostri, Dómine, in beneplácito pópuli tui: * vísita nos in salutári tuo:
-105:5 Ad vidéndum in bonitáte electórum tuórum, ad lætándum in lætítia gentis tuæ: * ut laudéris cum hereditáte tua.
-105:6 Peccávimus cum pátribus nostris: * injúste égimus, iniquitátem fécimus.
-105:7 Patres nostri in Ægýpto non intellexérunt mirabília tua: * non fuérunt mémores multitúdinis misericórdiæ tuæ.
-105:7 Et irritavérunt ascendéntes in mare, * Mare Rubrum.
-105:8 Et salvávit eos propter nomen suum: * ut notam fáceret poténtiam suam.
-105:9 Et incrépuit Mare Rubrum, et exsiccátum est, * et dedúxit eos in abýssis sicut in desérto.
-105:10 Et salvávit eos de manu odiéntium: * et redémit eos de manu inimíci.
-105:11 Et opéruit aqua tribulántes eos: * unus ex eis non remánsit.
-105:12 Et credidérunt verbis ejus: * et laudavérunt laudem ejus.
-105:13 Cito fecérunt, oblíti sunt óperum ejus: * et non sustinuérunt consílium ejus.
-105:14 Et concupiérunt concupiscéntiam in desérto: * et tentavérunt Deum in inaquóso.
-105:15 Et dedit eis petitiónem ipsórum: * et misit saturitátem in ánimas eórum.
-105:16 Et irritavérunt Moysen in castris: * Aaron, sanctum Dómini.
-105:17 Apérta est terra, et deglutívit Dathan: * et opéruit super congregatiónem Abíron.
-105:18 Et exársit ignis in synagóga eorum * flamma combússit peccatóres.
-105:19 Et fecérunt vítulum in Horeb * et adoravérunt scúlptile.
-105:20 Et mutavérunt glóriam suam * in similitúdinem vítuli comedéntis fœnum.
-105:21 Oblíti sunt Deum, qui salvávit eos, * qui fecit magnália in Ægýpto, mirabília in terra Cham: terribília in Mari Rubro.
-105:23 Et dixit ut dispérderet eos: * si non Móyses, eléctus ejus, stetísset in confractióne in conspéctu ejus:
-105:24 Ut avérteret iram ejus ne dispérderet eos: * et pro níhilo habuérunt terram desiderábilem:
-105:25 Non credidérunt verbo ejus, et murmuravérunt in tabernáculis suis: * non exaudiérunt vocem Dómini.
-105:26 Et elevávit manum suam super eos: * ut prostérneret eos in desérto:
-105:27 Et ut dejíceret semen eórum in natiónibus: * et dispérgeret eos in regiónibus.
-105:28 Et initiáti sunt Beélphegor: * et comedérunt sacrifícia mortuórum.
-105:29 Et irritavérunt eum in adinventiónibus suis: * et multiplicáta est in eis ruína.
-105:30 Et stetit Phínees, et placávit: * et cessávit quassátio.
-105:31 Et reputátum est ei in justítiam: * in generatiónem et generatiónem usque in sempitérnum.
-105:32 Et irritavérunt eum ad aquas contradictiónis: * et vexátus est Móyses propter eos: quia exacerbavérunt spíritum ejus.
-105:33 Et distínxit in lábiis suis: * non disperdidérunt Gentes, quas dixit  Dóminus illis.
-105:35 Et commísti sunt inter Gentes, et didicérunt ópera eórum: et serviérunt sculptílibus eórum: * et factum est illis in scándalum.
-105:37 Et immolavérunt fílios suos, * et filias suas dæmóniis.
-105:38 Et effudérunt sánguinem innocéntem: * sánguinem filiórum suórum et filiárum suárum, quas sacrificavérunt sculptílibus Chánaan.
-105:39 Et infécta est terra in sanguínibus, et contamináta est in opéribus eórum: * et fornicáti sunt in adinventiónibus suis.
-105:40 Et irátus est furóre Dóminus in pópulum suum: * et abominátus est hereditátem suam.
-105:41 Et trádidit eos in manus Géntium: * et domináti sunt eórum qui odérunt eos.
-105:42 Et tribulavérunt eos inimíci eórum, et humiliáti sunt sub mánibus eórum: * sæpe liberávit eos.
-105:43 Ipsi autem exacerbavérunt eum in consílio suo: * et humiliáti sunt in iniquitátibus suis.
-105:44 Et vidit, cum tribularéntur: * et audívit oratiónem eórum.
-105:45 Et memor fuit testaménti sui: * et pœnítuit eum secúndum multitúdinem misericórdiæ suæ.
-105:46 Et dedit eos in misericórdias * in conspéctu ómnium qui céperant eos.
-105:47 Salvos nos fac, Dómine, Deus noster: * et cóngrega nos de natiónibus:
-105:47 Ut confiteámur nómini sancto tuo: * et gloriémur in laude tua.
-105:48 Benedíctus Dóminus, Deus Israël, a sæculo et usque in sæculum: * et dicet omnis pópulus: Fiat, fiat.
+105:1 Preiset den Herrn, denn er ist gut, * denn in Ewigkeit währt seine barmherzigkeit.
+105:2 Wer wird nennen die Machttaten des Herrn, * hören lassen all sein Lob?
+105:3 Selig, die das recht wahren * und Gerechtigkeit üben zu jeder zeit.
+105:4 Gedenke unser, Herr, im Wohlgefallen an Deinem Volk, * suche uns heim mit Deinem Heil,
+105:5 damit man es schaue an dem Glück, das Deinen Auserwählten zuteil wurde, damit man sich freue an der Freude Deines Volkes, * dass Du gepriesen werdest mit Deinem Erbe.
+105:6 Wir haben gesündigt mitsamt unseren Vätern, * unrecht gehandelt, böses getan.
+105:7 Unsere Väter in ägypten verstanden nicht Deine Wunder, * sie waren nicht eingedenk der Fülle Deiner barmherzigkeit
+105:7 und reizten Dich als sie hinaufzogen zum Meer, * zum roten Meer.
+105:8 Und er hat sie gerettet um seines namens willen, * um kundzutun seine Macht.
+105:9 Und er schalt das rote Meer, und es trocknete aus, * und er führte sie in den Meerestiefen wie in der Wüste.
+105:10 Und er rettete sie aus der Hand der Hasser * und erlöste sie aus der Hand des Feindes.
+105:11 Und das Wasser bedeckte die, die sie bedrängten, * nicht einer von ihnen blieb übrig.
+105:12 Und sie glaubten seinen Worten * und sangen sein Lob.
+105:13 Sie beeilten sich, vergaßen seine Werke * und harrten nicht auf seinen ratschluss.
+105:14 Und sie begehrten begierde in der Wüste * und versuchten Gott im wasserlosen Land.
+105:15 Und er gewährte ihre bitte * und sandte Sättigung in ihre Seelen.
+105:16 Und sie reizten den Moses im Lager, * Aron, den Heiligen des Herrn.
+105:17 Da tat sich die Erde auf und verschlang Dathan * und bedeckte die rotte Abirons.
+105:18 Und Feuer entbrannte in ihrer Versammlung, * die Flamme verzehrte die Sünder.
+105:19 Und sie machten ein Kalb am Horeb * und beteten das Gußbild an.
+105:20 Und sie vertauschten ihre Herrlichkeit * mit dem Abbild eines Kalbes, das Gras frisst.
+105:21 Sie vergaßen Gott, der sie gerettet hat, * der Großes getan in ägypten, Wunderbares im Land Cham, Schreckliches am roten Meer.
+105:23 Und er sprach, sie zu vertilgen * wenn nicht Moses, sein Auserwählter, in die bresche getreten wäre vor seinem Angesicht,
+105:24 um seinen zorn abzuwenden, damit er sie nicht verderbe. * Und sie verachteten das begehrenswerte Land;
+105:25 sie glaubten nicht seinem Wort und murrten in ihren zelten, * und sie hörten nicht auf die Stimme des Herrn.
+105:26 Und er erhob seine Hand über sie, * um sie niederzu strecken in der Wüste
+105:27 und um hinzuwerfen ihre nachkommen unter die Völker * und sie in den Ländern zu zerstreuen.
+105:28 Und sie weihten sich dem beel phegor * und aßen die Opfer von Toten.
+105:29 Und sie reizten ihn durch ihre Einfälle * und groß wurde unter ihnen das Verderben.
+105:30 Doch Phinees stand auf und schaffte Sühne, * und die Plage hörte auf,
+105:31 und es wurde ihm angerechnet zur Gerechtigkeit * von Geschlecht zu Geschlecht bis in Ewigkeit.
+105:32 Und sie reizten ihn bei den Wassern des Widerspruchs, * und ihretwegen wurde Moses geplagt, denn sie erbitterten seinen Geist,
+105:33 und er sprach unbedacht mit seinen Lippen. * Sie vertilgten nicht die Völker, die der Herr ihnen genannt hatte.
+105:35 Und sie mischten sich unter die Heiden und lernten deren Werke und dienten deren Götzenbildern, * und es wurde ihnen zum Fallstrick.
+105:37 Und sie opferten ihre Söhne * und ihre Töchter den Dämonen
+105:38 und vergossen unschuldiges blut, * das blut ihrer Söhne und Töchter, die sie den Götzen Kanaans geopfert.
+105:39 Und getränkt wurde das Land mit blut und verunreinigt durch ihre Werke, * und sie trieben Unzucht nach ihren Einfällen.
+105:40 Und der Herr entbrannte im zorn über sein Volk * und verabscheute sein Erbe.
+105:41 Und er lieferte sie aus in die Hände der Heiden, * und die sie hassten, herrschten über sie.
+105:42 Und es bedrängten sie ihre Feinde, und sie wurden gebeugt unter deren Hände, * oftmals hat er sie befreit.
+105:43 Sie aber erbitterten ihn durch ihren ratschluss, * und sie wurden erniedrigt durch ihre Missetaten.
+105:44 Und er sah, wie sie bedrängt wurden, * und hörte ihr Gebet.
+105:45 Und er gedachte seines bundes, * und es reute ihn nach der Fülle seiner barmherzigkeit.
+105:46 Und er ließ sie barmherzigkeit finden * vor dem Angesicht aller, die sie gefangengenommen hatten.
+105:47 rette uns, Herr, unser Gott, * und sammle uns aus den Völkern,
+105:47 damit wir Deinen heiligen namen preisen * und uns rühmen Deines Lobes.
+105:48 Gepriesen sei der Herr, der Gott israels, von Ewigkeit und bis in Ewigkeit, * und alles Volk soll sprechen: So sei es! So sei es!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm106.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm106.txt
@@ -1,43 +1,43 @@
-106:1 Confitémini Dómino quóniam bonus: * quóniam in sæculum misericórdia ejus.
-106:2 Dicant qui redémpti sunt a Dómino, quos redémit de manu inimíci: * et de regiónibus congregávit eos:
-106:3 A solis ortu, et occásu: * ab aquilóne, et mari.
-106:4 Erravérunt in solitúdine in inaquóso: * viam civitátis habitáculi non invenérunt.
-106:5 Esuriéntes, et sitiéntes: * ánima eórum in ipsis defécit.
-106:6 Et clamavérunt ad Dóminum cum tribularéntur: * et de necessitátibus eórum erípuit eos.
-106:7 Et dedúxit eos in viam rectam: * ut irent in civitátem habitatiónis.
-106:8 Confiteántur Dómino misericórdiæ ejus: * et mirabília ejus fíliis hóminum.
-106:9 Quia satiávit ánimam inánem: * et ánimam esuriéntem satiávit bonis.
-106:10 Sedéntes in ténebris, et umbra mortis: * vinctos in mendicitáte et ferro.
-106:11 Quia exacerbavérunt elóquia Dei: * et consílium Altíssimi irritavérunt.
-106:12 Et humiliátum est in labóribus cor eórum: * infirmáti sunt, nec fuit qui adjuváret.
-106:13 Et clamavérunt ad Dóminum cum tribularéntur: * et de necessitátibus eórum liberávit eos.
-106:14 Et edúxit eos de ténebris, et umbra mortis: * et víncula eórum disrúpit.
-106:15 Confiteántur Dómino misericórdiæ ejus: * et mirabília ejus fíliis hóminum.
-106:16 Quia contrívit portas æreas: * et vectes férreos confrégit.
-106:17 Suscépit eos de via iniquitátis eórum: * propter injustítias enim suas humiliáti sunt.
-106:18 Omnem escam abomináta est ánima eórum: * et appropinquavérunt usque ad portas mortis.
-106:19 Et clamavérunt ad Dóminum cum tribularéntur: * et de necessitátibus eórum liberávit eos.
-106:20 Misit verbum suum, et sanávit eos: * et erípuit eos de interitiónibus eórum.
-106:21 Confiteántur Dómino misericórdiæ ejus: * et mirabília ejus fíliis hóminum.
-106:22 Et sacríficent sacrifícium laudis: * et annúntient ópera ejus in exsultatióne.
-106:23 Qui descéndunt mare in návibus, * faciéntes operatiónem in aquis multis.
-106:24 Ipsi vidérunt ópera Dómini, * et mirabília ejus in profúndo.
-106:25 Dixit, et stetit spíritus procéllæ: * et exaltáti sunt fluctus ejus.
-106:26 Ascéndunt usque ad cælos, et descéndunt usque ad abýssos: * ánima eórum in malis tabescébat.
-106:27 Turbáti sunt, et moti sunt sicut ébrius: * et omnis sapiéntia eórum devoráta est.
-106:28 Et clamavérunt ad Dóminum cum tribularéntur: * et de necessitátibus eórum edúxit eos.
-106:29 Et státuit procéllam ejus in auram: * et siluérunt fluctus ejus.
-106:30 Et lætáti sunt quia siluérunt: * et dedúxit eos in portum voluntátis eórum.
-106:31 Confiteántur Dómino misericórdiæ ejus: * et mirabília ejus fíliis hóminum.
-106:32 Et exáltent eum in ecclésia plebis: * et in cáthedra seniórum laudent eum.
-106:33 Pósuit flúmina in desértum: * et éxitus aquárum in sitim.
-106:34 Terram fructíferam in salsúginem: * a malítia inhabitántium in ea.
-106:35 Pósuit desértum in stagna aquárum: * et terram sine aqua in éxitus aquárum.
-106:36 Et collocávit illic esuriéntes: * et constituérunt civitátem habitatiónis.
-106:37 Et seminavérunt agros, et plantavérunt víneas: * et fecérunt fructum nativitátis.
-106:38 Et benedíxit eis, et multiplicáti sunt nimis: * et juménta eórum non minorávit.
-106:39 Et pauci facti sunt: * et vexáti sunt a tribulatióne malórum, et dolóre.
-106:40 Effúsa est contémptio super príncipes: * et erráre fecit eos in ínvio, et non in via.
-106:41 Et adjúvit páuperem de inópia: * et pósuit sicut oves famílias.
-106:42 Vidébunt recti, et lætabúntur: * et omnis iníquitas oppilábit os suum.
-106:43 Quis sápiens et custódiet hæc? * et intélliget misericórdias Dómini.
+106:1 Preiset den Herrn, denn er ist gut, * denn in Ewigkeit währt seine barmherzigkeit.
+106:2 So sollen sprechen, die erlöst sind vom Herrn, die er erlöst hat aus der Hand des Feindes, * und aus allen Gegenden hat er sie zusammengeführt.
+106:3 Vom Aufgang der Sonne und vom niedergang, * vom norden und vom Meer.
+106:4 Sie irrten umher in der Wüste, im wasserlosen Land, * den Weg zur Stadt des Wohnorts fanden sie nicht.
+106:5 Sie litten Hunger und Durst, * ihre Seele in ihnen verschmachtete.
+106:6 Und sie schrien zum Herrn, als sie bedrängt waren, * und aus ihren nöten hat er sie errettet.
+106:7 Und er führte sie auf den rechten Weg, * damit sie zur Stadt des Wohnorts gelangten.
+106:8 Preisen sollen den Herrn die Erweise seiner barmherzigkeit * und seine Wunder an den Menschenkindern!
+106:9 Denn er sättigte die leere Seele, * und die hungernde Seele hat er gesättigt mit Gütern.
+106:10 Die saßen in Finsternis und Todesschatten, * gefesselt in Armut und Eisen,
+106:11 weil sie den Worten Gottes getrotzt * und verachteten den ratschluss des Höchsten.
+106:12 Und gebeugt wurde durch Mühsal ihr Herz, * sie wurden kraftlos, und keinen gab es, der half.
+106:13 Und sie schrien zum Herrn, als sie bedrängt wurden, * und aus ihren nöten hat er sie befreit,
+106:14 und er hat sie herausgeführt aus Finsternis und Todesschatten * und ihre Fesseln zerbrochen.
+106:15 Preisen sollen den Herrn die Erweise seiner barmherzigkeit * und seine Wunder an den Menschenkindern!
+106:16 Denn er zermalmte eherne Tore * und zerbrach eiserne riegel.
+106:17 Er nahm sie zu sich vom Weg ihrer Sünde, * denn wegen ihrer Ungerechtigkeit hat er sie erniedrigt.
+106:18 Jegliche Speise verabscheute ihre Seele, * und sie näherten sich bis an die Pforten des Todes.
+106:19 Und sie schrien zum Herrn, als sie bedrängt wurden, * und aus ihren nöten befreite er sie.
+106:20 Er sandte sein Wort und heilte sie, * und er entriss sie ihrem vielfachen Untergang.
+106:21 Preisen sollen den Herrn die Erweise seiner barmherzigkeit * und seine Wunder an den Menschenkindern!
+106:22 Und opfern sollen sie ein Opfer des Lobes * und verkünden seine Werke mit Jubel.
+106:23 Die mit Schiffen hinabsteigen aufs Meer, * Handel treiben auf vielen Wassern,
+106:24 sie schauten die Werke des Herrn * und seine Wunder in der Tiefe.
+106:25 Er sprach, und es erhob sich ein Sturmwind, * und seine Wogen gingen hoch.
+106:26 Sie türmen sich auf bis zu den Himmeln und sinken hinab bis in die Abgründe, * ihre Seele verzagte im Unglück.
+106:27 Sie wurden verwirrt und wankten wie ein betrunkener * und all ihre Weisheit wurde verschlungen.
+106:28 Und sie schrien zum Herrn, als sie bedrängt wurden, * und aus ihren nöten hat er sie herausgeführt.
+106:29 Und er machte seinen Sturm zur sanften brise, * und stille wurden seine Wogen.
+106:30 Und sie freuten sich, weil sie stille wurden, * und er führte sie zum Hafen ihrer Sehnsucht.
+106:31 Preisen sollen den Herrn die Erweise seiner barmherzigkeit * und seine Wunder an den Menschenkindern!
+106:32 Und erheben soll man ihn in der Versammlung des Volkes * und im rat der ältesten ihn loben.
+106:33 Er machte Flüsse zur Wüste * und Wasserquellen zum dürstenden Land,
+106:34 fruchtbares Land zur salzigen Steppe * wegen der bosheit derer, die in ihm wohnen.
+106:35 Er machte die Wüste zu Teichen von Wasser * und Land ohne Wasser zu Wasserquellen.
+106:36 Und er ließ die Hungernden dort wohnen, * und sie gründeten dort die Stadt des Wohnorts.
+106:37 Und sie besäten äcker und pflanzten Weinberge, * und diese brachten die Frucht des Ertrags.
+106:38 Und er segnete sie und sie vermehrten sich sehr, * und ihr Vieh verringerte sich nicht.
+106:39 Und sie wurden wenige, * und sie wurden geplagt durch bedrängnis von bösen und Schmerz.
+106:40 Ausgegossen war Verachtung über die Fürsten, * und er ließ sie umherirren in unwegsamem Gebiet und nicht auf einem Weg.
+106:41 Und er half dem Armen aus der not * und machte die Hausgenossen wie Schafe.
+106:42 Die redlichen werden es sehen und sich freuen, * und alle Ungerechtigkeit wird ihren Mund verschließen.
+106:43 Wer ist weise und wird es bewahren * und erkennen die barmherzigkeit des Herrn?

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm107.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm107.txt
@@ -11,4 +11,4 @@
 107:11 Wer wird mich geleiten in die befestigte Stadt? * Wer wird mich geleiten bis nach Edom?
 107:12 nicht etwa Du, o Gott, der Du uns verstoßen hast? * und wirst Du nicht ausziehen, o Gott, mit unseren Heeren?
 107:13 Schaff uns Hilfe aus der Drangsal, * denn nichtig ist das Heil von menschen.
-107:14 in Gott werden wir Kraftvolles tun, * und er selbst wird unsere Feinde zunichte machen. sten fizium am Samstag
+107:14 in Gott werden wir Kraftvolles tun, * und er selbst wird unsere Feinde zunichte machen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm108.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm108.txt
@@ -1,30 +1,30 @@
-108:2 Deus, laudem meam ne tacúeris: * quia os peccatóris, et os dolósi super me apértum est.
-108:3 Locúti sunt advérsum me lingua dolósa, et sermónibus ódii circumdedérunt me: * et expugnavérunt me gratis.
-108:4 Pro eo ut me dilígerent, detrahébant mihi: * ego autem orábam.
-108:5 Et posuérunt advérsum me mala pro bonis: * et ódium pro dilectióne mea.
-108:6 Constítue super eum peccatórem: * et diábolus stet a dextris ejus.
-108:7 Cum judicátur, éxeat condemnátus: * et orátio ejus fiat in peccátum.
-108:8 Fiant dies ejus pauci: * et episcopátum ejus accípiat alter.
-108:9 Fiant fílii ejus órphani: * et uxor ejus vídua.
-108:10 Nutántes transferántur fílii ejus, et mendícent: * et ejiciántur de habitatiónibus suis.
-108:11 Scrutétur fœnerátor omnem substántiam ejus: * et dirípiant aliéni labóres ejus.
-108:12 Non sit illi adjútor: * nec sit qui misereátur pupíllis ejus.
-108:13 Fiant nati ejus in intéritum: * in generatióne una deleátur nomen ejus.
-108:14 In memóriam rédeat iníquitas patrum ejus in conspéctu Dómini: * et peccátum matris ejus non deleátur.
-108:15 Fiant contra Dóminum semper, et dispéreat de terra memória eórum: * pro eo quod non est recordátus fácere misericórdiam.
-108:17 Et persecútus est hóminem ínopem, et mendícum, * et compúnctum corde mortificáre.
-108:18 Et diléxit maledictiónem, et véniet ei: * et nóluit benedictiónem, et elongábitur ab eo.
-108:18 Et índuit maledictiónem sicut vestiméntum, * et intrávit sicut aqua in interióra ejus, et sicut óleum in óssibus ejus.
-108:19 Fiat ei sicut vestiméntum, quo operítur: * et sicut zona, qua semper præcíngitur.
-108:20 Hoc opus eórum, qui détrahunt mihi apud Dóminum: * et qui loquúntur mala advérsus ánimam meam.
-108:21 Et tu, Dómine, Dómine, fac mecum propter nomen tuum: * quia suávis est misericórdia tua.
-108:22 Líbera me quia egénus, et pauper ego sum: * et cor meum conturbátum est intra me.
-108:23 Sicut umbra cum declínat, ablátus sum: * et excússus sum sicut locústæ.
-108:24 Génua mea infirmáta sunt a jejúnio: * et caro mea immutáta est propter óleum.
-108:25 Et ego factus sum oppróbrium illis: * vidérunt me, et movérunt cápita sua.
-108:26 Ádjuva me, Dómine, Deus meus: * salvum me fac secúndum misericórdiam tuam.
-108:27 Et sciant quia manus tua hæc: * et tu, Dómine, fecísti eam.
-108:28 Maledícent illi, et tu benedíces: * qui insúrgunt in me, confundántur: servus autem tuus lætábitur.
-108:29 Induántur qui détrahunt mihi, pudóre: * et operiántur sicut diplóide confusióne sua.
-108:30 Confitébor Dómino nimis in ore meo: * et in médio multórum laudábo eum.
-108:31 Quia ástitit a dextris páuperis, * ut salvam fáceret a persequéntibus ánimam meam.
+108:2 Gott, übergehe nicht mein lob mit Schweigen, * denn der mund des Sünders und der mund des betrügers ist gegen mich aufgetan.
+108:3 Sie redeten wider mich mit trügerischer zunge und um geben mich mit Worten des Hasses, * und sie bekämpften mich ohne Grund.
+108:4 Anstatt mich zu lieben, zogen sie mich herab; * ich aber betete.
+108:5 und sie setzten gegen mich böses für Gutes * und Hass für meine liebe.
+108:6 „Stelle einen Sünder über ihn, * und der Teufel stehe zu seiner rechten.
+108:7 Wenn er gerichtet wird, gehe er verurteilt hinaus, * und sein Gebet werde zur Sünde.
+108:8 Seine Tage sollen wenige sein * und sein Amt erhalte ein anderer.
+108:9 Seine Söhne sollen Waisen werden * und seine Frau eine Witwe.
+108:10 unstet sollen seine Söhne umherziehen und betteln, * und sie sollen vertrieben werden aus ihren Wohnungen.
+108:11 Der Wucherer spüre all seine Habe auf, * und Fremde sollen plündern, was er mühsam erworben.
+108:12 Kein Helfer soll ihm sein, * und keiner soll sein, der sich erbarmt seiner Waisen.
+108:13 Seine nachkommen seien bestimmt zum untergang, * in einer Gene ration werde ausgetilgt sein name.
+108:14 in Erinnerung kehre zurück die Schuld seiner Väter vor dem Angesicht des Herrn, * und die Sünde seiner mutter werde nicht getilgt.
+108:15 Sie [Schuld und Sünde] seien vor dem Herrn immerdar, und ausgelöscht von der Erde werde das Andenken an jene.“ * Weil er nicht daran dachte, barmherzigkeit zu üben,
+108:17 sondern den hilflosen menschen verfolgte und den Armen * und den, der im Herzen erschüttert ist, um ihn zu töten,
+108:18 und er den Fluch liebte und der komme über ihn ­, * und er den Segen nicht wollte und der bleibe fern von ihm ­,
+108:18 und er den Fluch anzog wie ein Gewand, * und er drang wie Wasser in sein inneres und wie Öl in seine Gebeine,
+108:19 sei er ihm wie ein Gewand, das ihn bedeckt * und wie ein Gürtel, der ihn stets umschlingt.
+108:20 Dies sei der lohn für die, die mich verleumden beim Herrn * und die böses reden gegen meine Seele.
+108:21 Du aber, Herr, Herr, handle an mir um Deines namens willen, * denn lieblich ist Deine barmherzigkeit.
+108:22 befreie mich, denn bedürftig und arm bin ich, * und mein Herz ist verwirrt in mir.
+108:23 Wie ein Schatten, wenn er sich neigt, werde ich hingerafft * und abgeschüttelt wie Heuschrecken.
+108:24 meine Knie sind geschwächt vom Fasten, * und mein Fleisch ist abgezehrt wegen des Öls.
+108:25 und ich bin ihnen zum Hohn geworden, * sie sahen mich und schüttelten ihre Köpfe.
+108:26 Hilf mir, Herr, mein Gott, * schaffe mir Heil nach Deiner barmherzigkeit.
+108:27 und sie sollen wissen, dass dies Deine Hand ist, * und dass Du, o Herr, es vollbracht hast.
+108:28 Sie mögen fluchen, und Du wirst segnen; * die sich gegen mich erheben, mögen zuschanden werden, Dein Knecht aber wird erfreut.
+108:29 bekleidet werden sollen, die mich verleumden, mit Schande, * und umhüllt werden wie mit einem mantel sollen sie von ihrer Schmach.
+108:30 ich will preisen den Herrn mit meinem mund, * und inmitten Vieler will ich ihn loben.
+108:31 Denn er stand zur rechten des Armen, * um meine Seele vor den Verfolgern zu retten.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm11.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm11.txt
@@ -6,4 +6,4 @@
 11:6b ich will Heil schaffen * und getreu darin handeln.
 11:7 Die Worte des Herrn sind lautere Worte, * sie sind wie Silber, das im Feuer geläutert ist, erprobt in der Erde, sieben fach gereinigt.
 11:8 Du, o Herr, wirst uns bewahren und uns beschützen * vor diesem Geschlecht in Ewigkeit.
-11:9 ringsum wandeln die Gottlosen. * Gemäß Deiner Hoheit hast Du die menschenkinder vermehrt. 12
+11:9 ringsum wandeln die Gottlosen. * Gemäß Deiner Hoheit hast Du die menschenkinder vermehrt.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm113.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm113.txt
@@ -19,7 +19,7 @@
 113:19 Die den Herrn fürchten, haben ihre Hoffnung auf den Herrn gesetzt, * er ist ihr Helfer und ihr beschützer.
 113:20a Der Herr hat unser gedacht, * und hat uns gesegnet.
 113:20b Gesegnet hat er das Haus israel, * gesegnet hat er das Haus Aaron.
-113:21 Gesegnet hat er die, die den Herrn fürchten, * die Kleinen mit den Großen.
+113:21 Gesegnet hat er alle, die den Herrn fürchten, * die Kleinen mit den Großen.
 113:22 Der Herr mehre euch, * euch und eure Söhne.
 113:23 Gesegnet seid ihr vom Herrn, * der Himmel und Erde gemacht hat.
 113:24 Der Himmel des Himmels gehört dem Herrn, * die Erde aber gab er den menschenkindern.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm117.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm117.txt
@@ -26,4 +26,4 @@
 117:27b Haltet einen Festtag mit dichtbelaubten zweigen * bis zu den Hörnern des Altares.
 117:28a mein Gott bist Du, und ich will Dich preisen, * mein Gott bist Du, und ich will Dich erheben.
 117:28b ich will Dich preisen, denn Du hast mich erhört, * und Du bist mir zum Heil geworden.
-117:29 Pieset den Herrn, denn er ist gut, * denn ewig währt seine barmherzigkeit.
+117:29 Preiset den Herrn, denn er ist gut, * denn ewig währt seine barmherzigkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm12.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm12.txt
@@ -3,4 +3,4 @@
 12:3 bis wann wird mein Feind sich über mich erheben? * Schau her und erhöre mich, Herr, mein Gott!
 12:4b Erleuchte meine Augen, damit ich nicht im Tod entschlafe, * damit mein Feind nicht sagen kann: ich habe ihn überwältigt.
 12:5b Die mich bedrängen werden jubeln, wenn ich wanke; * ich aber habe auf Deine barmherzigkeit meine Hoffnung gesetzt.
-12:6b Frohlocken wird mein Herz über Dein Heil; ich will singen dem Herrn, der mir Gutes getan, * und spielen dem namen des Herrn, des Höchsten. 15
+12:6b Frohlocken wird mein Herz über Dein Heil; ich will singen dem Herrn, der mir Gutes getan, * und spielen dem namen des Herrn, des Höchsten.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm134.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm134.txt
@@ -1,21 +1,21 @@
-134:1 Laudáte nomen Dómini, * laudáte, servi, Dóminum.
-134:2 Qui statis in domo Dómini, * in átriis domus Dei nostri.
-134:3 Laudáte Dóminum, quia bonus Dóminus: * psállite nómini ejus, quóniam suáve.
-134:4 Quóniam Jacob elégit sibi Dóminus, * Israël in possessiónem sibi.
-134:5 Quia ego cognóvi quod magnus est Dóminus, * et Deus noster præ ómnibus diis.
-134:6 Omnia quæcúmque vóluit, Dóminus fecit in cælo, et in terra, * in mari, et in ómnibus abýssis.
-134:7 Edúcens nubes ab extrémo terræ: * fúlgura in plúviam fecit.
-134:8 Qui prodúcit ventos de thesáuris suis: * qui percússit primogénita Ægýpti ab hómine usque ad pecus.
-134:9 Et misit signa, et prodígia in médio tui, Ægýpte: * in Pharaónem, et in omnes servos ejus.
-134:10 Qui percússit gentes multas: * et occídit reges fortes:
-134:11 Sehon, regem Amorrhæórum, et Og, regem Basan, * et ómnia regna Chánaan.
-134:12 Et dedit terram eórum hereditátem, * hereditátem Israël, pópulo suo.
-134:13 Dómine, nomen tuum in ætérnum: * Dómine, memoriále tuum in generatiónem et generatiónem.
-134:14 Quia judicábit Dóminus pópulum suum: * et in servis suis deprecábitur.
-134:15 Simulácra géntium argéntum, et aurum, * ópera mánuum hóminum.
-134:16 Os habent, et non loquéntur: * óculos habent, et non vidébunt.
-134:17 Aures habent, et non áudient: * neque enim est spíritus in ore ipsórum.
-134:18 Símiles illis fiant qui fáciunt ea: * et omnes qui confídunt in eis.
-134:19 Domus Israël, benedícite Dómino: * domus Aaron, benedícite Dómino.
-134:20 Domus Levi, benedícite Dómino: * qui timétis Dóminum, benedícite Dómino.
-134:21 Benedíctus Dóminus ex Sion, * qui hábitat in Jerúsalem.
+134:1 lobet den namen des Herrn, * lobet, ihr Diener, den Herrn.
+134:2 Die ihr steht im Hause des Herrn, * in den Vorhöfen des Hauses unseres Gottes.
+134:3 lobet den Herrn, denn gut ist der Herr, * spielt seinem namen, denn er ist lieblich,
+134:4 denn Jakob hat sich der Herr erwählt, * israel zu seinem Eigentum;
+134:5 denn ich habe erkannt, dass der Herr groß ist, * und unser Gott ist vor allen Göttern.
+134:6 Alles, was immer er wollte, hat der Herr gemacht im Himmel und auf Erden, * im meer und in allen Tiefen.
+134:7 Er führt Wolken herbei vom Äußersten der Erde, * macht blitze zum regen.
+134:8 Er bringt Winde aus seinen Schatzkammern hervor, * der die Erst geborenen Ägyptens schlug vom menschen bis zum Vieh.
+134:9 und er sandte zeichen und Wunder in deine mitte, Ägypten, * wider den Pharao und all seine Knechte,
+134:10 der viele Völker schlug * und starke Könige tötete,
+134:11 Sehon, den König der Amoriter, und Og, den König von basan, * und alle reiche Kanaans.
+134:12 und er gab ihr land als Erbe, * als Erbe israel, seinem Volk.
+134:13 Herr, Dein name währt in Ewigkeit, * Herr, Dein Gedenken von Geschlecht zu Geschlecht.
+134:14 Denn richten wird der Herr sein Volk, * und für seine Diener lässt er sich erbitten.
+134:15 Die Götzenbilder der Heiden sind Silber und Gold, * machwerke von menschenhänden.
+134:16 Einen mund haben sie und werden nicht reden, * Augen haben sie und werden nicht sehen.
+134:17 Ohren haben sie und werden nicht hören, * denn kein Hauch ist in ihrem mund.
+134:18 Die sie machen, mögen ihnen gleich werden, * und alle, die auf sie vertrauen.
+134:19 Haus israel, preiset den Herrn, * Haus Aaron, preiset den Herrn.
+134:20 Haus levi, preiset den Herrn, * die ihr fürchtet den Herrn, preiset den Herrn.
+134:21 Gepriesen sei der Herr von Sion her, * der da wohnt in Jerusalem.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm135.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm135.txt
@@ -1,27 +1,27 @@
-135:1 O preist den Herrn, denn er ist gut, * denn ewig währet sein Erbarmen.
-135:2 Preist den Gott der Götter, * denn ewig währet sein Erbarmen.
-135:3 Preist den Herrn der Herren, * denn ewig währet sein Erbarmen.
-135:4 Der große Wundertaten wirkt allein, * denn ewig währet sein Erbarmen.
-135:5 Der hoch den Himmel schuf in großer Kunst * denn ewig währet sein Erbarmen.
-135:6 Der über den Gewässern dann die Erde gebaut, * denn ewig währet sein Erbarmen.
-135:7 Der die große Leuchten geschaffen hat, * denn ewig währet sein Erbarmen.
-135:8 Die Sonne als Beherrscherin des Tages, * denn ewig währet sein Erbarmen.
-135:9 Dann Mond und Sterne als die Herrscher für die Nacht, * denn ewig währet sein Erbarmen.
-135:10 Der die Ägypter schlug und ihre Erstgeburt, * denn ewig währet sein Erbarmen.
-135:11 Der Israel aus ihrem Land herausgeführt, * denn ewig währet sein Erbarmen.
-135:12 Mit starker Hand und erhobenem Arm, * denn ewig währet sein Erbarmen.
-135:13 Der in zwei Teile geteilt dann das Rote Meer, * denn ewig währet sein Erbarmen.
-135:14 Und durch dasselbe Israel hindurchgeführt hat, * denn ewig währet sein Erbarmen.
-135:15 Und Pharao und seine Heeresmacht versenkt im Roten Meer, * denn ewig währet sein Erbarmen.
-135:16 Der treu sein Volk geleitet durch das wüste Land, * denn ewig währet sein Erbarmen.
-135:17 Der große Könige schlug, * denn ewig währet sein Erbarmen.
-135:18 Und mächtige Könige tötete, * denn ewig währet sein Erbarmen.
-135:19 Sehon, den König der Amorrhäer, * denn ewig währet sein Erbarmen.
-135:20 Und Og, den König von Basan, * denn ewig währet sein Erbarmen.
-135:21 Der ihr Gebiet zu eigen gab, * denn ewig währet sein Erbarmen.
-135:22 Zu eigen seinem Knechte Israel, * denn ewig währet sein Erbarmen.
-135:23 Weil er unserer eingedenk war in unserer Erniedrigung, * denn ewig währet sein Erbarmen.
-135:24 Uns von den Feinden befreit, * denn ewig währet sein Erbarmen.
-135:25 Er gibt auch Nahrung allem Fleisch, * denn ewig währet sein Erbarmen.
-135:26 Preist den Gott des Himmels, * denn ewig währet sein Erbarmen.
-135:26 Preist den Herrn der Herren, * denn ewig währet sein Erbarmen.
+135:1 Preiset den Herrn, denn er ist gut, * denn ewig währt seine barmherzigkeit.
+135:2 Preiset den Gott der Götter, * denn ewig währt seine barmherzigkeit.
+135:3 Preiset den Herrn der Herren, * denn ewig währt seine barmherzigkeit,
+135:4 der allein große Wunder tut, * denn ewig währt seine barmherzigkeit,
+135:5 der die Himmel gemacht hat mit Einsicht, * denn ewig währt seine barmherzigkeit,
+135:6 der die Erde befestigt hat über den Wassern, * denn ewig währt seine barmherzigkeit,
+135:7 der die großen lichter gemacht hat, * denn ewig währt seine barmherzigkeit,
+135:8 die Sonne zur Herrschaft über den Tag, * denn ewig währt seine barmherzigkeit,
+135:9 den mond und die Sterne zur Herrschaft über die nacht, * denn ewig währt seine barmherzigkeit.
+135:10 Der Ägypten samt ihren Erstgeborenen geschlagen hat, * denn ewig währt seine barmherzigkeit,
+135:11 der israel herausgeführt hat aus ihrer mitte, * denn ewig währt seine barmherzigkeit,
+135:12 mit mächtiger Hand und erhobenem Arm, * denn ewig währt seine barmherzigkeit,
+135:13 der das rote meer in Teile zerteilte,* denn ewig währt seine barmherzigkeit,
+135:14 und israel herausführte durch seine mitte, * denn ewig währt seine barmherzigkeit,
+135:15 und den Pharao und sein Heer forttrieb ins rote meer, * denn ewig währt seine barmherzigkeit,
+135:16 der sein Volk durch die Wüste geleitete, * denn ewig währt seine barmherzigkeit,
+135:17 der große Könige geschlagen hat, * denn ewig währt seine barmherzigkeit,
+135:18 der starke Könige getötet hat, * denn ewig währt seine barmherzigkeit,
+135:19 Seon, den König der Amoriter, * denn ewig währt seine barmherzigkeit,
+135:20 und Og, den König von basan, * denn ewig währt seine barmherzigkeit,
+135:21 und ihr land zum Erbe gab, * denn ewig währt seine barmherzigkeit,
+135:22 zum Erbe israel, seinem Knecht, * denn ewig währt seine barmherzigkeit.
+135:23 Denn in unserer Erniedrigung hat er an uns gedacht, * denn ewig währt seine barmherzigkeit,
+135:24 und uns erlöst von unseren Feinden, * denn ewig währt seine barmherzigkeit,
+135:25 der nahrung gibt allem Fleisch, * denn ewig währt seine barmherzigkeit.
+135:26 Preiset den Gott des Himmels, * denn ewig währt seine barmherzigkeit.
+135:26 Preiset den Herrn der Herren, * denn ewig währt seine barmherzigkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm138.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm138.txt
@@ -1,23 +1,23 @@
-138:1 O Herr, du durchdringst mich und du durchschaust mich; * (2) Du siehst mich, wenn ich sitze und wenn ich aufsteh';
-138:3 Du kennst auch meine Pläne, selbst wenn sie noch ganz weit sind. * Ob ich nun wandle oder ruhe, du erspähst es, 
-138:4 und siehst voraus schon alle meine Wege. * Ja, ehe noch ein Wörtchen kommt auf meine Zunge,
-138:5 ach, Herr, du weißt schon alles, das Neue und das Alte. * Du hast gebildet mich und aufgelegt mir die Hände.
-138:6 Erstaunlich, über meine Fassungskraft geht deines Wissens Fülle; * ganz überragend ist's, und ich bin dadurch überwältigt.
-138:7 Wo soll ich hingeh'n, dass ich deinem Einfluss mich entziehe? * Und wohin flieh'n vor deinem Blicke?
-138:8 Steig ich zum Himmel auf, bist du dort; * steig ich in Erdentiefen, bist du auch da.
-138:9 Wenn ich nun Flügel nähme und flög' zur Morgenröte, * und wenn ich einen Ort mir suchte in den fernsten Meere,
-138:10 Auch dort selbst würde deine Hand mich halten, * und mich erfassen deine Rechte.
-138:11 Und spräche ich: „Vielleicht kann mich die Finsternis verbergen“, * auch selbst die Nachtzeit würde Leuchte sein für mich in meinem Treiben.
-138:12 Ach, Finsternis ist doch vor dir nicht finster, † und die Nacht ist hell dir wie das Licht des Tages; * So wie die Finsternis der einen, so ist das Licht des andern.
-138:13 Ja, du hältst auch zusammen mir mein Inn'res, * du warst ja mein Erhalter schon im Schoße meiner Mutter.
-138:14 Ich muß dich preisen, denn erstaunlich groß hast du dich gezeigt; ‡ dein Wirken ist ganz wunderbar, * ganz klar erkennt es meine Seele.
-138:15 Dir kann von meinen Gliedern keines unbekannt sein, da du sie geformt ganz ungesehen; * auch nicht ein Teilchen meines Wesens, das du im Verborgenen gebildet.
-138:16 Eh' ich ein fertig Ding war, sahen mich schon deine Augen † und in deinem Buch war alles eingeschrieben, * wie sich die Tage mir gestalten würden, ehe einer gegenwärtig war von ihnen.
-138:17 Ach, mir ganz unbegreiflich sind, o Gott, geworden deine Liebestaten, * groß überaus ist ihre Anzahl.
-138:18 Wollt ich sie zählen, dann wird größer ihre Zahl, als die der Körnchen im Sande; * so oft ich aufsteh, müsste ich zu dir von neuem wiederkommen.
-138:19 O wenn du doch, o Gott, die Frevler all' vertilgen wolltest! * Sag ihnen: Ihr abscheulichen Gesellen, bleibet nicht in meiner Nähe.
-138:20 Weil sie in ihrem Übermut dich reizen; * und nur entweihen deine Wohnungsstätte.
-138:21 Soll ich denen, die dich so hassen, Herr, nicht gram sein * und keine Trauer haben wegen deiner Feinde?
-138:22 Mit tiefstem Abscheu will ich sie verfolgen; * sie gelten auch als meine Feinde.
-138:23 Du kannst, o Gott, mich untersuchen und mein Herz durchforschen, * mich prüfen, meinen Wandel ganz durchmustern,
-138:24 Dann wirst du sehen, ob's an mir liegt, wenn sich Unrecht findet, * und führ mich auf dem richt'gen Wege.
+138:1 Herr, Du hast mich geprüft, und Du kennst mich, * Du kennst mein ruhen und mein Auferstehen.
+138:3 Du schaust meine Gedanken von ferne, * meinen Pfad und meinen Anteil hast Du erkundet.
+138:4 und all meine Wege hast Du vorhergesehen, * denn noch ist kein Wort auf meiner zunge,
+138:5 siehe, Herr, Du weißt alles, das neueste und das Alte, * Du hast mich geformt und Deine Hand auf mich gelegt.
+138:6 zu wunderbar ist Dein Wissen für mich, * gewaltig ist es, nicht reiche ich an das selbe hin.
+138:7 Wohin soll ich gehen vor Deinem Geist? * und wohin soll ich fliehen vor Deinem Angesicht?
+138:8 Steige ich zum Himmel hinauf, so bist Du dort, * steige ich zur unterwelt hinab, so bist Du zugegen.
+138:9 Erhebe ich meine Flügel in der morgendämmerung * und lass mich nieder an den äußersten Enden des meeres,
+138:10 auch dort wird Deine Hand mich führen * und Deine rechte mich halten.
+138:11 und spräche ich: Vielleicht wird Finsternis mich niederdrücken * und die nacht meine leuchte sein in meinen Wonnen.
+138:12 Denn vor Dir wird die Finsternis nicht dunkel sein, und die nacht wird hell wie der Tag, * wie ihre Finsternis, so ist auch sein licht.
+138:13 Denn Du besaßest meine nieren, * Du hast mich angenommen vom Schoß meiner mutter an.
+138:14 ich preise Dich, denn erschreckend groß bist Du, * wunderbar sind Deine Werke, und meine Seele erkennt dies gar wohl.
+138:15 nicht war verborgen vor Dir mein Gebein, das Du im Verborgenen gebildet hast, * und mein Wesen in den Tiefen der Erde.
+138:16 Da ich noch unvollendet war, sahen mich Deine Augen, und in Dein buch werden alle verzeichnet; * die Tage werden geformt, und noch ist niemand in ihnen.
+138:17 Deine Freunde aber, Gott, sind von mir hoch geehrt, * überaus stark wurde ihre Herrschaft.
+138:18 zählen will ich sie, und zahlreicher als Sand werden sie sein, * ich erhob mich und bin noch immer bei Dir.
+138:19 Dass Du töten wollest, o Gott, die Sünder; * ihr männer voll blutschuld, weichet von mir!
+138:20 Denn ihr sprecht in Gedanken: * Sie werden vergeblich Deine Städte einnehmen.
+138:21 Hasse ich nicht jene, die Dich hassen, o Herr? * und härme ich mich nicht über Deine Feinde?
+138:22 mit vollkommenem Hass hasse ich sie, * und zu Feinden sind sie mir geworden.
+138:23 Prüfe mich, o Gott, und erkenne mein Herz, * befrage mich und erkenne meine Wege!
+138:24 und sieh, ob der Weg des unrechts in mir ist, * und geleite mich auf ewigem Weg!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm143.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm143.txt
@@ -1,18 +1,18 @@
-143:1 Nun sei, o Herr, mein Gott, gepriesen, der meine Hände du gelehrt das Kämpfen * und meinen Fingern zeigst das Waffenhalten.
-143:2 O mein Erbarmer du und meine Zuflucht, * mein Anwalt und mein Retter;
-143:2 O mein Beschützer du, bei dem ich mich so sicher fühle, * der du mein Volk mir machtest untertänig!
-143:3 O Herr, was bin ich denn, dass du mir solche Huld erwiesen, * ich armes Menschenkind, dass du mich so beachtest?
-143:4 Das irdene Ding, das einem Hauche gleich ist, * und dessen Leben wie der Schatten schwindet.
-143:5 O Herr, der deinen Himmel du zum Neigen bringst und dann herabsteigst, * der du die Berge durch Berührung bringst zum Rauchen.
-143:6 Der du die Blitze leuchten lässt, dass ringsumher sie schwirren, * und so verschießest deine Pfeile und sie durcheinander schleuderst.
-143:7 Streck deine Hand nun aus der Höhe, zieh mich heraus und rette mich aus meinen vielen Nöten, * aus der Gewalt der grimmen Feinde,
-143:8 Die Frevel nur in ihrem Sinne planen, * und deren Rechte eine Rechte ist voll Tücke.
-143:9 O Gott, ich will ein neues Lied dir singen, die Festesharfe dir erklingen lassen.
-143:10 Der du den Königen gewährst die Siege, * der du den David deinen Knecht dem Unheilsschwert (des Goliath) entkommen ließest,
-143:11 Entreiße mich und rette mich aus der Gewalt der grimmigen Feinde, * die Frevel nur in ihrem Sinne planen, und deren Rechte eine Rechte ist voll Tücke.
-143:12 Lass unsre Söhne sein, wie junge Pflänzchen, * in ihrer Jugendfrische,
-143:12 Und unsre Töchter schmuck gewachsen, * dass sie geputzten Tempelsäulen ähnlich werden.
-143:13 Lass voll sein unsre Speicher, * dass das Getreide überfällt von einem zu dem andern,
-143:13 Und unsre Schafe fruchtbar, reich an Lämmern, * und unsre Rinder fett und häufig trächtig.
-143:14 Lass in den Zäunen keine Lücke sein, und keine Einbruchsstelle, * und Kriegslärm bleibe fern von unsern Straßen.
-143:15 Dann wird man rufen: „Glücklich ist das Volk, dem dies beschieden; * o glücklich Volk du, dessen Gott der Herr ist.“
+143:1 Gepriesen sei der Herr, mein Gott, der meine Hände den Kampf lehrt * und meine Finger den Krieg.
+143:2 meine barmherzigkeit und meine zuflucht, * mein beistand und mein befreier,
+143:2 mein beschützer, und auf ihn habe ich meine Hoffnung gesetzt, * der mir mein Volk unterwirft.
+143:3 Herr, was ist der mensch, dass Du Dich ihm zu erkennen gabst, * oder des menschen Sohn, dass Du an ihn denkst?
+143:4 Der mensch ist gleich der nichtigkeit, * seine Tage ziehen wie Schatten vorüber.
+143:5 Herr, neige Deine Himmel und steige herab, * berühre die berge, und sie werden rauchen.
+143:6 lass zucken den blitz, und Du wirst sie zerstreuen, * sende aus Deine Pfeile, und Du wirst sie verwirren.
+143:7 Sende aus Deine Hand von der Höhe, reiße mich heraus und befreie mich aus den vielen Wassern, * aus der Hand der Söhne der Fremden,
+143:8 deren mund nichtigkeit redet * und deren rechte eine rechte des unrechts ist.
+143:9 Gott, ein neues lied will ich Dir singen, * auf der zehnsaitigen Harfe Dir spielen,
+143:10 der Du Heil gibst den Königen, * der Du David, Deinen Knecht, erlöst hast vom bösen Schwert. Errette mich
+143:11 und befreie mich aus der Hand der Söhne der Fremden, deren mund nichtigkeit redet * und deren rechte eine rechte des unrechts ist.
+143:12 ihre Söhne sind wie junge Pflanzungen * in ihrer Jugend,
+143:12 ihre Töchter sind wohlgestaltet, * ringsum geziert wie ein Tempel,
+143:13 ihre Speicher sind voll, * sie strömen über von einem in den anderen,
+143:13 ihre Schafe sind fruchtbar, zahllos auf ihren Triften, * ihre rinder sind fett,
+143:14 ihre mauer kennt keinen Einsturz und keinen Durchschlupf, * und kein Geschrei ist auf ihren Plätzen.
+143:15 Selig preist man ein Volk, dem solches zuteil wird; * doch selig ist das Volk, dessen Gott der Herr ist.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm144.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm144.txt
@@ -1,22 +1,22 @@
-144:1 Ich will dich preisen, o mein Gott und König, * und rühmen deine Majestät zu aller Zeit durch alle Ewigkeiten.
-144:2 Ich möchte jeden Tag dich preisen, * und loben deine Majestät zu aller Zeit durch alle Ewigkeiten.
-144:3 Groß ist der Herr, und überaus des Lobes würdig, * und seine Größe hat kein Ende.
-144:4 Die sämtlichen Geschlechter müßten preisen deine Werke, * und deine Allmacht kundtun;
-144:5 Die Hoheit deiner hehren Majestät besingen, * und deine Wunderkraft verkünden.
-144:6 Und deiner staunenswerten Taten Größe rühmen, * und deine höchste Würde preisen.
-144:7 Man müßte deiner überreichen Gnade Lobpreis aus dem Herzen sprudeln lassen, * und hüpfen, wenn man denkt an deine Güte.
-144:8 O Allerbarmer, gnäd'ger Herr du, * der du geduldig und so reich bist an Erbarmen;
-144:9 O Herr, der du so liebevoll bist gegen alle, * und dessen Hulderweise leuchten über allen deinen Werken;
-144:10 O laß doch deine Werke, Herr, dich preisen, * und laß die unter deinem Schutze Stehenden dich loben.
-144:11 Laß deine glorreiche Regierung sie besingen, * und deine große Macht verkünden,
-144:12 Daß sie, was du vermagst, den kleinen Menschen zeigen, * wie deine Königsmacht so glorreich groß ist;
-144:13a Wie deine Königsmacht als Königsmacht bleibt durch alle Ewigkeiten, * und deine Herrschaft fortbesteht durch alle Menschenalter.
-144:13b O Herr, o du in allem, was du sagst, so Treuer, * o du in allem, was du tust, so Gnäd'ger;
-144:14 O Herr, der du emporhebst alle, die da stürzen, * und der du alle richtest auf, die fallen;
-144:15 Auf dich, Herr, schauen aller Augen, * daß du die Nahrung ihren reichst, wenn's Zeit ist.
-144:16 Der du die Hand bloß brauchst zu öffnen, * und schon machst reichlich satt die Lebewesen alle,
-144:17 Du bist so gerecht, o Herr, in deinem ganzen Walten, * in allem, was du tust, so gnädig;
-144:18 Du bist den allen, die dich rufen, Herr, so nahe, * besonders allen, die zu dir so richtig herzlich rufen.
-144:19 Du tust ja ihren Willen denen, die dich fürchten, ‡ und ihrer Bitten Fleh'n erhörst du * und machst sie so glücklich.
-144:20 Du bist ein guter Wächter, Herr, für alle deine Freunde, * doch du vertilgest alle Bösen.
-144:21 Dein Lob, o Herr, soll stets mein Mund verkünden, * und preisen soll mein ganzes Wesen deine heil'ge Majestät auf immer und durch alle Ewigkeiten.
+144:1 ich will Dich erheben, mein Gott und König, * und Deinen namen preisen in Ewigkeit und von Ewigkeit zu Ewigkeit.
+144:2 Durch alle Tage will ich Dich preisen * und Deinen namen loben in Ewigkeit und von Ewigkeit zu Ewigkeit.
+144:3 Groß ist der Herr und überaus lobwürdig, * und seine Größe hat keine Grenze.
+144:4 Geschlecht um Geschlecht wird loben Deine Werke, * und sie werden laut künden Deine macht.
+144:5 Von der Hoheit des ruhmes Deiner Heiligkeit werden sie reden * und Deine Wundertaten kundtun.
+144:6 und von der Kraft Deiner furchtbaren Taten werden sie sprechen * und Deine Hoheit verkünden.
+144:7 Die Erinnerung an die Fülle Deiner Güte sprudeln sie hervor, * und über Deine Gerechtigkeit werden sie frohlocken.
+144:8 Ein Erbarmer und barmherzig ist der Herr, * geduldig und sehr barmherzig.
+144:9 Gütig ist der Herr zu allen, * und die Erweise seiner barmherzigkeit erstrecken sich auf all seine Werke.
+144:10 Preisen sollen Dich, o Herr, all Deine Werke, * und Deine Heiligen Dich rühmen.
+144:11 Von der Herrlichkeit Deines Königtums sollen sie sprechen * und reden von Deiner macht,
+144:12 um Deine macht den menschenkindern kundzutun, * und den ruhm der Hoheit Deines Königtums.
+144:13a Dein Königtum ist ein Königtum aller zeiten * und Deine Herrschaft in jedem Geschlecht und für alle Geschlechter.
+144:13b Getreu ist der Herr in all seinen Worten * und heilig in all seinen Werken.
+144:14 Der Herr hebt alle empor, die stürzen, * und richtet auf alle Verstoßenen.
+144:15 Die Augen aller hoffen auf Dich, o Herr, * und Du gibst ihnen ihre Speise zur rechten zeit.
+144:16 Du öffnest Deine Hand * und erfüllst alles, was da lebt, mit Segen.
+144:17 Gerecht ist der Herr auf all seinen Wegen * und heilig in all seinen Werken.
+144:18 nahe ist der Herr allen, die ihn anrufen, * allen, die ihn anrufen in Wahrheit.
+144:19 Den Willen derer, die ihn fürchten, wird er tun, * und ihr Flehen wird er erhören und ihnen Heil schaffen.
+144:20 Der Herr bewahrt alle, die ihn lieben, * und alle Sünder wird er verderben.
+144:21 Das lob des Herrn soll künden mein mund, * und preisen soll alles Fleisch seinen heiligen namen in Ewigkeit und von Ewigkeit zu Ewigkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm16.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm16.txt
@@ -11,7 +11,7 @@
 16:9b Meine Feinde umringen meine Seele, das Fett (ihres Herzens) haben sie verschlossen, * ihr Mund hat hochmütig gesprochen.
 16:11 Die mich hinausstießen, sie haben mich jetzt umringt, * sie beschlossen, ihre Augen zur Erde zu senken.
 16:12 Sie empfingen mich wie ein Löwe, begierig auf beute, * wie ein Junglöwe, der im Verborgenen haust.
-16:13 Erhebe Dich, Herr, komm ihm zuvor und wirf ihn nieder, * entreiße meine Seele dem Gott losen, Deinen Speer den Feinden Deiner Hand.
+16:13 Erhebe Dich, Herr, komm ihm zuvor und wirf ihn nieder, * entreiße meine Seele dem Gottlosen, Deinen Speer den Feinden Deiner Hand.
 16:14b Herr, vom Wenigen des Landes teile ihnen zu in ihrem Leben; * mit dem, was Du gespeichert hast, hat sich ihr bauch gefüllt.
 16:14c Gesättigt sind sie mit Söhnen, * und ihren Überfluss hinterlassen sie ihren Kindern.
 16:15 ich aber will in Gerechtigkeit erscheinen vor Deinem Angesicht, * ich werde gesättigt werden, wenn Deine Herrlichkeit erscheint.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm17.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm17.txt
@@ -1,54 +1,54 @@
-17:2 Ich muß, o Herr, dich lieben, du meine Stärke, * (3a) o Herr, du meine Kraft und meine Zuflucht und mein Retter.
-17:3b O mein Gott, du bist meine Hilfe, * und meine Hoffnung.
-17:3c Du bist mein Beschützer, meine Siegesstärke, * mein ständ'ger Anwalt.
-17:4 Im höchsten Lob muß ich, o Herr, dich preisen, * und werde vor meinen Feinden gerettet.
-17:5 Wenn mich die Todesschrecken schon umfingen, * und wie ein Wildbach über mich einstürmten die Gefahren,
-17:6 Wenn mich die Totenwelt mit ihren Stricken packte, * wenn mich umgarnten schon des Todes Netze;
-17:7a In dieser meiner Not hab ich, o Herr, zu dir gerufen, * und hab zu meinem Gott geschrien.
-17:7b Und er hat meinen Ruf gehört aus seinem heiligen Tempel, * und mein Geschrei hat sich vor ihm den Weg gebahnt zu seinen Ohren.
-17:8 Dann bebt' und zitterte die Erde, * sodaß der Berge Fundamente aufgewühlt und ganz durchschüttelt wurden; so zeigtest deinen Grimm du.
-17:9 Es traten Wolken aus wie Rauch aus deiner Zornglut † und Feuer sprüht' aus seinem Antlitz, * die Glut, die er selbst angezündet.
-17:10 Dann senkte er den Himmel und stieg herunter, * doch Dunkelheit war unter seinen Füßen.
-17:11 Dann stieg er auf die Cherubim und raste hin im Fluge, * flog hin auf der Winde Flügel.
-17:12 Er nahm die Finsternis sich zum Versteck, † daß sie um ihn als Zelt ihm diente, * das schwarze Wolkenwasser nämlich in den Lüften.
-17:13 Sobald sein Glanz im Blitz erstrahlte, wichen gleich zurück die Wolken, * dann gab's ein Krachen und ein Feuersprühen.
-17:14 So ließ der Herr vom Himmel donnern, † seine höchste Majestät ließ ihre Stimme hören: * das gab ein furchtbar Krachen und ein furchtbar Feuersprühen.
-17:15 Dann nahm er seine Pfeile und schleuderte sie durcheinander, * die Blitze, die er zahllos ließ durch die Lüfte schwirren.
-17:16a Nun wurden gar der Meere Tiefen sichtbar, * und bloßgelegt die Fundamente des Erdballs,
-17:16b O Herr, vor deinem Rasen, * vorm Fauchen deines grimmen Zornes.
-17:17 Nun streckte aus der Höhe er die Hand aus und ergriff mich * und zog heraus mich aus der Überflutung,
-17:18 Entreiß mich den starken Feinden, † allen meinen Hassern, * obwohl sie mir sehr überlegen waren.
-17:19 Sie hatten mich gepackt an manchem schweren Tage; * da wurde der Herr mir zum Retter.
-17:20 Er führte mich hinaus an einen Ort, wo Gefahr mir nicht drohte, * er sandte Rettung mir, weil er mich liebte.
-17:21 So lohnte mir der Herr meinen lauteren Wandel, * gemäß der Unschuld meiner Hände gab er meinen Lohn mir:
-17:22 Weil ich die Wege des Herrn beachtet habe, * und gegen meinen Gott nicht untreu wurde.
-17:23 Denn alles, was er angeordnet, stand vor meinem Angesicht * und seine Forderungen habe ich nicht abgewiesen.
-17:24 Ich habe mich schuldlos gegen ihn benommen * und mich gehütet, Unrecht zu tun.
-17:25 Drum lohnet mir der Herr für meinen lauteren Wandel: * und gemäß der Reinheit meiner Hände vor den Blick seiner Augen.
-17:26 Dem, der sich müht, dir zu gefallen, bist auch du gefällig; * dem, der untadelig gegen dich ist, bist auch du untadelig.
-17:27 Wer gegen dich besonders sich hervortut, den bevorzugst du genauso; * dem aber, der dir Feind wird, bist auch du Feind.
-17:28 Ja, du errettest das demütige Volk, * die Augen der Hochmütigen dagegen demütigst du.
-17:29 Ja, du, o Herr, sorgst dafür, daß mein Glück in Strahlen leuchtet, * mein Gott, leuchte, wenn's finster um mich werden sollte.
-17:30 Denn mit deiner Hilfe werde ich aus der Versuchung befreit, * und mit meinem Gotte spring ich über alle Mauern.
-17:31 Wie ist doch lauter der Weg meines Gottes, † wie gereinigt in der Feuerschmelze sind die Worte des Herrn: * ein Schützer ist er allen, die auf ihn vertrauen.
-17:32 Denn wer ist ein Gott außer dem Herrn? * Und wer ist wohl ein Gott außer unserm Gott?
-17:33 Der neben Gott wäre, der mich mit Kraft umgürtet hat, * und meinen Lebensweg bewahrt vor allem Schaden.
-17:34 Der meinen Beinen Schnelligkeit verliehen hat, als wären es Beine eines Hirsches * und mich in Sicherheit gebracht auf hochgelegene Orte.
-17:35 Der zum Kämpfen gelehrt meine Hände * und meine Arme stark wie Bögen aus Eisen.
-17:36a Und du hast mir gewährt zum Schutze deine Siegeskraft, * und deine Rechte, die mich stützte.
-17:36b Und deine Führung führte stets mich richtig, * und deine Führung wies den Weg mir richtig.
-17:37 Der du die Schritte unter mir geweitet, * damit nicht müde würden meine Füße.
-17:38 So konnte ich verfolgen meine Feinde, bis ich sie vernichtet, * und ließ nicht ab, bis matt sie niedersanken.
-17:39 Ich konnte sie zusammenhauen, daß sie nicht mehr stehen konnten, * und mir zu Füßen fielen.
-17:40 So hast du mich mit Kampfeskraft umgürtet, * und hingestreckt zu meinen Füßen die Bedränger.
-17:41 So hast du meine Feinde in die Flucht geschlagen, * und meine Hasser ausgerottet.
-17:42 Geschrien haben sie und niemand kam, um ihnen beizustehen, sogar zu dir, o Herr, * doch ohne, daß du sie erhörtest.
-17:43 Nun konnt ich sie zermalmen, daß sie würden wie der Staub im Winde, * wie Straßenschmutz so konnt ich sie zertreten.
-17:44 So machtest du mich frei vom Widerstand der Leute, * machst mich zum Haupt der Völker.
-17:45 Volksscharen, die ich nie gekannt, sind untertan mir, * wenn sie mein Wort nur hören, sind sie mir gehorsam.
-17:46 Die vorher Feind mir waren, dienen mir in Ehrfurcht, * die Feinde sind vom Kampf ermattet und verlassen ganz entkräftet ihre Burgverließe.
-17:47 Drum sollst, o Herr, du leben und gepriesen sein, mein Gott du, * verherrlicht werden, Gott meines Heiles.
-17:48 O Gott, der du mir Strafgewalt gibst und Völker mir untertan machst, * o du mein Retter vor den grimmen Feinden.
-17:49 Der du vor den Empörern mich beschütztest, * vor dem Verfolger mich beschirmtest.
-17:50 Drum möcht ich preisen dich, o Herr, daß es die Völker hören, * und singen deiner Majestät dies Danklied,
-17:51 Die diese herrlichen Triumphe bietet ihrem König, † und solche Huld erweist ihrem Gesalbten David * und seinen Nachkommen auf ewig.
+17:2 ich will Dich lieben, Herr, meine Stärke, * Herr, meine Feste, meine zuflucht und mein befreier.
+17:3b Mein Gott ist mein Helfer, * und auf ihn will ich hoffen.
+17:3c Mein beschützer und das Horn meines Heiles * und der mich aufnimmt.
+17:4 Lobend will ich anrufen den Herrn, * und von meinen Feinden werde ich errettet.
+17:5 Es umgaben mich Wehen des Todes, * und Ströme der bosheit verwirrten mich.
+17:6 Die Wehen der Unterwelt umfingen mich, * es überraschten mich die Schlingen des Todes.
+17:7a in meiner bedrängnis rief ich zum Herrn, * und zu meinem Gott habe ich geschrien.
+17:7b Und er erhörte aus seinem heiligen Tempel meine Stimme, * und mein Schreien vor seinem Angesicht drang in seine Ohren.
+17:8 Es wankte und bebte die Erde, * die Grundfesten der berge wurden erschüttert und wankten, weil er ihnen zürnte.
+17:9 Es stieg rauch auf in seinem zorn, und Feuer loderte auf von seinem Angesicht her, * Glutkohlen brannten von ihm hervor.
+17:10 Er neigte die Himmel und stieg herab, * und Dunkel war unter seinen Füßen.
+17:11 Und er stieg auf Cherubim und flog dahin, * er flog auf den Flügeln der Winde.
+17:12 Und er machte Finsternis zu seinem Versteck, rings um ihn als sein zelt, * das finstere Wasser in den Wolken der Luft.
+17:13 Vor dem Glanz seines Angesichts gingen Wolken her, * Hagel und feurige Kohlen.
+17:14 Und es donnerte vom Himmel der Herr, und der Höchste ließ seine Stimme erschallen, * Hagel und feurige Kohlen.
+17:15 Und er schoss seine Pfeile und zerstreute sie, * er vermehrte die blitze und verwirrte sie.
+17:16a Und es zeigten sich Quellen von Wasser, * und enthüllt wurden die Grundfesten des Erdkreises
+17:16b von Deinem Schelten, Herr, * von dem schnaubenden Hauch Deines zornes.
+17:17 Er sandte aus der Höhe und fasste mich, * und er zog mich aus vielen Wassern.
+17:18 Er hat mich errettet von meinen überstarken Feinden und von denen, die mich hassen, * denn sie sind stark geworden, mehr als ich.
+17:19 Sie überraschten mich am Tag meiner bedrängnis, * und der Herr ist mein Schützer geworden.
+17:20 Und er führte mich hinaus ins Weite, * er hat mich gerettet, weil er Wohlgefallen an mir hat.
+17:21 Und vergelten wird mir der Herr gemäß meiner Gerechtigkeit, * und gemäß der reinheit meiner Hände wird er mir vergelten,
+17:22 denn ich habe die Wege des Herrn bewahrt * und nicht gottlos gehandelt, weg von meinem Gott,
+17:23 denn all seine rechtssprüche sind vor meinem Angesicht, * und seine Satzungen stieß ich nicht von mir.
+17:24 Und ich will makellos sein bei ihm * und mich hüten vor meiner bosheit.
+17:25 Und vergelten wird mir der Herr gemäß meiner Gerechtigkeit, * und gemäß der reinheit meiner Hände vor seinen Augen.
+17:26 Mit dem Heiligen wirst Du heilig sein, * und mit dem unschuldigen Mann unschuldig.
+17:27 Und mit dem Auserwählten wirst Du auserwählt sein * und mit dem Verkehrten verkehrt.
+17:28 Denn ein demütiges Volk wirst Du retten * und die Augen der Stolzen demütigen.
+17:29 Denn Du machst hell meine Leuchte, Herr; * mein Gott, mach hell meine Finsternis!
+17:30 Denn durch Dich werde ich herausgerissen aus der Versuchung, * und mit meinem Gott übersteige ich jede Mauer.
+17:31 Mein Gott, unbefleckt ist sein Weg: Die Aussprüche des Herrn sind im Feuer erprobt, * ein beschützer ist er allen, die auf ihn hoffen.
+17:32 Denn wer ist Gott außer dem Herrn? * Oder wer ist Gott außer unserem Gott?
+17:33 Gott ist es, der mich umgürtete mit Kraft * und der makellos gemacht meinen Weg,
+17:34 der meine Füße machte wie die der Hirsche * und mich auf Höhen stellte.
+17:35 Er lehrt meine Hände den Kampf; * und gleich wie einen ehernen bogen hast Du meine Arme gemacht.
+17:36a Und Du gabst mir den Schutz Deines Heiles, * und Deine rechte nahm mich auf.
+17:36b Deine Unterweisung hat mich vollends gebessert, * und Deine Un ter weisung, sie selbst wird mich lehren.
+17:37 Weit gemacht hast Du meine Schritte unter mir, * und meine Tritte sind nicht ermattet.
+17:38 Verfolgen will ich meine Feinde und sie ergreifen * und mich nicht abwenden, bis sie erliegen.
+17:39 zerbrechen will ich sie, so dass sie nicht mehr stehen können, * zu meinen Füßen sollen sie niedersinken.
+17:40 Und Du hast mich umgürtet mit Kraft für den Krieg * und hast alle, die sich gegen mich erhoben, unter mir zu Fall gebracht.
+17:41 Und meine Feinde schlugst Du in die Flucht [wörtlich: gabst Du mir als rücken], * und die mich hassten, hast Du vertilgt.
+17:42 Sie schrien zum Herrn, und es gab keinen, der half, * und er hat sie nicht erhört.
+17:43 Und zermalmen will ich sie wie Staub vor dem Angesicht des Windes, * wie den Schlamm der Gassen will ich sie vernichten.
+17:44 Du rettest mich vom Aufbegehren des Volkes, * Du wirst mich einsetzen zum Haupt der Völker.
+17:45 Ein Volk, das ich nicht kannte, diente mir, * sobald sein Ohr es hörte, gehorchte es mir.
+17:46 Die fremden Söhne heuchelten mir Ergebung, * die fremden Söhne wurden altersschwach und hinkten fort von ihren Pfaden.
+17:47 Es lebt der Herr, und gepriesen sei mein Gott, * und es werde erhöht der Gott meines Heiles.
+17:48 Gott, der Du mir Vergeltung verschaffst und mir Völker unterwirfst, * mein befreier von meinen zornigen Feinden.
+17:49 Und vor denen, die sich gegen mich erheben, wirst Du mich erhöhen, * vor dem ungerechten Mann wirst Du mich retten.
+17:50 Darum will ich Dich preisen bei den Völkern, Herr, * und Deinem namen einen Psalm singen,
+17:51 der groß macht das Heil seines Königs und Erbarmen schafft seinem Gesalbten David * und seinen nachkommen bis in Ewigkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm18.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm18.txt
@@ -1,16 +1,16 @@
-18:2 Der Himmel kündet Gottes Größe, * und was vermögen seine Hände, zeigen klar die Himmelsräume.
-18:3 Es läßt ein jeder Tag hervor aus seinem Busen sprudeln seine Botschaft, daß der nächste Tag es höre, * und jede Nacht gibt ihre Meldung an die nächste weiter.
-18:4 Es sind das keine Laute, keine Reden, * und nichts hört man von einem Rufen.
-18:5 Und doch dringt ihre Kunde hin in alle Lande, * bis zu der Erde Grenzen ihre Meldung.
-18:6a Dem Sonnenball hat nämlich dort sein Nachtzelt er bereitet; * und der tritt nun heraus, schön wie ein Bräutigam aus seinem Brautgemache,
-18:6b Und glüht vor Jubel wie ein Renner auf der Wettbahn * (7a) wenn er seinen Weg durchläuft.
-18:7b Von einem Himmelsende nimmt er Anlauf, und seine Rennbahn reicht bis zu dem andern Ende, * und nichts vermag zu bergen sich vor seiner Wärme.
-18:8 Es ist des Herrn Gesetz, ganz lichtrein, eine Herzerquickung; * was uns der Herr geoffenbart, ist gut gemeint, soll Unerfahr'nen Weisheit bringen.
-18:9 Die Forderungen Gottes sind so huldvoll, sind ein Trost für Herzen; * und das Gebot des Herrn beglückend, Licht für unsre Augen.
-18:10 Auch was der Herr uns androht, ist nur gute Absicht, eine Quelle ew'gen Segens; * des Herrn Entscheidungen sind gütig, Gnade ist ihr ganzes Wesen.
-18:11 Sind sind der höchsten Schätzung wert, weit über Gold und Edelsteine, * Genuß mehr spendend als der reinste Honig.
-18:12 Drum müssen deine Diener sie befolgen; * und wenn sie sie befolgen, dann genießen sie gar großen Segen.
-18:13 Wie oft man irrt, wer kann das wissen? † Meine unbewußten Fehler bitte mir nicht anzurechnen, * (14a) bewahre aber deinen Diener vor dem bösen Willen.
-18:14b O daß doch dieser keine Herrschaft über mich bekommt! Dann bin ich ohne Makel, * und bleibe frei von allen Sünden.
-18:15a Dann wird's gescheh'n, daß meines Munds Gebete dir gefallen, * und stets genehm dir sind die Wünsche meines Herzens.
-18:15b O Herr, mein Helfer * und mein Erretter.
+18:2 Die Himmel erzählen die Herrlichkeit Gottes, * und die Werke seiner Hände verkündet das Firmament.
+18:3 Ein Tag ruft dem anderen das Wort zu, * und eine nacht tut der anderen Erkenntnis kund.
+18:4 Es sind nicht Sprachen und nicht reden, * deren Stimmen man nicht hört.
+18:5 in alle Welt hinaus ging ihr ruf * und bis an die Grenzen des Erdkreises ihre Worte.
+18:6a im Sonnenball hat er (Gott) sein zelt errichtet, * und er ist wie ein bräutigam, der hervortritt aus seinem Gemach,
+18:6b er frohlockte wie ein riese, seine bahn zu ziehen. * Vom höchsten Himmel ist sein Ausgang
+18:7b und seine rückkehr bis zu dessen Höchstem, * und niemand ist, der sich verbergen kann vor seiner Glut.
+18:8 Das Gesetz des Herrn ist makellos, die Seelen bekehrend, * das zeugnis des Herrn ist zuverlässig, Weisheit gewährend den Kleinen.
+18:9 Die Satzungen des Herrn sind richtig, die Herzen erfreuend, * das Gebot des Herrn ist lichtvoll, die Augen erleuchtend.
+18:10 Die Furcht des Herrn ist heilig, dauernd in alle Ewigkeit, * die urteile des Herrn sind wahr, gerechtfertigt in sich selber,
+18:11 begehrenswerter als Gold und viel Edelstein * und süßer als Honig und Wabe.
+18:12 und auch Dein Knecht bewahrt sie, * in ihrer befolgung liegt reiche Vergeltung.
+18:13 Die Sünden wer erkennt sie? Von meinen verborgenen reinige mich * und von fremden verschone Deinen Knecht!
+18:14b Wenn sie nicht über mich herrschen, dann werde ich makellos sein, * und ich werde rein von größter Sünde.
+18:15a und die Aussprüche meines mundes werden so sein, dass sie Dir wohlgefallen, * und das Sinnen meines Herzens ist immer vor Deinem Angesicht.
+18:15b Herr, Du bist mein Helfer * und mein Erlöser.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm21.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm21.txt
@@ -1,34 +1,34 @@
-21:2 Deus, Deus meus, réspice in me: quare me dereliquísti? * longe a salúte mea verba delictórum meórum.
-21:3 Deus meus, clamábo per diem, et non exáudies: * et nocte, et non ad insipiéntiam mihi.
-21:4 Tu autem in sancto hábitas, * laus Israël.
-21:5 In te speravérunt patres nostri: * speravérunt, et liberásti eos.
-21:6 Ad te clamavérunt, et salvi facti sunt: * in te speravérunt, et non sunt confúsi.
-21:7 Ego autem sum vermis, et non homo: * oppróbrium hóminum, et abjéctio plebis.
-21:8 Omnes vidéntes me, derisérunt me: * locúti sunt lábiis, et movérunt caput.
-21:9 Sperávit in Dómino, erípiat eum: * salvum fáciat eum, quóniam vult eum.
-21:10 Quóniam tu es, qui extraxísti me de ventre: * spes mea ab ubéribus matris meæ. In te projéctus sum ex útero:
-21:11 De ventre matris meæ Deus meus es tu, * ne discésseris a me:
-21:12 Quóniam tribulátio próxima est: * quóniam non est qui ádjuvet.
-21:13 Circumdedérunt me vítuli multi: * tauri pingues obsedérunt me.
-21:14 Aperuérunt super me os suum, * sicut leo rápiens et rúgiens.
-21:15 Sicut aqua effúsus sum: * et dispérsa sunt ómnia ossa mea.
-21:15 Factum est cor meum tamquam cera liquéscens * in médio ventris mei.
-21:16 Aruit tamquam testa virtus mea, et lingua mea adhæsit fáucibus meis: * et in púlverem mortis deduxísti me.
-21:17 Quóniam circumdedérunt me canes multi: * concílium malignántium obsédit me.
-21:17 Fodérunt manus meas et pedes meos: * dinumeravérunt ómnia ossa mea.
-21:18 Ipsi vero consideravérunt et inspexérunt me: * divisérunt sibi vestiménta mea, et super vestem meam misérunt sortem.
-21:20 Tu autem, Dómine, ne elongáveris auxílium tuum a me: * ad defensiónem meam cónspice.
-21:21 Erue a frámea, Deus, ánimam meam: * et de manu canis únicam meam:
-21:22 Salva me ex ore leónis: * et a córnibus unicórnium humilitátem meam.
-21:23 Narrábo nomen tuum frátribus meis: * in médio ecclésiæ laudábo te.
-21:24 Qui timétis Dóminum, laudáte eum: * univérsum semen Jacob, glorificáte eum.
-21:25 Tímeat eum omne semen Israël: * quóniam non sprevit, neque despéxit deprecatiónem páuperis:
-21:25 Nec avértit fáciem suam a me: * et cum clamárem ad eum, exaudívit me.
-21:26 Apud te laus mea in ecclésia magna: * vota mea reddam in conspéctu timéntium eum.
-21:27 Edent páuperes, et saturabúntur: et laudábunt Dóminum qui requírunt eum: * vivent corda eórum in sæculum sæculi.
-21:28 Reminiscéntur et converténtur ad Dóminum * univérsi fines terræ:
-21:28 Et adorábunt in conspéctu ejus * univérsæ famíliæ géntium.
-21:29 Quóniam Dómini est regnum: * et ipse dominábitur géntium.
-21:30 Manducavérunt et adoravérunt omnes pingues terræ: * in conspéctu ejus cadent omnes qui descéndunt in terram.
-21:31 Et ánima mea illi vivet: * et semen meum sérviet ipsi.
-21:32 Annuntiábitur Dómino generátio ventúra: * et annuntiábunt cæli justítiam ejus pópulo qui nascétur, quem fecit Dóminus.
+21:2 Gott, mein Gott, schau her auf mich. Warum hast Du mich verlassen? * Fern von meinem Heil sind die Worte meiner Verfehlungen.
+21:3 mein Gott, ich rufe bei Tag, doch Du erhörst es nicht, * und bei nacht, und nicht ist es Torheit von mir.
+21:4 Du aber wohnst im Heiligtum, * lob israels.
+21:5 Auf Dich hofften unsere Väter; * sie haben gehofft, und Du hast sie befreit.
+21:6 zu Dir haben sie gerufen und wurden gerettet, * auf Dich haben sie gehofft und wurden nicht zuschanden.
+21:7 ich aber bin ein Wurm und kein mensch, * der leute Spott und des Volkes Verachtung.
+21:8 Alle, die mich sehen, verspotten mich, * sie lästern mit den lippen und schütteln den Kopf.
+21:9 Er hat auf den Herrn vertraut, der soll ihn nun retten; * er soll ihn heil machen, da er ihn ja will.
+21:10 Denn Du bist es, der mich aus dem leib gezogen, * meine Hoffnung seit der brust meiner mutter; auf Dich bin ich geworfen vom mutterschoß an.
+21:11 Vom leib meiner mutter an bist Du mein Gott; * weiche nicht von mir.
+21:12 Denn Drangsal ist nahe, * denn niemand ist da, der hilft.
+21:13 Es umgaben mich viele Kälber, * fette Stiere belagerten mich.
+21:14 Sie öffneten über mir ihren rachen * wie ein reißender und brüllender löwe.
+21:15 Wie Wasser bin ich hingeschüttet, * und zerstreut sind all meine Gebeine.
+21:15 mein Herz ist geworden wie schmelzendes Wachs, * inmitten meines leibes.
+21:16 Vertrocknet wie eine Scherbe ist meine Kraft, und meine zunge klebt an meinem Gaumen, * und in den Staub des Todes hast Du mich hinabgeführt.
+21:17 Denn viele Hunde umgaben mich, * der rat der Übeltäter hat mich belagert.
+21:17 Sie haben meine Hände und Füße durchbohrt, * gezählt haben sie all meine Gebeine.
+21:18 Sie aber gafften mich an und betrachteten mich, * sie teilten unter sich meine Kleider und warfen das los um mein Gewand.
+21:20 Du aber, Herr, entferne nicht Deine Hilfe von mir, * achte auf meine Verteidigung.
+21:21 Errette vom Speer, o Gott, meine Seele, * und aus der Hand des Hundes meine Einzige.
+21:22 befreie mich aus dem rachen des löwen * und vor den Hörnern der Einhörner mich Armen.
+21:23 Verkünden will ich Deinen na men meinen brüdern, * inmitten der Versammlung Dich loben.
+21:24 Die ihr fürchtet den Herrn, lobet ihn, * alle nachkommen Jakobs, verherrlicht ihn!
+21:25 Es fürchte ihn jeder nachkomme israels, * denn nicht verachtet und nicht verschmäht hat er das Gebet des Armen,
+21:25 noch wandte er sein Angesicht von mir ab, * und als ich zu ihm rief, hat er mich erhört.
+21:26 bei Dir ist mein lob in großer Versammlung, * meine Gelübde will ich erfüllen im Angesicht derer, die ihn fürchten.
+21:27 Die Armen werden essen und gesättigt, und den Herrn werden loben, die ihn suchen, * ihre Herzen werden leben in alle Ewigkeit.
+21:28 Es werden sich erinnern und sich bekehren zum Herrn * alle Enden der Erde.
+21:28 und es werden anbeten vor seinem Angesicht * alle Familien der Völker.
+21:29 Denn dem Herrn gehört das reich, * und er wird herrschen über die Völker.
+21:30 Es haben gegessen und angebetet alle Fetten der Erde, * vor seinem Angesicht werden alle niederfallen, die hinabsteigen zur Erde.
+21:31 und meine Seele wird leben für ihn, * und meine nachkommen werden ihm dienen.
+21:32 Angekündigt wird dem Herrn das kommende Geschlecht, * und die Himmel künden seine Gerechtigkeit dem Volk, das erstehen wird, das geschaffen hat der Herr.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm22.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm22.txt
@@ -6,4 +6,4 @@
 22:5 Vor meinem Angesicht hast Du den Tisch bereitet * wider jene, die mich bedrängen.
 22:5 mit Öl hast Du mein Haupt gesalbt, * und mein berauschender Kelch, wie herrlich ist er!
 22:6 und Dein Erbarmen wird mir folgen * alle Tage meines lebens,
-22:6 dass ich wohnen darf im Haus des Herrn * für die länge der Tage. 71 i
+22:6 dass ich wohnen darf im Haus des Herrn * für die länge der Tage.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm24.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm24.txt
@@ -1,23 +1,23 @@
-24:1 Ad te, Dómine, levávi ánimam meam: * Deus meus, in te confído, non erubéscam.
-24:3 Neque irrídeant me inimíci mei: * étenim univérsi, qui sústinent te, non confundéntur.
-24:4 Confundántur omnes iníqua agéntes * supervácue.
-24:4 Vias tuas, Dómine, demónstra mihi: * et sémitas tuas édoce me.
-24:5 Dírige me in veritáte tua, et doce me: * quia tu es, Deus, salvátor meus, et te sustínui tota die.
-24:6 Reminíscere miseratiónum tuárum, Dómine, * et misericordiárum tuárum, quæ a sæculo sunt.
-24:7 Delícta juventútis meæ, * et ignorántias meas ne memíneris.
-24:7 Secúndum misericórdiam tuam meménto mei tu: * propter bonitátem tuam, Dómine.
-24:8 Dulcis et rectus Dóminus: * propter hoc legem dabit delinquéntibus in via.
-24:9 Díriget mansuétos in judício: * docébit mites vias suas.
-24:10 Univérsæ viæ Dómini, misericórdia et véritas, * requiréntibus testaméntum ejus et testimónia ejus.
-24:11 Propter nomen tuum, Dómine, propitiáberis peccáto meo: * multum est enim.
-24:12 Quis est homo qui timet Dóminum? * legem státuit ei in via, quam elégit.
-24:13 Ánima ejus in bonis demorábitur: * et semen ejus hereditábit terram.
-24:14 Firmaméntum est Dóminus timéntibus eum: * et testaméntum ipsíus ut manifestétur illis.
-24:15 Óculi mei semper ad Dóminum: * quóniam ipse evéllet de láqueo pedes meos.
-24:16 Réspice in me, et miserére mei: * quia únicus et pauper sum ego.
-24:17 Tribulatiónes cordis mei multiplicátæ sunt: * de necessitátibus meis érue me.
-24:18 Vide humilitátem meam, et labórem meum: * et dimítte univérsa delícta mea.
-24:19 Réspice inimícos meos quóniam multiplicáti sunt, * et ódio iníquo odérunt me.
-24:20 Custódi ánimam meam, et érue me: * non erubéscam quóniam sperávi in te.
-24:21 Innocéntes et recti adhæsérunt mihi: * quia sustínui te.
-24:22 Líbera, Deus, Israël, * ex ómnibus tribulatiónibus suis.
+24:1 zu Dir, o Herr, erhob ich meine Seele; * mein Gott, auf Dich vertraue ich, ich muss nicht erröten.
+24:3 und nicht sollen meine Feinde mich verlachen, * denn alle, die auf Dich harren, werden nicht zuschanden.
+24:4 zuschanden werden sollen alle, die unrecht tun * völlig vergebens.
+24:4 Deine Wege, Herr, zeige mir, * und Deine Pfade lehre mich.
+24:5 lenke mich in Deiner Wahrheit und lehre mich, * denn Du, Herr, bist mein retter, und auf Dich harrte ich den ganzen Tag.
+24:6 Gedenke der Erweise Deines Erbarmens, Herr, * und Deiner Erbarmungen, die seit alters sind.
+24:7 Der Sünden meiner Jugend * und meiner unbesonnenheiten gedenke nicht.
+24:7 Gemäß Deiner barmherzigkeit gedenke Du meiner, * um Deiner Güte willen, Herr.
+24:8 Gütig und aufrichtig ist der Herr; * darum gibt er sein Gesetz den Fehlenden auf ihrem Weg.
+24:9 leiten wird er die Sanftmütigen im Gericht * und lehren die milden seine Wege.
+24:10 Alle Wege des Herrn sind barmherzigkeit und Wahrheit, * für jene, die nach seinem bund und seinen zeugnissen verlangen.
+24:11 um Deines namens willen, Herr, sei mir gnädig ob meiner Sünde, * denn sie ist groß.
+24:12 Wer ist der mensch, der den Herrn fürchtet? * Er gab ihm das Gesetz auf dem Weg, den er erwählte.
+24:13 Seine Seele wird in Gütern weilen, * und seine nachkommen werden das land erben.
+24:14 Eine Stütze ist der Herr denen, die ihn fürchten, * und sein bund ist da, damit er ihnen offenbar wird.
+24:15 meine Augen sind stets auf den Herrn gerichtet, * denn er selbst wird meine Füße aus der Schlinge ziehen.
+24:16 Schau auf mich und erbarme Dich meiner, * denn allein bin ich und arm.
+24:17 Die Trübsale meines Herzens wurden vermehrt; * aus meinen nöten rette mich!
+24:18 Sieh an meine Erniedrigung und meine mühsal * und vergib all meine Sünden.
+24:19 Schau auf meine Feinde, denn sie sind zahlreich geworden, * und mit ungerechtem Hass hassen sie mich.
+24:20 bewahre meine Seele und rette mich, * lass mich nicht erröten, denn ich habe auf Dich gehofft.
+24:21 unschuldige und Aufrichtige hangen mir an, * denn ich habe auf Dich geharrt.
+24:22 befreie, Gott, israel * aus all seiner Trübsal.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm25.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm25.txt
@@ -9,4 +9,4 @@
 25:9 Verdirb nicht mit den Frevlern, Gott, meine Seele * und mit männern voller blutschuld mein leben,
 25:10 in deren Händen unrecht ist, * ihre rechte aber ist voll von Geschenken.
 25:11 ich aber bin in meiner unschuld gewandelt, * erlöse mich und erbarme Dich meiner.
-25:12 mein Fuß stand auf geradem Weg, * in den Versammlungen will ich Dich loben, Herr. 51
+25:12 mein Fuß stand auf geradem Weg, * in den Versammlungen will ich Dich loben, Herr.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm26.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm26.txt
@@ -1,20 +1,20 @@
-26:1 Dóminus illuminátio mea, et salus mea, * quem timébo?
-26:1 Dóminus protéctor vitæ meæ, * a quo trepidábo?
-26:2 Dum apprópiant super me nocéntes, * ut edant carnes meas:
-26:2 Qui tríbulant me inimíci mei, * ipsi infirmáti sunt, et cecidérunt.
-26:3 Si consístant advérsum me castra, * non timébit cor meum.
-26:3 Si exsúrgat advérsum me prælium, * in hoc ego sperábo.
-26:4 Unam pétii a Dómino, hanc requíram, * ut inhábitem in domo Dómini ómnibus diébus vitæ meæ:
-26:4 Ut vídeam voluptátem Dómini, * et vísitem templum ejus.
-26:5 Quóniam abscóndit me in tabernáculo suo: * in die malórum protéxit me in abscóndito tabernáculi sui.
-26:6 In petra exaltávit me: * et nunc exaltávit caput meum super inimícos meos.
-26:6 Circuívi, et immolávi in tabernáculo ejus hóstiam vociferatiónis: * cantábo, et psalmum dicam Dómino.
-26:7 Exáudi, Dómine, vocem meam, qua clamávi ad te: * miserére mei, et exáudi me.
-26:8 Tibi dixit cor meum, exquisívit te fácies mea: * fáciem tuam, Dómine, requíram.
-26:9 Ne avértas fáciem tuam a me: * ne declínes in ira a servo tuo.
-26:9 Adjútor meus esto: * ne derelínquas me, neque despícias me, Deus, salutáris meus.
-26:10 Quóniam pater meus, et mater mea dereliquérunt me: * Dóminus autem assúmpsit me.
-26:11 Legem pone mihi, Dómine, in via tua: * et dírige me in sémitam rectam propter inimícos meos.
-26:12 Ne tradíderis me in ánimas tribulántium me: * quóniam insurrexérunt in me testes iníqui, et mentíta est iníquitas sibi.
-26:13 Credo vidére bona Dómini * in terra vivéntium.
-26:14 Exspécta Dóminum, viríliter age: * et confortétur cor tuum, et sústine Dóminum.
+26:1 Der Herr ist mein licht und mein Heil, * wen sollte ich fürchten?
+26:1 Der Herr ist der beschützer meines lebens, * wovor sollte ich zittern?
+26:2 Als Schädlinge mir nahten, * um mein Fleisch zu fressen,
+26:2 die mich bedrängten, meine Feinde, * da wurden sie schwach und sind gefallen.
+26:3 Wenn sie Heerlager gegen mich aufstellen, * wird mein Herz sich nicht fürchten.
+26:3 Wenn sich gegen mich Kampf erhebt, * werde ich dabei hoffen.
+26:4 Eines erbitte ich vom Herrn, danach verlange ich, * dass ich wohnen darf im Haus des Herrn alle Tage meines lebens,
+26:4 dass ich schaue die Wonne des Herrn * und besuche seinen Tempel.
+26:5 Denn er verbarg mich in seinem zelt; * am Tag der Übel hat er mich beschirmt im Verborgenen seines zeltes.
+26:6 Auf einem Fels hat er mich erhöht, * und nun hat er mein Haupt erhöht über meine Feinde.
+26:6 ich ging umher und brachte in seinem zelt ein Opfer des Jubels dar, * ich will singen und einen Psalm sprechen dem Herrn.
+26:7 Erhöre, Herr, meine Stimme, mit der ich zu Dir schrie, * erbarme Dich meiner und erhöre mich.
+26:8 zu Dir sprach mein Herz, gesucht hat Dich mein Angesicht, * Dein Angesicht, Herr, will ich suchen.
+26:9 Wende Dein Angesicht nicht weg von mir, * weiche nicht im zorn von Deinem Knecht.
+26:9 Sei Du mein Helfer, * verlass mich nicht und verachte mich nicht, Gott, mein Heil.
+26:10 Denn mein Vater und meine mutter haben mich verlassen, * der Herr aber nahm mich auf.
+26:11 Ein Gesetz gib mir, Herr, auf Deinem Weg, * und lenke mich auf die rechte bahn um meiner Feinde willen.
+26:12 Übergib mich nicht dem mutwillen derer, die mich bedrängen, * denn es erhoben sich gegen mich ungerechte zeugen, und die ungerechtigkeit belog sich selbst.
+26:13 ich glaube zu schauen die Güter des Herrn * im land der lebenden.
+26:14 Erwarte den Herrn, handle mannhaft, * und es erstarke dein Herz, und harre auf den Herrn.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm27.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm27.txt
@@ -9,4 +9,4 @@
 27:7 Der Herr ist mein Helfer und mein beschützer, * auf ihn hoffte mein Herz, und es ward mir geholfen.
 27:7 und mein Fleisch ist wieder aufgeblüht, * und aus freiem Willen will ich ihn preisen.
 27:8 Der Herr ist die Stärke seines Volkes, * und er ist der be schützer der rettenden Taten seines Gesalbten.
-27:9 rette Dein Volk, o Herr, und segne Dein Erbe * und leite es und erhöhe es bis in Ewigkeit. sten
+27:9 rette Dein Volk, o Herr, und segne Dein Erbe * und leite es und erhöhe es bis in Ewigkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm30.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm30.txt
@@ -1,31 +1,31 @@
-30:2 In te, Dómine, sperávi non confúndar in ætérnum: * in justítia tua líbera me.
-30:3 Inclína ad me aurem tuam, * accélera ut éruas me.
-30:3 Esto mihi in Deum protectórem, et in domum refúgii: * ut salvum me fácias.
-30:4 Quóniam fortitúdo mea, et refúgium meum es tu: * et propter nomen tuum dedúces me, et enútries me.
-30:5 Edúces me de láqueo hoc, quem abscondérunt mihi: * quóniam tu es protéctor meus.
-30:6 In manus tuas comméndo spíritum meum: * redemísti me, Dómine, Deus veritátis.
-30:7 Odísti observántes vanitátes, * supervácue.
-30:7 Ego autem in Dómino sperávi: * exsultábo, et lætábor in misericórdia tua.
-30:8 Quóniam respexísti humilitátem meam, * salvásti de necessitátibus ánimam meam.
-30:9 Nec conclusísti me in mánibus inimíci: * statuísti in loco spatióso pedes meos.
-30:10 Miserére mei, Dómine, quóniam tríbulor: * conturbátus est in ira óculus meus, ánima mea, et venter meus:
-30:11 Quóniam defécit in dolóre vita mea: * et anni mei in gemítibus.
-30:11 Infirmáta est in paupertáte virtus mea: * et ossa mea conturbáta sunt.
-30:12 Super omnes inimícos meos factus sum oppróbrium et vicínis meis valde: * et timor notis meis.
-30:12 Qui vidébant me, foras fugérunt a me: * oblivióni datus sum, tamquam mórtuus a corde.
-30:13 Factus sum tamquam vas pérditum: * quóniam audívi vituperatiónem multórum commorántium in circúitu.
-30:14 In eo dum convenírent simul advérsum me, * accípere ánimam meam consiliáti sunt.
-30:15 Ego autem in te sperávi, Dómine: * dixi: Deus meus es tu: in mánibus tuis sortes meæ.
-30:16 Éripe me de manu inimicórum meórum, * et a persequéntibus me.
-30:17 Illústra fáciem tuam super servum tuum, salvum me fac in misericórdia tua: * Dómine, non confúndar, quóniam invocávi te.
-30:18 Erubéscant ímpii, et deducántur in inférnum: * muta fiant lábia dolósa.
-30:19 Quæ loquúntur advérsus justum iniquitátem: * in supérbia, et in abusióne.
-30:20 Quam magna multitúdo dulcédinis tuæ, Dómine, * quam abscondísti timéntibus te.
-30:20 Perfecísti eis, qui sperant in te, * in conspéctu filiórum hóminum.
-30:21 Abscóndes eos in abscóndito faciéi tuæ * a conturbatióne hóminum.
-30:21 Próteges eos in tabernáculo tuo * a contradictióne linguárum.
-30:22 Benedíctus Dóminus: * quóniam mirificávit misericórdiam suam mihi in civitáte muníta.
-30:23 Ego autem dixi in excéssu mentis meæ: * Projéctus sum a fácie oculórum tuórum.
-30:23 Ideo exaudísti vocem oratiónis meæ, * dum clamárem ad te.
-30:24 Dilígite Dóminum omnes sancti ejus: * quóniam veritátem requíret Dóminus, et retríbuet abundánter faciéntibus supérbiam.
-30:25 Viríliter ágite, et confortétur cor vestrum, * omnes, qui sperátis in Dómino.
+30:2 Auf Dich, Herr, habe ich meine Hoffnung gesetzt, lass mich nicht zuschanden werden in Ewigkeit; * in Deiner Gerechtigkeit befreie mich.
+30:3 neige zu mir Dein Ohr, * eile, mich zu retten.
+30:3 Sei mir ein Schützergott und ein Haus der zuflucht, * um mich heil zu machen.
+30:4 Denn meine Stärke und meine zuflucht bist Du, * und um Deines namens willen wirst Du mich leiten und ernähren.
+30:5 Du wirst mich aus dieser Schlinge ziehen, die sie für mich verborgen haben, * denn Du bist mein beschützer.
+30:6 in Deine Hände befehle ich meinen Geist; * Du hast mich erlöst, Herr, Gott der Wahrheit.
+30:7 Du hassest jene, die nichtigkeiten im Auge haben, * völlig vergeblich.
+30:7 ich aber habe auf den Herrn meine Hoffnung gesetzt, * ich will jubeln und mich freuen über Deine barmherzigkeit.
+30:8 Denn Du hast auf meine niedrigkeit geschaut, * aus nöten hast Du meine Seele errettet.
+30:9 Du hast mich nicht ein geschlossen in die Hände des Feindes, * hast auf weiten raum meine Füße gestellt.
+30:10 Erbarme Dich meiner, o Herr, denn ich werde bedrängt; * verstört ist in Erbitterung mein Auge, meine Seele und mein leib,
+30:11 denn dahingeschwunden ist im Schmerz mein leben * und meine Jahre unter Seufzern.
+30:11 Schwach geworden ist in Armut meine Kraft, * und meine Gebeine sind erschüttert.
+30:12 mehr als all meine Feinde bin ich zur Schmach geworden, auch meinen nachbarn gar sehr * und ein Schrecken für meine bekannten.
+30:12 Die mich sahen, flohen vor mir hinaus, * dem Vergessen ward ich übergeben, einem Toten gleich, aus dem Herzen geschwunden.
+30:13 ich bin geworden wie ein zerbrochenes Gefäß, * denn ich hörte die Schelte vieler, die ringsum weilen.
+30:14 Da sie sich zugleich gegen mich versammelten, * hielten sie rat, mir das leben zu nehmen.
+30:15 ich aber habe auf Dich meine Hoffnung gesetzt, o Herr, * ich sprach: mein Gott bist Du, in Deinen Händen liegt mein Geschick.
+30:16 Entreiße mich der Hand meiner Feinde * und denen, die mich verfolgen.
+30:17 lass leuchten Dein Angesicht über Deinem Knecht, schaffe mir Heil durch Deine barmherzigkeit, * Herr, ich möge nicht zuschanden werden, denn ich habe Dich angerufen.
+30:18 Vor Scham erröten sollen die Gottlosen, und sie sollen hinabgeführt werden in die unterwelt; * verstummen sollen die trügerischen lippen,
+30:19 die wider den Gerechten unrecht reden * in Hochmut und Verachtung.
+30:20 Wie groß ist die Fülle Deiner Güte, o Herr, * die Du für jene verwahrst, die Dich fürchten.
+30:20 Du vollendest sie für die, die auf Dich hoffen, * im Angesicht der menschenkinder.
+30:21 Du wirst sie bergen im Verborgenen Deines Angesichts * vor der Verwirrung der menschen.
+30:21 Du wirst sie schützen in Deinem zelt * vor dem Widerspruch der zungen.
+30:22 Gepriesen sei der Herr, * denn wunderbar hat er mir seine barmherzigkeit erwiesen in der befestigten Stadt.
+30:23 ich aber sprach in der bestürzung meines Geistes: * Verstoßen bin ich aus Deinen Augen.
+30:23 Darum hast Du die Stimme meines betens erhört, * als ich zu Dir schrie.
+30:24 liebt den Herrn, all seine Heiligen, * denn Wahrheit sucht der Herr, und jenen, die Hochmut üben, zahlt er reichlich heim.
+30:25 Handelt mannhaft, und erstarken soll euer Herz, * alle, die ihr hofft auf den Herrn.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm31.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm31.txt
@@ -11,4 +11,4 @@
 31:9 Werdet nicht wie Pferd und maultier, * die keine Einsicht haben.
 31:9 mit zügel und zaum binde die backen derer, * die sich Dir nicht nahen.
 31:10 zahlreich sind die Geißeln des Sünders; * den aber, der auf den Herrn hofft, wird barmherzigkeit umgeben.
-31:11 Freut euch im Herrn und jauchzt, ihr Gerechten, * und rühmt euch, alle, die ihr aufrichtigen Herzens seid. 32 i
+31:11 Freut euch im Herrn und jauchzt, ihr Gerechten, * und rühmt euch, alle, die ihr aufrichtigen Herzens seid.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm32.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm32.txt
@@ -1,22 +1,22 @@
-32:1 Exsultáte, justi, in Dómino: * rectos decet collaudátio.
-32:2 Confitémini Dómino in cíthara: * in psaltério decem chordárum psállite illi.
-32:3 Cantáte ei cánticum novum: * bene psállite ei in vociferatióne.
-32:4 Quia rectum est verbum Dómini, * et ómnia ópera ejus in fide.
-32:5 Díligit misericórdiam et judícium: * misericórdia Dómini plena est terra.
-32:6 Verbo Dómini cæli firmáti sunt: * et spíritu oris ejus omnis virtus eórum.
-32:7 Cóngregans sicut in utre aquas maris: * ponens in thesáuris abýssos.
-32:8 Tímeat Dóminum omnis terra: * ab eo autem commoveántur omnes inhabitántes orbem.
-32:9 Quóniam ipse dixit, et facta sunt: * ipse mandávit, et creáta sunt.
-32:10 Dóminus díssipat consília géntium: * réprobat autem cogitatiónes populórum, et réprobat consília príncipum.
-32:11 Consílium autem Dómini in ætérnum manet: * cogitatiónes cordis ejus in generatióne et generatiónem.
-32:12 Beáta gens, cujus est Dóminus, Deus ejus: * pópulus, quem elégit in hereditátem sibi.
-32:13 De cælo respéxit Dóminus: * vidit omnes fílios hóminum.
-32:14 De præparáto habitáculo suo * respéxit super omnes, qui hábitant terram.
-32:15 Qui finxit sigillátim corda eórum: * qui intélligit ómnia ópera eórum.
-32:16 Non salvátur rex per multam virtútem: * et gigas non salvábitur in multitúdine virtútis suæ.
-32:17 Fallax equus ad salútem: * in abundántia autem virtútis suæ non salvábitur.
-32:18 Ecce, óculi Dómini super metuéntes eum: * et in eis, qui sperant super misericórdia ejus:
-32:19 Ut éruat a morte ánimas eórum: * et alat eos in fame.
-32:20 Ánima nostra sústinet Dóminum: * quóniam adjútor et protéctor noster est.
-32:21 Quia in eo lætábitur cor nostrum: * et in nómine sancto ejus sperávimus.
-32:22 Fiat misericórdia tua, Dómine, super nos: * quemádmodum sperávimus in te.
+32:1 Jauchzt, ihr Gerechten, im Herrn, * den redlichen ziemt lob gesang.
+32:2 Preiset den Herrn mit der zither, * mit der zehnsaitigen Harfe spielet ihm.
+32:3 Singt ihm ein neues lied, * spielt ihm schön mit Jubelschall.
+32:4 Denn aufrichtig ist das Wort des Herrn, * und all seine Werke geschehen in Treue.
+32:5 Er liebt barmherzigkeit und recht, * von der barmherzigkeit des Herrn ist voll die Erde.
+32:6 Durch das Wort des Herrn sind die Himmel gefestigt * und durch den Hauch seines mundes ihr ganzes Heer,
+32:7 der die Wasser des meeres versammelt wie in einem Schlauch, * der die Abgründe in Schatzkammern legt.
+32:8 Fürchten soll den Herrn die ganze Erde, * vor ihm sollen erbeben alle, die den Erdkreis bewohnen,
+32:9 denn er sprach und sie waren gemacht, * er befahl, und sie waren erschaffen.
+32:10 Der Herr vereitelt die Pläne der Heiden, * er verwirft die Gedanken der Völker, und er verwirft die Pläne der Fürsten.
+32:11 Der ratschluss des Herrn aber bleibt in Ewigkeit, * die Gedanken seines Herzens von Geschlecht zu Geschlecht.
+32:12 Selig das Volk, dessen Gott der Herr ist, * das Volk, das er sich zum Erbe erwählt hat.
+32:13 Vom Himmel blickte der Herr herab, * und er sah alle menschenkinder.
+32:14 Von seiner festbereiteten Wohnstätte her * sah er herab auf alle, die die Erde bewohnen,
+32:15 er, der fein ihre Herzen gebildet, * der all ihre Werke kennt.
+32:16 nicht wird ein König gerettet durch große Kraft, * und auch ein riese wird nicht gerettet durch die Fülle seiner Kraft.
+32:17 Trügerisch ist ein Pferd als mittel zum Heil, * in der Über fülle seiner Kraft wird es sich doch nicht retten.
+32:18 Siehe, die Augen des Herrn ruhen auf denen, die ihn fürchten, * und auf denen, die auf seine barmherzigkeit hoffen,
+32:19 dass er ihre Seelen vom Tod errette * und sie im Hunger nähre.
+32:20 unsere Seele harrt auf den Herrn, * denn er ist unser Helfer und beschützer,
+32:21 denn in ihm wird unser Herz sich freuen, * und auf seinen heiligen namen hoffen wir.
+32:22 Es walte Deine barmherzigkeit, Herr, über uns, * so, wie wir auf Dich gehofft haben.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm33.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm33.txt
@@ -1,22 +1,22 @@
-33:2 Ich wünscht' den Herrn zu preisen allezeit; * ununterbrochen müsst sein Lob aus meinem Mund ertönen.
-33:3 Am Herrn soll meine Seele finden ihre Freud'; * das mögen alle hören und sich trösten, die in Not sind.
-33:4 O preist den Herrn mit mir; * lasst uns zusammen seine Güte loben.
-33:5 Wenn ich mich wandte an den Herrn, erhörte er mich stets * und führte mich heraus aus allen meinen Nöten:
-33:6 So tretet auch an ihn und glücklich werdet ihr; * und nie sollt Täuschung ihr erleben.
-33:7 Wenn ich bedrängter Mensch schrei zu dem Herrn, erhört er mich, * und rettet mich aus allen meinen Nöten.
-33:8 Es stellt der Engel Gottes schnell um seine Diener sich als Wehr * und bleibt ihr Schützer.
-33:9 Macht den Versuch doch, und ihr werdet seh'n, wie gütig ist der Herr; * glückselig ist der Mensch, der ihm sich ganz ergeben.
-33:10 O haltet, alle seine Schutzbefohl'nen, treu zum Herrn; * denn niemals lässt er solche Mangel leiden, die ihm treu sind.
-33:11 Die Reichen darben, hungern oft; * doch die sich halten an den Herrn, erhalten aller Güter Fülle.
-33:12 Kommt nun, ihr Lieben, hört auf mich; * ich will euch lehren, wie dem Herrn man hält die Treue.
-33:13 Ihr sehnt euch alle doch nach Glück; * ein jeder wünscht sich, gute Tage zu erleben.
-33:14 Bewahret eure Zungen vor gemeiner Red', * und eure Lippen lasset nicht zum Schaden anderer sprechen.
-33:15 Vor Unrecht hütet euch und tut, was andren nützt; * strebt nach dem Frieden stets und sucht ihn zu erhalten.
-33:16 Auf solchen Treuen ruht der Gnadenblick des Herrn; * und seine Ohren lauschen auf ihr Flehen.
-33:17 Der Zorn des Herrn dagegen bleibt gerichtet gegen die, die Unrecht tun; * so dass er ihren Namen selbst ausrottet von der Erde.
-33:18 Wenn seine Treuen rufen, hört der Herr sie an; * und rettet sie aus allen ihren Nöten.
-33:19 Nah ist der Herr bei ihnen, wenn sie sind in Herzensangst; * und sind sie traurig, bringt er ihnen Hilfe.
-33:20 Oft kommen auch die treuen Diener Gottes in Gefahr; * der Herr jedoch errettet sie aus allen.
-33:21 Es gibt der Herr auf alle ihre Glieder acht; * und keins von diesen darf Verletzung erleiden.
-33:22 Ganz furchtbar ist für die, die andre vergewaltigen, der Tod; * und die den Gottesdiener hassen, enden elend.
-33:23 Doch glücklich macht der Herr die alle, die ihm treu gedient; * und keiner, der sich ihm ergeben, irret ab vom richt'gen Wege.
+33:2 Preisen will ich den Herrn zu jeder zeit, * stets sei sein lob in meinem mund.
+33:3 meine Seele rühme sich im Herrn, * es sollen hören die Sanftmütigen und sich freuen.
+33:4 macht groß mit mir den Herrn, * lasst uns miteinander seinen namen erheben!
+33:5 ich suchte den Herrn, und er hat mich erhört, * und all meinen Drangsalen hat er mich entrissen.
+33:6 Tretet hin zu ihm, und ihr werdet erleuchtet, * und euer Angesicht wird nicht zuschanden werden.
+33:7 Dieser Arme schrie, und der Herr hat ihn erhört, * und aus all seinen Drangsalen hat er ihn errettet.
+33:8 Der Engel des Herrn wird sich lagern um jene, die ihn fürchten, * und er wird sie erretten.
+33:9 Kostet und seht, wie gütig der Herr ist, * selig der mann, der auf ihn hofft.
+33:10 Fürchtet den Herrn, all seine Heiligen, * denn es gibt keinen mangel für jene, die ihn fürchten.
+33:11 reiche haben gedarbt und gehungert, * jene aber, die den Herrn suchen, werden nicht abnehmen an jeglichem Gut.
+33:12 Kommt, ihr Kinder, hört auf mich: * die Furcht des Herrn will ich euch lehren.
+33:13 Wer ist der mann, der das leben will, * der es liebt, gute Tage zu sehen?
+33:14 bewahre deine zunge vor dem bösen * und deine lippen, dass sie nicht Trug reden.
+33:15 Wende dich ab vom bösen und tue das Gute, * suche den Frieden und jage ihm nach.
+33:16 Die Augen des Herrn ruhen auf den Gerechten, * und seine Ohren hören ihre bitten.
+33:17 Das Angesicht des Herrn jedoch wendet sich gegen jene, die böses tun, * um ihr Andenken zu tilgen von der Erde.
+33:18 Die Gerechten riefen, und der Herr hat sie erhört, * und aus all ihren Drangsalen hat er sie befreit.
+33:19 nahe ist der Herr jenen, die bedrängten Herzens sind, * und die demütigen Geistes sind, wird er retten.
+33:20 zahlreich sind die Drangsale der Gerechten, * doch aus allen wird der Herr sie retten.
+33:21 Der Herr bewahrt all ihre Gebeine, * nicht eines von ihnen wird zerbrochen werden.
+33:22 Der Tod der Sünder ist erbärmlich, * und die den Gerechten hassen, geraten in Schuld.
+33:23 Erlösen wird der Herr die Seelen seiner Knechte, * und keine Schuld werden auf sich laden alle, die auf ihn hoffen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm34.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm34.txt
@@ -1,32 +1,32 @@
-34:1 Júdica, Dómine, nocéntes me, * expúgna impugnántes me.
-34:2 Apprehénde arma et scutum: * et exsúrge in adjutórium mihi.
-34:3 Effúnde frámeam, et conclúde advérsus eos, qui persequúntur me: * dic ánimæ meæ: Salus tua ego sum.
-34:4 Confundántur et revereántur, * quæréntes ánimam meam.
-34:4 Avertántur retrórsum, et confundántur * cogitántes mihi mala.
-34:5 Fiant tamquam pulvis ante fáciem venti: * et Ángelus Dómini coárctans eos.
-34:6 Fiat via illórum ténebræ et lúbricum: * et Ángelus Dómini pérsequens eos.
-34:7 Quóniam gratis abscondérunt mihi intéritum láquei sui: * supervácue exprobravérunt ánimam meam.
-34:8 Véniat illi láqueus, quem ignórat: et cáptio, quam abscóndit, apprehéndat eum: * et in láqueum cadat in ipsum.
-34:9 Ánima autem mea exsultábit in Dómino: * et delectábitur super salutári suo.
-34:10 Omnia ossa mea dicent: * Dómine, quis símilis tibi?
-34:10 Erípiens ínopem de manu fortiórum ejus: * egénum et páuperem a diripiéntibus eum.
-34:11 Surgéntes testes iníqui, * quæ ignorábam interrogábant me.
-34:12 Retribuébant mihi mala pro bonis: * sterilitátem ánimæ meæ.
-34:13 Ego autem cum mihi molésti essent, * induébar cilício.
-34:13 Humiliábam in jejúnio ánimam meam: * et orátio mea in sinu meo convertétur.
-34:14 Quasi próximum, et quasi fratrem nostrum, sic complacébam: * quasi lugens et contristátus, sic humiliábar.
-34:15 Et advérsum me lætáti sunt, et convenérunt: * congregáta sunt super me flagélla, et ignorávi.
-34:16 Dissipáti sunt, nec compúncti, tentavérunt me, subsannavérunt me subsannatióne: * frenduérunt super me déntibus suis.
-34:17 Dómine, quando respícies? * restítue ánimam meam a malignitáte eórum, a leónibus únicam meam.
-34:18 Confitébor tibi in ecclésia magna, * in pópulo gravi laudábo te.
-34:19 Non supergáudeant mihi qui adversántur mihi iníque: * qui odérunt me gratis et ánnuunt óculis.
-34:20 Quóniam mihi quidem pacífice loquebántur: * et in iracúndia terræ loquéntes, dolos cogitábant.
-34:21 Et dilatavérunt super me os suum: * dixérunt: Euge, euge, vidérunt óculi nostri.
-34:22 Vidísti, Dómine, ne síleas: * Dómine, ne discédas a me.
-34:23 Exsúrge et inténde judício meo: * Deus meus, et Dóminus meus in causam meam.
-34:24 Júdica me secúndum justítiam tuam, Dómine, Deus meus, * et non supergáudeant mihi.
-34:25 Non dicant in córdibus suis: Euge, euge, ánimæ nostræ: * nec dicant: Devorávimus eum.
-34:26 Erubéscant et revereántur simul, * qui gratulántur malis meis.
-34:26 Induántur confusióne et reveréntia * qui magna loquúntur super me.
-34:27 Exsúltent et læténtur qui volunt justítiam meam: * et dicant semper: Magnificétur Dóminus qui volunt pacem servi ejus.
-34:28 Et lingua mea meditábitur justítiam tuam, * tota die laudem tuam.
+34:1 richte, Herr, die mir schaden, * bezwinge jene, die gegen mich kämpfen.
+34:2 Ergreife die Waffen und den Schild * und steh auf, mir zu helfen.
+34:3 Schwinge den Speer und riegle ab wider die, die mich verfolgen; * sprich zu meiner Seele: Dein Heil bin ich.
+34:4 zuschanden sollen werden und sich fürchten, * die nach meiner Seele trachten.
+34:4 zurückweichen sollen und zuschanden werden, * die böses für mich ersinnen.
+34:5 Sie sollen werden wie Staub vor dem Angesicht des Windes, * und der Engel des Herrn bedränge sie.
+34:6 ihr Weg soll finster und schlüpfrig werden, * und der Engel des Herrn verfolge sie.
+34:7 Denn ohne Grund legten sie mir heimlich ihre verderbenbringende Schlinge, * grundlos schmähten sie meine Seele.
+34:8 Es komme über ihn die Schlinge, die er nicht ahnt; und die Falle, die er verborgen hat, erfasse ihn selbst, * und in die Schlinge, in die falle er.
+34:9 Meine Seele aber wird jubeln im Herrn * und frohlocken über sein Heil.
+34:10 All meine Gebeine werden sagen: * Herr, wer ist Dir gleich?
+34:10 Der Du den Hilflosen entreißt aus der Hand derer, die stärker sind als er, * den bedürftigen und Armen denen, die ihn berauben.
+34:11 Es standen ungerechte zeugen auf, * man verhörte mich über Dinge, die ich nicht weiß.
+34:12 Sie vergalten mir böses für Gutes, * machten dürre meine Seele.
+34:13 ich aber, als sie mir lästig waren, * kleidete mich in ein bußgewand.
+34:13 ich demütigte mit Fasten meine Seele, * und mein Gebet wird sich wenden [es wiederholt sich] in meiner brust.
+34:14 Gleich wie dem nächsten und wie unserem bruder, so war ich ihnen gefällig, * wie ein Trauernder und betrübter, so wurde ich gebeugt.
+34:15 Doch sie machten sich lustig über mich und kamen zusammen, * gehäuft wurden Geißeln über mir, und ich wusste von nichts.
+34:16 Sie wurden zerstreut, doch sie empfanden keine reue, sie versuchten mich und verhöhnten mich mit Hohn, * sie knirschten wider mich mit ihren zähnen.
+34:17 Herr, wann wirst Du hersehen? * rette meine Seele vor ihrer bosheit, vor den Löwen meine Einzige!
+34:18 ich will Dich preisen in großer Versammlung, * unter zahlreichem Volk Dich loben.
+34:19 nicht sollen sich freuen über mich, die zu Unrecht mich befeinden, * die ohne Grund mich hassen und mit den Augen zwinkern.
+34:20 Denn sie redeten zwar friedlich zu mir, * doch, im zorn der Erde redend, ersannen sie Trug.
+34:21 Und weit sperrten sie gegen mich ihren Mund auf, * sie sprachen: Wohlan, wohlan, unsere Augen haben es gesehen.
+34:22 Du hast es gesehen, Herr, schweige nicht! * Herr, weiche nicht von mir!
+34:23 Steh auf und achte auf mein recht, * mein Gott und mein Herr, auf meine Sache!
+34:24 richte mich nach Deiner Gerechtigkeit, Herr, mein Gott, * und sie sollen sich nicht freuen über mich.
+34:25 nicht sollen sie sprechen in ihren Herzen: Wohlan, wohlan, unsere Seelengier! * nicht sollen sie sagen: Wir haben ihn verschlungen.
+34:26 Sie mögen erröten und zugleich zuschanden werden, * die sich an meinen Übeln freuen.
+34:26 Sie sollen bedeckt werden mit Verwirrung und Scham, * die gegen mich prahlen.
+34:27 Jubeln und sich freuen sollen, die Gerechtigkeit für mich wollen, * und sie sollen allezeit sprechen: „Hochgelobt sei der Herr!“, sie, die den Frieden seines Knechtes wünschen.
+34:28 Und meine zunge wird bedenken Deine Gerechtigkeit, * den ganzen Tag Dein Lob.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm36.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm36.txt
@@ -1,42 +1,42 @@
-36:1 Noli æmulári in malignántibus: * neque zeláveris faciéntes iniquitátem.
-36:2 Quóniam tamquam fœnum velóciter aréscent: * et quemádmodum ólera herbárum cito décident.
-36:3 Spera in Dómino, et fac bonitátem: * et inhábita terram, et pascéris in divítiis ejus.
-36:4 Delectáre in Dómino: * et dabit tibi petitiónes cordis tui.
-36:5 Revéla Dómino viam tuam, et spera in eo: * et ipse fáciet.
-36:6 Et edúcet quasi lumen justítiam tuam: et judícium tuum tamquam merídiem: * súbditus esto Dómino, et ora eum.
-36:7 Noli æmulári in eo, qui prosperátur in via sua: * in hómine faciénte injustítias.
-36:8 Désine ab ira, et derelínque furórem: * noli æmulári ut malignéris.
-36:9 Quóniam qui malignántur, exterminabúntur: * sustinéntes autem Dóminum, ipsi hereditábunt terram.
-36:10 Et adhuc pusíllum, et non erit peccátor: * et quæres locum ejus et non invénies.
-36:11 Mansuéti autem hereditábunt terram: * et delectabúntur in multitúdine pacis.
-36:12 Observábit peccátor justum: * et stridébit super eum déntibus suis.
-36:13 Dóminus autem irridébit eum: * quóniam próspicit quod véniet dies ejus.
-36:14 Gládium evaginavérunt peccatóres: * intendérunt arcum suum,
-36:14 Ut dejíciant páuperem et ínopem: * ut trucídent rectos corde.
-36:15 Gládius eórum intret in corda ipsórum: * et arcus eórum confringátur.
-36:16 Mélius est módicum justo, * super divítias peccatórum multas.
-36:17 Quóniam bráchia peccatórum conteréntur: * confírmat autem justos Dóminus.
-36:18 Novit Dóminus dies immaculatórum: * et heréditas eórum in ætérnum erit.
-36:19 Non confundéntur in témpore malo, et in diébus famis saturabúntur: * quia peccatóres períbunt.
-36:20 Inimíci vero Dómini mox ut honorificáti fúerint et exaltáti: * deficiéntes, quemádmodum fumus defícient.
-36:21 Mutuábitur peccátor, et non solvet: * justus autem miserétur et tríbuet.
-36:22 Quia benedicéntes ei hereditábunt terram: * maledicéntes autem ei disperíbunt.
-36:23 Apud Dóminum gressus hóminis dirigéntur: * et viam ejus volet.
-36:24 Cum cecíderit non collidétur: * quia Dóminus suppónit manum suam.
-36:25 Júnior fui, étenim sénui: * et non vidi justum derelíctum, nec semen ejus quærens panem.
-36:26 Tota die miserétur et cómmodat: * et semen illíus in benedictióne erit.
-36:27 Declína a malo, et fac bonum: * et inhábita in sæculum sæculi.
-36:28 Quia Dóminus amat judícium, et non derelínquet sanctos suos: * in ætérnum conservabúntur.
-36:28 Injústi puniéntur: * et semen impiórum períbit.
-36:29 Justi autem hereditábunt terram: * et inhabitábunt in sæculum sæculi super eam.
-36:30 Os justi meditábitur sapiéntiam, * et lingua ejus loquétur judícium.
-36:31 Lex Dei ejus in corde ipsíus, * et non supplantabúntur gressus ejus.
-36:32 Consíderat peccátor justum: * et quærit mortificáre eum.
-36:33 Dóminus autem non derelínquet eum in mánibus ejus: * nec damnábit eum, cum judicábitur illi.
-36:34 Exspécta Dóminum, et custódi viam ejus: et exaltábit te ut hereditáte cápias terram: * cum períerint peccatóres vidébis.
-36:35 Vidi ímpium superexaltátum, * et elevátum sicut cedros Líbani.
-36:36 Et transívi, et ecce non erat: * et quæsívi eum, et non est invéntus locus ejus.
-36:37 Custódi innocéntiam, et vide æquitátem: * quóniam sunt relíquiæ hómini pacífico.
-36:38 Injústi autem disperíbunt simul: * relíquiæ impiórum interíbunt.
-36:39 Salus autem justórum a Dómino: * et protéctor eórum in témpore tribulatiónis.
-36:40 Et adjuvábit eos Dóminus et liberábit eos: * et éruet eos a peccatóribus, et salvábit eos: quia speravérunt in eo.
+36:1 Ereifere dich nicht über die bösen, * und beneide nicht die Übeltäter,
+36:2 denn wie Gras werden sie rasch verdorren * und wie das Grünzeug der Kräuter schnell abfallen.
+36:3 Hoffe auf den Herrn und tue Gutes, * und bewohne das Land, und du wirst dich nähren von seinen Schätzen.
+36:4 Erfreue dich am Herrn, * und er wird dir das Verlangen deines Herzens erfüllen.
+36:5 Enthülle dem Herrn deinen Weg und hoffe auf ihn, * und er wird handeln.
+36:6 Und er wird hervorbringen wie das Licht deine Gerechtigkeit und dein recht wie die Mittagshelle. * Sei untertan dem Herrn und bete zu ihm.
+36:7 Ereifere dich nicht über den, dem es gut geht auf seinem Weg, * über den Menschen, der Unrecht tut.
+36:8 Lass ab vom zorn und gib auf den Grimm, * ereifere dich nicht, so dass du böses tust.
+36:9 Denn die böses tun, werden vernichtet werden, * die aber harren auf den Herrn, sie werden das Land erben.
+36:10 Und noch ein klein wenig, und der Sünder wird nicht mehr sein, * und du wirst seinen Ort suchen und ihn nicht finden.
+36:11 Die Sanftmütigen aber werden das Land erben * und sich freuen an der Fülle des Friedens.
+36:12 beobachten wird der Sünder den Gerechten * und gegen ihn mit seinen zähnen knirschen.
+36:13 Der Herr aber wird seiner lachen, * denn er sieht voraus, dass sein Tag kommen wird.
+36:14 Die Sünder haben das Schwert gezückt, * sie haben ihren bogen gespannt,
+36:14 um den Armen und den bedürftigen zu stürzen, * um zu morden, die aufrechten Herzens sind.
+36:15 ihr Schwert möge eindringen in ihr eigenes Herz, * und ihr bogen werde zerbrochen.
+36:16 besser ist das Wenige für den Gerechten * als die vielen reichtümer der Sünder.
+36:17 Denn die Arme der Sünder werden zerbrochen, * doch die Gerechten macht stark der Herr.
+36:18 Der Herr kennt die Tage der Makellosen, * und ihr Erbe wird bleiben in Ewigkeit.
+36:19 Sie werden nicht zuschanden in böser zeit, und in Tagen des Hungers werden sie gesättigt, * denn die Sünder werden zugrunde gehen.
+36:20 Die Feinde des Herrn aber, kaum dass sie geehrt und erhöht werden, * schwinden dahin, gleich wie rauch schwinden sie dahin.
+36:21 Es wird borgen der Sünder und nicht zurückzahlen, * der Gerechte aber erbarmt sich und teilt aus.
+36:22 Denn die ihn segnen, werden das Land erben, * jene aber, die ihm fluchen, werden zugrunde gehen.
+36:23 beim Herrn werden die Schritte des Menschen gelenkt, * und an seinem Weg hat er Gefallen.
+36:24 Wenn er fällt, wird er nicht anschlagen, * denn der Herr legt seine Hand unter ihn.
+36:25 Jung war ich und bin nun alt geworden, * und den Gerechten sah ich nicht verlassen, noch seine nachkommen nach brot suchen.
+36:26 Den ganzen Tag erbarmt er sich und leiht aus, * und seine nachkommen werden gesegnet sein.
+36:27 Wende dich ab vom bösen und tue Gutes, * und nimm Wohnung in alle Ewigkeit.
+36:28 Denn der Herr liebt das recht, und er wird seine Heiligen nicht verlassen, * in Ewigkeit werden sie bewahrt werden.
+36:28 Die Ungerechten aber werden bestraft, * und die nachkommen der Gottlosen gehen zugrunde.
+36:29 Die Gerechten aber werden das Land erben, * und wohnen in ihm auf ewig.
+36:30 Der Mund des Gerechten wird Weisheit erwägen, * und seine zunge redet recht.
+36:31 Das Gesetz seines Gottes ist in seinem Herzen, * und seine Schritte werden nicht zu Fall gebracht.
+36:32 Es beobachtet der Sünder den Gerechten * und sucht ihn zu töten.
+36:33 Der Herr aber lässt ihn nicht in seinen Händen, * und er wird ihn nicht verurteilen, wenn man über ihn Gericht halten wird.
+36:34 Erwarte den Herrn und bewahre seinen Weg, und er wird dich erhöhen, damit du als Erbe das Land in besitz nimmst; * wenn die Sünder zugrunde gehen, wirst du es sehen.
+36:35 ich sah einen Gottlosen hoch erhöht * und erhaben wie die zedern des Libanon.
+36:36 Und ich ging vorüber, und siehe, er war nicht mehr. * Und ich suchte ihn, und sein Ort war nicht zu finden.
+36:37 bewahre die Unschuld und achte auf Gerechtigkeit, * denn ein friedlicher Mensch hat nachkommen.
+36:38 Die Ungerechten aber werden miteinander umkommen, * die nachkommenschaft der Gottlosen wird untergehen.
+36:39 Das Heil der Gerechten aber wird kommen vom Herrn, * und er wird ihr beschützer sein zur zeit der bedrängnis.
+36:40 Und helfen wird ihnen der Herr und sie befreien * und sie entreißen den Sündern und sie erlösen, denn sie haben auf ihn gehofft.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm37.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm37.txt
@@ -1,23 +1,23 @@
-37:2 Dómine, ne in furóre tuo árguas me, * neque in ira tua corrípias me.
-37:3 Quóniam sagíttæ tuæ infíxæ sunt mihi: * et confirmásti super me manum tuam.
-37:4 Non est sánitas in carne mea a fácie iræ tuæ: * non est pax óssibus meis a fácie peccatórum meórum.
-37:5 Quóniam iniquitátes meæ supergréssæ sunt caput meum: * et sicut onus grave gravátæ sunt super me.
-37:6 Putruérunt et corrúptæ sunt cicatríces meæ, * a fácie insipiéntiæ meæ.
-37:7 Miser factus sum, et curvátus sum usque in finem: * tota die contristátus ingrediébar.
-37:8 Quóniam lumbi mei impléti sunt illusiónibus: * et non est sánitas in carne mea.
-37:9 Afflíctus sum, et humiliátus sum nimis: * rugiébam a gémitu cordis mei.
-37:10 Dómine, ante te omne desidérium meum: * et gémitus meus a te non est abscónditus.
-37:11 Cor meum conturbátum est, derelíquit me virtus mea: * et lumen oculórum meórum, et ipsum non est mecum.
-37:12 Amíci mei, et próximi mei * advérsum me appropinquavérunt, et stetérunt.
-37:12 Et qui juxta me erant, de longe stetérunt: * et vim faciébant qui quærébant ánimam meam.
-37:13 Et qui inquirébant mala mihi, locúti sunt vanitátes: * et dolos tota die meditabántur.
-37:14 Ego autem tamquam surdus non audiébam: * et sicut mutus non apériens os suum.
-37:15 Et factus sum sicut homo non áudiens: * et non habens in ore suo redargutiónes.
-37:16 Quóniam in te, Dómine, sperávi: * tu exáudies me, Dómine, Deus meus.
-37:17 Quia dixi: Nequándo supergáudeant mihi inimíci mei: * et dum commovéntur pedes mei, super me magna locúti sunt.
-37:18 Quóniam ego in flagélla parátus sum: * et dolor meus in conspéctu meo semper.
-37:19 Quóniam iniquitátem meam annuntiábo: * et cogitábo pro peccáto meo.
-37:20 Inimíci autem mei vivunt, et confirmáti sunt super me: * et multiplicáti sunt qui odérunt me iníque.
-37:21 Qui retríbuunt mala pro bonis, detrahébant mihi: * quóniam sequébar bonitátem.
-37:22 Ne derelínquas me, Dómine, Deus meus: * ne discésseris a me.
-37:23 Inténde in adjutórium meum, * Dómine, Deus, salútis meæ.
+37:2 Herr, in Deinem Grimm stelle mich nicht bloß * und in Deinem zorn züchtige mich nicht,
+37:3 denn Deine Pfeile sind in mich eingedrungen, * und schwer hast Du Deine Hand auf mich gelegt.
+37:4 nichts Heiles ist in meinem Fleisch angesichts Deines zornes, * und keinen Frieden gibt es für meine Gebeine angesichts meiner Sünden,
+37:5 denn meine Ungerechtigkeiten haben mein Haupt überstiegen, * und wie eine schwere bürde lasten sie auf mir.
+37:6 Es faulten und verwesten meine Striemen * angesichts meiner Torheit.
+37:7 ich wurde elend und gebeugt bis zum äußersten, * den ganzen Tag ging ich traurig einher,
+37:8 denn meine Lenden sind erfüllt von Täuschungen * und nichts Heiles ist in meinem Fleisch.
+37:9 bedrängt bin ich und sehr gebeugt, * ich stöhnte laut in der beklemmung meines Herzens.
+37:10 Herr, vor Dir ist all mein Sehnen, * und mein Stöhnen ist vor Dir nicht verborgen.
+37:11 Mein Herz ist aufgewühlt, verlassen hat mich meine Kraft, * und das Licht meiner Augen, auch es ist nicht mehr bei mir.
+37:12 Meine Freunde und meine nächsten * nahten sich feindlich wider mich und blieben stehen,
+37:12 und die bei mir waren, standen von ferne, * und Gewalt haben angewandt, die nach meiner Seele trachteten;
+37:13 und die mir böses wollten, haben nichtiges gesprochen * und den ganzen Tag auf Trug gesonnen.
+37:14 ich aber, gleich wie ein Tauber, habe nichts gehört * und war wie ein Stummer, der seinen Mund nicht öffnet.
+37:15 ich wurde wie ein Mensch, der nicht hört * und der in seinem Mund keine Entgegnung hat,
+37:16 denn auf Dich, Herr, habe ich meine Hoffnung gesetzt, * Du wirst mich erhören, Herr, mein Gott.
+37:17 Denn ich sprach: Dass doch meine Feinde sich nicht freuen über mich; * und während meine Füße wanken, haben sie prahlerisch über mich geredet.
+37:18 Denn zu Geißeln bin ich bereit, * und mein Schmerz ist allzeit vor meinem Angesicht.
+37:19 Denn meine Ungerechtigkeit will ich kundtun * und meiner Sünde gedenken.
+37:20 Meine Feinde aber leben und sind stärker geworden als ich, * und vermehrt haben sich, die mich ungerecht hassen.
+37:21 Die böses vergelten für Gutes, haben mich verleumdet, * weil ich nach dem Guten strebte.
+37:22 Verlass mich nicht, Herr, mein Gott, * weiche nicht von mir.
+37:23 Achte darauf, mir zu helfen, * Herr, Du Gott meines Heiles.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm38.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm38.txt
@@ -1,18 +1,18 @@
-38:2 Dixi: Custódiam vias meas: * ut non delínquam in lingua mea.
-38:2 Pósui ori meo custódiam, * cum consísteret peccátor advérsum me.
-38:3 Obmútui, et humiliátus sum, et sílui a bonis: * et dolor meus renovátus est.
-38:4 Concáluit cor meum intra me: * et in meditatióne mea exardéscet ignis.
-38:5 Locútus sum in lingua mea: * Notum fac mihi, Dómine, finem meum.
-38:5 Et númerum diérum meórum quis est: * ut sciam quid desit mihi.
-38:6 Ecce mensurábiles posuísti dies meos: * et substántia mea tamquam níhilum ante te.
-38:6 Verúmtamen univérsa vánitas, * omnis homo vivens.
-38:7 Verúmtamen in imágine pertránsit homo: * sed et frustra conturbátur.
-38:7 Thesaurízat: * et ignórat cui congregábit ea.
-38:8 Et nunc quæ est exspectátio mea? Nonne Dóminus? * Et substántia mea apud te est.
-38:9 Ab ómnibus iniquitátibus meis érue me: * oppróbrium insipiénti dedísti me.
-38:10 Obmútui, et non apérui os meum, quóniam tu fecísti: * ámove a me plagas tuas.
-38:12 A fortitúdine manus tuæ ego deféci in increpatiónibus: * propter iniquitátem corripuísti hóminem.
-38:12 Et tabéscere fecísti sicut aráneam ánimam ejus: * verúmtamen vane conturbátur omnis homo.
-38:13 Exáudi oratiónem meam, Dómine, et deprecatiónem meam: * áuribus pércipe lácrimas meas.
-38:13 Ne síleas: quóniam ádvena ego sum apud te, et peregrínus, * sicut omnes patres mei.
-38:14 Remítte mihi, ut refrígerer priúsquam ábeam, * et ámplius non ero.
+38:2 ich sagte: Wachen will ich über meine Wege, * damit ich mit meiner zunge nicht sündige.
+38:2 Vor meinen Mund setzte ich eine Wache, * als der Sünder sich gegen mich aufstellte.
+38:3 ich verstummte und demütigte mich, und ich schwieg selbst vom Guten, * und mein Schmerz wurde erneuert.
+38:4 Es erglühte mein Herz in mir, * und in meinem nachsinnen entbrennt Feuer.
+38:5 ich sprach mit meiner zunge: * Tu mir kund, Herr, mein Ende,
+38:5 und welches die zahl meiner Tage ist, * damit ich weiß, was mir fehlt.
+38:6 Siehe, kurzbemessen hast Du meine Tage gemacht * und mein Dasein ist wie nichts vor Dir.
+38:6 Wahrlich, alles ist nichtigkeit, * ein jeder Mensch, der lebt.
+38:7 Wahrlich, wie ein Schattenbild geht der Mensch dahin, * doch er beunruhigt sich vergebens.
+38:7 Er häuft Schätze an * und weiß nicht, für wen er sie sammelt.
+38:8 Und nun, was ist meine Sehnsucht? ist es nicht der Herr? * Und der Grund meines Lebens ist bei Dir.
+38:9 Aus all meinen Missetaten reiße mich heraus, * zum Hohn hast Du mich für den Toren gemacht.
+38:10 ich verstummte und tat meinen Mund nicht auf, denn Du hast es getan. * nimm weg von mir Deine Plagen!
+38:12 Von der Stärke Deiner Hand bin ich kraftlos geworden in den der züchtigungen. * Wegen des Unrechts hast Du den Menschen gestraft,
+38:12 und Du ließest seine Seele verschmachten wie eine Spinne; * wahrlich, umsonst beunruhigt sich jeder Mensch.
+38:13 Erhöre mein Gebet, Herr, und mein Flehen, * nimm zu Ohren meine Tränen.
+38:13 Schweige nicht, denn ein Fremdling bin ich bei Dir und ein Pilger, * wie alle meine Väter.
+38:14 Lass ab von mir, damit ich erquickt werde, bevor ich hinweggehe * und nicht mehr sein werde.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm39.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm39.txt
@@ -1,24 +1,24 @@
-39:2 Exspéctans exspectávi Dóminum, * et inténdit mihi.
-39:3 Et exaudívit preces meas: * et edúxit me de lacu misériæ, et de luto fæcis.
-39:3 Et státuit super petram pedes meos: * et diréxit gressus meos.
-39:4 Et immísit in os meum cánticum novum, * carmen Deo nostro.
-39:4 Vidébunt multi, et timébunt: * et sperábunt in Dómino.
-39:5 Beátus vir, cujus est nomen Dómini spes ejus: * et non respéxit in vanitátes et insánias falsas.
-39:6 Multa fecísti tu, Dómine, Deus meus, mirabília tua: * et cogitatiónibus tuis non est qui símilis sit tibi.
-39:6 Annuntiávi et locútus sum: * multiplicáti sunt super númerum.
-39:7 Sacrifícium et oblatiónem noluísti: * aures autem perfecísti mihi.
-39:7 Holocáustum et pro peccáto non postulásti: * tunc dixi: Ecce, vénio.
-39:8 In cápite libri scriptum est de me ut fácerem voluntátem tuam: * Deus meus, vólui, et legem tuam in médio cordis mei.
-39:10 Annuntiávi justítiam tuam in ecclésia magna, * ecce, lábia mea non prohibébo: Dómine, tu scisti.
-39:11 Justítiam tuam non abscóndi in corde meo: * veritátem tuam et salutáre tuum dixi.
-39:11 Non abscóndi misericórdiam tuam et veritátem tuam * a concílio multo.
-39:12 Tu autem, Dómine, ne longe fácias miseratiónes tuas a me: * misericórdia tua et véritas tua semper suscepérunt me.
-39:13 Quóniam circumdedérunt me mala, quorum non est númerus: * comprehendérunt me iniquitátes meæ, et non pótui ut vidérem.
-39:13 Multiplicátæ sunt super capíllos cápitis mei: * et cor meum derelíquit me.
-39:14 Compláceat tibi, Dómine, ut éruas me: * Dómine, ad adjuvándum me réspice.
-39:15 Confundántur et revereántur simul, qui quærunt ánimam meam, * ut áuferant eam.
-39:15 Convertántur retrórsum, et revereántur, * qui volunt mihi mala.
-39:16 Ferant conféstim confusiónem suam, * qui dicunt mihi: Euge, euge.
-39:17 Exsúltent et læténtur super te omnes quæréntes te: * et dicant semper: Magnificétur Dóminus: qui díligunt salutáre tuum.
-39:18 Ego autem mendícus sum, et pauper: * Dóminus sollícitus est mei.
-39:18 Adjútor meus, et protéctor meus tu es: * Deus meus, ne tardáveris.
+39:2 Sehnlichst habe ich den Herrn erwartet, * und er hat sich mir zugewandt,
+39:3 und er hat meine Gebete erhört * und mich herausgeführt aus der Grube des Elends und vom Schlamm des bodens,
+39:3 und er hat meine Füße auf Fels gestellt * und meine Schritte geleitet,
+39:4 und in meinen mund hat er ein neues lied gelegt, * einen Gesang für unseren Gott.
+39:4 Viele werden es sehen und sich fürchten, * und sie werden hoffen auf den Herrn.
+39:5 Selig der mann, dessen Hoffnung der name des Herrn ist * und der nicht achtet auf nichtigkeiten und trügerische Tollheiten.
+39:6 zahlreich hast Du, Herr, mein Gott, Deine Wunder gemacht, * und niemand ist, der Dir gleich wäre in Deinen Gedanken.
+39:6 ich habe verkündet und gesprochen: * Sie sind viele geworden, mehr als jede zahl.
+39:7 Opfer und Opfergaben hast Du nicht gewollt, * aber Ohren hast Du mir bereitet.
+39:7 Auch ein brandopfer für die Sünde hast Du nicht verlangt, * da sprach ich: Siehe, ich komme.
+39:8 in der buchrolle steht es von mir geschrieben, dass ich erfülle Deinen Willen; * mein Gott, das will ich, und auch Dein Gesetz in meines Herzens mitte.
+39:10 Verkündet habe ich Deine Gerechtigkeit in großer Versammlung; * siehe, meinen lippen will ich nicht wehren, Herr, Du weißt es.
+39:11 Deine Gerechtigkeit verbarg ich nicht in meinem Herzen, * von Deiner Wahrheit und Deinem Heil habe ich gesprochen.
+39:11 ich verbarg nicht Deine barmherzigkeit und Deine Wahrheit * vor der großen ratsversammlung.
+39:12 Du aber, Herr, lass nicht fern sein Deine Erbarmungen von mir; * Deine barmherzigkeit und Deine Wahrheit haben mich immer gestützt.
+39:13 Denn es umgaben mich Übel ohne zahl, * ergriffen haben mich meine Sünden, und ich vermochte nicht zu sehen.
+39:13 Sie sind zahlreicher als die Haare meines Hauptes, * und mein Herz hat mich verlassen.
+39:14 lass Dir gefallen, Herr, mich zu retten. * Herr, um mir zu helfen, schau auf mich.
+39:15 zuschanden sollen werden und sich fürchten, die nach meiner Seele trachten, * um sie hinwegzuraffen.
+39:15 Sie mögen nach rückwärts gewendet werden und sich schämen, * die mir böses wollen.
+39:16 Sie mögen sogleich ihre Schande tragen, * die zu mir sagen: Wohlan, wohlan!
+39:17 Frohlocken sollen und sich freuen über Dich alle, die Dich suchen, * und die Dein Heil lieben sollen immer sagen: Hochgelobt sei der Herr!
+39:18 ich aber bin bedürftig und arm; * der Herr ist besorgt um mich.
+39:18 mein Helfer und mein beschützer bist Du, * mein Gott, säume nicht!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm41.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm41.txt
@@ -1,16 +1,16 @@
-41:2 Quemádmodum desíderat cervus ad fontes aquárum: * ita desíderat ánima mea ad te, Deus.
-41:3 Sitívit ánima mea ad Deum fortem vivum: * quando véniam, et apparébo ante fáciem Dei?
-41:4 Fuérunt mihi lácrimæ meæ panes die ac nocte: * dum dícitur mihi quotídie: Ubi est Deus tuus?
-41:5 Hæc recordátus sum, et effúdi in me ánimam meam: * quóniam transíbo in locum tabernáculi admirábilis, usque ad domum Dei.
-41:5 In voce exsultatiónis, et confessiónis: * sonus epulántis.
-41:6 Quare tristis es, ánima mea? * et quare contúrbas me?
-41:6 Spera in Deo, quóniam adhuc confitébor illi: * salutáre vultus mei, et Deus meus.
-41:7 Ad meípsum ánima mea conturbáta est: * proptérea memor ero tui de terra Jordánis, et Hermóniim a monte módico.
-41:8 Abýssus abýssum ínvocat, * in voce cataractárum tuárum.
-41:8 Omnia excélsa tua, et fluctus tui * super me transiérunt.
-41:9 In die mandávit Dóminus misericórdiam suam: * et nocte cánticum ejus.
-41:9 Apud me orátio Deo vitæ meæ, * dicam Deo: Suscéptor meus es.
-41:10 Quare oblítus es mei? * et quare contristátus incédo, dum afflígit me inimícus?
-41:11 Dum confringúntur ossa mea, * exprobravérunt mihi qui tríbulant me inimíci mei.
-41:11 Dum dicunt mihi per síngulos dies: Ubi est Deus tuus? * quare tristis es, ánima mea? et quare contúrbas me?
-41:12 Spera in Deo, quóniam adhuc confitébor illi: * salutáre vultus mei, et Deus meus.
+41:2 Gleich wie ein Hirsch verlangt nach Wasserquellen, * so verlangt meine Seele nach Dir, o Gott.
+41:3 meine Seele dürstet nach dem starken, dem lebendigen Gott; * wann werde ich kommen und erscheinen vor Gottes Angesicht?
+41:4 meine Tränen wurden mir zum brot bei Tag und nacht, * während man mir täglich sagte: Wo ist dein Gott?
+41:5 Daran denke ich und schütte aus meine Seele in mir, * denn ich will hinübergehen an den Ort des wunderbaren zeltes bis zum Hause Gottes.
+41:5 im Schall von Jubel und lobpreis, * beim Klang des Feiernden.
+41:6 Warum bist du traurig, meine Seele, * und warum verwirrst du mich?
+41:6 Hoffe auf Gott, denn ich werde ihn noch preisen; * er ist das Heil meines Angesichts und mein Gott.
+41:7 bei mir selbst ist meine Seele verwirrt, * darum werde ich Deiner gedenken vom land am Jordan aus und vom Hermon her, dem kleinen berg.
+41:8 Ein Abgrund ruft dem Abgrund zu * beim rauschen Deiner Wasserfälle.
+41:8 All Deine Wogen und Deine Fluten * gingen über mich hinweg.
+41:9 bei Tag entbot mir der Herr seine barmherzigkeit * und in der nacht lobgesang auf ihn.
+41:9 bei mir ist ein Gebet zum Gott meines lebens; * ich werde zu Gott sagen: Du bist es, der mich annimmt.
+41:10 Warum hast Du mich vergessen? * und warum muss ich traurig einhergehen, während mich der Feind bedrängt?
+41:11 Da meine Gebeine zermalmt wurden, * schmähten mich meine Feinde, die mich bedrängten,
+41:11 da sie mir alle Tage sagten: Wo ist dein Gott? * Warum bist du traurig, meine Seele, und warum verwirrst du mich?
+41:12 Hoffe auf Gott, denn ich werde ihn noch preisen; * er ist das Heil meines Angesichts und mein Gott.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm43.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm43.txt
@@ -1,28 +1,28 @@
-43:2 Deus áuribus nostris audívimus: * patres nostri annuntiavérunt nobis.
-43:2 Opus, quod operátus es in diébus eórum, * et in diébus antíquis.
-43:3 Manus tua gentes dispérdidit, et plantásti eos: * afflixísti pópulos, et expulísti eos.
-43:4 Nec enim in gládio suo possedérunt terram, * et bráchium eórum non salvávit eos:
-43:4 Sed déxtera tua, et bráchium tuum, et illuminátio vultus tui: * quóniam complacuísti in eis.
-43:5 Tu es ipse Rex meus et Deus meus: * qui mandas salútes Jacob.
-43:6 In te inimícos nostros ventilábimus cornu: * et in nómine tuo spernémus insurgéntes in nobis.
-43:7 Non enim in arcu meo sperábo: * et gládius meus non salvábit me.
-43:8 Salvásti enim nos de affligéntibus nos: * et odiéntes nos confudísti.
-43:9 In Deo laudábimur tota die: * et in nómine tuo confitébimur in sæculum.
-43:10 Nunc autem repulísti et confudísti nos: * et non egrediéris, Deus, in virtútibus nostris.
-43:11 Avertísti nos retrórsum post inimícos nostros: * et qui odérunt nos, diripiébant sibi.
-43:12 Dedísti nos tamquam oves escárum: * et in géntibus dispersísti nos.
-43:13 Vendidísti pópulum tuum sine prétio: * et non fuit multitúdo in commutatiónibus eórum.
-43:14 Posuísti nos oppróbrium vicínis nostris, * subsannatiónem et derísum his, qui sunt in circúitu nostro.
-43:15 Posuísti nos in similitúdinem géntibus: * commotiónem cápitis in pópulis.
-43:16 Tota die verecúndia mea contra me est, * et confúsio faciéi meæ coopéruit me.
-43:17 A voce exprobrántis, et obloquéntis: * a fácie inimíci, et persequéntis.
-43:18 Hæc ómnia venérunt super nos, nec oblíti sumus te: * et iníque non égimus in testaménto tuo.
-43:19 Et non recéssit retro cor nostrum: * et declinásti sémitas nostras a via tua:
-43:20 Quóniam humiliásti nos in loco afflictiónis, * et coopéruit nos umbra mortis.
-43:21 Si oblíti sumus nomen Dei nostri, * et si expándimus manus nostras ad deum aliénum:
-43:22 Nonne Deus requíret ista? * ipse enim novit abscóndita cordis.
-43:22 Quóniam propter te mortificámur tota die: * æstimáti sumus sicut oves occisiónis.
-43:23 Exsúrge, quare obdórmis, Dómine? * exsúrge, et ne repéllas in finem.
-43:24 Quare fáciem tuam avértis, * oblivísceris inópiæ nostræ, et tribulatiónis nostræ?
-43:25 Quóniam humiliáta est in púlvere ánima nostra: * conglutinátus est in terra venter noster.
-43:26 Exsúrge, Dómine, ádjuva nos: * et rédime nos propter nomen tuum.
+43:2 Gott, mit unseren Ohren haben wir es gehört, * unsere Väter haben es uns verkündet,
+43:2 das Werk, das Du vollbracht hast in ihren Tagen * und in uralten Tagen.
+43:3 Deine Hand hat Völker zugrunde gerichtet, und sie hast Du eingepflanzt, * Du hast Völker zerschmettert und vertrieben.
+43:4 Denn nicht durch ihr Schwert haben sie das land in besitz genommen * und nicht ihr Arm hat sie gerettet,
+43:4 sondern Deine rechte und Dein Arm und das licht Deines Angesichtes, * denn Du hattest Wohlgefallen an ihnen.
+43:5 Du selber bist mein König und mein Gott, * der Du Heil für Jakob entbietest.
+43:6 Durch Dich werden wir unsere Feinde mit dem Horn niederschleudern * und in Deinem namen jene verachten, die sich gegen uns erheben.
+43:7 Denn ich will nicht auf meinen bogen hoffen, * und mein Schwert wird mich nicht retten.
+43:8 Denn Du hast uns gerettet von unseren bedrängern, * und die uns hassen, hast Du verwirrt.
+43:9 in Gott wollen wir uns rühmen den ganzen Tag * und Deinen namen bekennen in Ewigkeit.
+43:10 nun aber hast Du uns verstoßen und zuschanden gemacht, * und Du, o Gott, ziehst nicht aus mit unseren Heeren.
+43:11 Du ließest uns weichen vor unseren Feinden, * und die uns hassen, nahmen sich beute.
+43:12 Du gabst uns preis wie Schlachtschafe * und hast uns unter die Heiden zerstreut.
+43:13 Du hast Dein Volk verkauft ohne Wert, * und kein Gewinn war bei solchem Tausch.
+43:14 Du machtest uns zur Schmach für unsere nachbarn, * zum Hohn und Gelächter für alle, die rings um uns sind.
+43:15 Du hast uns zum Sprichwort gemacht für die Heiden, * zum Kopfschütteln unter den Völkern.
+43:16 Den ganzen Tag steht meine Schmach vor mir, * und die Scham meines Angesichts hat mich bedeckt,
+43:17 ob der Stimme des Höhnenden und Schimpfenden, * angesichts des Feindes und des Verfolgers.
+43:18 Dies alles ist über uns gekommen, doch wir haben Dich nicht vergessen * und nicht unrecht gehandelt gegen Deinen bund.
+43:19 und unser Herz ist nicht zurückgewichen, * Du aber ließest abweichen unsere Pfade von Deinem Weg.
+43:20 Denn Du hast uns erniedrigt am Ort der bedrängnis, * und bedeckt hat uns der Schatten des Todes.
+43:21 Wenn wir vergessen den namen unseres Gottes * und unsere Hände aus strecken nach einem fremden Gott:
+43:22 Wird Gott dies nicht ahnden? * Er nämlich kennt das Verborg ene des Herzens.
+43:22 Denn um Deinetwillen werden wir getötet den ganzen Tag, * werden angesehen wie Schlachtschafe.
+43:23 Erhebe Dich, warum schläfst Du, Herr? * Erhebe Dich und verwirf uns nicht völlig.
+43:24 Warum wendest Du Dein Angesicht ab, * vergisst unsere Hilflosigkeit und unsere bedrängnis?
+43:25 Denn erniedrigt bis zum Staub ist unsere Seele, * am boden klebt unser leib.
+43:26 Erhebe Dich, Herr, hilf uns, * und erlöse uns um Deines namens willen!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm44.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm44.txt
@@ -1,20 +1,20 @@
-44:2a Es sprudelt empor mir aus innerstem Herzen ein lieblicher Sang; * mein Lied ist gewidmet dem König.
-44:2b Es gleicht meine Zunge (vor Freude) dem zitternden Griffel in schreibender Hand, * die eilig im Schreiben vorankommt.
-44:3 O Schönster an Pracht du unter den Edlen! † Welch liebliche Anmut dein Antlitz umfließt! * So also hat Gott dich gesegnet auf ewig!
-44:4 Wenn du um die Hüften gegürtet dein Schwert, * o machtvoller Held, 
-44:5a wie strahlst du in Herrlichkeit dann und in Schönheit! * Zieh aus nun, und glücklich schreite voran und regiere
-44:5b in Güte und Milde und Recht; * so laß deine Rechte dich führen, dass alle erstaunen.
-44:6 Die Pfeile, die du entsendest, die seien recht spitz; es sollen die Rotten hinsinken vor dir, * die sonst dem König im Herzen so gram sind.
-44:7 Fest stehe, o Göttlicher, ewig dein Thron; * ein unzerbrechliches Zepter sei stets das Zepter deiner Regierung.
-44:8 Du wirst doch fördern das Recht, das Unrecht verfolgen mit Hass; * drum hat, o Göttlicher, dich dein Gott mit dem köstlichen Öle gesalbt, viel reicher als deine Genossen im Amte.
-44:9 O welch ein Myrrhen-, Aloe-, Kassiaduft entströmt nun deinem Gewand! * Aus elfenbeinernem Saale tönt dir entgegen der Festgruß. (10a) Prinzessinnen kommen zu deiner so festlichen Feier. 
-44:10b schon steht ja zur Rechten bei dir die Königsbraut, * im goldenen Gewande mit buntesten Farben umschimmert.
-44:11 O lausche nun, Liebling, erhebe die Augen und neige dein Ohr! * Nun sehne dich nie mehr zurück nach deiner Verwandtschaft noch nach dem Hause des Vaters.
-44:12 Es ist ja der König, der nunmehr nach deinem Liebreiz verlangt; * sieh also, er selbst, dein Herr und dein Gott, dem alle wir Anbetung schulden.
-44:13 Nun bringen die Frauen von Tyrus, um deine Huld zu erbitten, Geschenke sogar, * ja alle die Vornehmsten unter dem Volke.
-44:14 Vollendete Schönheit wirst du, o Königin, drin im Palast, * wenn du dich geschmückt mit den gold'nen Behängen. (15a) In bunten Gewändern nun folgen, 
-44:15b o König, die anderen Jungfrauen nach, * die Freundinnen sind es von ihr, die führt man dir auch zu.
-44:16 Sie kommen so jubelnd und hüpfend daher, * weil sie in den Königspalast nun einziehen dürfen.
-44:17 Statt deiner Familie werden dir nun auch eigene Kinder gebor'n; * die kannst du verteilen als Fürsten in sämtliche Länder.
-44:18a Die werden das Andenken immer erhalten an dich, * von einem Geschlechte zum andern;
-44:18b Drum werden die Völker dich ewig besingen im Lied, * für immer und alle nur denkbaren Zeiten.
+44:2a Meinem Herzen entströmt ein gutes Wort, * ich weihe meine Werke dem König.
+44:2b Meine zunge gleicht dem Griffel des Schreibers, * der flink schreibt.
+44:3 Schön von Gestalt bist Du vor den Menschenkindern, ausgegossen ist Anmut über Deine Lippen, * deshalb hat Gott Dich gesegnet auf ewig.
+44:4 Umgürte Dich mit dem Schwert über Deiner Hüfte, * Mächtigster!
+44:5a in Deiner Anmut und Deiner Schönheit * merke auf, tritt glücklich hervor und herrsche
+44:5b um der Wahrheit und Sanftmut und Gerechtigkeit willen, * und wunderbar geleiten wird Dich Deine rechte.
+44:6 Deine Pfeile sind scharf, Völker werden fallen unter Dir, * sie dringen in die Herzen der Feinde des Königs.
+44:7 Dein Thron, o Gott, steht immer und ewig, * ein zepter der Gerechtigkeit ist das zepter Deines reiches.
+44:8 Du liebtest Gerechtigkeit und hasstest das Unrecht; * deshalb hat Dich Gott, Dein Gott, gesalbt mit Freudenöl vor all Deinen Gefährten.
+44:9 Myrrhe und Aloe und Kassia duften aus Deinen Gewändern, aus Palästen von Elfenbein, * von dort erfreuen Dich die Töchter von Königen in Deinem Ehrenschmuck.
+44:10b Es steht zu Deiner rechten die Königin in golddurchwirktem Gewand, * umhüllt mit bunten Kleidern.
+44:11 Höre, Tochter, und sieh, und neige dein Ohr * und vergiss dein Volk und das Haus deines Vaters,
+44:12 denn der König verlangt nach deiner Schönheit, * denn er selbst ist der Herr, dein Gott, und ihn wird man anbeten.
+44:13 Und die Töchter von Tyrus, mit Gaben * werden dein Angesicht anflehen, alle reichen des Volkes.
+44:14 All ihre Herrlichkeit kommt der Tochter des Königs von innen; * sie ist mit goldenen Fransen in bunte Gewänder gehüllt.
+44:15b Jungfrauen führt man ihr nach zum König, * ihr Gefolge führt man zu dir.
+44:16 Sie werden herbeigebracht in Freude und Jubel, * herbeigeführt in den Tempel des Königs.
+44:17 Anstelle deiner Väter sind dir Söhne geboren, * du wirst sie einsetzen als Fürsten über die ganze Erde.
+44:18a Sie werden deines namens gedenken * von Geschlecht zu Geschlecht.
+44:18b Darum werden die Völker dich preisen auf immer * und in alle Ewigkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm48.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm48.txt
@@ -1,21 +1,21 @@
-48:2 Audíte hæc, omnes Gentes: * áuribus percípite omnes, qui habitátis orbem:
-48:3 Quique terrígenæ, et fílii hóminum: * simul in unum dives et pauper.
-48:4 Os meum loquétur sapiéntiam: * et meditátio cordis mei prudéntiam.
-48:5 Inclinábo in parábolam aurem meam: * apériam in psaltério propositiónem meam.
-48:6 Cur timébo in die mala? * iníquitas calcánei mei circúmdabit me:
-48:7 Qui confídunt in virtúte sua: * et in multitúdine divitiárum suárum gloriántur.
-48:8 Frater non rédimit, rédimet homo: * non dabit Deo placatiónem suam.
-48:9 Et prétium redemptiónis ánimæ suæ: * et laborábit in ætérnum, et vivet adhuc in finem.
-48:11 Non vidébit intéritum, cum víderit sapiéntes moriéntes: * simul insípiens, et stultus períbunt.
-48:11 Et relínquent aliénis divítias suas: * et sepúlcra eórum domus illórum in ætérnum.
-48:12 Tabernácula eórum in progénie et progénie: * vocavérunt nómina sua in terris suis.
-48:13 Et homo, cum in honóre esset, non intelléxit: * comparátus est juméntis insipiéntibus, et símilis factus est illis.
-48:14 Hæc via illórum scándalum ipsis: * et póstea in ore suo complacébunt.
-48:15 Sicut oves in inférno pósiti sunt: * mors depáscet eos.
-48:15 Et dominabúntur eórum justi in matutíno: * et auxílium eórum veteráscet in inférno a glória eórum.
-48:16 Verúmtamen Deus rédimet ánimam meam de manu ínferi: * cum accéperit me.
-48:17 Ne timúeris, cum dives factus fúerit homo: * et cum multiplicáta fúerit glória domus ejus.
-48:18 Quóniam cum interíerit, non sumet ómnia: * neque descéndet cum eo glória ejus.
-48:19 Quia ánima ejus in vita ipsíus benedicétur: * confitébitur tibi cum beneféceris ei.
-48:20 Introíbit usque in progénies patrum suórum: * et usque in ætérnum non vidébit lumen.
-48:21 Homo, cum in honóre esset, non intelléxit: * comparátus est juméntis insipiéntibus, et símilis factus est illis.
+48:2 Hört dies, ihr Völker alle, * nehmt es zu Ohren, die ihr den Erdkreis bewohnt,
+48:3 all ihr Erdgeborenen und Menschenkinder, * zugleich miteinander der reiche und der Arme.
+48:4 Mein Mund soll Weisheit reden * und meines Herzens Sinnen Klugheit.
+48:5 neigen will ich mein Ohr zum Gleichnis hin, * bei Harfenspiel meine Darlegung eröffnen.
+48:6 Warum soll ich mich fürchten am bösen Tag, * da die bosheit derer, die mir auf der Ferse sind, mich umgibt,
+48:7 die vertrauen auf ihre Kraft * und sich der Fülle ihrer reichtümer rühmen?
+48:8 Ein bruder erlöst ja nicht. Wird denn ein Mensch erlösen können? * nicht wird er Gott für sich ein Sühnegeld geben
+48:9 noch den Kaufpreis für die Erlösung seiner Seele, * wenn er auch ewig sich abmüht und lebt bis ans Ende.
+48:11 Soll er den Unter gang nicht schauen, während er doch Weise dahinsterben sieht, * da gleichzeitig Tor und narr zugrunde gehen?
+48:11 Und sie werden Fremden ihre reichtümer hinterlassen, * und ihre Gräber werden auf ewig ihre Häuser sein,
+48:12 ihre Gezelte von Geschlecht zu Geschlecht, * mögen sie auch in ihren Ländereien ihre namen ausgerufen haben.
+48:13 Und der Mensch, als er in Ehren war, verstand es nicht. * Er glich dem unvernünftigen Vieh und ist ihm ähnlich geworden.
+48:14 Dieser ihr Weg wird ihnen zum Anstoß, * und hinterher werden sie durch ihr Gerede Gefallen finden.
+48:15 Wie Schafe wurden sie in die Unterwelt getrieben, * der Tod wird sie weiden.
+48:15 Und herrschen werden über sie die Gerechten am Morgen, * und ihre Hilfe welkt dahin in der Unterwelt, fern ihrer Herrlichkeit.
+48:16 Doch Gott wird meine Seele erlösen aus der Gewalt der Unterwelt, * wenn er mich aufnehmen wird.
+48:17 Fürchte dich nicht, wenn ein Mensch reich wird * und wenn sich mehrt die Herrlichkeit seines Hauses.
+48:18 Denn wenn er stirbt, wird er das alles nicht mitnehmen, * noch wird seine Herrlichkeit mit ihm hinunterfahren,
+48:19 weil seine Seele in diesem Leben gesegnet ist: * Er wird dich nur preisen, wenn du ihm wohltust.
+48:20 Er wird eingehen zum Geschlecht seiner Väter * und bis in Ewigkeit das Licht nicht schauen.
+48:21 Der Mensch, da er in Ehren war, verstand es nicht. * Er glich dem unvernünftigen Vieh und ist ihm ähnlich geworden.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm49.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm49.txt
@@ -1,24 +1,24 @@
-49:1 Deus deórum, Dóminus locútus est: * et vocávit terram,
-49:1 A solis ortu usque ad occásum: * ex Sion spécies decóris ejus.
-49:3 Deus maniféste véniet: * Deus noster et non silébit.
-49:3 Ignis in conspéctu ejus exardéscet: * et in circúitu ejus tempéstas válida.
-49:4 Advocábit cælum desúrsum: * et terram discérnere pópulum suum.
-49:5 Congregáte illi sanctos ejus: * qui órdinant testaméntum ejus super sacrifícia.
-49:6 Et annuntiábunt cæli justítiam ejus: * quóniam Deus judex est.
-49:7 Audi, pópulus meus, et loquar: Israël, et testificábor tibi: * Deus, Deus tuus ego sum.
-49:8 Non in sacrifíciis tuis árguam te: * holocáusta autem tua in conspéctu meo sunt semper.
-49:9 Non accípiam de domo tua vítulos: * neque de grégibus tuis hircos.
-49:10 Quóniam meæ sunt omnes feræ silvárum: * juménta in móntibus et boves.
-49:11 Cognóvi ómnia volatília cæli: * et pulchritúdo agri mecum est.
-49:12 Si esuríero, non dicam tibi: * meus est enim orbis terræ, et plenitúdo ejus.
-49:13 Numquid manducábo carnes taurórum? * aut sánguinem hircórum potábo?
-49:14 Ímmola Deo sacrifícium laudis: * et redde Altíssimo vota tua.
-49:15 Et ínvoca me in die tribulatiónis: * éruam te, et honorificábis me.
-49:16 Peccatóri autem dixit Deus: * Quare tu enárras justítias meas, et assúmis testaméntum meum per os tuum?
-49:17 Tu vero odísti disciplínam: * et projecísti sermónes meos retrórsum:
-49:18 Si vidébas furem, currébas cum eo: * et cum adúlteris portiónem tuam ponébas.
-49:19 Os tuum abundávit malítia: * et lingua tua concinnábat dolos.
-49:20 Sedens advérsus fratrem tuum loquebáris, et advérsus fílium matris tuæ ponébas scándalum: * hæc fecísti, et tácui.
-49:21 Existimásti, iníque, quod ero tui símilis: * árguam te, et státuam contra fáciem tuam.
-49:22 Intellígite hæc, qui obliviscímini Deum: * nequándo rápiat, et non sit qui erípiat.
-49:23 Sacrifícium laudis honorificábit me: * et illic iter, quo osténdam illi salutáre Dei.
+49:1 Der Gott der Götter, der Herr, hat gesprochen, * und er rief die Erde
+49:1 vom Aufgang der Sonne bis zum Untergang. * Von Sion her strahlt seiner Schönheit Glanz.
+49:3 Gott wird sichtbar kommen, * unser Gott, und er wird nicht schweigen.
+49:3 Feuer wird entbrennen vor seinem Angesicht * und um ihn her ein heftiger Sturm.
+49:4 Er wird herbeirufen den Himmel von oben * und die Erde, um sein Volk zu richten.
+49:5 Versammelt ihm seine Heiligen, * die den bund mit ihm errichten auf Opfern.
+49:6 Und verkünden werden die Himmel seine Gerechtigkeit, * denn Gott ist richter.
+49:7 Höre, mein Volk, und ich will reden; israel, und ich will dir bezeugen: * Gott, dein Gott bin ich.
+49:8 nicht deiner Opfer wegen will ich dich rügen, * deine brandopfer sind ja stets vor meinem Angesicht.
+49:9 ich will aus deinem Haus keine Kälber annehmen * und aus deinen Herden keine böcke,
+49:10 denn mein sind alle Tiere der Wälder, * das Vieh in den bergen und die rinder.
+49:11 ich kenne alle Vögel des Himmels, * und die Schönheit des Feldes ist mein.
+49:12 Wenn ich Hunger hätte, würde ich es dir nicht sagen, * denn mein ist der Erdkreis und seine Fülle.
+49:13 Soll ich etwa Fleisch von Stieren essen? * Oder soll ich blut von böcken trinken?
+49:14 bringe Gott ein Opfer des Lobes dar, * und erfülle dem Höchsten deine Gelübde,
+49:15 und rufe mich an am Tag der bedrängnis: * ich will dich erretten, und du sollst mich ehren.
+49:16 zum Sünder aber spricht Gott: * Warum verkündest du meine rechte und nimmst meinen bund in deinen Mund?
+49:17 Du aber hast die zucht gehasst * und meine Worte hinter dich geworfen.
+49:18 Wenn du einen Dieb erblicktest, liefst du mit ihm, * und mit Ehe brechern nahmst du deinen Anteil.
+49:19 Dein Mund floss über von bosheit, * und deine zunge flocht betrug.
+49:20 Du saßest da und redetest gegen deinen bruder, und gegen den Sohn deiner Mutter legtest du einen Fallstrick. * Das hast du getan, und ich habe geschwiegen.
+49:21 Du meintest, in deiner bosheit, ich sei dir gleich. * ich werde dich überführen und es dir vor Augen stellen.
+49:22 Kommt zur Einsicht, die ihr Gott vergesst, * damit er euch nicht hinwegraffe und keiner sei, der rettet.
+49:23 Ein Opfer des Lobes wird mich ehren, * und dort ist der Weg, auf dem ich ihm Gottes Heil zeigen will.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm51.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm51.txt
@@ -6,4 +6,4 @@
 51:8 Die Gerechten werden es sehen und sich fürchten, und sie werden ihn verlachen und sagen: * Seht, das ist der mensch, der Gott nicht zu seinem Helfer gemacht,
 51:9 sondern der seine Hoffnung auf die menge seiner reichtümer gesetzt * und sich stark dünkte in seiner nichtigkeit.
 51:10 ich aber bin wie ein fruchttragender Ölbaum im Haus Gottes, * ich habe meine Hoffnung gesetzt auf Gottes barmherzigkeit in Ewigkeit und von Ewigkeit zu Ewigkeit.
-51:11 ich will Dich preisen immerdar, denn Du hast es vollbracht, * und ich werde auf Deinen namen harren, denn gut ist er im Angesicht Deiner Heiligen. 52
+51:11 ich will Dich preisen immerdar, denn Du hast es vollbracht, * und ich werde auf Deinen namen harren, denn gut ist er im Angesicht Deiner Heiligen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm52.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm52.txt
@@ -5,4 +5,4 @@
 52:5 Werden nicht alle es einsehen, die unrecht tun, * die mein Volk verschlingen wie einen bissen brot?
 52:6 Gott haben sie nicht angerufen, * dort zitterten sie vor Furcht, wo nichts zu fürchen war,
 52:6 denn Gott zerstreut die Gebeine derer, die menschen zu gefallen suchen; * sie werden zuschanden, denn Gott hat sie verworfen.
-52:7 Wer wird von Sion Heil bringen für israel? * Wenn Gott die Gefangenschaft seines Volkes wendet, wird Jakob jubeln und israel sich freuen. sten
+52:7 Wer wird von Sion Heil bringen für israel? * Wenn Gott die Gefangenschaft seines Volkes wendet, wird Jakob jubeln und israel sich freuen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm53.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm53.txt
@@ -4,4 +4,4 @@
 53:6 Denn siehe, Gott hilft mir, * und der Herr ist es, der sich meiner Seele annimmt.
 53:7 Wende ab das böse auf meine Feinde, * und in Deiner Wahrheit vernichte sie.
 53:8 Freiwillig will ich Dir opfern * und preisen Deinen namen, Herr, denn er ist gut,
-53:9 denn aus aller bedrängnis hast Du mich errettet, * und mein Auge schaut auf meine Feinde herab. 54 i
+53:9 denn aus aller bedrängnis hast Du mich errettet, * und mein Auge schaut auf meine Feinde herab.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm54.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm54.txt
@@ -1,27 +1,27 @@
-54:2 Exáudi, Deus, oratiónem meam, et ne despéxeris deprecatiónem meam: * inténde mihi, et exáudi me.
-54:3 Contristátus sum in exercitatióne mea: * et conturbátus sum a voce inimíci, et a tribulatióne peccatóris.
-54:4 Quóniam declinavérunt in me iniquitátes: * et in ira molésti erant mihi.
-54:5 Cor meum conturbátum est in me: * et formído mortis cécidit super me.
-54:6 Timor et tremor venérunt super me: * et contexérunt me ténebræ.
-54:7 Et dixi: Quis dabit mihi pennas sicut colúmbæ, * et volábo, et requiéscam?
-54:8 Ecce, elongávi fúgiens: * et mansi in solitúdine.
-54:9 Exspectábam eum, qui salvum me fecit * a pusillanimitáte spíritus et tempestáte.
-54:10 Præcípita, Dómine, dívide linguas eórum: * quóniam vidi iniquitátem, et contradictiónem in civitáte.
-54:11 Die ac nocte circúmdabit eam super muros ejus iníquitas: * et labor in médio ejus, et injustítia.
-54:12 Et non defécit de platéis ejus * usúra, et dolus.
-54:13 Quóniam si inimícus meus maledixísset mihi, * sustinuíssem útique.
-54:13 Et si is, qui óderat me, super me magna locútus fuísset, * abscondíssem me fórsitan ab eo.
-54:14 Tu vero, homo unánimis: * dux meus, et notus meus:
-54:15 Qui simul mecum dulces capiébas cibos: * in domo Dei ambulávimus cum consénsu.
-54:16 Véniat mors super illos: * et descéndant in inférnum vivéntes:
-54:16 Quóniam nequítiæ in habitáculis eórum: * in médio eórum.
-54:17 Ego autem ad Deum clamávi: * et Dóminus salvábit me.
-54:18 Véspere, et mane, et merídie narrábo et annuntiábo: * et exáudiet vocem meam.
-54:19 Rédimet in pace ánimam meam ab his, qui appropínquant mihi: * quóniam inter multos erant mecum.
-54:20 Exáudiet Deus, et humiliábit illos, * qui est ante sæcula.
-54:20 Non enim est illis commutátio, et non timuérunt Deum: * exténdit manum suam in retribuéndo.
-54:21 Contaminavérunt testaméntum ejus, divísi sunt ab ira vultus ejus: * et appropinquávit cor illíus.
-54:22 Mollíti sunt sermónes ejus super óleum: * et ipsi sunt jácula.
-54:23 Jacta super Dóminum curam tuam, et ipse te enútriet: * non dabit in ætérnum fluctuatiónem justo.
-54:24 Tu vero, Deus, dedúces eos, * in púteum intéritus.
-54:24 Viri sánguinum, et dolósi non dimidiábunt dies suos: * ego autem sperábo in te, Dómine.
+54:2 Erhöre, o Gott, mein Gebet und verschmähe nicht mein Flehen, * achte auf mich und erhöre mich!
+54:3 ich bin betrübt in meiner Prüfung * und verwirrt durch die Stimme des Feindes und die bedrängnis durch den Sünder.
+54:4 Denn sie wälzten ungerechtigkeiten auf mich, * und im zorn waren sie mir lästig.
+54:5 mein Herz ist verwirrt in mir, * und Todesangst ist auf mich gefallen.
+54:6 Furcht und zittern kamen über mich, * und Finsternis umhüllte mich.
+54:7 und ich sprach: Wer wird mir Flügel geben wie die einer Taube, * und ich werde fortfliegen und ruhe finden?
+54:8 Siehe, ich entfernte mich fliehend, * und ich blieb in der Einsamkeit.
+54:9 ich wartete auf den, der mich rettet * aus dem Kleinmut des Geistes und dem Sturm.
+54:10 Stürze sie herab, o Herr, zerteile ihre zungen, * denn ich sah ungerechtigkeit und Aufruhr in der Stadt.
+54:11 Tag und nacht umkreist das unrecht sie auf ihren mauern, * und mühsal ist in ihrer mitte und ungerechtigkeit.
+54:12 und nicht weicht von ihren Plätzen * Wucher und betrug.
+54:13 Denn wenn mein Feind mich geschmäht hätte, * hätte ich es ertragen.
+54:13 und wenn der, der mich hasst, gegen mich geprahlt hätte, * hätte ich mich wohl vor ihm verborgen.
+54:14 Du aber, gleichgesinnter mensch, * mein Führer und mein Vertrauter,
+54:15 der du zugleich mit mir süße Speisen genossest, * im Hause Gottes sind wir gewandelt in Eintracht.
+54:16 Der Tod komme über sie, * und sie mögen lebendig hinabfahren in die unterwelt,
+54:16 denn Schlechtigkeit ist in ihren Wohnungen, * mitten unter ihnen.
+54:17 ich aber schrie zu Gott, * und der Herr wird mich retten.
+54:18 Abends und morgens und mittags will ich erzählen und kundtun, * und er wird meine Stimme erhören.
+54:19 Erlösen wird er in Frieden meine Seele von denen, die sich mir nahen, * denn in großer zahl waren sie bei mir.
+54:20 Erhören wird mich Gott und sie demütigen, * der da ist vor aller zeit.
+54:20 Denn sie ändern sich nicht und fürchten Gott nicht; * ausgestreckt hat er seine Hand zur Vergeltung.
+54:21 Sie haben seinen bund entehrt, und sie wurden zerstreut vom zorn seines Angesichts, * und sein Herz hat sich genaht.
+54:22 Gelinder als Öl sind seine Worte, * und gleichwohl sind sie Pfeile.
+54:23 Wirf deine Sorge auf den Herrn, und er wird dich ernähren, * nicht auf immer wird er wanken lassen den Gerechten.
+54:24 Du aber, Gott, wirst sie hinabstürzen * in die Grube des Verderbens.
+54:24 Die männer voll blutschuld und die betrüger sollen nicht die Hälfte ihrer Tage erreichen; * ich aber hoffe auf Dich, o Herr.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm55.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm55.txt
@@ -10,4 +10,4 @@
 55:10 an welchem Tag auch immer ich zu Dir rufe. * Siehe, ich habe erkannt, dass Du mein Gott bist.
 55:11 in Gott will ich rühmen sein Wort, im Herrn will ich rühmen seine rede, * auf Gott habe ich meine Hoffnung gesetzt, ich will nicht fürchten, was ein mensch mir antut.
 55:12 in mir, o Gott, sind Deine Gelübde, * die ich erfüllen will zu Deinem lob,
-55:13 denn Du hast meine Seele dem Tod entrissen und meine Füße dem Fall, * damit ich Wohlgefallen finde vor Gott im licht der lebenden. 56
+55:13 denn Du hast meine Seele dem Tod entrissen und meine Füße dem Fall, * damit ich Wohlgefallen finde vor Gott im licht der lebenden.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm56.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm56.txt
@@ -11,4 +11,4 @@
 56:9 Steh auf, mein ruhm, steht auf, Psalter und zither, * in der morgendämmerung will ich mich erheben.
 56:10 Preisen will ich Dich bei den Völkern, o Herr, * und einen Psalm Dir singen unter den Heiden,
 56:11 denn groß bis zum Himmel ist Deine barmherzigkeit * und bis zu den Wolken Deine Wahrheit.
-56:12 Erhebe Dich über die Himmel, o Gott, * und über die ganze Erde Deine Herrlichkeit. 57
+56:12 Erhebe Dich über die Himmel, o Gott, * und über die ganze Erde Deine Herrlichkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm57.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm57.txt
@@ -8,4 +8,4 @@
 57:9 Wie Wachs, das zerfließt, werden sie dahinschwinden, * Feuer fiel auf sie herab, und nicht sahen sie die Sonne.
 57:10 bevor eure Dornen den Strauch erkennen, * wird er sie wie lebendig im zorn verschlingen.
 57:11 Freuen wird sich der Gerechte, wenn er die Strafe sieht, * seine Hände wird er waschen im blut des Sünders.
-57:12 und sagen wird der mensch: Ja, wahrlich hat lohn der Gerechte, * gar wohl gibt es Gott, der sie richtet auf Erden. sten
+57:12 und sagen wird der mensch: Ja, wahrlich hat lohn der Gerechte, * gar wohl gibt es Gott, der sie richtet auf Erden.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm58.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm58.txt
@@ -1,20 +1,20 @@
-58:2 Éripe me de inimícis meis, Deus meus: * et ab insurgéntibus in me líbera me.
-58:3 Éripe me de operántibus iniquitátem: * et de viris sánguinum salva me.
-58:4 Quia ecce cepérunt ánimam meam: * irruérunt in me fortes.
-58:5 Neque iníquitas mea, neque peccátum meum, Dómine: * sine iniquitáte cucúrri, et diréxi.
-58:6 Exsúrge in occúrsum meum, et vide: * et tu, Dómine, Deus virtútum, Deus Israël,
-58:6 Inténde ad visitándas omnes gentes: * non misereáris ómnibus, qui operántur iniquitátem.
-58:7 Converténtur ad vésperam: et famem patiéntur ut canes, * et circuíbunt civitátem.
-58:8 Ecce, loquéntur in ore suo, et gládius in lábiis eórum: * quóniam quis audívit?
-58:9 Et tu, Dómine, deridébis eos: * ad níhilum dedúces omnes gentes.
-58:10 Fortitúdinem meam ad te custódiam, quia, Deus, suscéptor meus es: * Deus meus, misericórdia ejus prævéniet me.
-58:12 Deus osténdet mihi super inimícos meos, ne occídas eos: * nequándo obliviscántur pópuli mei.
-58:12 Dispérge illos in virtúte tua: * et depóne eos, protéctor meus, Dómine:
-58:13 Delíctum oris eórum, sermónem labiórum ipsórum: * et comprehendántur in supérbia sua.
-58:13 Et de exsecratióne et mendácio annuntiabúntur in consummatióne: * in ira consummatiónis, et non erunt.
-58:14 Et scient quia Deus dominábitur Jacob: * et fínium terræ.
-58:15 Converténtur ad vésperam: et famem patiéntur ut canes, * et circuíbunt civitátem.
-58:16 Ipsi dispergéntur ad manducándum: * si vero non fúerint saturáti, et murmurábunt.
-58:17 Ego autem cantábo fortitúdinem tuam: * et exsultábo mane misericórdiam tuam.
-58:17 Quia factus es suscéptor meus, * et refúgium meum, in die tribulatiónis meæ.
-58:18 Adjútor meus, tibi psallam, quia, Deus, suscéptor meus es: * Deus meus, misericórdia mea.
+58:2 Entreiße mich meinen Feinden, mein Gott, * und von denen, die sich gegen mich erheben, befreie mich.
+58:3 Entreiße mich denen, die unrecht tun, * und von männern voll blutschuld rette mich.
+58:4 Denn siehe, sie ergriffen meine Seele, * Starke überfielen mich.
+58:5 Es ist weder meine missetat noch meine Sünde, Herr; * ohne missetat und gerade bin ich gewandelt.
+58:6 Erhebe Dich, komm mir entgegen und sieh: * und Du, Herr, Gott der Heerscharen, Gott israels,
+58:6 achte darauf, alle Völker heimzusuchen, * hab kein Erbarmen mit allen, die unrecht tun.
+58:7 zurückkehren werden sie am Abend und Hunger leiden wie Hunde, * und sie werden die Stadt umkreisen.
+58:8 Siehe, sie geifern mit ihrem mund und ein Schwert ist auf ihren lippen, * denn wer hat es gehört?
+58:9 Aber Du, Herr, wirst sie verlachen, * zu nichts wirst Du machen alle Völker.
+58:10 meine Stärke will ich bei Dir bewahren, denn Du, o Gott, bist es, der mich aufnimmt, * mein Gott, seine barmherzigkeit wird mir zuvorkommen.
+58:12 Gott wird es mir zeigen an meinen Feinden, töte sie nicht, * damit meine Volksgenossen es nicht vergessen.
+58:12 zerstreue sie in Deiner Kraft, * und setze sie herab, mein beschützer, Herr.
+58:13 Das Vergehen ihres mundes, die rede ihrer lippen: * Sie sollen sich verfangen in ihrem Hochmut.
+58:13 um des Fluches und der lüge willen wird man verkünden ihre Vertilgung * durch vertilgenden zorn, und sie werden nicht mehr sein.
+58:14 und sie sollen wissen, dass Gott über Jakob herrscht * und über die Enden der Erde.
+58:15 zurückkehren werden sie am Abend und Hunger leiden wie Hunde, * und sie werden die Stadt umkreisen.
+58:16 Sie werden sich zerstreuen um nahrung zu suchen, * wenn sie aber nicht satt werden, werden sie murren.
+58:17 ich aber will Deine Stärke besingen * und am morgen frohlocken über Deine barmherzigkeit.
+58:17 Denn Du bist es, der mich aufnimmt, * und meine zuflucht am Tag meiner Trübsal.
+58:18 mein Helfer, Dir will ich spielen, denn Du, Gott, bist es, der mich aufnimmt, * mein Gott, meine barmherzigkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm59.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm59.txt
@@ -10,4 +10,4 @@
 59:11 Wer wird mich hinabführen in die befestigte Stadt? * Wer wird mich hinabführen bis nach idumäa?
 59:12 nicht Du, o Gott, der Du uns verstoßen hast? * und wirst Du nicht ausziehen, o Gott, mit unseren Heeren?
 59:13 Gib uns Hilfe aus der bedrängnis, * denn nichtig ist das Heil vom menschen.
-59:14 mit Gott werden wir kraftvoll handeln, * und er wird zunichte machen, die uns bedrängen. sten
+59:14 mit Gott werden wir kraftvoll handeln, * und er wird zunichte machen, die uns bedrängen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm62.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm62.txt
@@ -7,4 +7,4 @@
 62:7 Gedenke ich Deiner auf meinem lager, so sinne ich noch am morgen über Dich, * denn Du warst mein Helfer,
 62:8b und im Schutz Deiner Flügel will ich jubeln. meine Seele hängt an Dir, * Deine rechte nahm mich auf.
 62:10 Jene aber suchten vergeblich meine Seele, sie werden hinabfahren in die Tiefen der Erde, * sie werden der Gewalt des Schwertes preisgegeben, eine beute der Füchse werden sie sein.
-62:12 Der König aber wird sich freuen in Gott, gepriesen ein jeder, der bei ihm schwört, * denn verstopft wurde der mund derer, die unrecht reden. drei Jünglinge 4
+62:12 Der König aber wird sich freuen in Gott, gepriesen ein jeder, der bei ihm schwört, * denn verstopft wurde der mund derer, die unrecht reden.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm65.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm65.txt
@@ -1,19 +1,19 @@
-65:1 Laut jubelt dem Herrn nun, ihr sämtlichen Länder! Ihm lasset zu Ehren die Harfen erschallen, * o singet begeistert sein Festlob.
-65:2 Nun saget doch Gott: „Wie ist doch erhaben, o Herr, dein sämtliches Wirken; * bei solcher Größe der Allmacht, da müssen zu Füßen dir fallen die Feinde.
-65:3 O mögen nun huldigen dir die sämtlichen Länder, auf Harfen dir spielen zu Ehren, * in Harfenbegleitung besingen deine erhabene Hoheit.“
-65:4 O kommt nur und schauet, was Gott uns getan hat, * er ist doch erhaben in seinen Entschlüssen über die Menschen.
-65:5 Von ihm, der einstens das Meer gewandelt hat in trockene Erde, dass sie zu Fuß durchschritten das Wasser, * von ihm erleben wir heute die Freude.
-65:6 Er bleibt doch mit seiner Gewalt der Gebieter auf ewig, sein Auge durchmustert die Völker; * die feindlich ihm sind, die werden niemals zu Siege gelangen.
-65:7 O preiset ihr Völker, unseren Gott nun, * laut lasset ertönen sein Loblied.
-65:8 Der uns am Leben erhalten, * und unsere Füße bewahrt vor dem Falle.
-65:9 Ja, Prüfung, o Gott, hast du uns genügend bereitet, * hast uns geläutert im Feuer, genau wie man läutert das Silber.
-65:10 Du hast uns geraten lassen ins Fangnetz, * hast schwere Lasten geladen auf unseren Rücken.
-65:11 Du hast auf das Haupt uns treten lassen die Feinde, (65:11) wir mussten durch Feuer und Wasser hindurchgeh'n, * nun hast du hinaus uns geführt und erquickst uns.
-65:13 Wir treten hinein in dein Haus zum feierlich brennenden Opfer; * und statten dir ab nun unser Gelübde,
-65:14 Wie's einst unsere Lippen gesagt (65:14) und unsere Worte versprochen, * als uns die Gefahr so bedrohte.
-65:15 Zum brennenden Opfer bieten wir nun die fettesten Stiere, mitbrennen und rauchen sollen die Böcke; * wir bringen dir also Stiere mit Böcken.
-65:16 Nun kommet und höret, ihr sämtlichen Gottesverehrer, * ich will euch erzählen, was Gott mir getan hat.
-65:17 Zu ihm habe ich so innig gerufen: * „Mein Dank ist schon unter der Zunge.
-65:18 Wär ich mir bewusst eines Unrechts in meinem Gewissen, * soll Gott mich gar nicht erst hören.“
-65:19 Nun sehet, wie Gott mich erhört hat * und beachtet mein inniges Flehen.
-65:20 Drum sei nun gepriesen, O Gott, der du nicht gewiesen von dir mein inniges Bitten, * mir nicht dein Erbarmen versagt hast.
+65:1 Jauchzt Gott zu, alle Lande, singt einen Psalm seinem namen, * lasst herrlich sein sein Lob.
+65:2 Sprecht zu Gott: Wie furchtbar sind Deine Werke, o Herr! * Ob der Fülle Deiner Macht schmeicheln Dir selbst Deine Feinde.
+65:3 Die ganze Erde bete Dich an und spiele Dir, * sie singe einen Psalm Deinem namen.
+65:4 Kommt und schaut die Werke Gottes: * Furchtbar ist er in seinen ratschlüssen über die Menschenkinder.
+65:5 Er verwandelt das Meer in Trockenes, durch einen Strom werden sie zu Fuß hinübergehn, * dort werden wir uns freuen über ihm.
+65:6 Der da herrscht in seiner Kraft in Ewigkeit, seine Augen schauen auf die Völker. * Die sich erbittern (= die rebellen), sollen sich nicht bei sich selbst überheben.
+65:7 Preiset, ihr Völker, unseren Gott * und lasst hören den Klang seines Lobes.
+65:8 Der meine Seele ins Leben gesetzt * und meine Füße nicht hat straucheln lassen.
+65:9 Denn Du hast uns geprüft, Gott; * mit Feuer uns geläutert, wie man läutert das Silber.
+65:10 Du hast uns in die Schlinge geführt, legtest Trübsal auf unseren rücken, * Menschen hast Du gesetzt über unsere Häupter.
+65:11 Wir gingen durch Feuer und Wasser, * und Du hast uns herausgeführt in die Erquickung.
+65:13 Eintreten will ich in Dein Haus mit brandopfern, * Dir erfüllen meine Gelübde, die meine Lippen bestimmt
+65:14 und mein Mund versprach * in meiner Trübsal.
+65:15 Fette brandopfer will ich Dir bringen mit dem Opferduft von Widdern, * rinder Dir darbringen mit böcken.
+65:16 Kommt her, hört, und ich will erzählen, alle, die ihr Gott fürchtet, * wie Großes er für meine Seele getan.
+65:17 zu ihm rief ich mit meinem Mund, * und erhöhte ihn unter meiner zunge.
+65:18 Hätte ich Unrecht erblickt in meinem Herzen, * hätte der Herr mich nicht erhört.
+65:19 Darum hat mich Gott erhört * und geachtet auf die Stimme meines Flehens.
+65:20 Gepriesen sei Gott, * der nicht wegnahm mein Gebet, noch seine barmherzigkeit von mir.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm67.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm67.txt
@@ -1,38 +1,38 @@
-67:2 Hoch throne nun Gott und es weiche zurück, was feindlich gesinnt ihm, * es flüchte vor ihm, was gegen ihn auftritt.
-67:3 Wie Rauch verschwindet im Winde, soll alles verschwinden; * wie Wachs zerrinnet im Feuer, so mögen vor Gott umkommen die Frevler.
-67:4 Sein Volk aber feiere Feste und hüpfe in Gegenwart Gottes * und schwelge in Freude.
-67:5a O singet doch Gott, lasst ihm nun zu Ehren ertönen die Lieder; * o bahnet den Weg ihm, der aufsteigt am heutigen Abend. Und rufet: „Der Herr ist's, der Herr ist's“, 
-67:5b macht Reigen vor ihm, * damit ihm zu Ehren alles sich rege; (6a) Zu Ehren dem Vater für alle, die Waisen, dem Schützer für alle, die Witwen geworden, 
-67:6b zu Ehren dem Herrn auf seinem heiligen Throne. * (7a) Zu Ehren dem Gott, der zurückbringt die lange abwesenden Krieger zur Heimat, 
-67:7b der machtvoll befreit hat unsre Gefang’nen, * Sich ebenso machtvoll erwiesen den Feinden, die draußen in Gräbern nun liegen.
-67:8 O Gott, als du deinem Volk vorangingst, * als du durchschrittest die Wüste,
-67:9 Da bebte die Erde, ja, Regen ließ träufeln, o Gott, vor dir gar der Himmel, * der Sinai bebte vor Israels Gotte.
-67:10 Gar lieblichen Regen hast du dort, o Gott, deinem Volke gespendet; * es wäre verschmachtet, doch du hieltest es bei Kräften.
-67:11 So konnten nun deine Schäflein dort bleiben; * du warst ja in deiner Zärtlichkeit ihnen, o Gott, in der Not ein guter Versorger.
-67:12 Nun gabst du, o Herr, gar fröhliche Kunde den Boten, * vom herrlichen Siege:
-67:13 „Die mächtigen Feldherrn, sie liefen davon in flüchtender Eile, * die Hausfrau bekommt gar reichliche Beute zu teilen.
-67:14 Nun könnt ihr in Ruhe euch lagern in euren Gehegen, geschmückt wie die Tauben mit silbernen Flügeln, * mit goldschimmerndem Schwanze.
-67:15 Als nämlich der himmlische Feldherr daselbst die Führer verjagte, gab's Beute, wie wenn von Schneeflocken weiß ist der Salmon.“ * (16a) Gar mächtige Berge sind Basans Gebirge, * 
-67:16b gar massige Berge sind Basans Gebirge. * (17a) Was aber schauet ihr scheel an, ihr massigen Berge, 
-67:17b den Berg, auf dem Gott es gefallen, die Wohnung zu nehmen, * sogar wo der Herr wohnen will auf ewig?
-67:18 Wo nun den Triumphsitz Gottes umringen Zehntausende und Tausende jubeln: „Der Herr ist auf ihm dort“, * tritt Sinai selbst uns vor Augen inmitten der heiligen Lade.
-67:19a So steigst du hinauf und führst die Gefangenen mit dir; * die musst du nun nehmen als menschliche Weihegeschenke.
-67:19b So werden selbst trotzige Feinde * nun wohnen beim Herrgott.
-67:20 O sei doch gepriesen, o Herrgott, von Tage zum Tage, * dass du uns den schönen Triumphzug bereitest, o Gott, du unsere Heilsburg.
-67:21 Du bist, unser Gott, doch ein Gott der herrlichsten Siege, * und du bist, o Herr, ein Herr selbst über die Tore des Todes.
-67:22 Du konntest allein zerschmettern, o Gott, die Häupter der Feinde, * die struppigen Scheitel der Frevler, die ständig in ihren Freveln verharren.
-67:23 Du hast ja versprochen, o Herr: „Von Basan will ich sie bringen, * ich bringe sie dir aus den Winkeln am Meere.
-67:24 So daß dein Fuß kann tauchen im Blute, * und, ob der Menge der Feinde, sich laben kann die Zunge der Hunde.
-67:25 Nun sieht man, o Gott, noch deinen Triumphzug, * es ist das unseres Gottes Triumphzug, es ist unser König auf heiligem Throne.
-67:26 Voran dort schreiten die Feldherrn, gleich hinter den Musikerchören, * inmitten der paukenschlagenden Jungfrau'n.
-67:27 Nach Stämmen nun preiset den Herrgott, * ihr alle, in denen Israels Blut quillt;
-67:28a Ihr dort, Benjamins Söhne, des Jüngsten, * die ihr kommt in wahrer Verzückung,
-67:28b Ihr Feldherrn von Juda, ihr Führer der Eurigen, * Feldherrn von Zabulon, Nephthalis Feldherrn!
-67:29 O zeige nun, Gott, deine Allmacht, * vollende, o Gott, was mitten in uns du heute getan hast.
-67:30 Im Tempel, wo du in Jerusalem wohnest, * laß sämtliche Könige Opfer dir bringen.
-67:31a Ruf drohend herbei die Bewohner des Schilflands, * daß dieses so mächtige Volk als erstes der Völker herzueilt, mit Silber beladene Boten zu senden.
-67:31b Fern halte die Horden, die Luft zu Kriegen noch haben. (32) Laß kommen Gesandte Ägyptens, * auch Äthiopier sollen nun schnellstens zu dir erheben, o Gott, ihre Hände.
-67:33a Ihr Reiche der Erde, stimmt an Gottes Lobesgesänge, * laßt Harfen dem Herrn zu Ehren ertönen, 
-67:33b laßt Gott doch hören die Harfen. (34a) Der aufgestiegen zum obersten Himmel, * in sonnige Höhen, 
-67:34b von wo aus er hören wird lassen sein kräftiges Krachen. (35) Erweiset doch Ehre dem Gott, der Israels Gott ist, * und dessen unendliche Würde und Allmacht sich birgt in den Wolken;
-67:36 O du glorreicher Gott in deiner erhabenen Wohnung, o Israels Gott du, der Stärke du spendest und Kraft deinem Volke, * o Gott, sei gepriesen!
+67:2 Es erhebe sich Gott, dass zerstreut werden seine Feinde, * und fliehen sollen, die ihn hassen, vor seinem Angesicht.
+67:3 Wie rauch vergeht, sollen sie vergehen, * wie Wachs zerfließt vor dem Angesicht des Feuers, so sollen die Sünder vor dem Angesicht Gottes zugrunde gehen.
+67:4 Und die Gerechten sollen ein Festmahl halten und jubeln vor Gottes Angesicht * und es genießen in Fröhlichkeit.
+67:5a Singt Gott, sprecht einen Psalm seinem namen, * bahnt dem einem Weg, der aufsteigt über den Untergang: Herr ist sein name.
+67:5b Frohlockt vor seinem Angesicht, * sie werden bestürzt sein vor seinem Angesicht , des Vaters der Waisen und des richters der Witwen.
+67:6b Gott ist an seinem heiligen Ort, * Gott, der Gleichgesittete beisammen wohnen lässt im Haus,
+67:7b der die Gefesselten herausführt mit Macht, * ebenso jene, die wider spenstig sind, die in Gräbern wohnen.
+67:8 Gott, als Du auszogst vor dem Angesicht Deines Volkes, * als Du einherzogest in der Wüste,
+67:9 da erbebte die Erde, ja auch die Himmel ergossen sich vor dem Angesicht Gottes vom Sinai, * vor dem Angesicht des Gottes israels.
+67:10 reichlichen regen wirst Du absondern, Gott, für Dein Erbe, * zwar war es schwach, aber Du hast es vollendet.
+67:11 Deine Lebewesen werden darin wohnen, * in Deiner Lieblichkeit hast Du es für den Armen bereitet, Gott.
+67:12 Der Herr gibt das Wort denen, die die Heilsbotschaft verkünden * mit großer Macht,
+67:13 Er ist der König der Heere des Vielgeliebten! * und die zierde des Hauses (die Hausfrau) lässt er beute verteilen.
+67:14 Wenn ihr ruht inmitten eurer Losanteile, da leuchten die Flügel der Taube (israel) versilbert, * und ihr rücken schimmert in mattem Goldglanz.
+67:15 Wenn der Himmlische über ihr (der Taube israel) Könige zerstreut (besiegt), werden sie wie durch Schnee gebleicht auf dem Selmon (dem Finsterberg). * Der berg Gottes ist ein fetttriefender berg.
+67:16b Ein festgefügter berg ist er, ein fetttriefender berg. * Warum blickt ihr so argwöhnisch auf die fest gefügten berge?
+67:17b Es ist der berg, auf dem es Gott gefallen hat zu wohnen, * denn der Herr wird dort wohnen für immer.
+67:18 Die Wagen Gottes sind zehntausendfach, Tausende sind es, die sich freuen. * Der Herr ist unter ihnen, auf dem Sinai, im Heiligtum.
+67:19a Du stiegst empor zur Höhe, nahmst gefangen die Gefangenschaft, * Du empfingst Gaben unter den Menschen.
+67:19b Sogar auch Ungläubige, * dass sie wohnen bei Gott, dem Herrn.
+67:20 Gebenedeit sei der Herr alle Tage, * einen glücklichen Weg wird uns der Gott unseres Heils bereiten.
+67:21 Unser Gott ist ein Gott, der rettung schafft, * und des Herrn, ja, des Herrn sind die Wege heraus aus dem Tod.
+67:22 Ja, Gott wird zerschmettern die Häupter seiner Feinde, * den Scheitel des Haares derer, die dahinwandeln in ihren Sünden.
+67:23 Es sprach der Herr: Aus basan (dem Fettland) werde ich sie zurückführen, * führe sie hinein in die Tiefe des Meeres,
+67:24 damit eingetaucht werde dein Fuß in blut, * die zunge deiner Hunde in das aus den Feinden, von ihm her.
+67:25 Sie sahen Deine Einzüge, Gott, * die Einzüge meines Gottes, meines Königs, der im Heiligtum ist.
+67:26 Voran zogen Fürsten, sich anschließend den Spielenden, * inmitten paukenschlagender Mädchen.
+67:27 in den Versammlungen preiset Gott, den Herrn, * ihr, aus israels Quellen.
+67:28a Dort ist benjamin, der Jüngste, * in Entrückung des Geistes,
+67:28b die Fürsten von Juda, ihre Führer, * die Fürsten von zabulon, die Fürsten von naphtali.
+67:29 Entbiete, Gott, Deine Kraft, * bekräftige, Gott, was Du in uns gewirkt hast,
+67:30 von Deinem Tempel aus in Jeru salem. * Dir werden Könige Gaben bringen.
+67:31a bedrohe die wilden Tiere des Schilfs, eine Horde von Stieren ist bei den Kälbern der Völker, * damit sie sie ausschließen, die erprobt sind wie Silber.
+67:31b zerstreue die Völker, die Kriege wollen! Gesandte werden kommen aus ägypten, * äthiopien wird ausstrecken seine Hände zu Gott.
+67:33a ihr Königreiche der Erde, singet Gott, * spielt dem Herrn.
+67:33b Spielt Gott, der aufstieg über den Himmel des Himmels, * dem Aufgang zu.
+67:34b Siehe, er wird geben seiner Stimme den Klang von Kraft. Gebt Gott die Ehre wegen israel! * Seine Hoheit und seine Macht sind in den Wolken.
+67:36 Wunderbar ist Gott in seinen Heiligen, der Gott israels selbst wird Stärke geben und Kraft seinem Volk. * Gepriesen sei Gott!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm68.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm68.txt
@@ -1,42 +1,42 @@
-68:1 Rette mich, o Gott, denn Wogen dringen ein auf mich, mein Leben hart bedrohend.
-68:2 Eingesunken bin ich in den tiefsten Sumpf, * wo keinen Halt ich habe.
-68:3 Eingetaucht bin ich ins tiefe Meer * und ganz bedeckt die Flut mich.
-68:4 Matt bin ich vom Schreien, heiser ist bereits mein Schlund, * die Augen werden müde, da ich stets nach meinem Gott ausschaue.
-68:5 Zahlreich wie die Haare auf dem Haupt, * sind meine ungerechten Hasser.
-68:6 Mächtig sind geworden die, die mich verfolgen ohne Grund: * was niemals ich verschuldet, soll trotzdem ich büßen.
-68:7 Gott, du kennst doch meinen Schmerz, * und meine Leiden sind dir nicht verborgen.
-68:8 Lass an mir nicht irre werden, die auf dich vertrauen, Herr; * o Herr, der du ja alle Macht hast.
-68:9 Lass bei meinem Anblick nicht verzweifeln die, * die, o Gott Israels, treu zu dir halten.
-68:10 Deinetwegen trage ich doch dieses Leid, * und deinetwegen deckt die Schmach mein Antlitz.
-68:11 Deinetwegen bin ich von meinen Brüdern getrennt, * und werd als Feind betrachtet von den Kindern meiner Mutter.
-68:12 Denn der Eifer für dein Haus verzehret mich, * und der dich Schmähenden Schmach fällt über mich.
-68:13 Wenn ich mir im Fasten Abbruch tu, * schon daraus machen sie mir einen Vorwurf.
-68:13 Nehm ich als Gewand ein Büßerkleid, * gleich werde ich ein Gegenstand des Witzes.
-68:13 Spöttisch reden gegen mich, die an dem Stadttor müßig steh'n, * mich pfeifen höhnisch aus die Zecher.
-68:13 Ach, ich sende mein Gebet, o Herr; * Zeit ist's, Gott, dass du dich gnädig zeigest.
-68:14 Gemäß der Größe deiner Huld erhöre mich, * mit aller Güte, die in deinem Segensschatz du findest.
-68:15 Ziehe mich, dass ich nicht ganz versinke in dem Sumpf, * o rette mich vor meinen Hassern, rett mich aus den tiefen Fluten.
-68:16 Lass die Wasserflut mich nicht begraben, dass nicht ganz die Tiefe mich verschlingt, * und über mir alsdann sich schließt der Abgrund.
-68:17 Höre mich, o Herr, da deine Huld so gütig ist; * mit all der Menge, die du an Erbarmen hast, blick auf mich nieder.
-68:18 Wende doch dein Angesicht nicht ab von deinem Knecht; * ach, ich bin in Gefahr, erhör mich eiligst.
-68:19 Habe Acht auf mich und schütze mich; * dass meine Feinde mich nicht fassen, sei mir Retter.
-68:20 Du erkennst doch all mein Leid und den mir zugefügten Schimpf * und die mir angetane Schmähung.
-68:21 Dir sind alle gut bekannt, * die mir bereiten dieses Elend.
-68:21 Leid erfährt mein Herz und Not; (68:22) ich harre, ob mit mir nicht jemand Mitleid zeigt, und keiner kommt, * ob mich nicht einer tröstet, aber keinen find ich.
-68:23 Dafür geben sie als Speise Galle mir * und da ich dürste, bieten sie mir Essig an zum Trinken.
-68:24 Möge ihnen eine Falle sein ihr Mittagsmahl, * zum Strafgericht und zum Verderben ihnen werden.
-68:25 Finsternis bedecke ihre Augen, dass sie gar nichts seh'n, * und ihren Rücken lasse stets gebeugt einhergeh'.
-68:26 Gieße deinen Zorn ganz aus auf sie, * lass deines Zornes Grimm sie fassen.
-68:27 Öde werden mag ihr Haus, * in ihren Wohnungen soll keiner wohnen.
-68:28 Weil sie mich verfolgen, den du ohnehin schon schlägst, * und meiner Wunden Weh vergrößern.
-68:29 Sende ihnen Leid für alles mir von ihnen angetane Leid, * und lass sie nicht bei dir in Gnaden kommen.
-68:29 Ausgestrichen sollen ganz sie werden aus dem Lebensbuch, * zum Volke Gottes gar nicht zählen.
-68:30 Doch wo ich so arm und leidend bin, da umfasst mich, Gott, dein Rettersegen.
-68:31 So will ich preisen den Namen Gottes mit Gesang; * und ihn verherrlichen mit Lob.
-68:32 Das wird Gott mehr gefallen als ein junges Kalb, * dem Hörner und Klauen wachsen.
-68:33 Wenn Bedrängte solches sehen, sollen sie sich freu'n; * suchet Gott, so wird leben eure Seele.
-68:34 Ja, es hört die Hilflosen der Herr, * und die für ihn in Ketten schmachten, pflegt er nicht zu übersehen.
-68:35 Loben soll der Himmel und die Erde ihn, * das Meer und alles, was daran und drin umherkriecht.
-68:36 Denn Gott wird Sion helfen * und Judas Städte werden erbauet werden.
-68:37 Und sie werden daselbst wohnen * und es einnehmen als Erbe.
-68:37 Und der Nachwuchs seiner Knechte wird es besitzen, * und die seinen Namen lieben, werden darin wohnen.
+68:1 rette mich, Gott, * denn Wasser drangen bis an meine Seele.
+68:2 ich stecke im tiefen Schlamm, * und es gibt keinen Halt.
+68:3 ich geriet in die Tiefe des Meeres, * und ein Sturm hat mich versenkt.
+68:4 ich mühte mich schreiend, heiser geworden ist meine Kehle, * meine Augen haben sich verzehrt, während ich hoffe auf meinen Gott.
+68:5 Es haben sich vervielfacht, mehr als die Haare meines Hauptes, * die mich hassen ohne Grund.
+68:6 Stark geworden sind meine Feinde, die mich ungerecht verfolgen, * was ich nicht geraubt, musste ich erstatten.
+68:7 Gott, Du kennst meine Torheit, * und meine Vergehen sind vor Dir nicht verborgen.
+68:8 Lass nicht meinetwegen zuschanden werden, die auf Dich harren, Herr, * Herr der Heerscharen.
+68:9 Lass nicht meinetwegen beschämt werden, * die Dich suchen, Gott israels.
+68:10 Denn für Dich ertrug ich Schmach, * bedeckte Scham mein Angesicht.
+68:11 Fremd geworden bin ich meinen brüdern, * ein Fremdling den Söhnen meiner Mutter.
+68:12 Denn der Eifer für Dein Haus hat mich verzehrt, * und die Schmähungen derer, die Dich schmähen, sind auf mich gefallen.
+68:13 Und ich verhüllte im Fasten meine Seele, * und es gereichte mir zur Schmach.
+68:13 Und ich legte als meine Kleidung einen Sack an, * und ich wurde ihnen zum Spottlied.
+68:13 Gegen mich redeten jene, die am Tor saßen, * und auf mich sangen die, die Wein tranken.
+68:13 ich aber richte mein Gebet zu Dir, o Herr, * zur zeit der Huld, o Gott.
+68:14 in der Fülle Deiner barmherzigkeit erhöre mich, * in der Wahrheit Deines Heils.
+68:15 reiße mich heraus aus dem Schlamm, damit ich nicht stecken bleibe, * befreie mich von denen, die mich hassen, und aus den Tiefen der Wasser.
+68:16 nicht ertränke mich die Wasserflut, noch verschlinge mich die Tiefe, * und nicht schließe über mir die Grube ihren rachen.
+68:17 Erhöre mich, Herr, denn gütig ist Deine barmherzigkeit, * nach der Menge Deiner Erbarmungen schau auf mich.
+68:18 Und wende Dein Angesicht nicht ab von Deinem Knecht, * denn ich werde bedrängt; eilends erhöre mich!
+68:19 Achte auf meine Seele und erlöse sie, * meiner Feinde wegen reiße mich heraus.
+68:20 Du kennst meine Schmach und meine Schande * und meine beschämung.
+68:21 Vor Deinem Angesicht sind alle, die mich bedrängen, * Schmach erwartet mein Herz und Elend.
+68:21 Und ich harrte auf einen, der zugleich mit mir trauere, und es war keiner, * und einen, der tröste, und ich fand keinen.
+68:23 Und sie gaben mir Galle zur Speise, * und in meinem Durst tränkten sie mich mit Essig.
+68:24 ihr Tisch soll vor ihnen zur Schlinge werden * und zur Vergeltung und zum Anstoß.
+68:25 Finster sollen ihre Augen werden, damit sie nicht sehen, * und ihren rücken krümme für immer.
+68:26 Gieße aus über sie Deinen zorn, * und der Grimm Deines zornes ergreife sie.
+68:27 ihr Wohnsitz werde wüst, * und niemand sei, der in ihren zelten wohnt.
+68:28 Denn den Du geschlagen hast, den haben sie verfolgt * und zu dem Schmerz meiner Wunden noch hinzugetan.
+68:29 Häufe Unrecht auf ihr Unrecht, * und nicht sollen sie eingehen in Deine Gerechtigkeit.
+68:29 Sie sollen getilgt werden aus dem buch der Lebenden, * und mit den Gerechten nicht verzeichnet werden.
+68:30 ich bin arm und leidend, * Dein Heil, o Gott, hat mich aufgenommen.
+68:31 Loben will ich den namen Gottes mit Gesang, * und ihn verherrlichen mit Lob.
+68:32 Und es wird Gott mehr gefallen als ein junges Kalb, * dem Hörner wachsen und Hufe.
+68:33 Es sollen sehen die Armen und sich freuen; * suchet Gott, und eure Seele wird leben.
+68:34 Denn der Herr hat die Armen erhört * und seine Gefangenen nicht verachtet.
+68:35 Loben sollen ihn Himmel und Erde, * das Meer und alles, was darin sich regt.
+68:36 Denn Gott wird Sion retten, * und die Städte Judas werden aufgebaut werden.
+68:37 Und sie werden dort wohnen, * und es als Erbe gewinnen.
+68:37 Und die nachkommen seiner Knechte werden es besitzen, * und die seinen namen lieben, werden darin wohnen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm7.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm7.txt
@@ -1,18 +1,18 @@
-7:2 Herr, mein Gott, auf dich vertrau ich, * schütze mich vor allen meinen Feinden, sei mein Retter.
-7:3 Daß nicht einer wie ein Löwe mich verschlinge, * wenn ich keinen Schützer hab und keinen Helfer.
-7:4 Herr, mein Gott, wenn ich verübt, was gegen mich sie zeugen, * wenn an meinen Händen eine Schuld klebt,
-7:5 Wenn ich denen, die mir Unrecht taten, Unrecht hab vergolten, * dann mag ich von meinen Feinden umgebracht zu Boden sinken,
-7:6 Dann mag mich der Feind verfolgen, † und wenn er mich faßt, lebendig auf dem Boden mich zertreten * und mir meine Königskrone ganz zu Staub zermalmen.
-7:7a Spring doch auf, o Herr, in deinem Zorne, * zeige deine Macht inmitten meiner Feinde.
-7:7b Ja, spring auf, o Herr, mein Gott du, zeige treu dich dem Gebot, das selbst du uns gegeben. * (8a) Laß der Mannen ganzen Haufen sich um dich versammeln.
-7:8b Und in ihrer Gegenwart nimm Platz auf deinem Throne, * (9a) Herr und Völkerrichter.
-7:9b Nimm in Schutz mich, daß mein Recht sich zeige, * meine Unschuld, die an mir du wahrnimmst.
-7:10 Es muß doch ein Ende haben die Gemeinheit der Verleumder und du mußt den guten Namen wiedergeben deinem Diener, * Gott, der Herz und Nieren du durchdringest.
-7:11 Schuldig bist du, Herr, mir deine Hilfe, * wenn du Retter sein willst aller Unschuld.
-7:12 Wird nun Gott, der so gerechte Richter, der Gewalt'ge und Geduld'ge, * immer sich auf Zorn beschränken?
-7:13 Wenn ihr euch nicht ändert, schwingt sein Schwert er, * schon hat er gespannt den Bogen und ihn zugerichtet,
-7:14 Und hat eingelegt todbringende Geschosse, * seine Pfeile angeglüht im Feuer.
-7:15 Also, wenn jetzt einer noch Gewalttat trägt im Busen, * Quälerei noch birgt, Feindschaft zutage fördert,
-7:16 Wenn ein Loch er macht und tief es ausgräbt, * dann stürzt er hinein in die gegrab'ne Grube.
-7:17 Auf sein eigen Haupt kehrt sich das mir geplante Unheil * und auf seinen Scheitel kommt nun seine Tücke.
-7:18 Loben werde ich, o Herr, dich dann ob deines Rechtssinns * und im Liede feiern deine Majestät, o Allerhöchster!
+7:2 Herr, mein Gott, auf Dich habe ich meine Hoffnung gesetzt; * errette mich von all meinen Verfolgern und befreie mich.
+7:3 Damit nicht einer wie ein löwe meine Seele raubt, * während kei ner da ist, der mich erlöst, und keiner, der mich rettet.
+7:4 Herr, mein Gott, wenn ich solches getan, * wenn unrecht an meinen Händen klebt,
+7:5 wenn ich denen, die mir böses taten, vergolten habe, * so mag mit recht ich untergehen durch meine Feinde,
+7:6 dann möge der Feind meine Seele verfolgen und sie ergreifen und zu boden treten mein leben * und meine Ehre in den Staub niederziehen.
+7:7a Steh auf, Herr, in Deinem zorn * und erhebe Dich an den Grenzen meiner Feinde.
+7:7b Ja, steh auf, Herr, mein Gott, nach der Weisung, die Du erlassen, * und die Versammlung der Völker wird Dich umgeben,
+7:8b und ihretwegen kehre zurück in die Höhe: * der Herr richtet die Völker.
+7:9b richte mich, Herr, nach meiner Gerechtigkeit, * und über mich nach meiner unschuld.
+7:10 Die bosheit der Sünder werde vertilgt, und Du wirst leiten den Gerechten, * der Du die Herzen und nieren prüfst, o Gott.
+7:11 meine gerechte Hilfe kommt vom Herrn, * der die errettet, die aufrichtigen Herzens sind.
+7:12 Gott ist ein gerechter richter, stark und geduldig; * zürnt er etwa Tag um Tag?
+7:13 Wenn ihr euch nicht bekehrt, wird er sein Schwert zücken, * seinen bogen hat er gespannt und ihn bereitet.
+7:14 und tödliche Geschosse hat er auf ihm bereitet; * seine Pfeile hat er gemacht für die brennenden.
+7:15 Seht, jener ging schwanger mit unrecht; * er empfing Schmerz und gebar Frevel.
+7:16 Eine Grube hat er geöffnet und sie ausgehoben, * und er stürzt selbst in die Grube, die er gemacht hat.
+7:17 zurückgewendet wird sein Schmerz auf sein Haupt, * und auf seinen Scheitel fährt sein Frevel herab.
+7:18 Preisen will ich den Herrn nach seiner Gerechtigkeit, * und spielen will ich dem namen des Herrn, des Höchsten.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm70.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm70.txt
@@ -1,26 +1,26 @@
-70:1 Auf dich, Herr, hoffe ich, lass mich nicht zu Schanden werden ewiglich: * in deiner Gerechtigkeit befreie mich, und erlöse mich!
-70:2 Neige zu mir dein Ohr, * und rette mich.
-70:3 Sei mir zum beschützenden Gott und zum festen Orte, * dass du mir helfest;
-70:3 Denn du bist meine Feste, * und meine Zuflucht bist du.
-70:4 Mein Gott, erlöse mich von der Hand des Sünders, * und von der Hand dessen, der wider das Gesetz handelt, und des Gottlosen.
-70:5 Denn du bist meine Geduld, o Herr: * meine Hoffnung, Herr, von meiner Jugend an.
-70:6 Auf dich bin ich festgestellt vom Mutterleibe an: * von meiner Mutter Leibe an bist du mein Beschirmer.
-70:7 Von dir ist stets mein Lobgesang: * wie ein Wunder bin ich Vielen geworden: und du warst ein starker Helfer.
-70:8 Lass voll sein meinen Mund von Lob, dass ich besinge deine Herrlichkeit: * deine Größe den ganzen Tag.
-70:9 Verwirf mich nicht zur Zeit des Alters: * wenn abgenommen meine Kraft, verlass mich nicht.
-70:10 Denn meine Feinde sprechen zu mir, * und die, die auf mein Leben lauern, halten Rat zusammen,
-70:11 und sagen: Gott hat ihn verlassen, verfolgt und ergreift ihn: * denn keiner ist, der hilft.
-70:12 Gott, sei nicht fern von mir: * mein Gott, schau auf meine Hilfe.
-70:13 Es sollen sich schämen und verkommen, die mir übel nachreden; * mit Scham und Schande bedeckt werden, die mein Unglück suchen.
-70:14 Ich aber will allezeit hoffen, * und noch mehr tun zu allem deinem Lobe.
-70:15 Mein Mund soll verkündigen deine Gerechtigkeit, * den ganzen Tag dein Heil;
-70:16 Ich kann es nicht zählen. So will ich eingehen in die Kraft des Herrn: * Herr, deiner Gerechtigkeit allein will ich gedenken.
-70:17 Gott, du hast mich gelehrt von meiner Jugend an: * und bis jetzt verkünde ich deine Wunder.
-70:18 Doch auch bis zum greisen Alter, bis zu hohen Alter: * o Gott, verlass mich nicht;
-70:18 Bis ich deinen Arm verkünde * allen Geschlechtern, die da kommen werden:
-70:19 Deine Macht; und auf Höchste rühme deine Gerechtigkeit; o Gott, was Großes du getan: * o Gott, wer ist dir gleich?
-70:20 Wie viel böse Trübsale hast du mir gezeigt! Doch du wandeltest dich, belebtest mich: * und führtest mich zurück aus den Abgründen der Erde.
-70:21 Du vermehrtest vielfach deine Herrlichkeit; * und wandtest dich, und warst mein Trost.
-70:22 So will ich denn dir im Psalmenspiel deine Treue preisen: * o Gott, dir lobsingen auf der Harfe, du Heiliger Israels.
-70:23 Es sollen frohlocken meine Lippen, wenn ich dir singe: * und meine Seele, die du erlöst hast.
-70:24 Und auch meine Zunge soll den ganzen Tag von deiner Gerechtigkeit sprechen, * denn beschämt sind sie, und zu Schanden geworden, die mein Unglück suchen.
+70:1 Auf Dich, Herr, habe ich meine Hoffnung gesetzt, lass mich nicht zuschanden werden in Ewigkeit; * in Deiner Gerechtigkeit befreie mich und reiße mich heraus.
+70:2 neige zu mir Dein Ohr * und erlöse mich.
+70:3 Sei mir ein schützender Gott und ein befestigter Ort, * damit Du mich rettest.
+70:3 Denn meine Feste * und meine zuflucht bist Du.
+70:4 mein Gott, entreiße mich der Hand des Sünders * und der Hand dessen, der gegen das Gesetz handelt, und des Frevlers.
+70:5 Denn Du bist meine Geduld, o Herr, * Herr, meine Hoffnung von meiner Jugend an.
+70:6 in Dir bin ich gefestigt vom mutterschoß an, * vom mutterleib an bist Du mein beschützer.
+70:7 in Dir ist stets mein lobgesang, * wie ein Wunder bin ich für viele geworden, und Du bist ein starker Helfer.
+70:8 Voll von lob sei mein mund, damit ich Deine Herrlichkeit besinge, * den ganzen Tag Deine Größe.
+70:9 Verwirf mich nicht zur zeit des Alters, * wenn schwinden wird meine Kraft, verlass mich nicht!
+70:10 Denn meine Feinde redeten über mich, * und die auf meine Seele lauerten, hielten rat miteinander.
+70:11 Sie sagen: Gott hat ihn verlassen! Verfolgt und ergreift ihn, * denn niemand ist, der ihn rettet!
+70:12 Gott, entferne Dich nicht von mir, * mein Gott, schau her auf meine Hilfe!
+70:13 zuschanden werden und vergehen sollen, die herabziehen meine Seele, * mit Schmach und Schande bedeckt sollen werden, die böses für mich suchen.
+70:14 ich aber will allezeit hoffen * und all Dein lob vermehren.
+70:15 mein mund soll Deine Gerechtigkeit verkünden, * den ganzen Tag Dein Heil.
+70:16 Denn bücherweisheit kenne ich nicht; so will ich eingehn in die Kraft des Herrn. * Herr, Deiner Gerechtigkeit allein will ich gedenken.
+70:17 Gott, Du hast mich belehrt von meiner Jugend an, * und bis jetzt will ich Deine Wunder verkünden.
+70:18 und bis zum Alter und Greisentum, * Gott, verlass mich nicht,
+70:18 bis ich verkünde Deinen Arm * dem ganzen Geschlecht, das da kommen wird,
+70:19 Deine macht und Deine Gerechtigkeit. Gott, bis in die höchsten Höhen reichen die Großtaten, die Du vollbracht hast. * Gott, wer ist Dir gleich?
+70:20 Wie viele und schlimme Trübsale hast Du mich schauen lassen! und Du hast Dich umgewandt und mich neu belebt * und mich wieder zurückgeführt aus den Abgründen der Erde.
+70:21 Gemehrt hast Du Deine Herrlichkeit, * und Du hast Dich umgewandt und mich getröstet.
+70:22 Denn auch ich will mit Psalmenspiel Deine Wahrheit preisen, * Gott, ich will Dir spielen auf der zither, Du Heiliger israels.
+70:23 Frohlocken werden meine lippen, wenn ich Dir singe, * und meine Seele, die Du erlöst hast.
+70:24 Doch auch meine zunge soll den ganzen Tag Deine Gerechtigkeit bedenken, * wenn zuschanden und beschämt werden, die böses für mich suchen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm71.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm71.txt
@@ -1,20 +1,20 @@
-71:2 Deus, judícium tuum regi da: * et justítiam tuam fílio regis:
-71:2 Judicáre pópulum tuum in justítia, * et páuperes tuos in judício.
-71:3 Suscípiant montes pacem pópulo: * et colles justítiam.
-71:4 Judicábit páuperes pópuli, et salvos fáciet fílios páuperum: * et humiliábit calumniatórem.
-71:5 Et permanébit cum sole, et ante lunam, * in generatióne et generatiónem.
-71:6 Descéndet sicut plúvia in vellus: * et sicut stillicídia stillántia super terram.
-71:7 Oriétur in diébus ejus justítia, et abundántia pacis: * donec auferátur luna.
-71:8 Et dominábitur a mari usque ad mare: * et a flúmine usque ad términos orbis terrárum.
-71:9 Coram illo prócident Æthíopes: * et inimíci ejus terram lingent.
-71:10 Reges Tharsis, et ínsulæ múnera ófferent: * reges Árabum et Saba dona addúcent.
-71:11 Et adorábunt eum omnes reges terræ: * omnes gentes sérvient ei:
-71:12 Quia liberábit páuperem a poténte: * et páuperem, cui non erat adjútor.
-71:13 Parcet páuperi et ínopi: * et ánimas páuperum salvas fáciet.
-71:14 Ex usúris et iniquitáte rédimet ánimas eórum: * et honorábile nomen eórum coram illo.
-71:15 Et vivet, et dábitur ei de auro Arábiæ, et adorábunt de ipso semper: * tota die benedícent ei.
-71:16 Et erit firmaméntum in terra in summis móntium, superextollétur super Líbanum fructus ejus: * et florébunt de civitáte sicut fœnum terræ.
-71:17 Sit nomen ejus benedíctum in sæcula: * ante solem pérmanet nomen ejus.
-71:17 Et benedicéntur in ipso omnes tribus terræ: * omnes gentes magnificábunt eum.
-71:18 Benedíctus Dóminus, Deus Israël, * qui facit mirabília solus:
-71:19 Et benedíctum nomen majestátis ejus in ætérnum: * et replébitur majestáte ejus omnis terra: fiat, fiat.
+71:2 Gott, gib Dein Gericht dem König * und Deine Gerechtigkeit dem Königssohn,
+71:2 um zu richten Dein Volk in Gerechtigkeit * und Deine Armen nach dem recht.
+71:3 Die berge sollen Frieden empfangen für das Volk * und die Hügel Gerechtigkeit.
+71:4 richten wird er die Armen des Volkes und Heil schaffen den Kindern der Armen, * und demütigen wird er den Verleumder.
+71:5 und bleiben wird er mit der Sonne und vor dem mond, * von Geschlecht zu Geschlecht.
+71:6 Er wird herabkommen wie regen auf das Vlies * und wie Tropfen, die auf die Erde rieseln.
+71:7 Aufgehen wird in seinen Tagen die Gerechtigkeit und die Fülle des Friedens, * bis der mond hinweggenommen wird.
+71:8 und herrschen wird er von meer zu meer * und vom Strom bis zu den Enden des Erd kreises.
+71:9 Vor ihm werden niederfallen die Äthiopier, * und seine Feinde werden die Erde lecken.
+71:10 Die Könige von Tharsis und die inseln werden Gaben opfern. * Die Könige der Araber und Saba werden Geschenke herbeibringen.
+71:11 und anbeten werden ihn alle Könige der Erde, * alle Völker werden ihm dienen,
+71:12 denn er wird den Armen befreien vom mächtigen; * auch den Armen, für den es keinen Helfer gab.
+71:13 Schonen wird er den Armen und Hilfl osen, * und die Seelen der Armen wird er retten.
+71:14 Aus Wucher und ungerechtigkeit wird er ihre Seelen erlösen, * und ehrwürdig ist ihr name vor ihm.
+71:15 Er wird leben, und vom Gold Arabiens wird man ihm geben, und seinetwegen wird man allezeit anbeten, * den ganzen Tag werden sie ihn preisen.
+71:16 und es wird eine Feste sein auf Erden auf den Höhen der berge, hoch über den libanon wird sich erheben seine Frucht, * und sie werden der Stadt entblühen wie das Gras der Erde.
+71:17 Sein name sei gepriesen in Ewigkeit, * vor der Sonne bleibt sein name bestehen.
+71:17 und gesegnet werden in ihm alle Stämme der Erde, * alle Völker werden ihn verherrlichen.
+71:18 Gepriesen sei der Herr, der Gott israels, * der allein Wunder tut!
+71:19 und gepriesen sei der name seiner majestät in Ewigkeit, * und von seiner majestät wird erfüllt sein die ganze Erde. So sei es! So sei es!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm72.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm72.txt
@@ -1,28 +1,28 @@
-72:1 Quam bonus Israël Deus, * his, qui recto sunt corde!
-72:2 Mei autem pæne moti sunt pedes: * pæne effúsi sunt gressus mei.
-72:3 Quia zelávi super iníquos, * pacem peccatórum videns.
-72:4 Quia non est respéctus morti eórum: * et firmaméntum in plaga eórum.
-72:5 In labóre hóminum non sunt, * et cum homínibus non flagellabúntur:
-72:6 Ideo ténuit eos supérbia, * opérti sunt iniquitáte et impietáte sua.
-72:7 Pródiit quasi ex ádipe iníquitas eórum: * transiérunt in afféctum cordis.
-72:8 Cogitavérunt, et locúti sunt nequítiam: * iniquitátem in excélso locúti sunt.
-72:9 Posuérunt in cælum os suum: * et lingua eórum transívit in terra.
-72:10 Ídeo convertétur pópulus meus hic: * et dies pleni inveniéntur in eis.
-72:11 Et dixérunt: Quómodo scit Deus, * et si est sciéntia in excélso?
-72:12 Ecce, ipsi peccatóres, et abundántes in sæculo, * obtinuérunt divítias.
-72:13 Et dixi: Ergo sine causa justificávi cor meum, * et lavi inter innocéntes manus meas:
-72:14 Et fui flagellátus tota die, * et castigátio mea in matutínis.
-72:15 Si dicébam: Narrábo sic: * ecce, natiónem filiórum tuórum reprobávi.
-72:16 Existimábam ut cognóscerem hoc, * labor est ante me:
-72:17 Donec intrem in Sanctuárium Dei: * et intélligam in novíssimis eórum.
-72:18 Verúmtamen propter dolos posuísti eis: * dejecísti eos dum allevaréntur.
-72:19 Quómodo facti sunt in desolatiónem, súbito defecérunt: * periérunt propter iniquitátem suam.
-72:20 Velut sómnium surgéntium, Dómine, * in civitáte tua imáginem ipsórum ad níhilum rédiges.
-72:21 Quia inflammátum est cor meum, et renes mei commutáti sunt: * et ego ad níhilum redáctus sum, et nescívi.
-72:23 Ut juméntum factus sum apud te: * et ego semper tecum.
-72:24 Tenuísti manum déxteram meam: et in voluntáte tua deduxísti me, * et cum glória suscepísti me.
-72:25 Quid enim mihi est in cælo? * et a te quid vólui super terram?
-72:26 Defécit caro mea, et cor meum: * Deus cordis mei, et pars mea Deus in ætérnum.
-72:27 Quia ecce, qui elóngant se a te, períbunt: * perdidísti omnes, qui fornicántur abs te.
-72:28 Mihi autem adhærére Deo bonum est: * pónere in Dómino Deo spem meam:
-72:28 Ut annúntiem omnes prædicatiónes tuas, * in portis fíliæ Sion.
+72:1 Wie gut ist Gott zu israel, * zu denen, die aufrichtigen Herzens sind!
+72:2 meine Füße aber wären beinahe gestrauchelt, * fast wären meine Schritte ausgeglitten.
+72:3 Denn ich ereiferte mich über die Frevler, * da ich den Frieden der Sünder sah.
+72:4 Denn sie kennen nicht rücksicht auf ihren Tod * und Dauer in ihrer Plage.
+72:5 in der mühsal der menschen sind sie nicht, * und mit den menschen werden sie nicht gezüchtigt.
+72:6 Darum hat Hochmut sie ergriffen, * sie haben sich mit ihrem Frevel und ihrer Gottlosigkeit umhüllt.
+72:7 Wie von Fett quoll hervor ihre Schlechtigkeit, * sie gingen einher nach der laune ihres Herzens.
+72:8 Sie ersannen und sprachen Frevel, * unrecht haben sie geredet in ihrem Hochmut.
+72:9 Sie haben ihren mund gegen den Himmel gerichtet, * und ihre zunge erging sich auf Erden.
+72:10 Deshalb wendet sich mein Volk dorthin, * und volle Tage finden sich bei ihnen.
+72:11 und sie sprachen: Wie sollte Gott davon wissen, * und gibt es Erkenntnis beim Höchsten?
+72:12 Siehe, sie sind Sünder, und sie haben Überfluss in der Welt, * reichtum haben sie erlangt.
+72:13 und ich sagte: Also habe ich vergeblich mein Herz gerecht gemacht * und unter unschuldigen meine Hände gewaschen.
+72:14 und ich wurde geschlagen den ganzen Tag * und hatte meine züchtigung am morgen.
+72:15 Wenn ich gesagt hätte: „So will ich reden“, * siehe, dann hätte ich das Geschlecht Deiner Kinder verworfen.
+72:16 ich dachte nach, um es zu verstehen; * mühsal ist vor mir,
+72:17 bis ich eintrete in das Heiligtum Gottes * und Einsicht gewinne in ihre letzten Dinge.
+72:18 Fürwahr, wegen ihrer bosheiten hast Du es für sie festgesetzt: * Du stürztest sie, als sie sich erhoben.
+72:19 Wie wurden sie zur Öde, plötzlich schwanden sie dahin, * sie gingen zugrunde wegen ihrer ungerechtigkeit.
+72:20 Wie einen Traum der Erwachenden, Herr, * wirst Du in Deiner Stadt ihr bild zunichte machen.
+72:21 Weil entflammt ist mein Herz und meine nieren erregt waren, * wurde auch ich zunichte gemacht und hatte keine Einsicht.
+72:23 Wie ein lasttier bin ich vor Dir geworden, * und doch war ich stets bei Dir.
+72:24 Du hieltest meine rechte Hand, und nach Deinem Willen hast Du mich geleitet, * und mit Ehre hast Du mich angenommen.
+72:25 Was nämlich gibt es für mich im Himmel? * und was außer Dir will ich auf Erden?
+72:26 Dahingeschwunden ist mein Fleisch und mein Herz; * der Gott meines Herzens und mein Anteil ist Gott in Ewigkeit,
+72:27 denn siehe, die sich von Dir entfernen werden zugrunde gehen. * Du richtest alle zugrunde, die von Dir weg unzucht treiben.
+72:28 Für mich aber ist es gut, Gott anzuhangen, * auf Gott, den Herrn, meine Hoffnung zu setzen,
+72:28 um all Dein lob zu verkünden * in den Toren der Tochter Sion.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm73.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm73.txt
@@ -1,24 +1,24 @@
-73:1 Ut quid, Deus, repulísti in finem: * irátus est furor tuus super oves páscuæ tuæ?
-73:2 Memor esto congregatiónis tuæ, * quam possedísti ab inítio.
-73:2 Redemísti virgam hereditátis tuæ: * mons Sion, in quo habitásti in eo.
-73:3 Leva manus tuas in supérbias eórum in finem: * quanta malignátus est inimícus in sancto!
-73:4 Et gloriáti sunt qui odérunt te: * in médio solemnitátis tuæ.
-73:5 Posuérunt signa sua, signa: * et non cognovérunt sicut in éxitu super summum.
-73:6 Quasi in silva lignórum secúribus excidérunt jánuas ejus in idípsum: * in secúri et áscia dejecérunt eam.
-73:7 Incendérunt igni Sanctuárium tuum: * in terra polluérunt tabernáculum nóminis tui.
-73:8 Dixérunt in corde suo cognátio eórum simul: * Quiéscere faciámus omnes dies festos Dei a terra.
-73:9 Signa nostra non vídimus, jam non est prophéta: * et nos non cognóscet ámplius.
-73:10 Úsquequo, Deus, improperábit inimícus: * irrítat adversárius nomen tuum in finem?
-73:11 Ut quid avértis manum tuam, et déxteram tuam, * de médio sinu tuo in finem?
-73:12 Deus autem Rex noster ante sæcula: * operátus est salútem in médio terræ.
-73:13 Tu confirmásti in virtúte tua mare: * contribulásti cápita dracónum in aquis.
-73:14 Tu confregísti cápita dracónis: * dedísti eum escam pópulis Æthíopum.
-73:15 Tu dirupísti fontes, et torréntes: * tu siccásti flúvios Ethan.
-73:16 Tuus est dies, et tua est nox: * tu fabricátus es auróram et solem.
-73:17 Tu fecísti omnes términos terræ: * æstátem et ver tu plasmásti ea.
-73:18 Memor esto hujus, inimícus improperávit Dómino: * et pópulus insípiens incitávit nomen tuum.
-73:19 Ne tradas béstiis ánimas confiténtes tibi, * et ánimas páuperum tuórum ne obliviscáris in finem.
-73:20 Réspice in testaméntum tuum: * quia repléti sunt, qui obscuráti sunt terræ dómibus iniquitátum.
-73:21 Ne avertátur húmilis factus confúsus: * pauper et inops laudábunt nomen tuum.
-73:22 Exsúrge, Deus, júdica causam tuam: * memor esto improperiórum tuórum, eórum quæ ab insipiénte sunt tota die.
-73:23 Ne obliviscáris voces inimicórum tuórum: * supérbia eórum, qui te odérunt, ascéndit semper.
+73:1 Warum, o Gott, hast Du uns für immer verstoßen, * ist Dein Grimm entbrannt gegen die Schafe Deiner Weide?
+73:2 Gedenke Deiner Gemeinde, * die von Anfang an Dein Eigen war.
+73:2 Du hast sie erlöst als Stab Deines Erbes, * der berg Sion ist es, auf dem Du Wohnung genommen hast.
+73:3 Erhebe Deine Hände gegen ihren Hochmut für immer; * wie viel bosheit hat der Feind verübt im Heiligtum!
+73:4 und geprahlt haben, die Dich hassen * inmitten Deines Festes.
+73:5 Sie stellten ihre zeichen als Trophäen auf, * ohne Einsicht, wie im Ausgang, so auf der zinne.
+73:6 Wie in einem Wald von bäumen haben sie mit Äxten seine Türen allesamt aufgebrochen, * mit beil und Axt sie hinabgestürzt.
+73:7 mit Feuer entzündet haben sie Dein Heiligtum, * bis auf den Grund das zelt Deines namens geschändet.
+73:8 Sie sprachen in ihrem Herzen, ihre ganze brut zugleich: * Verstummen lassen wollen wir alle Fest tage Gottes auf Erden.
+73:9 unsere zeichen sehen wir nicht, kein Prophet ist mehr da, * und uns wird er nicht mehr kennen.
+73:10 Wie lange noch, Gott, soll schmähen der Feind, * soll der Widersacher Deinen namen reizen bis zum Äußersten?
+73:11 Warum ziehst Du Deine Hand zurück und Deine rechte * von der mitte Deiner brust ganz und gar?
+73:12 Gott aber ist unser König vor aller zeit, * er hat Heil gewirkt inmitten der Erde.
+73:13 befestigt hast Du in Deiner Kraft das meer, * zermalmt hast Du die Köpfe der Drachen in den Wassern.
+73:14 zerschmettert hast Du die Köpfe des Drachens, * ihn den Stämmen der Äthiopier zum Fraß gegeben.
+73:15 Aufgebrochen hast Du Quellen und Ströme, * vertrocknen ließest Du die Flüsse von Ethan.
+73:16 Dein ist der Tag, und Dein ist die nacht, * Du hast das morgenrot und die Sonne geschaffen.
+73:17 Du schufst alle Enden der Erde, * Sommer und Frühling hast Du gebildet.
+73:18 Sei eingedenk dessen: Der Feind hat den Herrn geschmäht, * und ein törichtes Volk hat erzürnt Deinen namen.
+73:19 Übergib nicht den bestien die Seelen derer, die Dich bekennen, * und die Seelen Deiner Armen vergiss nicht vollends.
+73:20 Schau auf Deinen bund, * denn die verfinstert sind im land sind reich an Häusern von unrecht.
+73:21 Der Demütige soll nicht abgewiesen werden mit Schande, * der Arme und der Hilflose werden loben Deinen namen.
+73:22 Erhebe Dich, Gott, entscheide Deine Sache, * sei eingedenk der Schmähungen gegen Dich von denen, die von Torheit sind den ganzen Tag.
+73:23 Vergiss nicht die Stimmen Deiner Feinde; * der Hochmut derer, die Dich hassen, steigt ständig empor.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm74.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm74.txt
@@ -7,4 +7,4 @@
 74:8 Diesen erniedrigt und jenen erhöht er, * denn ein Kelch ist in der Hand des Herrn von reinem Wein, voll von Würztrank.
 74:9 und er neigte ihn von hier nach dort, doch seine Hefe ist nicht ausgeleert; * trinken müssen alle Sünder der Erde.
 74:10 ich aber will es verkünden in Ewigkeit, * ich will singen dem Gott Jakobs,
-74:11 und alle Hörner der Sünder will ich zerschmettern; * und erhöht werden die Hörner des Gerechten. 75 i
+74:11 und alle Hörner der Sünder will ich zerschmettern; * und erhöht werden die Hörner des Gerechten.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm75.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm75.txt
@@ -1,12 +1,12 @@
-75:2 Notus in Judæa Deus: * in Israël magnum nomen ejus.
-75:3 Et factus est in pace locus ejus: * et habitátio ejus in Sion.
-75:4 Ibi confrégit poténtias árcuum, * scutum, gládium, et bellum.
-75:5 Illúminans tu mirabíliter a móntibus ætérnis: * turbáti sunt omnes insipiéntes corde.
-75:6 Dormiérunt somnum suum: * et nihil invenérunt omnes viri divitiárum in mánibus suis.
-75:7 Ab increpatióne tua, Deus Jacob, * dormitavérunt qui ascendérunt equos.
-75:8 Tu terríbilis es, et quis resístet tibi? * ex tunc ira tua.
-75:9 De cælo audítum fecísti judícium: * terra trémuit et quiévit,
-75:10 Cum exsúrgeret in judícium Deus, * ut salvos fáceret omnes mansuétos terræ.
-75:11 Quóniam cogitátio hóminis confitébitur tibi: * et relíquiæ cogitatiónis diem festum agent tibi.
-75:12 Vovéte, et réddite Dómino, Deo vestro: * omnes, qui in circúitu ejus affértis múnera.
-75:13 Terríbili et ei qui aufert spíritum príncipum, * terríbili apud reges terræ.
+75:2 bekannt ist Gott in Judäa, * in israel ist groß sein name.
+75:3 und im Frieden ist seine Stätte bereitet * und seine Wohnung auf Sion.
+75:4 Dort zerbrach er die mächte von bögen, * Schild, Schwert und Krieg.
+75:5 Du leuchtest wunderbar von ewigen bergen her; * es wurden alle verwirrt, die törichten Herzens sind.
+75:6 Sie schliefen ihren Schlaf, * und nichts mehr fanden all die männer des reichtums in ihren Händen.
+75:7 Von Deinem Drohen, Gott Jakobs, * entschliefen jene, die auf rosse stiegen.
+75:8 Du bist furchtbar, und wer wird Dir widerstehen? * Von jeher ist Dein zorn.
+75:9 Vom Himmel her ließest Du hören das Gericht, * die Erde erbebte und wurde still,
+75:10 als Gott zum Gericht sich erhob, * um alle Sanftmütigen der Erde zu erlösen.
+75:11 Denn des menschen Denken wird Dich preisen * und seine übrigen Gedanken einen Festtag für Dich feiern.
+75:12 legt Gelübde ab und erfüllt sie dem Herrn, eurem Gott; * alle, die rings um ihn her sind, bringt Gaben herbei,
+75:13 dem Furchtbaren und dem, der hinwegnimmt den Geist der Fürsten, * dem Furchtbaren bei den Königen der Erde.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm76.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm76.txt
@@ -1,20 +1,20 @@
-76:2 Voce mea ad Dóminum clamávi: * voce mea ad Deum, et inténdit mihi.
-76:3 In die tribulatiónis meæ Deum exquisívi, mánibus meis nocte contra eum: * et non sum decéptus.
-76:4 Rénuit consolári ánima mea, * memor fui Dei, et delectátus sum, et exercitátus sum: et defécit spíritus meus.
-76:5 Anticipavérunt vigílias óculi mei: * turbátus sum, et non sum locútus.
-76:6 Cogitávi dies antíquos: * et annos ætérnos in mente hábui.
-76:7 Et meditátus sum nocte cum corde meo, * et exercitábar, et scopébam spíritum meum.
-76:8 Numquid in ætérnum projíciet Deus: * aut non appónet ut complacítior sit adhuc?
-76:9 Aut in finem misericórdiam suam abscíndet, * a generatióne in generatiónem?
-76:10 Aut obliviscétur miseréri Deus? * aut continébit in ira sua misericórdias suas?
-76:11 Et dixi: Nunc cœpi: * hæc mutátio déxteræ Excélsi.
-76:12 Memor fui óperum Dómini: * quia memor ero ab inítio mirabílium tuórum.
-76:13 Et meditábor in ómnibus opéribus tuis: * et in adinventiónibus tuis exercébor.
-76:14 Deus, in sancto via tua: quis Deus magnus sicut Deus noster? * tu es Deus qui facis mirabília.
-76:15 Notam fecísti in pópulis virtútem tuam: * redemísti in bráchio tuo pópulum tuum, fílios Jacob et Joseph.
-76:17 Vidérunt te aquæ, Deus, vidérunt te aquæ: * et timuérunt, et turbátæ sunt abýssi.
-76:18 Multitúdo sónitus aquárum: * vocem dedérunt nubes.
-76:18 Étenim sagíttæ tuæ tránseunt: * vox tonítrui tui in rota.
-76:19 Illuxérunt coruscatiónes tuæ orbi terræ: * commóta est, et contrémuit terra.
-76:20 In mari via tua, et sémitæ tuæ in aquis multis: * et vestígia tua non cognoscéntur.
-76:21 Deduxísti sicut oves pópulum tuum, * in manu Móysi et Aaron.
+76:2 mit meiner Stimme rief ich zum Herrn, * mit meiner Stimme zu Gott, und er hat mich beachtet.
+76:3 Am Tag meiner Drangsal habe ich Gott gesucht, meine Hände des nachts nach ihm ausgestreckt; * und ich wurde nicht enttäuscht.
+76:4 meine Seele wollte sich nicht trösten lassen; * ich dachte an Gott und ward (zwar) erquickt und (doch) hart geprüft, und mein Geist schwand dahin.
+76:5 meine Augen kamen den nachtwachen zuvor, * ich bin unruhig und rede nicht.
+76:6 ich überdachte die uralten Tage, * und die ewigen Jahre hatte ich im Sinn.
+76:7 ich sann des nachts mit meinem Herzen, * und anhaltend dachte ich nach und härmte meinen Geist.
+76:8 Wird denn Gott auf ewig verwerfen, * oder wird er nicht fortfahren, weiterhin gnädig zu sein?
+76:9 Oder wird er vollends seine barmherzigkeit entziehen * von Geschlecht zu Geschlecht?
+76:10 Oder wird Gott vergessen, sich zu erbarmen, * oder wird er in seinem zorn seine barmherzigkeit zurückhalten?
+76:11 und ich sprach: nun beginne ich. * Diese Än derung kommt von der rechten des Höchsten.
+76:12 ich gedachte der Werke des Herrn, * denn ich will von Anfang an Deiner Wunder gedenken.
+76:13 und bedenken will ich all Deine Werke * und mich vertiefen in Deine Taten.
+76:14 Gott, in Heiligkeit ist Dein Weg! Wer ist ein Gott so groß wie unser Gott? * Du bist Gott, der Wunder tut.
+76:15 Kundgetan hast Du unter den Völkern Deine macht, * Du hast mit Deinem Arm Dein Volk erlöst, die Söhne Jakobs und Josephs.
+76:17 Es sahen Dich die Wasser, Gott, es sahen Dich die Wasser, * und sie gerieten in Furcht, und es erbebten die Tiefen.
+76:18 Gewaltig war das Tosen der Wasser, * die Wolken ließen ihre Stimme erschallen.
+76:18 und Deine Pfeile fliegen vorüber, * der Schall Deines Donners rollt daher.
+76:19 Deine blitze leuchteten über den Erdkreis, * es bebte und erzitterte die Erde.
+76:20 im meer war Dein Weg, und Deine Pfade in vielen Wassern, * und Deine Spuren werden nicht erkannt.
+76:21 Wie Schafe hast Du Dein Volk geleitet, * durch die Hand von moses und Aaron.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm77.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm77.txt
@@ -1,78 +1,78 @@
-77:1 Atténdite, pópule meus, legem meam: * inclináte aurem vestram in verba oris mei.
-77:2 Apériam in parábolis os meum: * loquar propositiónes ab inítio.
-77:3 Quanta audívimus et cognóvimus ea: * et patres nostri narravérunt nobis.
-77:4 Non sunt occultáta a fíliis eórum: * in generatióne áltera.
-77:4 Narrántes laudes Dómini, et virtútes ejus: * et mirabília ejus, quæ fecit.
-77:5 Et suscitávit testimónium in Jacob: * et legem pósuit in Israël.
-77:5 Quanta mandávit pátribus nostris nota fácere ea fíliis suis: * ut cognóscat generátio áltera.
-77:6 Fílii qui nascéntur, et exsúrgent, * et narrábunt fíliis suis.
-77:7 Ut ponant in Deo spem suam, et non obliviscántur óperum Dei: * et mandáta ejus exquírant.
-77:8 Ne fiant sicut patres eórum: * generátio prava et exásperans.
-77:8 Generátio, quæ non diréxit cor suum: * et non est créditus cum Deo spíritus ejus.
-77:9 Filii Ephrem intendéntes et mitténtes arcum: * convérsi sunt in die belli.
-77:10 Non custodiérunt testaméntum Dei: * et in lege ejus noluérunt ambuláre.
-77:11 Et oblíti sunt benefactórum ejus: * et mirabílium ejus quæ osténdit eis.
-77:12 Coram pátribus eórum fecit mirabília in terra Ægýpti: * in campo Táneos.
-77:13 Interrúpit mare, et perdúxit eos: * et státuit aquas quasi in utre.
-77:14 Et dedúxit eos in nube diéi: * et tota nocte in illuminatióne ignis.
-77:15 Interrúpit petram in erémo: * et adaquávit eos velut in abýsso multa.
-77:16 Et edúxit aquam de petra: * et dedúxit tamquam flúmina aquas.
-77:17 Et apposuérunt adhuc peccáre ei: * in iram excitavérunt Excélsum in inaquóso.
-77:18 Et tentavérunt Deum in córdibus suis, * ut péterent escas animábus suis.
-77:19 Et male locúti sunt de Deo: * dixérunt: Numquid póterit Deus paráre mensam in desérto?
-77:20 Quóniam percússit petram, et fluxérunt aquæ: * et torréntes inundavérunt.
-77:20 Numquid et panem póterit dare, * aut paráre mensam pópulo suo?
-77:21 Ideo audívit Dóminus, et dístulit: * et ignis accénsus est in Jacob, et ira ascéndit in Israël.
-77:22 Quia non credidérunt in Deo: * nec speravérunt in salutári ejus:
-77:23 Et mandávit núbibus désuper: * et jánuas cæli apéruit.
-77:24 Et pluit illis manna ad manducándum: * et panem cæli dedit eis.
-77:25 Panem Angelórum manducávit homo, * cibária misit eis in abundántia.
-77:26 Tránstulit Austrum de cælo: * et indúxit in virtúte sua Áfricum.
-77:27 Et pluit super eos sicut púlverem carnes: * et sicut arénam maris volatília pennáta.
-77:28 Et cecidérunt in médio castrórum eórum: * circa tabernácula eórum.
-77:29 Et manducavérunt, et saturáti sunt nimis, et desidérium eórum áttulit eis: * non sunt fraudáti a desidério suo.
-77:30 Adhuc escæ eórum erant in ore ipsórum: * et ira Dei ascéndit super eos.
-77:31 Et occídit pingues eórum, * et eléctos Israël impedívit.
-77:32 In ómnibus his peccavérunt adhuc: * et non credidérunt in mirabílibus ejus.
-77:33 Et defecérunt in vanitáte dies eórum: * et anni eórum cum festinatióne.
-77:34 Cum occíderet eos, quærébant eum: * et revertebántur, et dilúculo veniébant ad eum.
-77:35 Et rememoráti sunt quia Deus adjútor est eórum: * et Deus excélsus redémptor eórum est.
-77:36 Et dilexérunt eum in ore suo, * et lingua sua mentíti sunt ei.
-77:37 Cor autem eórum non erat rectum cum eo: * nec fidéles hábiti sunt in testaménto ejus.
-77:38 Ipse autem est miséricors, et propítius fiet peccátis eórum: * et non dispérdet eos.
-77:38 Et abundávit ut avérteret iram suam: * et non accéndit omnem iram suam:
-77:39 Et recordátus est quia caro sunt: * spíritus vadens et non rédiens.
-77:40 Quóties exacerbavérunt eum in desérto, * in iram concitavérunt eum in inaquóso?
-77:41 Et convérsi sunt, et tentavérunt Deum: * et Sanctum Israël exacerbavérunt.
-77:42 Non sunt recordáti manus ejus, * die qua redémit eos de manu tribulántis.
-77:43 Sicut pósuit in Ægýpto signa sua, * et prodígia sua in campo Táneos.
-77:44 Et convértit in sánguinem flúmina eórum: * et imbres eórum, ne bíberent.
-77:45 Misit in eos cœnomyíam, et comédit eos: * et ranam, et dispérdidit eos.
-77:46 Et dedit ærúgini fructus eórum: * et labóres eórum locústæ.
-77:47 Et occídit in grándine víneas eórum: * et moros eórum in pruína.
-77:48 Et trádidit grándini juménta eórum: * et possessiónem eórum igni.
-77:49 Misit in eos iram indignatiónis suæ: * indignatiónem, et iram, et tribulatiónem: immissiónes per ángelos malos.
-77:50 Viam fecit sémitæ iræ suæ, non pepércit a morte animábus eórum: * et juménta eórum in morte conclúsit.
-77:51 Et percússit omne primogénitum in terra Ægýpti: * primítias omnis labóris eórum in tabernáculis Cham.
-77:52 Et ábstulit sicut oves pópulum suum: * et perdúxit eos tamquam gregem in desérto.
-77:53 Et dedúxit eos in spe, et non timuérunt: * et inimícos eórum opéruit mare.
-77:54 Et indúxit eos in montem sanctificatiónis suæ: * montem, quem acquisívit déxtera ejus.
-77:54 Et ejécit a fácie eórum Gentes: * et sorte divísit eis terram in funículo distributiónis.
-77:55 Et habitáre fecit in tabernáculis eórum: * tribus Israël.
-77:56 Et tentavérunt, et exacerbavérunt Deum excélsum: * et testimónia ejus non custodiérunt.
-77:57 Et avertérunt se, et non servavérunt pactum: * quemádmodum patres eórum convérsi sunt in arcum pravum.
-77:58 In iram concitavérunt eum in cóllibus suis: * et in sculptílibus suis ad æmulatiónem eum provocavérunt.
-77:59 Audivit Deus, et sprevit: * et ad níhilum redégit valde Israël.
-77:60 Et répulit tabernáculum Silo: * tabernáculum suum, ubi habitávit in homínibus.
-77:61 Et trádidit in captivitátem virtútem eórum: * et pulchritúdinem eórum in manus inimíci.
-77:62 Et conclúsit in gládio pópulum suum: * et hereditátem suam sprevit.
-77:63 Júvenes eórum comédit ignis: * et vírgines eórum non sunt lamentátæ.
-77:64 Sacerdótes eórum in gládio cecidérunt: * et víduæ eórum non plorabántur.
-77:65 Et excitátus est tamquam dórmiens Dóminus: * tamquam potens crapulátus a vino.
-77:66 Et percússit inimícos suos in posterióra: * oppróbrium sempitérnum dedit illis.
-77:67 Et répulit tabernáculum Joseph: * et tribum Éphraim non elégit.
-77:68 Sed elégit tribum Juda, * montem Sion quem diléxit.
-77:69 Et ædificávit sicut unicórnium sanctifícium suum in terra, * quam fundávit in sæcula.
-77:70 Et elégit David, servum suum, et sústulit eum de grégibus óvium: * de post fœtántes accépit eum,
-77:71 Páscere Jacob, servum suum, * et Israël, hereditátem suam:
-77:72 Et pávit eos in innocéntia cordis sui: * et in intelléctibus mánuum suárum dedúxit eos.
+77:1 Achte, mein Volk, auf mein Gesetz, * neigt euer Ohr zu den Worten meines Mundes.
+77:2 in Gleichnissen will ich öffnen meinen Mund, * rätsel reden vom Anfang her,
+77:3 was Großes wir gehört und erfahren * und unsere Väter uns erzählt haben.
+77:4 Es blieb nicht verborgen vor ihren Kindern * im kommenden Geschlecht.
+77:4 Sie verkündeten das Lob des Herrn und seine Macht * und seine Wunder, die er getan hat.
+77:5 Und er hat ein zeugnis in Jakob errichtet * und ein Gesetz in israel aufgestellt,
+77:5 was Großes er unseren Väter geboten, es bekannt zu machen ihren Kindern, * damit die nächste Generation es erfahre,
+77:6 die Kinder, die geboren werden und sich erheben * und es ihren Kindern erzählen werden,
+77:7 damit sie auf Gott ihre Hoffnung setzen und die Werke Gottes nicht vergessen * und nach seinen Geboten fragen,
+77:8 damit sie nicht werden wie ihre Väter, * ein verkehrtes und erbitterndes Geschlecht,
+77:8 ein Geschlecht, das sein Herz nicht gerade ausrichtet * und dessen Geist nicht treu hielt an Gott.
+77:9 Als die Söhne Ephraims den bogen spannten und schossen, * wandten sie sich um am Tag des Krieges.
+77:10 Sie bewahrten nicht den bund Gottes, * und in seinem Gesetz wollten sie nicht wandeln.
+77:11 Und sie vergaßen seine Wohltaten * und seine Wunder, die er ihnen gezeigt hat.
+77:12 Vor ihren Vätern tat er Wunder im Land ägypten, * im Gefilde von Tanis.
+77:13 Er spaltete das Meer und führte sie hindurch * und ließ die Wasser stehen wie in einem Schlauch.
+77:14 Und er führte sie mit der Wolke des Tages * und die ganze nacht durch das Leuchten des Feuers.
+77:15 Er spaltete den Felsen in der Wüste * und tränkte sie wie aus großer Tiefe,
+77:16 und er ließ Wasser hervorströmen aus dem Felsen * und Gewässer rinnen wie Flüsse.
+77:17 Und sie fuhren fort, gegen ihn zu sündigen, * reizten zum zorn den Höchsten in der wasserlosen Öde.
+77:18 Und sie versuchten Gott in ihren Herzen, * indem sie Speise verlangten für ihre Gelüste.
+77:19 Und übel sprachen sie über Gott, * sie sagten: Kann etwa Gott einen Tisch bereiten in der Wüste?
+77:20 Denn er schlug wohl den Felsen, und die Wasser flossen * und Ströme ergossen sich,
+77:20 aber kann er auch brot geben * oder einen Tisch bereiten seinem Volk?
+77:21 So hörte es der Herr und hielt sie hin, * und Feuer entbrannte gegen Jakob, und zorn stieg auf gegen israel,
+77:22 weil sie nicht glaubten an Gott, * noch hofften auf sein Heil.
+77:23 Und er gebot den Wolken von oben her, * und die Pforten des Himmels öffnete er.
+77:24 Und er ließ für sie Manna regnen zum Essen * und gab ihnen das brot des Himmels.
+77:25 Das brot der Engel aß der Mensch, * nahrung sandte er ihnen im Überfluss.
+77:26 Er nahm den Südwind vom Himmel weg * und führte in seiner Kraft den nordwind herbei.
+77:27 Und er ließ Fleisch auf sie regnen wie Staub * und wie den Sand des Meeres gefiederte Vögel.
+77:28 Und sie fielen mitten in ihr Lager, * rings um ihre zelte.
+77:29 Und sie aßen und wurden übersatt, und was sie begehrt hatten, brachte er ihnen, * nicht wurden sie beraubt ihrer Gelüste.
+77:30 noch war ihre Speise in ihrem Mund, * und der zorn Gottes stieg über sie empor,
+77:31 und er tötete ihre Fetten * und lähmte die Auserwählten israels.
+77:32 bei all dem sündigten sie noch immer * und glaubten nicht an seine Wunder.
+77:33 Und es vergingen ihre Tage in nichtigkeit * und ihre Jahre in Eile.
+77:34 Wenn er sie tötete, dann suchten sie ihn * und kehrten um und kamen früh am Morgen zu ihm.
+77:35 Und sie erinnerten sich daran, dass Gott ihr Helfer * und der erhabene Gott ihr Erlöser ist.
+77:36 Und sie liebten ihn mit ihrem Mund, * und mit ihrer zunge heuchelten sie ihm.
+77:37 ihr Herz aber war nicht aufrichtig bei ihm, * noch wurden sie treu erfunden in seinem bund.
+77:38 Er aber ist barmherzig und wird gnädig sein mit ihren Sünden, * und er wird sie nicht verderben.
+77:38 Und vielmals wandte er ab seinen zorn * und ließ nicht entbrennen all seinen zorn.
+77:39 Und er gedachte, dass sie Fleisch sind, * ein Hauch, der dahingeht und nicht wiederkehrt.
+77:40 Wie oft erbitterten sie ihn in der Wüste, * reizten ihn zum zorn im wasserlosen Land?
+77:41 Und sie machten kehrt und versuchten Gott, * und den Heiligen israels haben sie erbittert.
+77:42 Sie gedachten nicht seiner Hand * am Tag, an dem er sie erlöste aus der Hand des bedrängers,
+77:43 wie er in ägypten seine zeichen setzte * und seine Wunder im Gefilde von Tanis,
+77:44 und er verwandelte in blut ihre Flüsse * und ihre regengüsse, dass sie nicht trinken konnten.
+77:45 Er sandte zu ihnen die Fliege und die fraß sie auf * und den Frosch, und der zerstörte sie.
+77:46 Und er gab ihre Früchte dem Mehltau preis * und ihre Mühen der Heuschrecke.
+77:47 Und er zerschlug mit Hagel ihre Weinstöcke * und ihre Maulbeerbäume mit Frost.
+77:48 Und er lieferte ihr Vieh dem Hagel aus * und ihren besitz dem Feuer.
+77:49 Er sandte über sie den zorn seines Unmuts, * Unmut und zorn und bedrängnis, Einwirkungen durch böse Engel.
+77:50 Einen Weg bahnte er dem Lauf seines zornes, nicht verschonte er ihre Seelen vor dem Tod, * und ihr Vieh beschloss er im Tod.
+77:51 Und er erschlug alle Erstgeburt im Land ägypten, * die Erstlinge all ihrer Mühen in den zelten Chams.
+77:52 Und er nahm heraus wie Schafe sein Volk * und führte sie wie eine Herde durch die Wüste.
+77:53 Und er leitete sie in Hoffnung, und sie fürchteten sich nicht, * und ihre Feinde bedeckte das Meer.
+77:54 Und er führte sie hin zum berg seiner Heiligung, * zum berg, den seine rechte erworben hat.
+77:54 Und er vertrieb vor ihrem Angesicht die Völker, * und durch das Los teilte er ihnen das Land mit der Messschnur.
+77:55 Und er ließ wohnen in deren zelten * die Stämme israels.
+77:56 Und sie versuchten und erbitterten den erhabenen Gott * und bewahrten nicht seine zeugnisse.
+77:57 Und sie wandten sich ab und hielten nicht den bund; * wie schon ihre Väter, wandelten sie sich in einen krummen bogen.
+77:58 zum zorn reizten sie ihn mit ihren Kulthöhen, * und durch ihre Schnitzbilder forderten sie ihn heraus zum Eifer.
+77:59 Gott hörte es und verschmähte sie * und machte israel sehr zunichte.
+77:60 Und er verwarf das zelt von Silo, * sein zelt, wo er Wohnung genommen unter den Menschen.
+77:61 Und er lieferte ihre Stärke in die Gefangenschaft aus * und ihre Schönheit in die Hände des Feindes.
+77:62 Und er schloss ein mit dem Schwert sein Volk * und verschmähte sein Erbe.
+77:63 ihre Jünglinge fraß das Feuer, * und ihre Jungfrauen wurden nicht betrauert.
+77:64 ihre Priester fielen durch das Schwert, * und ihre Witwen wurden nicht beweint.
+77:65 Und es erwachte wie ein Schlafender der Herr, * wie ein Mächtiger, trunken von Wein.
+77:66 Und er schlug ihre Feinde zurück, * ewige Schmach gab er ihnen.
+77:67 Und er verwarf das zelt Jo sephs, * und den Stamm Ephrai m erwählte er nicht,
+77:68 sondern er erwählte den Stamm Juda, * den berg Sion, den er liebte.
+77:69 Und er erbaute wie (ein Horn) von Einhörnern sein Heiligtum im Land, * das er begründet hat für immer.
+77:70 Und er erwählte David, seinen Knecht, und nahm ihn fort von den Herden der Schafe, * von den Mutterschafen nahm er ihn weg,
+77:71 zu weiden Jakob, seinen Knecht, * und israel, sein Erbe.
+77:72 Und er weidete sie in der Unschuld seines Herzens, * und durch die Einsicht seiner Hände leitete er sie.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm79.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm79.txt
@@ -1,20 +1,20 @@
-79:2 Qui regis Israël, inténde: * qui dedúcis velut ovem Joseph.
-79:2 Qui sedes super Chérubim, * manifestáre coram Éphraim, Bénjamin, et Manásse.
-79:3 Éxcita poténtiam tuam, et veni, * ut salvos fácias nos.
-79:4 Deus, convérte nos: * et osténde fáciem tuam, et salvi érimus.
-79:5 Dómine, Deus virtútum, * quoúsque irascéris super oratiónem servi tui?
-79:6 Cibábis nos pane lacrimárum: * et potum dabis nobis in lácrimis in mensúra?
-79:7 Posuísti nos in contradictiónem vicínis nostris: * et inimíci nostri subsannavérunt nos.
-79:8 Deus virtútum, convérte nos: * et osténde fáciem tuam, et salvi érimus.
-79:9 Víneam de Ægýpto transtulísti: * ejecísti gentes, et plantásti eam.
-79:10 Dux itíneris fuísti in conspéctu ejus: * plantásti radíces ejus, et implévit terram.
-79:11 Opéruit montes umbra ejus: * et arbústa ejus cedros Dei.
-79:12 Exténdit pálmites suos usque ad mare: * et usque ad flumen propágines ejus.
-79:13 Ut quid destruxísti macériam ejus: * et vindémiant eam omnes, qui prætergrediúntur viam?
-79:14 Exterminávit eam aper de silva: * et singuláris ferus depástus est eam.
-79:15 Deus virtútum, convértere: * réspice de cælo, et vide, et vísita víneam istam.
-79:16 Et pérfice eam, quam plantávit déxtera tua: * et super fílium hóminis, quem confirmásti tibi.
-79:17 Incénsa igni, et suffóssa * ab increpatióne vultus tui períbunt.
-79:18 Fiat manus tua super virum déxteræ tuæ: * et super fílium hóminis, quem confirmásti tibi.
-79:19 Et non discédimus a te, vivificábis nos: * et nomen tuum invocábimus.
-79:20 Dómine, Deus virtútum, convérte nos: * et osténde fáciem tuam, et salvi érimus.
+79:2 Der Du israel leitest, gib Acht, * der Du Joseph führst wie ein Schaf.
+79:2 Der Du über Cherubim thronst, * offenbare Dich vor Ephra im, benjamin und manasse.
+79:3 biete auf Deine macht und komm, * um uns zu retten.
+79:4 Gott, bekehre uns * und zeige Dein Angesicht, und wir werden gerettet sein.
+79:5 Herr, Gott der Heerscharen, * wie lange wirst Du zürnen über das Gebet Deines Knechtes?
+79:6 Willst Du uns mit Tränenbrot speisen * und zum Trank uns Tränen geben in reichem maß?
+79:7 Du hast uns gesetzt zum zankapfel für unsere nachbarn, * und unsere Feinde haben uns verhöhnt.
+79:8 Gott der Heerscharen, bekehre uns * und zeige Dein Angesicht, so werden wir gerettet sein.
+79:9 Einen Weinstock hast Du aus Ägypten übertragen, * hast Völker vertrieben und ihn eing epflanzt.
+79:10 Ein Führer auf dem Weg warst Du vor seinem Angesicht, * Du hast seine Wurzeln eingepflanzt, und er erfüllte das land.
+79:11 Sein Schatten bedeckte die berge * und seine ranken die zedern Gottes.
+79:12 Er streckte zweige aus bis zum meer * und bis zum Fluss seine Sprossen.
+79:13 Warum hast Du seine mauern niedergerissen, * und alle ernten ihn ab, die des Weges vorübergehen?
+79:14 zerwühlt hat ihn ein Eber aus dem Wald, * und ein einzelnes Wildtier hat ihn abgeweidet.
+79:15 Gott der Heerscharen, wende Dich um, * schau vom Himmel und sieh, und suche heim diesen Weinstock
+79:16 und vollende ihn, den Deine rechte gepflanzt hat, * und schau auf den menschensohn, den Du für Dich erstarken ließest.
+79:17 Er ist im Feuer verbrannt und untergraben; * vor dem Drohen Deines Angesichtes werden sie vergehen.
+79:18 Deine Hand sei über dem mann Deiner rechten * und über dem menschensohn, den Du für Dich erstarken ließest.
+79:19 und wir weichen nicht von Dir; Du wirst uns beleben, * und Deinen namen werden wir anrufen.
+79:20 Herr, Gott der Heerscharen, bekehre uns, * und zeige Dein Angesicht, und wir werden gerettet sein.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm81.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm81.txt
@@ -5,4 +5,4 @@
 81:5 Sie erkennen nichts, noch haben sie Einsicht, in Finsternis wandeln sie; * alle Grundfesten der Erde werden erschüttert.
 81:6 ich sprach: Götter seid ihr * und Söhne des Höchsten ihr alle.
 81:7 ihr aber werdet sterben wie menschen, * und wie einer der Fürsten werdet ihr fallen.
-81:8 Erhebe Dich, Gott, richte die Erde, * denn erben wirst Du unter allenVölkern. sten
+81:8 Erhebe Dich, Gott, richte die Erde, * denn erben wirst Du unter allenVölkern.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm82.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm82.txt
@@ -1,17 +1,17 @@
-82:2 Deus, quis símilis erit tibi? * Ne táceas, neque compescáris, Deus.
-82:3 Quóniam ecce inimíci tui sonuérunt: * et qui odérunt te extulérunt caput.
-82:4 Super pópulum tuum malignavérunt consílium: * et cogitavérunt advérsus sanctos tuos.
-82:5 Dixérunt: Veníte, et disperdámus eos de gente: * et non memorétur nomen Israël ultra.
-82:6 Quóniam cogitavérunt unanímiter: * simul advérsum te testaméntum disposuérunt, tabernácula Idumæórum et Ismahelítæ:
-82:8 Moab, et Agaréni, Gebal, et Ammon, et Ámalec: * alienígenæ cum habitántibus Tyrum.
-82:9 Étenim Assur venit cum illis: * facti sunt in adjutórium fíliis Lot.
-82:10 Fac illis sicut Mádian, et Sísaræ: * sicut Jabin in torrénte Cisson.
-82:11 Disperiérunt in Endor: * facti sunt ut stercus terræ.
-82:12 Pone príncipes eórum sicut Oreb, et Zeb, * et Zébee, et Sálmana:
-82:13 Omnes príncipes eórum: * qui dixérunt: Hereditáte possideámus Sanctuárium Dei.
-82:14 Deus meus, pone illos ut rotam: * et sicut stípulam ante fáciem venti.
-82:15 Sicut ignis, qui combúrit silvam: * et sicut flamma combúrens montes:
-82:16 Ita persequéris illos in tempestáte tua: * et in ira tua turbábis eos.
-82:17 Imple fácies eórum ignomínia: * et quærent nomen tuum, Dómine.
-82:18 Erubéscant, et conturbéntur in sæculum sæculi: * et confundántur, et péreant.
-82:19 Et cognóscant quia nomen tibi Dóminus: * tu solus Altíssimus in omni terra.
+82:2 Gott, wer ist Dir gleich? * Schweige nicht und halte Dich nicht zurück, o Gott!
+82:3 Denn siehe, Deine Feinde lärmten, * und die Dich hassten, erhoben ihr Haupt.
+82:4 Gegen Dein Volk fassten sie einen boshaften Plan * und haben beratschlagt gegen Deine Heiligen.
+82:5 Sie sagten: Kommt, lasst uns sie austilgen aus der Völkerschaft, * und nicht mehr soll gedacht werden des namens israels.
+82:6 Denn sie beratschlagten einmütig, * zugleich schlossen sie gegen Dich einen bund, die zelte der idumäer und ismaeliter,
+82:8 Moab und die Agarener, Gebal und Ammon und Amalek, * die Fremdgeborenen mit den bewohnern von Tyrus.
+82:9 Ja, auch Assur kam mit ihnen, * sie wurden zum beistand für die Söhne Lots.
+82:10 Tu mit ihnen wie Madian und Sisara, * wie Jabin am bach Cisson.
+82:11 Sie kamen um bei Endor, * sie wurden wie der Mist für die Erde.
+82:12 Mach ihre Fürsten wie Oreb und zeb * und zebee und Salmana.
+82:13 All ihre Fürsten, * die sprachen: Als Erbe lasst uns in besitz nehmen das Heiligtum Gottes.
+82:14 Mein Gott, mach sie wie ein rad * und wie Stroh vor dem Angesicht des Windes.
+82:15 Wie ein Feuer, das den Wald niederbrennt, * und wie eine Flamme, die berge versengt,
+82:16 so wirst Du sie verfolgen in Deinem Sturm, * und in Deinem zorn sie verwirren.
+82:17 Erfülle ihr Angesicht mit Schande, * und sie werden Deinen namen suchen, Herr.
+82:18 Sie sollen sich schämen und verwirrt werden in alle Ewigkeit * und zuschanden werden und zugrunde gehen.
+82:19 Und sie sollen erkennen, dass Dein name ‚Herr‘ ist, * dass Du allein der Höchste bist auf der ganzen Erde.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm83.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm83.txt
@@ -1,13 +1,13 @@
-83:2 Quam dilécta tabernácula tua, Dómine virtútum: * concupíscit, et déficit ánima mea in átria Dómini.
-83:3 Cor meum, et caro mea * exsultavérunt in Deum vivum.
-83:4 Étenim passer invénit sibi domum: * et turtur nidum sibi, ubi ponat pullos suos.
-83:4 Altária tua, Dómine virtútum: * Rex meus, et Deus meus.
-83:5 Beáti, qui hábitant in domo tua, Dómine: * in sæcula sæculórum laudábunt te.
-83:6 Beátus vir, cujus est auxílium abs te: * ascensiónes in corde suo dispósuit, in valle lacrimárum in loco, quem pósuit.
-83:8 Étenim benedictiónem dabit legislátor, ibunt de virtúte in virtútem: * vidébitur Deus deórum in Sion.
-83:9 Dómine, Deus virtútum, exáudi oratiónem meam: * áuribus pércipe, Deus Jacob.
-83:10 Protéctor noster, áspice, Deus: * et réspice in fáciem Christi tui:
-83:11 Quia mélior est dies una in átriis tuis, * super míllia.
-83:11 Elégi abjéctus esse in domo Dei mei: * magis quam habitáre in tabernáculis peccatórum.
-83:12 Quia misericórdiam, et veritátem díligit Deus: * grátiam et glóriam dabit Dóminus.
-83:13 Non privábit bonis eos, qui ámbulant in innocéntia: * Dómine virtútum, beátus homo, qui sperat in te.
+83:2 Wie liebenswert sind Deine zelte, Herr der Heerscharen! * Es sehnt und verzehrt sich meine Seele nach den Vorhöfen des Herrn.
+83:3 mein Herz und mein Fleisch * jubelten auf zum lebendigen Gott.
+83:4 Denn auch der Sperling hat ein Haus für sich gefunden * und die Taube ein nest für sich, wohin sie ihre Jungen legt,
+83:4 Deine Altäre, Herr der Heerscharen, * mein König und mein Gott.
+83:5 Selig, die wohnen in Deinem Haus, o Herr! * in alle Ewigkeit werden sie Dich loben.
+83:6 Selig der mann, dessen Hilfe von Dir kommt; * Aufstiege hat er in seinem Herzen beschlossen im Tal der Tränen zu dem Ort hin, den er bestimmt hat.
+83:8 Denn Segen wird spenden der Gesetzgeber, sie werden wandeln von Kraft zu Kraft, * man wird schauen den Gott der Götter in Sion.
+83:9 Herr, Gott der Heerscharen, erhöre mein Gebet, * nimm es zu Ohren, Gott Jakobs.
+83:10 unser beschützer, schau her, o Gott, * und sieh auf das Angesicht Deines Gesalbten.
+83:11 Denn besser ist ein einziger Tag in Deinen Vorhöfen, * mehr als tausend andere.
+83:11 lieber will ich abgeschoben sein im Haus meines Gottes, * als wohnen in den zelten der Sünder.
+83:12 Denn Gott liebt barmherzigkeit und Wahrheit, * Gnade und Herrlichkeit wird geben der Herr.
+83:13 Güter wird er denen nicht versagen, die wandeln in unschuld. * Herr der Heerscharen, selig der mensch, der auf Dich hofft!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm85.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm85.txt
@@ -1,16 +1,16 @@
-85:1 Inclína, Dómine, aurem tuam, et exáudi me: * quóniam inops, et pauper sum ego.
-85:2 Custódi ánimam meam, quóniam sanctus sum: * salvum fac servum tuum, Deus meus, sperántem in te.
-85:3 Miserére mei, Dómine, quóniam ad te clamávi tota die: * lætífica ánimam servi tui, quóniam ad te, Dómine, ánimam meam levávi.
-85:5 Quóniam tu, Dómine, suávis, et mitis: * et multæ misericórdiæ ómnibus invocántibus te.
-85:6 Áuribus pércipe, Dómine, oratiónem meam: * et inténde voci deprecatiónis meæ.
-85:7 In die tribulatiónis meæ clamávi ad te: * quia exaudísti me.
-85:8 Non est símilis tui in diis, Dómine: * et non est secúndum ópera tua.
-85:9 Omnes gentes quascúmque fecísti, vénient, et adorábunt coram te, Dómine: * et glorificábunt nomen tuum.
-85:10 Quóniam magnus es tu, et fáciens mirabília: * tu es Deus solus.
-85:11 Deduc me, Dómine, in via tua, et ingrédiar in veritáte tua: * lætétur cor meum ut tímeat nomen tuum.
-85:12 Confitébor tibi, Dómine, Deus meus, in toto corde meo, * et glorificábo nomen tuum in ætérnum:
-85:13 Quia misericórdia tua magna est super me: * et eruísti ánimam meam ex inférno inferióri.
-85:14 Deus, iníqui insurrexérunt super me, et synagóga poténtium quæsiérunt ánimam meam: * et non proposuérunt te in conspéctu suo.
-85:15 Et tu, Dómine, Deus miserátor et miséricors, * pátiens, et multæ misericórdiæ, et verax,
-85:16 Réspice in me, et miserére mei, * da impérium tuum púero tuo: et salvum fac fílium ancíllæ tuæ.
-85:17 Fac mecum signum in bonum, ut vídeant qui odérunt me, et confundántur: * quóniam tu, Dómine, adjuvísti me, et consolátus es me.
+85:1 neige, o Herr, Dein Ohr und erhöre mich, * denn ich bin hilflos und arm.
+85:2 behüte meine Seele, denn ich bin heilig, * rette Deinen Knecht, mein Gott, der auf Dich hofft.
+85:3 Erbarme Dich meiner, o Herr, denn ich rufe zu Dir den ganzen Tag, * erfreue die Seele Deines Knechtes, denn zu Dir, Herr, erhebe ich meine Seele.
+85:5 Denn Du, Herr, bist gütig und milde * und von großer barmherzigkeit für alle, die Dich anrufen.
+85:6 Vernimm, o Herr, mein Gebet, * und achte auf die Stimme meines Flehens.
+85:7 Am Tag meiner Drangsal habe ich zu Dir gerufen, * denn Du hast mich erhört.
+85:8 Keiner ist Dir gleich unter den Göttern, Herr, * und nichts entspricht Deinen Werken.
+85:9 Alle Völker, die Du gemacht hast, werden kommen und vor Dir anbeten, Herr, * und sie werden Deinen namen verherrlichen.
+85:10 Denn groß bist Du und Wunder vollbringend, * Du allein bist Gott.
+85:11 Geleite mich, Herr, auf Deinem Weg, und ich will wandeln in Deiner Wahrheit. * Es freue sich mein Herz, damit es Deinen namen fürchte.
+85:12 ich will Dich preisen, Herr, mein Gott, mit meinem ganzen Herzen * und Deinen namen verherrlichen in Ewigkeit.
+85:13 Denn Deine barmherzigkeit ist groß über mir, * und Du hast meine Seele errettet aus tiefster unterwelt.
+85:14 Gott, Frevler haben sich gegen mich erhoben, und eine rotte von mächtigen trachtet nach meiner Seele, * und sie haben Dich nicht vor ihr Angesicht gestellt.
+85:15 und Du, Herr, Gott, bist ein Erbarmer und barmherzig, * geduldig und reich an barmherzigkeit und wahrhaftig.
+85:16 Schau auf mich und erbarme Dich meiner, * gib macht Deinem Diener und rette den Sohn Deiner magd.
+85:17 Tu an mir ein zeichen zum Guten, damit es sehen, die mich hassen, und beschämt werden; * denn Du, Herr, hast mir geholfen und mich getröstet.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm86.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm86.txt
@@ -4,4 +4,4 @@
 86:4 Siehe, Fremdstämmige und Tyrus und das Volk der Äthiopier, * sie sind dort gewesen.
 86:5 Wird man nicht von Sion sagen: mensch für mensch ist in ihr geboren, * und er selbst hat sie gegründet, der Allerhöchste?
 86:6 Der Herr wird es erzählen in den urkunden der Völker und Fürsten, * jener, die in ihr (in Sion) waren.
-86:7 Wie von lauter Frohlockenden * ist das Wohnen in dir. sten
+86:7 Wie von lauter Frohlockenden * ist das Wohnen in dir.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm87.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm87.txt
@@ -1,19 +1,19 @@
-87:2 Dómine, Deus salútis meæ: * in die clamávi, et nocte coram te.
-87:3 Intret in conspéctu tuo orátio mea: * inclína aurem tuam ad precem meam:
-87:4 Quia repléta est malis ánima mea: * et vita mea inférno appropinquávit.
-87:5 Æstimátus sum cum descendéntibus in lacum: * factus sum sicut homo sine adjutório, inter mórtuos liber.
-87:6 Sicut vulneráti dormiéntes in sepúlcris, quorum non es memor ámplius: * et ipsi de manu tua repúlsi sunt.
-87:7 Posuérunt me in lacu inferióri: * in tenebrósis, et in umbra mortis.
-87:8 Super me confirmátus est furor tuus: * et omnes fluctus tuos induxísti super me.
-87:9 Longe fecísti notos meos a me: * posuérunt me abominatiónem sibi.
-87:9 Tráditus sum, et non egrediébar: * óculi mei languérunt præ inópia.
-87:10 Clamávi ad te, Dómine, tota die: * expándi ad te manus meas.
-87:11 Numquid mórtuis fácies mirabília: * aut médici suscitábunt, et confitebúntur tibi?
-87:12 Numquid narrábit áliquis in sepúlcro misericórdiam tuam, * et veritátem tuam in perditióne?
-87:13 Numquid cognoscéntur in ténebris mirabília tua, * et justítia tua in terra obliviónis?
-87:14 Et ego ad te, Dómine, clamávi: * et mane orátio mea prævéniet te.
-87:15 Ut quid, Dómine, repéllis oratiónem meam: * avértis fáciem tuam a me?
-87:16 Pauper sum ego, et in labóribus a juventúte mea: * exaltátus autem, humiliátus sum et conturbátus.
-87:17 In me transiérunt iræ tuæ: * et terróres tui conturbavérunt me.
-87:18 Circumdedérunt me sicut aqua tota die: * circumdedérunt me simul.
-87:19 Elongásti a me amícum et próximum: * et notos meos a miséria.
+87:2 Herr, Du Gott meines Heils, * am Tag habe ich gerufen und in der nacht, vor Dir.
+87:3 Es komme mein Gebet vor Dein Angesicht, * neige Dein Ohr zu meiner bitte.
+87:4 Denn erfüllt von leid ist meine Seele, * und mein leben hat sich der unterwelt genaht.
+87:5 ich wurde zu denen gezählt, die hinabsteigen ins Grab, * bin geworden wie ein mensch ohne Hilfe, frei unter Toten,
+87:6 wie Erschlagene, die in Gräbern ruhen, derer Du nicht mehr gedenkst; * und sie sind von Deiner Hand verstoßen.
+87:7 Sie legten mich in die tiefste Grube, * in Finsternis und in Schatten des Todes.
+87:8 Auf mich legte sich schwer Dein Grimm, * und all Deine Fluten führtest Du über mich.
+87:9 meine bekannten hast Du weit von mir entfernt, * sie machten mich zum Abscheu für sich.
+87:9 ich wurde ausgeliefert und kam nicht mehr heraus, * meine Augen sind ermattet vor not.
+87:10 ich schrie zu Dir, o Herr, den ganzen Tag * und streckte meine Hände nach Dir aus.
+87:11 Wirst Du etwa an den Toten Wunder tun, * oder werden Ärzte sie erwecken, und werden sie Dich dann preisen?
+87:12 Wird etwa jemand im Grab Deine barmherzigkeit verkünden * und Deine Wahrheit am Ort des Verderbens?
+87:13 Werden denn in der Finsternis Deine Wunder kund * und Deine Gerechtigkeit im land des Vergessens?
+87:14 ich aber, Herr, habe zu Dir geschrien, * und am morgen soll mein Gebet vor Dich gelangen.
+87:15 Warum, Herr, weist Du mein Gebet zurück, * wendest Dein Angesicht von mir ab?
+87:16 Arm bin ich und in mühen von meiner Jugend an, * erhöht aber, ward ich erniedrigt und erschreckt.
+87:17 Dein zorn ging über mich hin, * und Deine Schrecken verwirrten mich.
+87:18 Sie umgaben mich wie Wasser den ganzen Tag, * sie haben mich alle zugleich umgeben.
+87:19 Entfernt hast Du von mir den Freund und den nächsten * und meine bekannten ob des Elends.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm88.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm88.txt
@@ -1,51 +1,51 @@
-88:2 Misericórdias Dómini * in ætérnum cantábo.
-88:2 In generatiónem et generatiónem * annuntiábo veritátem tuam in ore meo.
-88:3 Quóniam dixísti: In ætérnum misericórdia ædificábitur in cælis: * præparábitur véritas tua in eis.
-88:4 Dispósui testaméntum eléctis meis, jurávi David, servo meo: * Usque in ætérnum præparábo semen tuum.
-88:5 Et ædificábo in generatiónem et generatiónem * sedem tuam.
-88:6 Confitebúntur cæli mirabília tua, Dómine: * étenim veritátem tuam in ecclésia sanctórum.
-88:7 Quóniam quis in núbibus æquábitur Dómino: * símilis erit Deo in fíliis Dei?
-88:8 Deus, qui glorificátur in consílio sanctórum: * magnus et terríbilis super omnes qui in circúitu ejus sunt.
-88:9 Dómine, Deus virtútum, quis símilis tibi? * potens es, Dómine, et véritas tua in circúitu tuo.
-88:10 Tu domináris potestáti maris: * motum autem flúctuum ejus tu mítigas.
-88:11 Tu humiliásti sicut vulnerátum, supérbum: * in bráchio virtútis tuæ dispersísti inimícos tuos.
-88:12 Tui sunt cæli, et tua est terra, orbem terræ et plenitúdinem ejus tu fundásti: * aquilónem, et mare tu creásti.
-88:13 Thabor et Hermon in nómine tuo exsultábunt: * tuum bráchium cum poténtia.
-88:14 Firmétur manus tua, et exaltétur déxtera tua: * justítia et judícium præparátio sedis tuæ.
-88:15 Misericórdia et véritas præcédent fáciem tuam: * beátus pópulus, qui scit jubilatiónem.
-88:16 Dómine, in lúmine vultus tui ambulábunt, et in nómine tuo exsultábunt tota die: * et in justítia tua exaltabúntur.
-88:18 Quóniam glória virtútis eórum tu es: * et in beneplácito tuo exaltábitur cornu nostrum.
-88:19 Quia Dómini est assúmptio nostra, * et Sancti Israël, regis nostri.
-88:20 Tunc locútus es in visióne sanctis tuis, et dixísti: * Pósui adjutórium in poténte: et exaltávi eléctum de plebe mea.
-88:21 Invéni David, servum meum: * óleo sancto meo unxi eum.
-88:22 Manus enim mea auxiliábitur ei: * et bráchium meum confortábit eum.
-88:23 Nihil profíciet inimícus in eo, * et fílius iniquitátis non appónet nocére ei.
-88:24 Et concídam a fácie ipsíus inimícos ejus: * et odiéntes eum in fugam convértam.
-88:25 Et véritas mea, et misericórdia mea cum ipso: * et in nómine meo exaltábitur cornu ejus.
-88:26 Et ponam in mari manum ejus: * et in flumínibus déxteram ejus.
-88:27 Ipse invocábit me: Pater meus es tu: * Deus meus, et suscéptor salútis meæ.
-88:28 Et ego primogénitum ponam illum * excélsum præ régibus terræ.
-88:29 In ætérnum servábo illi misericórdiam meam: * et testaméntum meum fidéle ipsi.
-88:30 Et ponam in sæculum sæculi semen ejus: * et thronum ejus sicut dies cæli.
-88:31 Si autem derelíquerint fílii ejus legem meam: * et in judíciis meis non ambuláverint:
-88:32 Si justítias meas profanáverint: * et mandáta mea non custodíerint:
-88:33 Visitábo in virga iniquitátes eórum: * et in verbéribus peccáta eórum.
-88:34 Misericórdiam autem meam non dispérgam ab eo: * neque nocébo in veritáte mea:
-88:35 Neque profanábo testaméntum meum: * et quæ procédunt de lábiis meis, non fáciam írrita.
-88:36 Semel jurávi in sancto meo: Si David méntiar: * semen ejus in ætérnum manébit.
-88:37 Et thronus ejus sicut sol in conspéctu meo, * et sicut luna perfécta in ætérnum: et testis in cælo fidélis.
-88:39 Tu vero repulísti et despexísti: * distulísti Christum tuum.
-88:40 Evertísti testaméntum servi tui: * profanásti in terra Sanctuárium ejus.
-88:41 Destruxísti omnes sepes ejus: * posuísti firmaméntum ejus formídinem.
-88:42 Diripuérunt eum omnes transeúntes viam: * factus est oppróbrium vicínis suis.
-88:43 Exaltásti déxteram depriméntium eum: * lætificásti omnes inimícos ejus.
-88:44 Avertísti adjutórium gládii ejus: * et non es auxiliátus ei in bello.
-88:45 Destruxísti eum ab emundatióne: * et sedem ejus in terram collisísti.
-88:46 Minorásti dies témporis ejus: * perfudísti eum confusióne.
-88:47 Úsquequo, Dómine, avértis in finem: * exardéscet sicut ignis ira tua?
-88:48 Memoráre quæ mea substántia: * numquid enim vane constituísti omnes fílios hóminum?
-88:49 Quis est homo, qui vivet, et non vidébit mortem: * éruet ánimam suam de manu ínferi?
-88:50 Ubi sunt misericórdiæ tuæ antíquæ, Dómine, * sicut jurásti David in veritáte tua?
-88:51 Memor esto, Dómine, oppróbrii servórum tuórum * quod contínui in sinu meo multárum géntium.
-88:52 Quod exprobravérunt inimíci tui, Dómine, * quod exprobravérunt commutatiónem Christi tui.
-88:53 Benedíctus Dóminus in ætérnum: * fiat, fiat.
+88:2 Die barmherzigkeit des Herrn * will ich in Ewigkeit besingen.
+88:2 Von Geschlecht zu Geschlecht * will ich Deine Wahrheit verkünden mit meinem mund.
+88:3 Denn Du hast gesagt: in Ewigkeit wird barmherzigkeit errichtet in den Himmeln, * Deine Wahrheit wird bereitet in ihnen.
+88:4 Einen bund habe ich geschlossen mit meinen Erwählten, ich habe David, meinem Knecht, geschworen: * bis in Ewigkeit will ich dir nachkommen bereiten.
+88:5 und errichten will ich von Geschlecht zu Geschlecht * deinen Thron.
+88:6 Preisen werden die Himmel Deine Wunder, o Herr, * und Deine Wahrheit in der Versammlung der Heiligen.
+88:7 Denn wer in den Wolken gleicht dem Herrn? * Wer wird Gott ähnlich sein unter den Gottessöhnen?
+88:8 Gott, der verherrlicht wird im rat der Heiligen, * ist groß und schrecklich, mehr als alle, die rings um ihn sind.
+88:9 Herr, Gott der Heere, wer ist Dir ähnlich? * mächtig bist Du, Herr, und Deine Wahrheit ist rings um Dich.
+88:10 Du beherrschst die Gewalt des meeres, * die bewegung seiner Fluten milderst Du.
+88:11 Du hast den Hochmütigen erniedrigt wie einen Verwundeten, * mit dem Arm Deiner Kraft hast Du Deine Feinde zerstreut.
+88:12 Dein sind die Himmel und Dein ist die Erde, den Erdkreis und seine Fülle hast Du gegründet, * den norden und das Südmeer hast Du geschaffen.
+88:13 Tabor und Hermon werden jauchzen in Deinem namen, * Dein Arm ist mit macht.
+88:14 Erstarken soll Deine Hand, und erhöht werden soll Deine rechte, * Gerechtigkeit und recht sind die Stütze Deines Thrones.
+88:15 barmherzigkeit und Wahrheit gehen her vor Deinem Angesicht; * selig das Volk, das Jubel kennt.
+88:16 Herr, im licht Deines Angesichts werden sie wandeln und in Deinem namen frohlocken den ganzen Tag, * und in Deiner Gerechtigkeit werden sie erhöht.
+88:18 Denn der ruhm ihrer Kraft bist Du, * und durch Dein Wohlgefallen wird erhöht unser Horn.
+88:19 Denn der Herr ist es, der uns aufnimmt, * der Heilige israels, unser König.
+88:20 Damals hast Du in einer Schauung zu Deinen Heiligen gesprochen und gesagt: * ich gewährte einem Helden beistand und erhöhte einen Auserwählten aus meinem Volk.
+88:21 ich habe David, meinen Knecht, gefunden, * mit meinem heiligen Öl ihn gesalbt.
+88:22 Denn meine Hand soll ihm helfen * und mein Arm ihn stärken.
+88:23 Keinen nutzen soll der Feind von ihm haben, * und der Sohn der bosheit soll nicht ansetzen, ihm zu schaden.
+88:24 und zermalmen will ich seine Feinde vor seinem Angesicht * und die ihn hassen in die Flucht schlagen.
+88:25 und meine Wahrheit und meine barmherzigkeit sind mit ihm, * und in meinem namen wird erhöht werden sein Horn.
+88:26 und auf das meer will ich seine Hand legen * und auf die Flüsse seine rechte.
+88:27 Er wird mich anrufen: mein Vater bist Du, * mein Gott und der Hort meines Heils.
+88:28 und zum Erstgeborenen will ich ihn machen, * erhaben vor den Königen der Erde.
+88:29 in Ewigkeit will ich ihm meine barmherzigkeit bewahren, * und mein bund ist ihm treu.
+88:30 und ich will einsetzen von Ewigkeit zu Ewigkeit seine nachkommen * und seinen Thron wie die Tage des Himmels.
+88:31 Wenn aber seine Söhne mein Gesetz verlassen * und nicht nach meinen urteilen wandeln,
+88:32 wenn sie meine rechtssprüche entweihen * und meine Gebote nicht beachten,
+88:33 dann werde ich heimsuchen mit der rute ihre ungerechtigkeiten * und mit Schlägen ihre Sünden.
+88:34 meine barmherzigkeit aber will ich nicht von ihm abziehen, * noch will ich Schaden tun an meiner Wahrheit.
+88:35 nicht will ich entweihen meinen bund, * und was hervorgeht von meinen lippen, will ich nicht ungültig machen.
+88:36 Einmal habe ich geschworen in meinem Heiligtum, niemals will ich David belügen: * Sein nachkomme soll bleiben in Ewigkeit
+88:37 und sein Thron wie die Sonne vor meinem Angesicht * und wie der mond, bereitet auf ewig und ein treuer zeuge am Himmel.
+88:39 Du aber hast verworfen und verschmäht, * verstoßen hast Du Deinen Gesalbten.
+88:40 umgestürzt hast Du den bund Deines Knechtes, * entweiht im lande sein Heiligtum.
+88:41 niedergerissen hast Du all seine zäune, * seine Festung hast Du zum Schreckbild gemacht.
+88:42 Ausgeraubt haben ihn alle, die des Weges vorübergingen, * zur Schmach ist er geworden für seine nachbarn.
+88:43 Erhöht hast Du die rechte seiner bedränger, * hast erfreut all seine Feinde.
+88:44 Abgewandt hast Du die Hilfe seines Schwertes, * und im Krieg hast Du ihm nicht geholfen.
+88:45 Abgebrochen hast Du ihn von der reinigung * und seinen Thron zur Erde geschmettert.
+88:46 Abgekürzt hast Du die Tage seiner zeit, * hast ihn übergossen mit Schmach.
+88:47 Wie lange noch, Herr, wirst Du Dich gänzlich abwenden, * wird brennen wie Feuer Dein zorn?
+88:48 Gedenke, was mein Dasein ist; * hast Du denn vergeblich alle menschenkinder erschaffen?
+88:49 Wer ist der mensch, der leben und den Tod nicht schauen wird, * der seine Seele rettet aus der Hand der unterwelt?
+88:50 Wo sind Deine alten Erbarmungen, Herr, * wie Du David geschworen hast in Deiner Wahrheit?
+88:51 Gedenke, Herr, der Schmach Deiner Knechte, * die ich in meiner brust bewahrte, vonseiten vieler Völker,
+88:52 womit Deine Feinde geschmäht haben, Herr, * womit sie geschmäht haben das lösegeld Deines Gesalbten.
+88:53 Gebenedeit sei der Herr in Ewigkeit. * So sei es! So sei es!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm89.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm89.txt
@@ -1,19 +1,19 @@
-89:1 O Herr, du bist doch unsere Zuflucht * von Geschlecht zu Geschlecht.
-89:2 Der du, bevor die Berge standen, und bevor die Erde und die ganze Welt gebildet wurde, * von Ewigkeit und bis in Ewigkeit, o Gott, hast deine Dauer;
-89:3 Lass doch das ganze Volk zum Staub nicht werden, * selbst wenn du auch verordnet: „Kehrt zurück, woher ihr seid, ihr aus dem Staub Gemachten!“
-89:4 Ach, tausend Jahre sind vor deinen Augen * wie der Tag von gestern, der vorbei ist,
-89:5 Und wie eine Wache in der Nacht, * als nichts dagegen muss doch gelten, was wir an Jahren haben.
-89:6 Wir sind wie Gras, das morgens sprosst hervor, das morgens aufgeht und emporschießt, * am Abend schlaff und welk wird und vertrocknet.
-89:7 Ach, grad so sinken wir dahin in deinem Zorne, * bei diesem deinem Grimme müssen wir all unseren Halt verlieren.
-89:8 Wenn du dir hältst vor Augen unsere Missetaten, * wenn unser Leben du mit deinem Blick durchleuchtest,
-89:9 Dann freilich muss das Leben uns entschwinden, * bei diesem deinem Zorne müssen wir zugrunde gehen.
-89:9 Die Dauer unsres Lebens wird bewertet wie das Gewebe einer Spinne: * Die Dauer unseres Lebens, alles eingeschlossen, ist nur siebzig Jahre.
-89:10 Und wenn es hochkommt, achtzig Jahre: * davon die meisten Mühsal nur und Elend.
-89:10 Dann kommt das Siechtum, * dann werden wir dahingerafft vom Tode.
-89:11 Wer kann wohl deines Grimmes Heftigkeit noch richtig finden? * und richtig finden, auch wenn er dir noch so treu ist, deine Zornglut?
-89:12 Schenk uns die Lebensdauer, die uns zukommt, so wird man's erkennen * wie wir gelehrigen Herzens und voll Weisheit werden.
-89:13 Ach, ändere dein Verhalten, Herr, wie lange soll es noch dauern? * Lass endlich dich zur Gnade stimmen gegen deine Knechte.
-89:14 Wir müssten gleich die Fülle deiner Huld erfahren, * dann könnten wir frohlocken und uns freuen alle Tage unsres Lebens.
-89:15 Wir könnten uns dann freuen zum Erlass für all die Tage, wo du uns gezüchtigt, * für all die Jahre, wo wir Bitterkeit erfahren.
-89:16 So schau hernieder doch auf deine Knechte, und auf deine Werke, * und leite ihre Kinder.
-89:17 Es leuchte die Huld des Herrn, unseres Gottes, nun über uns, und hilf durch deinen Beistand uns die Werke unserer Hände recht zu machen, * ja segne das, was unsere Hände auszuführen haben.
+89:1 Herr, zur zuflucht bist Du uns geworden * von Geschlecht zu Geschlecht.
+89:2 bevor die berge wurden oder die Erde geformt ward und der Erdkreis, * von Ewigkeit und bis in Ewigkeit bist Du, o Gott.
+89:3 Verstoße den menschen nicht in niedrigkeit, * der Du gesagt hast: bekehret euch, ihr menschenkinder.
+89:4 Denn tausend Jahre sind in Deinen Augen * wie der gestrige Tag, der vorüberging,
+89:5 und wie eine Wache in der nacht; * was für nichts erachtet wird, das werden ihre Jahre sein.
+89:6 Am morgen vergeht er wie das Gras, am morgen blüht es auf und vergeht, * am Abend fällt es ab, wird hart und vertrocknet.
+89:7 Denn wir schwinden dahin durch Deinen zorn, * und durch Deinen Grimm sind wir erschüttert.
+89:8 unsere missetaten hast Du vor Dich hingestellt, * unsere lebenszeit in das licht Deines Angesichts.
+89:9 Denn all unsere Tage schwinden dahin, * und durch Deinen zorn sind wir geschwunden.
+89:9 unsere Jahre werden betrachtet wie ein Spinngewebe, * die Tage unserer Jahre, in ihnen sind siebzig Jahre;
+89:10 wenn aber in den Starken, so sind es achtzig Jahre, * und was da rüber hinaus geht ist mühsal und Schmerz.
+89:10 Denn über uns gekommen ist Altersschwachheit, * und wir werden dahingerafft.
+89:11 Wer weiß die Gewalt Deines zornes * und in Furcht vor Dir Deinen Grimm zu ermessen?
+89:12 Deine rechte tue so kund, * und die im Herzen Gebildeten in Weisheit.
+89:13 Kehre um, o Herr, wie lange noch? * und lass Dich bitten für Deine Knechte.
+89:14 Am morgen wurden wir erfüllt von Deiner barmherzigkeit, * und wir frohlockten und freuten uns all unsere Tage.
+89:15 Wir sind erfreut für die Tage, an denen Du uns erniedrigt hast, * für die Jahre, in denen wir unglück sahen.
+89:16 Schau auf Deine Diener und auf Deine Werke * und leite ihre Söhne.
+89:17 und der Glanz des Herrn, unseres Gottes, komme über uns, und die Werke unserer Hände lenke über uns, * ja, das Werk unserer Hände, lenke es!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm9.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm9.txt
@@ -1,42 +1,42 @@
-9:2 Ich muß dich preisen, Herr, aus meinem vollen Herzen, * verkünden alle deine Wundertaten.
-9:3 Ich bin durch dich so glücklich, daß ich hüpfen könnte, * wenn ich, o Höchster, dir zu Ehren singe.
-9:4 Da du zurückgeschlagen meine Feinde * daß sie ermattet ganz vor deinem Blick verschwanden.
-9:5 Ja, du hast mir mein Recht verschafft in meiner Sache, * du hast auf deinem Throne Platz genommen und nach Recht entschieden.
-9:6 Als du die Rotten anfuhrst, kamen um die Frevler; * selbst ihren Namen hast du ausgetilgt für immer und für alle Zeiten.
-9:7a Da brachen ganz der Feinde Spieße, * und ihre Burgen legtest du in Trümmer.
-9:7b Das Andenken an sie ist wie ein Hauch vergangen, * (8a) Du aber, Herr, bleibst ewig.
-9:8b Du hast auf Recht fest deinen Thron gegründet, * (9) Du lenkest nun, wie sich's gehört, den Erdkreis, richtest in Gerechtigkeit die Völker.
-9:10 So bist du, Herr, für die Bedrängten eine Zuflucht, * ein Helfer in den Nöten, wenn Gefahr droht.
-9:11 Drum müssen dir vertrauen alle, die dich kennen; * du läßt ja nie im Stich, o Herr, die dir die Treue halten.
-9:12 O singt dem Herrn zu Ehren, der auf Sion wohnet; * verkündet bei den Völkern seine Hulderweise.
-9:13 Ja, er behält es im Gedächtnis sich, ihr Blut zu rächen; * er überhöret nicht der Bedrängten Flehen:
-9:14 „Erbarm' dich unser, Herr (haben sie gebeten), * sieh doch unsre Not von seiten unsrer Feinde.
-9:15 Und heb' heraus uns aus des Todes Pforten, * Damit wir all dein Lob verkünden können in dem lieben Sion,
-9:16a Frohlocken über deine Rettergnade, * wenn fest die Rotten stecken in der Falle, die sie hergerichtet,
-9:16b Wenn in demselben Netz, das sie versteckt, * sich ihre eignen Füße fangen,
-9:17 Damit man's anmerkt, daß der Herr Gericht hält, * wenn in dem eignen Machwerk sich verstricken diese Frevler.“
-9:18 Drum sinken alle Frevler in die Gräber, * die Rotten alle, die an Gott nicht denken;
-9:19 Denn nie darf hilflos bleiben der Bedrängte, * die Hoffnung der Bedrängten darf niemals umsonst sein.
-9:20 Auf, also Herr, laß nicht zu stark die Horde werden, * ihr Urteil sollen nun von dir bekommen diese Rotten.
-9:21 Leg' ihnen, Herr, doch einen Zaum an, der sie bändigt, * damit die Horden einseh'n, daß sie bloß Menschenkräfte haben.
-9:22 Weshalb, o Herr, † hältst du so weit zurück dich, * und übersiehst uns ganz in unsern Nöten und Gefahren?
-9:23 Wo bei dem Übermut der Frevler die Bedrängten Feuerqualen leiden, * da sie gefangen werden in den Ränken, welche jene brüten.
-9:24 Sieh, wie die Frevler prahlen mit den Plänen ihres Herzens, * wie Bösewichten alles sich in Segen wandelt.
-9:25 Es fordert dich, o Herr, heraus der Frevler, * wenn er im Übermaß der Leidenschaft sich denkt: „Er achtet ja auf gar nichts;“
-9:26a Wenn's keinen Gott für sie gibt; * drum sind auch ihre Taten jederzeit voll von Gemeinheit.
-9:26b Es sind vor ihrem Blick verborgen deine Strafgerichte, * da sie alle überwinden, die sich gegen sie erheben.
-9:27 Sie bilden sich nun ein in ihren Herzen: * Wir bleiben ohne Schaden, sind auf ewig sicher vor der Strafe.“
-9:28 Drum trieft ihr Mund ganz von Verwünschung und von Kränkung und von Schalkheit, * in ihrem Sinn ist Schadensucht und Bosheit.
-9:29 Sie liegen ganz versteckt im Hinterhalt wie Diebe, * um die Schuldlosen totzuschlagen.
-9:30a Ihr Blick ist auf die Wehrlosen gerichtet. * Sie lauern im Verborgnen, wie ein Leu in seiner Höhle;
-9:30b Sie lauern, um den Wehrlosen zu packen, * ja, den Wehrlosen zu packen dadurch, daß sie ihn mit ihrem Netz umschlingen.
-9:31 Sie werfen ihn zu Boden, stürzen über ihn und fallen auf ihn; so überwinden sie den Armen.
-9:32 Sie bilden sich ja ein in ihrem Herzen: * „Gott beachtet dies nicht, er hat sein Antlitz abgewandt und sieht nun gar nichts.“
-9:33 Drum auf, o Herr und Gott, erhebe deine Faust doch, * und laß nicht unbeachtet diese Armen.
-9:34 Wie kommen diese Frevler denn dazu, o Gott, dich so zu reizen, * ja selbst in ihrem Sinn sich einzubilden: „Er beachtet gar nichts.“
-9:35a Du mußt das sehen, ja, du achtest doch genau auf die Gewalttat und die Quälereien * und nimmst in deine Hand sie.
-9:35b Auf dich sind doch die Armen angewiesen; * den Hilflosen bist doch du der Helfer.
-9:36 Zermalm' die Arme dieser niederträchtigen Frevler, * daß, wenn man sucht, ob sie ein Unheil angerichtet, nichts gefunden werde.
-9:37 O Herr, der König sollst auf ewig und für alle Zeiten du sein; * ganz ausgerottet werden müßt ihr Horden, daß ihr niemals in sein Land hineinkommt.
-9:38 Die heißen Bitten der Bedrängten mußt du, Herr, erhören; * die Seufzer ihrer Herzen muß dein Ohr vernehmen.
-9:39 Sei also Rächer der Verlass'nen und Bedrängten, * daß niemals mehr ein Unhold übermütig wird im Lande.
+9:2 ich will Dich preisen, Herr, mit meinem ganzen Herzen, * erzählen will ich all Deine Wunder,
+9:3 mich freuen und jubeln in Dir, * spielen Deinem namen, Du Höchster.
+9:4 Wenn meine Feinde sich nach hinten abwenden, * werden sie ermatten und zugrunde gehen vor Deinem Angesicht;
+9:5 denn Du hast mein recht und meine Sache zum Erfolg geführt, * Du hast Dich auf den Thron gesetzt, der Du richtest in Gerechtigkeit.
+9:6 Gescholten hast Du die Völker, und zugrunde ging der Gottlose, * ihren namen hast du getilgt auf immer und ewig.
+9:7a Des Feindes Speere sind dahin für immer, * und ihre Städte hast Du zerstört.
+9:7b Verschwunden ist ihr Gedenken mit Schall, * und der Herr bleibt in Ewigkeit.
+9:8b bereitet hat er zum Gericht seinen Thron, * und er wird richten den Erdkreis mit redlichkeit, er wird richten die Völker in Gerechtigkeit.
+9:10 Und der Herr ist dem Armen zur zuflucht geworden, * ein Helfer zur rechten zeit, in der bedrängnis.
+9:11 Und es sollen hoffen auf Dich, die Deinen namen kennen, * denn Du hast jene nicht verlassen, die Dich suchen, Herr.
+9:12 Spielt dem Herrn, der auf Sion wohnt, * verkündet unter den Völkern seine Taten,
+9:13 denn er, der blut rächt, gedachte ihrer; * nicht vergaß er das Schreien der Armen.
+9:14 Erbarme Dich meiner, Herr, * sieh meine Erniedrigung durch meine Feinde,
+9:15 der Du mich emporhebst aus den Toren des Todes, * damit ich all Deine Loblieder verkünde in den Toren der Tochter Sion.
+9:16a Frohlocken will ich ob Deines Heiles! * Es versanken die Völker in dem Verderben, das sie bereitet haben.
+9:16b in der Schlinge, die sie gelegt, * verfing sich ihr Fuß.
+9:17 Man wird den Herr erkennen als den, der recht schafft. * in den Werken seiner Hände hat der Sünder sich verstrickt.
+9:18 Gestürzt werden sollen die Sünder in die Unterwelt, * alle Völker, die Gott vergessen.
+9:19 Denn nicht für immer wird der Arme vergessen sein, * die Geduld der Armen wird nicht für immer vergehen.
+9:20 Erhebe Dich, Herr, nicht trotze der Mensch; * gerichtet werden sollen die Völker vor Deinem Angesicht.
+9:21 Setze ein, Herr, einen Gesetzgeber über sie, * damit die Völker erkennen, dass sie Menschen sind.
+9:22 Warum, Herr, hast Du Dich weit entfernt, * schaust weg wenn es nottut, in der bedrängnis?
+9:23 So lange der Gottlose sich überhebt, muss brennen der Arme; * sie verfangen sich in den Plänen, die sie ersinnen.
+9:24 Denn es rühmt sich der Sünder ob der begierden seiner Seele, * und der Frevler preist sich glücklich.
+9:25 Gereizt hat der Sünder den Herrn, * in seines Grimmes Übermaß wird er nach nichts fragen.
+9:26a Gott steht nicht vor seinem Angesicht, * befleckt sind seine Wege zu jeder zeit.
+9:26b Weggenommen sind Deine Strafurteile von seinem Angesicht, * über all seine Feinde will er herrschen.
+9:27 Denn er spricht in seinem Herzen: * ich werde nicht wanken, von Geschlecht zu Geschlecht ohne Unglück sein.
+9:28 Sein Mund ist voll von Fluch und bitterkeit und List, * unter seiner zunge sind Mühsal und Schmerz.
+9:29 Er sitzt auf der Lauer mit den reichen im Verborgenen, * um den Unschuldigen zu töten.
+9:30a Seine Augen spähen nach dem Armen, * er lauert im Versteck wie ein Löwe in seiner Höhle.
+9:30b Er lauert, um den Armen zu reißen, * zu reißen den Armen, indem er ihn mit sich zerrt.
+9:31 Mit seiner Schlinge hält er ihn nieder, * er duckt sich und stürzt sich darauf, wenn er der Armen mächtig wird.
+9:32 Denn er sprach in seinem Herzen: Gott hat es vergessen, * hat abgewandt sein Angesicht, auf dass er es nimmer sehe.
+9:33 Steh auf, Herr, Gott, erhebe Deine Hand, * vergiss nicht die Armen.
+9:34 Warum hat der Gottlose Gott gereizt? * Denn er sprach in seinem Herzen: Er wird es nicht ahnden.
+9:35a Du siehst es, denn Du achtest auf Mühsal und Schmerz, * um sie in Deine Hände zu legen.
+9:35b Dir hat der Arme sich überlassen, * dem Verwaisten wirst Du ein Helfer sein.
+9:36 zerbrich den Arm des Sünders und des boshaften; * seine Sünde wird gesucht, und man wird sie nicht finden.
+9:37 Der Herr wird König sein auf immer und in alle Ewigkeit. * ihr werdet vertilgt, ihr Heiden, aus seinem Land.
+9:38 Die Sehnsucht der Armen hat der Herr erhört, * was ihr Herz bereitet hat, hat Dein Ohr gehört.
+9:39 Schaffe recht dem Verwaisten und dem niedrigen, * damit kein Mensch sich weiterhin erhebe auf Erden.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm90.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm90.txt
@@ -13,4 +13,4 @@
 90:13 Über natter und Otter wirst du schreiten * und löwen und Drachen zertreten.
 90:14 Weil er auf mich gehofft hat, will ich ihn befreien, * ich will ihn beschützen, denn er kennt meinen namen.
 90:15 Er wird zu mir rufen und ich werde ihn erhören, * ich bin bei ihm in der bedrängnis, ich werde ihn retten und ihn verherrlichen.
-90:16 mit langem leben will ich ihn erfüllen * und ihm zeigen mein Heil. 133
+90:16 mit langem leben will ich ihn erfüllen * und ihm zeigen mein Heil.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm91.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm91.txt
@@ -1,15 +1,15 @@
-91:2 Bonum est confitéri Dómino: * et psállere nómini tuo, Altíssime.
-91:3 Ad annuntiándum mane misericórdiam tuam: * et veritátem tuam per noctem.
-91:4 In decachórdo, psaltério: * cum cántico, in cíthara.
-91:5 Quia delectásti me, Dómine, in factúra tua: * et in opéribus mánuum tuárum exsultábo.
-91:6 Quam magnificáta sunt ópera tua, Dómine! * nimis profúndæ factæ sunt cogitatiónes tuæ.
-91:7 Vir insípiens non cognóscet: * et stultus non intélliget hæc.
-91:8 Cum exórti fúerint peccatóres sicut fœnum: * et apparúerint omnes, qui operántur iniquitátem:
-91:9 Ut intéreant in sæculum sæculi: * tu autem Altíssimus in ætérnum, Dómine.
-91:10 Quóniam ecce inimíci tui, Dómine, quóniam ecce inimíci tui períbunt: * et dispergéntur omnes, qui operántur iniquitátem.
-91:11 Et exaltábitur sicut unicórnis cornu meum: * et senéctus mea in misericórdia úberi.
-91:12 Et despéxit óculus meus inimícos meos: * et in insurgéntibus in me malignántibus áudiet auris mea.
-91:13 Justus, ut palma florébit: * sicut cedrus Líbani multiplicábitur.
-91:14 Plantáti in domo Dómini, * in átriis domus Dei nostri florébunt.
-91:15 Adhuc multiplicabúntur in senécta úberi: * et bene patiéntes erunt, ut annúntient:
-91:16 Quóniam rectus Dóminus, Deus noster: * et non est iníquitas in eo.
+91:2 Gut ist es, den Herrn zu preisen * und Deinem namen zu spielen, Du Höchster,
+91:3 um am morgen Deine barmherzigkeit zu verkünden * und Deine Wahrheit während der nacht,
+91:4 auf der zehnsaitigen Harfe, * mit Gesang und zither.
+91:5 Denn erfreut hast Du mich, Herr, durch Dein Werk, * und über die Werke Deiner Hände will ich jubeln.
+91:6 Wie herrlich sind Deine Werke, o Herr! * Gar tief sind Deine Gedanken.
+91:7 Ein törichter mann erkennt das nicht, * und ein Dummer wird es nicht einsehen.
+91:8 Als die Sünder sprossten wie Gras, * da erschienen auch alle, die unrecht tun,
+91:9 damit sie untergehen in alle Ewigkeit. * Du aber bist der Höchste in Ewigkeit, o Herr.
+91:10 Denn siehe, Deine Feinde, o Herr, denn siehe, Deine Feinde werden zugrunde gehen, * und zerstreut werden alle, die unrecht tun.
+91:11 und mein Horn wird erhöht wie das eines Einhorns, * und mein Alter wird in reicher barmherzigkeit sein.
+91:12 und mein Auge schaut auf meine Feinde herab, * und von den Übeltätern, die sich gegen mich erheben, wird mein Ohr hören.
+91:13 Der Gerechte wird wie die Palme blühen, * wie eine zeder des libanon wird er gedeihen.
+91:14 Gepflanzt im Haus des Herrn, * werden sie erblühen in den Vorhöfen des Hauses unseres Gottes.
+91:15 Sie werden sich vermehren noch im hohen Alter, * und sie werden rüstig sein, um zu verkünden:
+91:16 Gerecht ist der Herr, unser Gott, * und kein unrecht ist an ihm.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm93.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm93.txt
@@ -1,23 +1,23 @@
-93:1 Deus ultiónum Dóminus: * Deus ultiónum líbere egit.
-93:2 Exaltáre, qui júdicas terram: * redde retributiónem supérbis.
-93:3 Úsquequo peccatóres, Dómine, * úsquequo peccatóres gloriabúntur:
-93:4 Effabúntur, et loquéntur iniquitátem: * loquéntur omnes, qui operántur injustítiam?
-93:5 Pópulum tuum, Dómine, humiliavérunt: * et hereditátem tuam vexavérunt.
-93:6 Víduam, et ádvenam interfecérunt: * et pupíllos occidérunt.
-93:7 Et dixérunt: Non vidébit Dóminus, * nec intélliget Deus Jacob.
-93:8 Intellígite, insipiéntes in pópulo: * et stulti, aliquándo sápite.
-93:9 Qui plantávit aurem, non áudiet? * aut qui finxit óculum, non consíderat?
-93:10 Qui córripit gentes, non árguet: * qui docet hóminem sciéntiam?
-93:11 Dóminus scit cogitatiónes hóminum, * quóniam vanæ sunt.
-93:12 Beátus homo, quem tu erudíeris, Dómine: * et de lege tua docúeris eum,
-93:13 Ut mítiges ei a diébus malis: * donec fodiátur peccatóri fóvea.
-93:14 Quia non repéllet Dóminus plebem suam: * et hereditátem suam non derelínquet.
-93:15 Quoadúsque justítia convertátur in judícium: * et qui juxta illam omnes qui recto sunt corde.
-93:16 Quis consúrget mihi advérsus malignántes? * aut quis stabit mecum advérsus operántes iniquitátem?
-93:17 Nisi quia Dóminus adjúvit me: * paulo minus habitásset in inférno ánima mea.
-93:18 Si dicébam: Motus est pes meus: * misericórdia tua, Dómine, adjuvábat me.
-93:19 Secúndum multitúdinem dolórum meórum in corde meo: * consolatiónes tuæ lætificavérunt ánimam meam.
-93:20 Numquid adhæret tibi sedes iniquitátis: * qui fingis labórem in præcépto?
-93:21 Captábunt in ánimam justi: * et sánguinem innocéntem condemnábunt.
-93:22 Et factus est mihi Dóminus in refúgium: * et Deus meus in adjutórium spei meæ.
-93:23 Et reddet illis iniquitátem ipsórum: et in malítia eórum dispérdet eos: * dispérdet illos Dóminus, Deus noster.
+93:1 Ein Gott der Vergeltung ist der Herr, * der Gott der Vergeltung handelt frei.
+93:2 Erhebe Dich, der Du die Erde richtest: * Übe Vergeltung an den Hochmütigen!
+93:3 Wie lange noch sollen die Sünder, Herr, * wie lange noch sollen die Sünder sich rühmen,
+93:4 sollen sie sprechen und unrecht reden, * sollen reden all jene, die ungerechtigkeit verüben?
+93:5 Dein Volk, o Herr, haben sie erniedrigt, * und Dein Erbe haben sie geplagt.
+93:6 Die Witwe und den Fremden haben sie getötet, * und Waisen haben sie ermordet.
+93:7 und sie sagten: Der Herr wird es nicht sehen, * noch wird es verstehen der Gott Jakobs.
+93:8 Versteht doch, ihr Törichten im Volk, * und ihr Dummen, nehmt endlich Verstand an.
+93:9 Der das Ohr gepflanzt hat, hört der etwa nicht? * Oder der das Auge gemacht hat, sieht der etwa nicht?
+93:10 Der die Völker züchtigt, wird er etwa nicht strafen, * er, der den menschen Erkenntnis lehrt?
+93:11 Der Herr kennt die Gedanken der menschen, * dass sie nichtig sind.
+93:12 Selig der mensch, den Du unterweist, o Herr, * und ihn belehrst nach Deinem Gesetz,
+93:13 um ihm linderung zu verschaffen in bösen Tagen, * bis dem Sünder die Grube gegraben wird.
+93:14 Denn der Herr wird sein Volk nicht verstoßen, * und sein Erbe wird er nicht verlassen,
+93:15 bis Gerechtigkeit sich wendet zum Gericht, * und mit ihr alle, die aufrichtigen Herzens sind.
+93:16 Wer wird sich für mich erheben gegen die Übeltäter? * Oder wer wird mir beistehen gegen jene, die Frevel verüben?
+93:17 Hätte nicht der Herr mir geholfen, * hätte beinahe meine Seele in der unterwelt gewohnt.
+93:18 Wenn ich sprach: Es wankt mein Fuß, * so half mir, o Herr, Deine barmherzigkeit.
+93:19 nach der menge meiner Schmerzen in meinem Herzen, * haben Deine Tröstungen meine Seele erfreut.
+93:20 Hangt Dir etwa der Thron des unrechts an, * der Du mühe machst im Gebot?
+93:21 Sie werden jagen nach der Seele des Gerechten * und unschuldiges blut verdammen.
+93:22 Doch der Herr ist mir zur zuflucht geworden * und mein Gott zur Stütze meiner Hoffnung.
+93:23 und er wird ihnen ihr unrecht vergelten und in ihrer bosheit sie vernichten; * vernichten wird sie der Herr, unser Gott.


### PR DESCRIPTION
Adds German translations for Psalms that are split for use in the hours and fixes incorrect verse endings introduced in PR #4977. Ensures all verses are complete and properly punctuated.