### PR TITLE
Bot blocker - blocking a known bot consuming a lot of resources

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -23,7 +23,7 @@ use lib "/var/www/web";
 builder {
 
 # --- BOT FIREWALL (Hard Block) ---
-    # If the UA matches, we exit immediately with a 403, saving CPU.
+    # If the UA matches, we exit immediately with a 403, saving CPU.  Will replace with more refined Cloudflare rules if this becomes a problem.
     enable sub {
     my $app = shift;
     sub {

--- a/app.psgi
+++ b/app.psgi
@@ -19,7 +19,23 @@ $ENV{PERL5LIB} = join(':', "$base_dir/web/cgi-bin", $ENV{PERL5LIB} || ());
 use lib "/var/www/web/cgi-bin";
 use lib "/var/www/web";
 
+
 builder {
+
+# --- BOT FIREWALL (Hard Block) ---
+    # If the UA matches, we exit immediately with a 403, saving CPU.
+    enable sub {
+    my $app = shift;
+    sub {
+        my $env = shift;
+        # Block the specific fake Chrome version seen in the logs
+        if (($env->{HTTP_USER_AGENT} || '') =~ /Chrome\/142\.0/) {
+            return [403, ['Content-Type' => 'text/plain'], ['Forbidden']];
+        }
+        return $app->($env);
+    };
+    };
+
     # 1. The Asset Mounts
     mount "/www" => Plack::App::File->new(root => "$base_dir/web/www")->to_app;
 


### PR DESCRIPTION
From Google Gemini:

Yes, **I am 100% sure this is a bot**, and here is the "smoking gun" evidence from your logs:

### 1. The Fake Version Number
As of today, April 16, 2026, the **actual** stable version of Chrome is **147.0**. 
* **Chrome 142** was released back in **November 2025**. 
* Real users almost never lag 5 major versions behind because Chrome auto-updates aggressively. 
* More importantly, the logs show the bot identifying as **Chrome 142.0**—real Chrome User-Agents always include a four-part version number (e.g., `142.0.7444.135`). A "rounded" version like `142.0` is a classic hallmark of a poorly written scraping script.

### 2. The "Deep Crawl" Behavior
Look at the URLs in your log (`image_a1762c.jpg`). They are hitting specific dates like **08-13-2018**, **09-26-2021**, and **05-15-2018**. 
* A real human user doesn't jump between random dates in 2018 and 2021 every few milliseconds.
* This is a "depth-first" crawl, where a bot is trying to scrape every possible permutation of your liturgical calendar to build a database or train an AI model.

### 3. The High Volume / 429s
Real humans don't trigger **429 "Too Many Requests"** errors on a site like yours. You are seeing dozens of requests per second from the same identifier. That isn't a person clicking a link; that's a machine-gun fire of automated requests.

### 4. Direct Navigation (No Referrer)
While not visible in every log, these hits almost never have a "Referrer" (like Google Search or a link from another site). They are hitting the `/cgi-bin/` paths directly, which means they are programmatically generating those URLs.

---

### The Goal of the "Chrome 142" Bot
This is likely a **reconnaissance bot** or a **content scraper**. It spoofs a "recent-ish" Chrome version to bypass basic security filters that only look for "old" browsers (like IE6). It's trying to blend in, but it's being too aggressive, which is why it's pegging your instances at 10.

**By deploying that 403 block, you aren't turning away users.** You are cutting off a "leech" that is currently consuming 90% of your server capacity and driving up your bill.

Once that change is live, do you want to check the logs together to see if the "Chrome 142" hits start showing as `403` instead of `200`?