### PR TITLE
Add interlinear font option to settings

### DIFF
--- a/web/cgi-bin/horas/webdia.pl
+++ b/web/cgi-bin/horas/webdia.pl
@@ -33,6 +33,11 @@ PrintTag
 
   my $is_mobile = ($officium eq 'Pofficium.pl');
   my $viewport_tag = $is_mobile ? '  <META NAME="viewport" CONTENT="width=device-width, initial-scale=0.75">' : '';
+  my $gf = our $glossfont;
+  my $gloss_color = ($gf =~ /(\#[0-9a-fA-F]+)\s*$/ || $gf =~ /([a-zA-Z]+)\s*$/) ? $1 : '';
+  $gloss_color = '' if $gloss_color eq 'italic' || $gloss_color eq 'bold';
+  my $gloss_weight = ($gf =~ /\bbold\b/) ? 'bold' : 'normal';
+  my $gloss_style  = ($gf =~ /\bitalic\b/) ? 'italic' : 'normal';
 
   print <<"PrintTag";
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
@@ -77,7 +82,7 @@ $viewport_tag
     .contrastbg { background: white; }
     .nigra { color: black; }
     .lw .gloss { display: none; }
-    body.interlinear .lw .gloss { display: inline; font-size: 0.85em; color: #9b7fc7; }
+    body.interlinear .lw .gloss { display: inline; font-size: 0.85em; color: $gloss_color; font-weight: $gloss_weight; font-style: $gloss_style; }
     body.interlinear .lw.learned .gloss { display: none; }
     body.interlinear .lw { cursor: pointer; }
 

--- a/web/www/horas/horas.dialog
+++ b/web/www/horas/horas.dialog
@@ -21,7 +21,8 @@ Title font~>$titlefont~>Entry~>12~>12;;
 Screen height~>$screenheight~>Entry~>12~>13;;
 Text width percent~>$textwidth~>Entry~>12~>14;;
 Testmode~>$testmode~>Optionmenu~>testmodes~>21;;
-Interlinear~>$interlinear~>Checkbutton~>~>23
+Interlinear~>$interlinear~>Checkbutton~>~>23;;
+Interlinear font~>$glossfont~>Entry~>12~>24
 
 [general]
 Expand~>$expand~>Optionmenu~>expansions;;

--- a/web/www/horas/horas.setup
+++ b/web/www/horas/horas.setup
@@ -21,7 +21,8 @@ $noflexa='1';;
 $langfb='English';;
 $testmode='Proper';;
 $singleCell='1';;
-$interlinear='0'
+$interlinear='0';;
+$glossfont=''
 
 [parameterscheck]
 bbtbbbtcccccnnbbbbbttbb

--- a/web/www/missa/missa.dialog
+++ b/web/www/missa/missa.dialog
@@ -15,7 +15,8 @@ Screen height~>$screenheight~>Entry~>12;;
 Text width percent~>$textwidth~>Entry~>12;;
 Don't use fancy characters~>$nofancychars~>Checkbutton;;
 Building script~>$building~>Checkbutton~>15;;
-Interlinear~>$interlinear~>Checkbutton~>~>17
+Interlinear~>$interlinear~>Checkbutton~>~>17;;
+Interlinear font~>$glossfont~>Entry~>12~>18
 
 [general]
 Version~>$version~>Optionmenu~>versions;;

--- a/web/www/missa/missa.setup
+++ b/web/www/missa/missa.setup
@@ -15,7 +15,8 @@ $textwidth='100';;
 $nofancychars='0';;
 $building='0';;
 $langfb='English';;
-$interlinear='0'
+$interlinear='0';;
+$glossfont=''
 
 [parameterscheck]
 ttobcccccccnnbbtb


### PR DESCRIPTION
Adds an "Interlinear font" option to the Options page for both the Office and Mass. Accepts the same format as other font fields (e.g. `italic purple`, `bold red`, `#9b7fc7`). Defaults to blank, which leaves the gloss text unstyled.