### PR TITLE
Add AI crawler blocks to robots.txt (Cloudflare managed content disab…

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,3 +1,36 @@
+# BEGIN Cloudflare Managed content
+User-agent: *
+Content-Signal: search=yes,ai-train=no
+Allow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: CloudflareBrowserRenderingCrawler
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: meta-externalagent
+Disallow: /
+# END Cloudflare Managed Content
+
 User-agent: *
 Crawl-delay: 10
 


### PR DESCRIPTION
Moving from Cloudflare's robot.txt to our repo's version, so that GCP Cloud Run enforces.  Otherwise, we can properly block the Google /CGI-bin/ hammering.