### PR TITLE
Fixing iCal output after "dioecesis" introduction

### DIFF
--- a/web/cgi-bin/horas/kalendar/ical.pl
+++ b/web/cgi-bin/horas/kalendar/ical.pl
@@ -31,7 +31,7 @@ EOH
     my ($yday, $ymonth, $yyear) = ydays_to_date($cday, $kyear);
     my ($dtstart) = sprintf("%04i%02i%02i", $yyear, $ymonth, $yday);
     my $day = sprintf("%02i-%02i-%04i", $ymonth, $yday, $yyear);
-    my ($e) = ordo_entry($day, $version1, '', 'winneronly');
+    my ($e) = ordo_entry($day, $version1, '', '', 'winneronly');
     $e = abbreviate_entry($e);
     my $uid = uuid();
     $output .= <<"EOE";


### PR DESCRIPTION
iCal output was in full HTML formatting, because the `ordo_entry` function didn't obtain the "winneronly" argument.