### PR TITLE
fix: switch Perl base image from ECR to Docker Hub to avoid rate limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN echo "{" > /build/buildinfo && \
     echo "}" >> /build/buildinfo
 
 # --- STAGE 2: Final Container ---
-FROM public.ecr.aws/docker/library/perl:5.40-slim AS final
+FROM perl:5.40-slim AS final
 LABEL maintainer="Thomas Randall <thomas.james.randall@gmail.com>"
 
 # 1. System dependencies


### PR DESCRIPTION
During today's incident, multiple simultaneous builds triggered by the interlinear feature merge caused repeated failures at Step 6 with toomanyrequests: Rate exceeded when pulling public.ecr.aws/docker/library/perl:5.40-slim from ECR.

Switching to the equivalent Docker Hub image (perl:5.40-slim) resolves the rate limit issue and makes the build pipeline more resilient when multiple builds fire simultaneously.

Tested successfully locally with Docker build before submitting.

@FAJ-Munich / @APMarcello3 - I don't think there's any other blockers here, but thought I'd check first before merging.