### PR TITLE
Force interlinear off when coming from DO landing page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -30,7 +30,7 @@
 <table border="1" style="text-align:center;margin-left:auto;margin-right:auto;width:50%;font-size:2em">
     <tr>
       <td>
-&nbsp;&nbsp;&nbsp;<a href="cgi-bin/horas/officium.pl">Desktop</a>&nbsp;&nbsp;&nbsp;</TD><TD>&nbsp;&nbsp;&nbsp;<a href="cgi-bin/horas/Pofficium.pl">Mobile</a>&nbsp;&nbsp;&nbsp;</TD><TD>&nbsp;&nbsp;&nbsp;<a href="cgi-bin/missa/missa.pl">Missale</a>&nbsp;&nbsp;&nbsp;</TD><TD>&nbsp;&nbsp;&nbsp;<a href="cgi-bin/horas/kalendar.pl">Ordo</a>&nbsp;&nbsp;&nbsp;</TD>
+&nbsp;&nbsp;&nbsp;<a href="cgi-bin/horas/officium.pl?interlinear=0">Desktop</a>&nbsp;&nbsp;&nbsp;</TD><TD>&nbsp;&nbsp;&nbsp;<a href="cgi-bin/horas/Pofficium.pl?interlinear=0">Mobile</a>&nbsp;&nbsp;&nbsp;</TD><TD>&nbsp;&nbsp;&nbsp;<a href="cgi-bin/missa/missa.pl?interlinear=0">Missale</a>&nbsp;&nbsp;&nbsp;</TD><TD>&nbsp;&nbsp;&nbsp;<a href="cgi-bin/horas/kalendar.pl">Ordo</a>&nbsp;&nbsp;&nbsp;</TD>
         </TABLE>
 
 <div style="text-align: center"><p style="font-size:1em"><div style="text-align:center"><p style="font-size:1em"><a href="https://venmo.com/divinumofficium"><img src="www/horas/venmo.jpg" width="25%"></a><img src="www/horas/singers.jpg" width="50%" alt="Singing the Divine Office"></a><a href="https://paypal.me/officium"><img src="www/horas/paypal.png" width="25%"></a></p>


### PR DESCRIPTION
having this on for a week or two should make the cookies updated enough to ensure the default from horas.setup is taken into account