### PR TITLE
Address #5036

### DIFF
--- a/web/cgi-bin/horas/specmatins.pl
+++ b/web/cgi-bin/horas/specmatins.pl
@@ -934,14 +934,30 @@ sub lectio : ScriptFunc {
   # Combine lessons 8 and 9 if there's a commemoration to be read in place of
   # lesson 9, and if the office of the day requires it. In fact the rubrics
   # always *permit* such a contraction, but we don't support that yet.
+  # Issue 5027 No. 5: Acknowledgement of this contraction for Tridentine version (trial)
   if ( $version !~ /1960/
     && $num == 8
-    && $rule =~ /Contract8/i
-    && (exists($winner{Lectio93}) || exists($commemoratio{Lectio7})))
+    && ($rule =~ /Contract8/i || $version =~ /Trident/i)
+    && !exists($winner{Responsory9})
+    && (exists($winner{Lectio93}) || exists($commemoratio{Lectio7}) || $homilyflag))
   {
-    %w = (columnsel($lang)) ? %winner : %winner2;
-    $w = $w{Lectio8} . $w{Lectio9};
-    setbuild2("ex Lectiones 8 et 9 fit una");
+    if (exists($winner{Lectio8}) && exists($winner{Lectio9})) {
+      my %win = (columnsel($lang)) ? %winner : %winner2;
+      $w = $win{Lectio8};
+      $w .= "\n\$rubrica NonaAdjuncta\n\/:«" unless $rule =~ /Contract8/i;
+      $w .= $win{Lectio9};
+      $w =~ s/\&teDeum\n*//g;
+      $w =~ s/\s+$/»:\//s unless $rule =~ /Contract8/i;
+      setbuild2("ex Lectiones 8 et 9 fit una");
+    } elsif (!exists($winner{Lectio8}) && exists($commune{Lectio8})) {
+      my %com = (columnsel($lang)) ? %commune : %commune2;
+      $w = $com{Lectio8};
+      $w .= "\n\$rubrica NonaAdjuncta\n\/:«" unless $rule =~ /Contract8/i;
+      $w .= $com{Lectio9};
+      $w =~ s/\&teDeum\n*//g;
+      $w =~ s/\s+$/»:\//s unless $rule =~ /Contract8/i;
+      setbuild2("ex Lectiones 8 et 9 fit una");
+    }
   }
   my $wo = $w;
 

--- a/web/www/horas/Deutsch/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Deutsch/Psalterium/Common/Rubricae.txt
@@ -70,3 +70,6 @@
 
 [Preces flexis genibus]
 /:kniend:/
+
+[NonaAdjuncta]
+/:Die neunte Lesung des Tagesoffiziums wird entweder weggelassen oder darf an die achte angeschlossen werden.:/

--- a/web/www/horas/English/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/English/Psalterium/Common/Rubricae.txt
@@ -83,3 +83,6 @@
 
 [Antiphona]
 /:intoned solely when the office is chanted:/
+
+[NonaAdjuncta]
+/:The ninth lesson of the office is either omitted or may be joined to the eight.:/

--- a/web/www/horas/Latin/Psalterium/Common/Rubricae.txt
+++ b/web/www/horas/Latin/Psalterium/Common/Rubricae.txt
@@ -166,3 +166,6 @@
 
 [Jube]
 /:Extra Chorum, quando ab uno tantum recitatur Officium dicitur: «Jube, Dómine, benedícere;» et subjungitur congruens Benedictio.:/
+
+[NonaAdjuncta]
+/:Nona lectio de Officio vel ommititur vel octavæ lectioni adjungitur.:/


### PR DESCRIPTION
close #5036
close #5027
This adds the left out 9th lesson on the respective days in footnote size, to easily see which words are ad libitum.

@Aurelianus24
NB: Given the delicate interplay of assigning the Scripture readings with the Transfer Tables for Scripture (aka InitiaTables), showing the omitted last scriptural reading on a Simplex feast as an optional extension to Lesson 2 is not implemented as suggested.