### PR TITLE
add glosses for terce words

### DIFF
--- a/lexicon-tools/lexicon_overrides.json
+++ b/lexicon-tools/lexicon_overrides.json
@@ -13987,7 +13987,8 @@
   "percussae": "struck",
   "percusserunt": "they struck",
   "percussum": "struck",
-  "percussus": "struck",
+  "percussus": "struck/smitten",
+  "percússus": "struck/smitten",
   "percépti": "received",
   "percéptio": "reception/receiving",
   "percípiet": "he will receive",
@@ -21166,5 +21167,16 @@
   "óffero": "I offer/present",
   "único": "only/unique",
   "únicus": "only/unique",
-  "ǽreum": "of bronze/brazen"
+  "ǽreum": "of bronze/brazen",
+  "cremium": "kindling/firewood",
+  "crémium": "kindling/firewood",
+  "adhaesit": "it clung/it cleaved",
+  "adhǽsit": "it clung/it cleaved",
+  "tecto": "roof/housetop",
+  "miscebam": "I was mixing/mingled",
+  "miscébam": "I was mixing/mingled",
+  "miserebuntur": "they will have mercy/compassion/pity",
+  "miserebúntur": "they will have mercy/compassion/pity",
+  "aspexit": "he looked upon/he beheld",
+  "aspéxit": "he looked upon/he beheld"
 }


### PR DESCRIPTION
Fixes interlinear glosses for crémium, percússus, adhǽsit, tecto, miscébam, miserebúntur, aspéxit.