### PR TITLE
Fix interlinear appearing enabled for users with old cookies

### DIFF
--- a/web/cgi-bin/horas/officium.pl
+++ b/web/cgi-bin/horas/officium.pl
@@ -119,6 +119,8 @@ if (!$setupsave) {
 set_runtime_options('general' . ($Ck ? 'c' : ''));    #$expand, $version, $lang2
 set_runtime_options('parameters');                    # priest, lang1 ... etc
 
+our $interlinear = 0 unless $setupsave || strictparam('interlinear') ne '';
+
 if ($command =~ s/changeparameters//) { getsetupvalue($command); }
 
 #print "Content-type: text/html; charset=utf-8\n\n"; #<= uncomment for debuggin "Internal Server Errors"

--- a/web/cgi-bin/horas/officium.pl
+++ b/web/cgi-bin/horas/officium.pl
@@ -120,6 +120,7 @@ set_runtime_options('general' . ($Ck ? 'c' : ''));    #$expand, $version, $lang2
 set_runtime_options('parameters');                    # priest, lang1 ... etc
 
 our $interlinear = 0 unless $setupsave || strictparam('interlinear') ne '';
+$glossfont = '' if $glossfont =~ /^[btonc]+$/;
 
 if ($command =~ s/changeparameters//) { getsetupvalue($command); }
 

--- a/web/cgi-bin/horas/popup.pl
+++ b/web/cgi-bin/horas/popup.pl
@@ -87,6 +87,7 @@ set_runtime_options('general');       #$expand, $version, $lang2
 set_runtime_options('parameters');    # priest, lang1 ... etc
 
 our $interlinear = 0 unless $setupsave || strictparam('interlinear') ne '';
+$glossfont = '' if $glossfont =~ /^[btonc]+$/;
 
 $popup = strictparam('popup');
 

--- a/web/cgi-bin/horas/popup.pl
+++ b/web/cgi-bin/horas/popup.pl
@@ -86,6 +86,8 @@ if (!$setupsave) {
 set_runtime_options('general');       #$expand, $version, $lang2
 set_runtime_options('parameters');    # priest, lang1 ... etc
 
+our $interlinear = 0 unless $setupsave || strictparam('interlinear') ne '';
+
 $popup = strictparam('popup');
 
 if ($popup !~ /^[\$\&][\&\w ]+$/) {

--- a/web/cgi-bin/horas/webdia.pl
+++ b/web/cgi-bin/horas/webdia.pl
@@ -394,6 +394,7 @@ sub getcookies {
       # $error = "Cookie $cname mismatch $name need $check has $param<br/>== $sti[-1]";
       return 0;
     }
+    pop @sti;    # remove check string so it never maps to a param slot
     setsetup($name, @sti);
     return 1;
   }

--- a/web/cgi-bin/missa/Cmissa.pl
+++ b/web/cgi-bin/missa/Cmissa.pl
@@ -111,6 +111,8 @@ if (!$setupsave) {
 set_runtime_options('generalc');      #$expand, $version, $lang2
 set_runtime_options('parameters');    # priest, lang1 ... etc
 
+our $interlinear = 0 unless $setupsave || strictparam('interlinear') ne '';
+
 if ($command eq 'changeparameters') { getsetupvalue($command); }
 
 #print "Content-type: text/html; charset=utf-8\n\n"; #<= uncomment for debuggin "Internal Server Errors"

--- a/web/cgi-bin/missa/Cmissa.pl
+++ b/web/cgi-bin/missa/Cmissa.pl
@@ -112,6 +112,7 @@ set_runtime_options('generalc');      #$expand, $version, $lang2
 set_runtime_options('parameters');    # priest, lang1 ... etc
 
 our $interlinear = 0 unless $setupsave || strictparam('interlinear') ne '';
+$glossfont = '' if $glossfont =~ /^[btonc]+$/;
 
 if ($command eq 'changeparameters') { getsetupvalue($command); }
 

--- a/web/cgi-bin/missa/missa.pl
+++ b/web/cgi-bin/missa/missa.pl
@@ -111,6 +111,7 @@ set_runtime_options('general');       #$expand, $version, $lang2
 set_runtime_options('parameters');    # priest, lang1 ... etc
 
 our $interlinear = 0 unless $setupsave || strictparam('interlinear') ne '';
+$glossfont = '' if $glossfont =~ /^[btonc]+$/;
 
 if ($command eq 'changeparameters') { getsetupvalue($command); }
 

--- a/web/cgi-bin/missa/missa.pl
+++ b/web/cgi-bin/missa/missa.pl
@@ -110,6 +110,8 @@ if (!$setupsave) {
 set_runtime_options('general');       #$expand, $version, $lang2
 set_runtime_options('parameters');    # priest, lang1 ... etc
 
+our $interlinear = 0 unless $setupsave || strictparam('interlinear') ne '';
+
 if ($command eq 'changeparameters') { getsetupvalue($command); }
 
 #print "Content-type: text/html; charset=utf-8\n\n"; <= uncomment for debuggin "Internal Server Errors"

--- a/web/cgi-bin/missa/mpopup.pl
+++ b/web/cgi-bin/missa/mpopup.pl
@@ -57,6 +57,7 @@ set_runtime_options('general');       #$expand, $version, $lang2
 set_runtime_options('parameters');    # priest, lang1 ... etc
 
 our $interlinear = 0 unless $setupsave || strictparam('interlinear') ne '';
+$glossfont = '' if $glossfont =~ /^[btonc]+$/;
 
 $popup = strictparam('popup');
 $background = ($whitebground) ? ' class="contrastbg"' : '';

--- a/web/cgi-bin/missa/mpopup.pl
+++ b/web/cgi-bin/missa/mpopup.pl
@@ -56,6 +56,8 @@ if (!$setupsave) {
 set_runtime_options('general');       #$expand, $version, $lang2
 set_runtime_options('parameters');    # priest, lang1 ... etc
 
+our $interlinear = 0 unless $setupsave || strictparam('interlinear') ne '';
+
 $popup = strictparam('popup');
 $background = ($whitebground) ? ' class="contrastbg"' : '';
 $only = ($lang1 && $lang1 =~ /$lang2/) ? 1 : 0;

--- a/web/www/horas/horas.setup
+++ b/web/www/horas/horas.setup
@@ -25,7 +25,7 @@ $interlinear='0';;
 $glossfont=''
 
 [parameterscheck]
-bbtbbbtcccccnnbbbbbttbb
+bbtbbbtcccccnnbbbbbttbbt
 
 [general]
 $expand='tota';;

--- a/web/www/missa/missa.setup
+++ b/web/www/missa/missa.setup
@@ -19,7 +19,7 @@ $interlinear='0';;
 $glossfont=''
 
 [parameterscheck]
-ttobcccccccnnbbtb
+ttobcccccccnnbbtbt
 
 [general]
 $version='Rubrics 1960 - 1960';;


### PR DESCRIPTION
Users with cookies saved before interlinear was added had the old `parameterscheck` string land in the `$interlinear` parameter slot when loaded. Since that string is non-empty, it was interpreted as "on" — so interlinear appeared enabled even though the user had never selected it.

Fix: reset `$interlinear` to 0 on page load unless explicitly set via the Options dialog or a URL parameter. Applied to `officium.pl`, `missa.pl`, `Cmissa.pl`, `popup.pl`, and `mpopup.pl`. Also corrects the `parameterscheck` length in `horas.setup` and `missa.setup` after `$glossfont` was added.

Testing: Reproduced by manually setting old pre-interlinear cookie values (`horasp` and `missap`) in the browser and navigating directly to the horas and missa pages. Confirmed the bug on the live site, and confirmed the fix works against the docker container instance with this fix.