### PR TITLE
Fix unclosed brackets in Monastic St. Vitus office header translations

### DIFF
--- a/web/www/horas/Deutsch/SanctiM/06-15M.txt
+++ b/web/www/horas/Deutsch/SanctiM/06-15M.txt
@@ -1,2 +1,2 @@
-[Officium (rubrica 1963)
+[Officium] (rubrica 1963)
 Hl. Vitus, Martyrer

--- a/web/www/horas/English/SanctiM/06-15M.txt
+++ b/web/www/horas/English/SanctiM/06-15M.txt
@@ -1,4 +1,4 @@
-[Officium (rubrica 1963)
+[Officium] (rubrica 1963)
 St. Vitus, Martyr
 
 [Oratio]

--- a/web/www/horas/Polski/SanctiM/06-15M.txt
+++ b/web/www/horas/Polski/SanctiM/06-15M.txt
@@ -1,4 +1,4 @@
-[Officium (rubrica 1963)
+[Officium] (rubrica 1963)
 Św. Wita Męczennika
 
 [Oratio]


### PR DESCRIPTION
Under Monastic 1963 on June 15, 2026, the commemoration heading at Lauds (vernacular side) is expected to read:

> Commemoration of St. Vitus, Martyr (English)

> Kommemoration Hl. Vitus, Martyrer (Deutsch)

> Wspominamy Św. Wita Męczennika (Polski)

Instead, the commemoration heading for these three languages is a mix of vernacular and Latin:

> Commemoration of S. Viti Martyris

> Kommemoration S. Viti Martyris

> Wspominamy S. Viti Martyris

Direct links to the bug on the live site:

- [English](https://www.divinumofficium.com/cgi-bin/horas/officium.pl?version=Monastic+-+1963&command=prayLaudes&date=6-15-2026&lang2=English#Laudes12)
- [Deutsch](https://www.divinumofficium.com/cgi-bin/horas/officium.pl?version=Monastic+-+1963&command=prayLaudes&date=6-15-2026&lang2=Deutsch#Laudes12)
- [Polski](https://www.divinumofficium.com/cgi-bin/horas/officium.pl?version=Monastic+-+1963&command=prayLaudes&date=6-15-2026&lang2=Polski#Laudes12)

The fix is to close the broken section headers in the corresponding data files.

This fix was verified locally with `docker compose up`.