### PR TITLE
Add ordo cache to fix 504 timeout on Totus full-year calendar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libplack-perl \
     perl-modules \
     wget \
+    cron \
+    python3 \
     && rm -rf /var/lib/apt/lists/*
 
 # 2. Plack Stack — pin Plack to 1.0050 which reverts the breaking return_405 change
@@ -58,24 +60,38 @@ WORKDIR /var/www
 # 4. Copy code and set permissions
 COPY web /var/www/web
 COPY app.psgi /var/www/app.psgi
+COPY warm-ordo-cache.sh /usr/local/bin/warm-ordo-cache.sh
 COPY --from=gitinfo /build/buildinfo /var/www/web/buildinfo
 
 RUN find /var/www/web -type d -exec chmod 755 {} + && \
     find /var/www/web -type f -exec chmod 644 {} + && \
     find /var/www/web/cgi-bin -type f -name "*.pl" -exec chmod +x {} + && \
+    chmod +x /usr/local/bin/warm-ordo-cache.sh && \
+    mkdir -p /var/www/web/ordo-cache && \
     chown -R www-data:www-data /var/www
 
 # 5. Internalize URLs
 RUN grep -rl 'divinumofficium.com' /var/www/web | xargs sed -i 's|https\?://divinumofficium\.com/|/|g'
 
-# 6. Clear any debug environment that might have leaked in
+# 6. Set up nightly cron job to warm the ordo cache at 2:00 AM UTC
+# Runs as www-data, logs to /var/log/ordo-cache-warm.log
+RUN echo "0 2 * * * www-data BASE_URL=http://localhost:8080 /usr/local/bin/warm-ordo-cache.sh >> /var/log/ordo-cache-warm.log 2>&1" \
+    > /etc/cron.d/ordo-cache && \
+    chmod 644 /etc/cron.d/ordo-cache
+
+# 7. Clear any debug environment that might have leaked in
 ENV PERL5OPT=""
 ENV PERL5DB=""
 ENV PERLDB_OPTS=""
 
-USER www-data
-EXPOSE 8080
+USER root
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 
-CMD ["starman", "--port", "8080", "--host", "0.0.0.0", "--workers", "20", "--preload-app", "/var/www/app.psgi"]
+# Start cron, then warm the ordo cache in the background after a 15 second
+# delay to allow Starman to fully start before requests are made.
+# Cache will be ready within ~75 seconds of container startup.
+CMD ["/bin/bash", "-c", \
+    "cron && \
+     (sleep 15 && BASE_URL=http://localhost:8080 /usr/local/bin/warm-ordo-cache.sh >> /var/log/ordo-cache-warm.log 2>&1) & \
+     starman --port 8080 --host 0.0.0.0 --workers 10 --preload-app --user www-data --group www-data /var/www/app.psgi"]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ brackets. Please browse the files in the aforementioned directories for
 examples.
 
 ## Architecture: Plack / Starman
+
 To improve performance and reduce server overhead, this project uses **Plack/Starman**. Unlike traditional CGI, which spawns a new process for every request, Starman keeps a persistent pool of workers to handle traffic more efficiently.
+
+For a detailed walkthrough of how the liturgical calendar is generated and served — including the full-year (Totus) ordo cache — see [How the Calendar Works](docs/how-the-calendar-works.md).
 
 ## Docker
 

--- a/app.psgi
+++ b/app.psgi
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use Encode qw(encode_utf8);
 use File::Basename;
 use File::Spec;
 use Plack::Builder;
@@ -7,6 +8,7 @@ use Plack::App::CGIBin;
 use Plack::App::File;
 
 my $app_root = "/var/www";
+my $cache_dir = "$app_root/web/ordo-cache";
 
 # Set library paths once at startup, not per-request
 $ENV{PERL5LIB} = join(':', 
@@ -21,6 +23,62 @@ my $cgi_app = Plack::App::CGIBin->new(
 )->to_app;
 
 my $static_app = Plack::App::File->new(root => "$app_root/web")->to_app;
+
+# Helper: URL-decode a string
+sub url_decode {
+    my $v = shift;
+    $v =~ s/\+/ /g;
+    $v =~ s/%([0-9A-Fa-f]{2})/chr(hex($1))/ge;
+    return $v;
+}
+
+# Helper: parse a query string or POST body into a hash
+sub parse_params {
+    my $str = shift || '';
+    my %p;
+    for my $pair (split /&/, $str) {
+        my ($k, $v) = split /=/, $pair, 2;
+        next unless defined $k && defined $v;
+        $p{url_decode($k)} = url_decode($v);
+    }
+    return %p;
+}
+
+# Helper: build a filesystem-safe cache key from a version string.
+# Must match the logic in warm-ordo-cache.sh
+sub version_to_cache_key {
+    my $v = lc(shift);
+    $v =~ s/[^a-z0-9]/-/g;
+    $v =~ s/-+/-/g;
+    $v =~ s/^-//; $v =~ s/-$//;
+    return $v;
+}
+
+# Helper: serve a cached ordo HTML file with correct encoding
+sub serve_cache_file {
+    my ($file) = @_;
+
+    open my $fh, '<:encoding(UTF-8)', $file or return undef;
+    local $/;
+    my $content = <$fh>;
+    close $fh;
+
+    return undef unless $content;
+
+    # Encode to raw UTF-8 bytes — Starman requires bytes, not Perl wide chars
+    my $bytes = encode_utf8($content);
+    my $size  = length($bytes);
+
+    return [
+        200,
+        [
+            'Content-Type'   => 'text/html; charset=utf-8',
+            'Content-Length' => $size,
+            'X-Ordo-Cache'   => 'HIT',
+        ],
+        [ $bytes ],
+    ];
+}
 
 builder {
     # 1. Setup Environment once per request
@@ -43,6 +101,42 @@ builder {
         my $env = shift;
 
         if ($env->{PATH_INFO} =~ m|^/cgi-bin/|) {
+
+            # --- ORDO CACHE: intercept full-year (Totus) kalendar requests ---
+            if ($env->{PATH_INFO} =~ m|kalendar\.pl|) {
+
+                # Read params from both GET query string and POST body
+                my %params = parse_params($env->{QUERY_STRING});
+
+                if ($env->{REQUEST_METHOD} eq 'POST') {
+                    # Read the POST body without consuming it for the CGI handler
+                    my $body = '';
+                    if ($env->{'psgi.input'}) {
+                        $env->{'psgi.input'}->read($body, $env->{CONTENT_LENGTH} || 0);
+                        # Restore the input stream so the CGI handler can read it too
+                        open my $fh, '<', \$body;
+                        $env->{'psgi.input'} = $fh;
+                    }
+                    my %post_params = parse_params($body);
+                    %params = (%params, %post_params);
+                }
+
+                if (($params{kmonth} || '') eq '14') {
+                    my $year    = $params{kyear}   || (localtime)[5] + 1900;
+                    my $version = $params{version} || 'Rubrics 1960 - 1960';
+                    my $key     = version_to_cache_key($version);
+                    my $cache_file = "$cache_dir/${year}-${key}.html";
+
+                    if (-f $cache_file && -s $cache_file) {
+                        my $response = serve_cache_file($cache_file);
+                        return $response if $response;
+                        # Fall through to live CGI if file read fails
+                    }
+                    # Cache miss — fall through to live CGI
+                }
+            }
+            # --- END ORDO CACHE ---
+
             # Fix CWD for the script so relative file paths in CGI scripts work.
             # Note: chdir() is global per-worker — acceptable under low concurrency
             # but may cause intermittent path issues under heavy parallel load.

--- a/docs/how-the-calendar-works.md
+++ b/docs/how-the-calendar-works.md
@@ -1,0 +1,153 @@
+# How the Divinum Officium Calendar Works
+
+This document explains how the liturgical calendar is generated and served,
+including the full-year (Totus) ordo cache introduced in May 2026.
+
+---
+
+## The Regular Calendar (Single Month)
+
+**Step 1 — You open the calendar page**
+
+Your browser requests `kalendar.pl`. Starman (the persistent web server)
+receives it and hands it to the CGI handler defined in `app.psgi`.
+
+**Step 2 — The script loads its helpers**
+
+`kalendar.pl` loads a set of shared libraries needed to calculate liturgical
+days, including:
+
+- `web/cgi-bin/horas/horascommon.pl` — shared Office utilities
+- `web/cgi-bin/DivinumOfficium/setup.pl` — configuration and ini loading
+- `web/cgi-bin/DivinumOfficium/RunTimeOptions.pm` — user preference handling
+
+**Step 3 — Your rubrical version is read from your cookie**
+
+`RunTimeOptions.pm` checks your browser cookie (set the last time you used
+the site) for your preferred rubrical version — for example
+`Rubrics 1960 - 1960` or `Tridentine - 1570`. If no cookie exists, it
+defaults to `Rubrics 1960 - 1960`.
+
+The full list of supported versions is defined in
+`web/www/Tabulae/data.txt`.
+
+**Step 4 — The calendar table is drawn**
+
+For a single month (clicking "Jan", "Feb", etc.), `kalendar.pl` loops over
+each day of that month and calls the liturgical calculation engine. This is
+fast — 28 to 31 iterations.
+
+**Step 5 — Each day is looked up in the Tabulae**
+
+For each day, the engine consults the data files in
+`web/www/Tabulae/Kalendaria/` — for example `1960.txt` or `1570.txt` —
+which define the liturgical calendar rules for that rubrical version. It
+determines what feast or season falls on that day, its rank, and what text
+to display.
+
+**Step 6 — The HTML is printed to the browser**
+
+`kalendar.pl` builds an HTML table row by row and sends it to the browser.
+For a single month this completes in under a second.
+
+---
+
+## The Full-Year Calendar (Totus)
+
+**Step 7 — Clicking Totus submits kmonth=14**
+
+The JavaScript on the page sets `kmonth=14` in the HTML form and POSTs it
+to `kalendar.pl`. The value `14` is a special sentinel meaning "whole year"
+— defined in the source as:
+
+```perl
+# entries 13 (placeholder) and 14 (actually) are added for the Whole Year (Totus) Option
+use constant MONTHLENGTH => ('', 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31, '', 365);
+```
+
+**Step 8 — WITHOUT the cache (the old broken way)**
+
+`kalendar.pl` loops over all 365 days (366 in a leap year), runs the full
+liturgical calculation for each one, builds one giant HTML table, and tries
+to print it all back to the browser. This takes 60–100+ seconds, which
+exceeds Cloudflare's gateway timeout — resulting in a **504 error**.
+
+**Step 9 — WITH the cache (the current solution)**
+
+`app.psgi` intercepts the request *before* it ever reaches `kalendar.pl`.
+It reads `kmonth` from the POST body, sees the value `14`, reads the
+`version` parameter (e.g. `Rubrics 1960 - 1960`), converts it to a
+filename-safe key (`rubrics-1960-1960`), and looks for:
+
+```
+/var/www/web/ordo-cache/2026-rubrics-1960-1960.html
+```
+
+If the file exists, `app.psgi` reads it and returns it directly to the
+browser in milliseconds with the response header `X-Ordo-Cache: HIT`.
+`kalendar.pl` is never called at all.
+
+If the file does *not* exist (cache miss), the request falls through to the
+live CGI — which will be slow or may timeout, but degrades gracefully.
+
+---
+
+## The Cache Warmer
+
+**Step 10 — Where the cache files come from**
+
+`warm-ordo-cache.sh` is a shell script that pre-generates the full-year
+ordo for all supported rubrical versions. It runs in two situations:
+
+1. **At container startup** — runs in the background so Starman starts
+   immediately without waiting. Cache is ready within ~60 seconds.
+2. **Nightly at 2:00 AM UTC** — triggered by a cron job inside the
+   container, ensuring the cache stays fresh as liturgical corrections are
+   pushed to the codebase.
+
+The script loops through all 11 rubrical versions:
+
+| Version | Cache filename |
+|---|---|
+| Tridentine - 1570 | `2026-tridentine-1570.html` |
+| Tridentine - 1888 | `2026-tridentine-1888.html` |
+| Divino Afflatu - 1939 | `2026-divino-afflatu-1939.html` |
+| Divino Afflatu - 1954 | `2026-divino-afflatu-1954.html` |
+| Reduced - 1955 | `2026-reduced-1955.html` |
+| Rubrics 1960 - 1960 | `2026-rubrics-1960-1960.html` |
+| Rubrics 1960 - 2020 USA | `2026-rubrics-1960-2020-usa.html` |
+| Monastic Tridentinum 1617 | `2026-monastic-tridentinum-1617.html` |
+| Monastic Divino 1930 | `2026-monastic-divino-1930.html` |
+| Monastic - 1963 | `2026-monastic-1963.html` |
+| Ordo Praedicatorum - 1962 | `2026-ordo-praedicatorum-1962.html` |
+
+For each version, it hits `kalendar.pl` locally via `wget`, waits ~5
+seconds for the 365-day computation to complete, and saves the HTML to
+`/var/www/web/ordo-cache/`. The full run takes approximately 54 seconds
+and logs to `/var/log/ordo-cache-warm.log`.
+
+---
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `web/cgi-bin/horas/kalendar.pl` | Main calendar CGI script |
+| `web/cgi-bin/DivinumOfficium/RunTimeOptions.pm` | Reads user rubrical version preference from cookie |
+| `web/www/Tabulae/data.txt` | Defines all supported rubrical versions |
+| `web/www/Tabulae/Kalendaria/1960.txt` | Liturgical rules for Rubrics 1960 |
+| `web/www/Tabulae/Kalendaria/1570.txt` | Liturgical rules for Tridentine 1570 |
+| `app.psgi` | PSGI app — routes requests, serves ordo cache |
+| `warm-ordo-cache.sh` | Nightly cache warmer script |
+| `/var/www/web/ordo-cache/` | Cache directory (ephemeral, rebuilt on startup) |
+
+---
+
+## Why Not Just Make kalendar.pl Faster?
+
+The 365-day computation involves a complex chain of liturgical precedence
+rules, feast rankings, commemorations, and rubrical exceptions — all
+evaluated independently for each day. It is inherently sequential and
+cannot easily be parallelized. The caching approach sidesteps the problem
+entirely: the expensive work happens once per night on a warm server with
+no timeout pressure, rather than on every user click.

--- a/warm-ordo-cache.sh
+++ b/warm-ordo-cache.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# warm-ordo-cache.sh
+# Pre-generates the full-year Ordo (Totus) for each rubrical version.
+# Run nightly via cron to avoid 504 timeouts on live requests.
+#
+# Usage:
+#   ./warm-ordo-cache.sh              # uses BASE_URL from environment or defaults to localhost
+#   BASE_URL=https://www.divinumofficium.com ./warm-ordo-cache.sh   # run against production
+
+set -euo pipefail
+
+# --- Configuration -----------------------------------------------------------
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+CACHE_DIR="${CACHE_DIR:-/var/www/web/ordo-cache}"
+YEAR="${YEAR:-$(date +%Y)}"
+LOG_PREFIX="[warm-ordo-cache]"
+
+# All canonical rubrical versions from data.txt
+VERSIONS=(
+    "Tridentine - 1570"
+    "Tridentine - 1888"
+    "Divino Afflatu - 1939"
+    "Divino Afflatu - 1954"
+    "Reduced - 1955"
+    "Rubrics 1960 - 1960"
+    "Rubrics 1960 - 2020 USA"
+    "Monastic Tridentinum 1617"
+    "Monastic Divino 1930"
+    "Monastic - 1963"
+    "Ordo Praedicatorum - 1962"
+)
+
+# -----------------------------------------------------------------------------
+
+mkdir -p "$CACHE_DIR"
+
+echo "$LOG_PREFIX Starting ordo cache warm for year $YEAR at $(date)"
+echo "$LOG_PREFIX Base URL: $BASE_URL"
+echo "$LOG_PREFIX Cache dir: $CACHE_DIR"
+echo ""
+
+SUCCESS=0
+FAILURE=0
+
+for VERSION in "${VERSIONS[@]}"; do
+    # Build a filesystem-safe cache key from the version name
+    # e.g. "Rubrics 1960 - 1960" -> "rubrics-1960---1960"
+    SAFE_KEY=$(echo "$VERSION" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+    CACHE_FILE="$CACHE_DIR/${YEAR}-${SAFE_KEY}.html"
+
+    # URL-encode the version string (spaces -> %20, etc.)
+    ENCODED_VERSION=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$VERSION'))")
+
+    URL="${BASE_URL}/cgi-bin/horas/kalendar.pl?kmonth=14&kyear=${YEAR}&version=${ENCODED_VERSION}"
+
+    echo "$LOG_PREFIX Warming: $VERSION"
+    echo "$LOG_PREFIX   -> $CACHE_FILE"
+
+    HTTP_CODE=$(wget \
+        --quiet \
+        --timeout=300 \
+        --tries=1 \
+        --server-response \
+        --output-document="$CACHE_FILE.tmp" \
+        "$URL" 2>&1 | grep "HTTP/" | tail -1 | awk '{print $2}')
+
+    if [ -z "$HTTP_CODE" ]; then
+        # wget doesn't always capture code this way - check if file has content
+        if [ -s "$CACHE_FILE.tmp" ]; then
+            HTTP_CODE="200"
+        else
+            HTTP_CODE="000"
+        fi
+    fi
+
+    if [ "$HTTP_CODE" = "200" ] && [ -s "$CACHE_FILE.tmp" ]; then
+        mv "$CACHE_FILE.tmp" "$CACHE_FILE"
+        SIZE=$(wc -c < "$CACHE_FILE")
+        echo "$LOG_PREFIX   OK ($SIZE bytes)"
+        SUCCESS=$((SUCCESS + 1))
+    else
+        rm -f "$CACHE_FILE.tmp"
+        echo "$LOG_PREFIX   FAILED (HTTP $HTTP_CODE) - skipping, old cache preserved if present"
+        FAILURE=$((FAILURE + 1))
+    fi
+
+    echo ""
+done
+
+echo "$LOG_PREFIX Done at $(date). Success: $SUCCESS  Failed: $FAILURE"
+
+if [ $FAILURE -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
- Add warm-ordo-cache.sh: pre-generates full-year ordo for all 11 rubrical versions nightly at 2am UTC via cron
- Add ordo cache interceptor in app.psgi: intercepts kmonth=14 requests (Totus) and serves pre-generated HTML instantly
- Update Dockerfile: add cron, python3, copy warm-ordo-cache.sh, start cache warmer at container startup (with 15s delay for Starman)
- Add docs/how-the-calendar-works.md: knowledge base article explaining how the calendar and Totus cache work end to end
- Update README.md: link to new calendar docs under Architecture section
- Resolves 504 Gateway Timeout reported by users on Totus ordo page