### PR TITLE
Guard leapyear() against undefined $year

### DIFF
--- a/web/cgi-bin/DivinumOfficium/Date.pm
+++ b/web/cgi-bin/DivinumOfficium/Date.pm
@@ -107,6 +107,7 @@ sub geteaster {
 # returns true if year is leap
 sub leapyear {
   my $year = shift;
+  return 0 unless $year;
   !(($year % 4) or !($year % 100) and ($year % 400));
 }
 

--- a/web/cgi-bin/DivinumOfficium/Date.pm
+++ b/web/cgi-bin/DivinumOfficium/Date.pm
@@ -360,5 +360,4 @@ sub date_to_days {
   if ($ret < -141427) { error("Date before the Gregorian Calendar!"); }
   return $ret;
 }
-
 1;


### PR DESCRIPTION
Follow-up to #5167 (Safeguard $date1) / [Issue 5167](https://github.com/DivinumOfficium/divinum-officium/issues/5172). The previous fix added a guard to day_of_week() but leapyear() remained unguarded. Since leapyear() is called by date_to_ydays(), nextday(), monthday(), get_sday(), and prevnext(), an undefined $year propagates warnings throughout Date.pm.

Adding return 0 unless $year fixes all cascading uninitialized value warnings seen in Cloud Run logs when kalendar.pl is called with missing or malformed date parameters.