### PR TITLE
fix: import apply_interlinear in webdia.pl

### DIFF
--- a/web/cgi-bin/horas/webdia.pl
+++ b/web/cgi-bin/horas/webdia.pl
@@ -1,5 +1,6 @@
 #!/usr/bin/perl
 use utf8;
+use DivinumOfficium::Lexicon qw(apply_interlinear);
 
 # Name : Laszlo Kiss
 # Date : 01-11-04


### PR DESCRIPTION
popup.pl and kalendar.pl both load webdia.pl but didn't have the apply_interlinear import, causing an "Undefined subroutine" crash when interlinear is enabled and a user expands sections like Ante/Post.

Moving the import into webdia.pl itself fixes all callers.

Closes https://github.com/DivinumOfficium/divinum-officium/issues/5192