### PR TITLE
fix: increase Starman workers from 10 to 20 to handle increased load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,4 +94,4 @@ ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD ["/bin/bash", "-c", \
     "cron && \
      (sleep 15 && BASE_URL=http://localhost:8080 /usr/local/bin/warm-ordo-cache.sh >> /var/log/ordo-cache-warm.log 2>&1) & \
-     starman --port 8080 --host 0.0.0.0 --workers 10 --preload-app --user www-data --group www-data /var/www/app.psgi"]
+     starman --port 8080 --host 0.0.0.0 --workers 20 --preload-app --user www-data --group www-data /var/www/app.psgi"]


### PR DESCRIPTION
Addresses the Cloud Run issue reported:

May 14, 2026 1:13:02 PM>: 
Since yesterday, every time I open Divinum Officium online, it shows a gateway timeout host error. Is this something temporary? 

Description: The site is currently experiencing widespread 504 gateway timeouts (9,600+ in the past 8 hours). Increasing Starman workers from 10 to 20 to handle the increased concurrent load, particularly following the interlinear feature merge which significantly increased response payload sizes and processing time.