### PR TITLE
add glosses for sext words

### DIFF
--- a/lexicon-tools/lexicon_overrides.json
+++ b/lexicon-tools/lexicon_overrides.json
@@ -16312,7 +16312,7 @@
   "qualescúmque": "of whatever kind",
   "qualiter": "how/in what manner",
   "qualívis": "of any kind whatever",
-  "quam": "whom/than",
+  "quam": "how/whom/than",
   "quamplura": "very many things",
   "quamplurima": "very many",
   "quamplurimi": "very many",
@@ -21178,5 +21178,14 @@
   "miserebuntur": "they will have mercy/compassion/pity",
   "miserebúntur": "they will have mercy/compassion/pity",
   "aspexit": "he looked upon/he beheld",
-  "aspéxit": "he looked upon/he beheld"
+  "aspéxit": "he looked upon/he beheld",
+  "pellem": "skin/hide",
+  "herodii": "of the stork/heron",
+  "heródii": "of the stork/heron",
+  "herinaciis": "hedgehogs/urchins",
+  "herináciis": "hedgehogs/urchins",
+  "cubilibus": "dens/lairs",
+  "cubílibus": "dens/lairs",
+  "illudendum": "to play/to sport",
+  "illudéndum": "to play/to sport"
 }


### PR DESCRIPTION
Fixes interlinear glosses for pellem, heródii, herináciis, cubílibus, illudéndum; expands quam to include 'how'.