### PR TITLE
Increase Starman workers from 10 to 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,4 +78,4 @@ EXPOSE 8080
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 
-CMD ["starman", "--port", "8080", "--host", "0.0.0.0", "--workers", "10", "--preload-app", "/var/www/app.psgi"]
+CMD ["starman", "--port", "8080", "--host", "0.0.0.0", "--workers", "20", "--preload-app", "/var/www/app.psgi"]


### PR DESCRIPTION
Now that Cloudflare rules have stabilized, the environments are under utilized.  Let's bump up the number of workers to reduce some of the need for more instances during a spike.