### PR TITLE
CIST: abício -> abjício: expanded to fit all similar cases, error in Psalms in C2p fixed

### DIFF
--- a/web/cgi-bin/horas/horascommon.pl
+++ b/web/cgi-bin/horas/horascommon.pl
@@ -2070,7 +2070,7 @@ sub spell_var {
     $t =~ s/(c)([aá]r[ií])(t|ss)/$1h$2$3/gi if $version =~ /cist/i;
     $t =~ s/>([aá]r[ií])(t|ss)/>h$1$2/gi if $version =~ /cist/i;
     $t =~ s/>aríssim/>haríssim/gi if $version =~ /cist/i;
-    $t =~ s/(A|a)b(i|í)ci/$1bj$2ci/gi if $version =~ /cist/i;
+    $t =~ s/\b(pro|pró|ab|ad|e)(i|í)ci/$1j$2ci/gi if $version =~ /cist/i;
   }
   return $t;
 }

--- a/web/www/horas/Latin/CommuneCist/C2p.txt
+++ b/web/www/horas/Latin/CommuneCist/C2p.txt
@@ -152,6 +152,9 @@ R. Exúltent justi in conspéctu Dei, * Allelúia, allelúia.
 V. Et delecténtur in lætítia.
 R. Allelúia, allelúia.
 
+[Ant Vespera 3]
+@:Ant Vespera
+
 [Versum 3]
 @:Versum 1
 


### PR DESCRIPTION
Psalms for second Vespers for C2p pointed to C1p, which has its own Psalms 109, 112, 115, 125, which is wrong for the Martyrs. Fixed.