### PR TITLE
Disallow all crawlers from /cgi-bin/ in robots.txt

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -33,6 +33,7 @@ Disallow: /
 
 User-agent: *
 Crawl-delay: 10
+Disallow: /cgi-bin/
 
 User-agent: Googlebot
 Disallow: /cgi-bin/


### PR DESCRIPTION
- Add Disallow: /cgi-bin/ to User-agent: * block
- Previously only Googlebot, bingbot, and Applebot were explicitly disallowed from CGI — all other crawlers had free access
- Googlebot has been hammering Pofficium.pl with historical date/version combinations causing significant GCP Cloud Run costs
- This change tells every crawler (who honors robots.txt) to stay out of /cgi-bin/ entirely