### PR TITLE
Update RunTimeOptions.pm - error in logs

### DIFF
--- a/web/cgi-bin/DivinumOfficium/RunTimeOptions.pm
+++ b/web/cgi-bin/DivinumOfficium/RunTimeOptions.pm
@@ -14,15 +14,21 @@ BEGIN {
 
 sub unequivocal {
   my ($value, $tablename) = @_;
+  
+  # Diagnostic Logging: If it's empty, report who called it
+  if (!defined $value || $value eq '') {
+      my (undef, $filename, $line, $subname) = caller(1);
+      warn "[DEBUG] unequivocal called with empty value. Called by: $subname at $filename line $line";
+      return; 
+  }
+  
   my @values_array = main::getdialog($tablename);
-
   my @r = grep {/$value/} @values_array;
 
   if (@r == 1) {
     return $r[0] =~ s/.*\///r;
   } else {
     @r = grep { $_ eq $value } @values_array;
-
     if (@r == 1) {
       return $r[0] =~ s/.*\///r;
     } else {

--- a/web/cgi-bin/DivinumOfficium/RunTimeOptions.pm
+++ b/web/cgi-bin/DivinumOfficium/RunTimeOptions.pm
@@ -14,14 +14,14 @@ BEGIN {
 
 sub unequivocal {
   my ($value, $tablename) = @_;
-  
+
   # Diagnostic Logging: If it's empty, report who called it
   if (!defined $value || $value eq '') {
-      my (undef, $filename, $line, $subname) = caller(1);
-      warn "[DEBUG] unequivocal called with empty value. Called by: $subname at $filename line $line";
-      return; 
+    my (undef, $filename, $line, $subname) = caller(1);
+    warn "[DEBUG] unequivocal called with empty value. Called by: $subname at $filename line $line";
+    return;
   }
-  
+
   my @values_array = main::getdialog($tablename);
   my @r = grep {/$value/} @values_array;
 
@@ -29,6 +29,7 @@ sub unequivocal {
     return $r[0] =~ s/.*\///r;
   } else {
     @r = grep { $_ eq $value } @values_array;
+
     if (@r == 1) {
       return $r[0] =~ s/.*\///r;
     } else {


### PR DESCRIPTION
Handling errors in log for when value is undefined.  Example JSON:

{
  **"textPayload": "[Tue Apr 28 14:17:26 2026] Cofficium.pl: Use of uninitialized value $value in regexp compilation at /var/www/web/cgi-bin/horas/../DivinumOfficium/RunTimeOptions.pm line 19.",**
  "insertId": "69f0c1760009b43663b27231",
  "resource": {
    "type": "cloud_run_revision",
    "labels": {
      "configuration_name": "divinum-officium",
      "revision_name": "divinum-officium-00434-5qp",
      "project_id": "cohesive-idiom-265623",
      "location": "us-east1",
      "service_name": "divinum-officium"
    }
  },
  "timestamp": "2026-04-28T14:17:26.635958Z",
  "labels": {
    "gcb-trigger-id": "ee200239-103b-466d-ad5c-ac80d4e50a46",
    "gcb-trigger-region": "global",
    "managed-by": "gcp-cloud-build-deploy-cloud-run",
    "commit-sha": "0ee1a2b24a8015962bd138e1fc2943775ee36256",
    "gcb-build-id": "0ebadd56-7678-4d29-866e-d8389d3984a1",
    "instanceId": "0007b734d9f9caeee5088351520700498067f8d1eedc4bc46c193e16dde7bad0742768316d62fd262e6e183f16967784234fe90271fde5bfccd5faddd1e9960ab879d503da34574691b3aae71a96"
  },
  "logName": "projects/cohesive-idiom-265623/logs/run.googleapis.com%2Fstderr",
  "receiveTimestamp": "2026-04-28T14:17:26.711473160Z"
}