### PR TITLE
Block crawlers from /cgi-bin/ to reduce excessive crawl load

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,2 +1,11 @@
 User-agent: *
 Crawl-delay: 10
+
+User-agent: Googlebot
+Disallow: /cgi-bin/
+
+User-agent: bingbot
+Disallow: /cgi-bin/
+
+User-agent: Applebot
+Disallow: /cgi-bin/


### PR DESCRIPTION
Controlling Search Engine traffic to just the main site, to ensure SEO without the massive amount of crawling traffic.