### PR TITLE
iCal: introduction of an extended version

### DIFF
--- a/web/cgi-bin/horas/kalendar.pl
+++ b/web/cgi-bin/horas/kalendar.pl
@@ -120,9 +120,6 @@ require "$Bin/kalendar/$mode.pl";
 if (strictparam('format') eq 'ical') {
   require "$Bin/kalendar/ical.pl";
   ical_output();
-} elsif (strictparam('format') eq 'ical_comm') {
-  require "$Bin/kalendar/ical.pl";
-  ical_comm_output();
 } else {
   html_output($kyear, $kmonth, $mode);
 }
@@ -221,8 +218,6 @@ sub html_output {
     my $iyear = $tyear != $kyear ? "&kyear=$kyear" : '';
     print
       "&nbsp;&nbsp;&nbsp;<A HREF='$ENV{PATH_INFO}?format=ical&version=$version1&dioecesis=$dioecesis$iyear'>iCal</A>";
-    print
-      "&nbsp;&nbsp;&nbsp;&nbsp;<A HREF='$ENV{PATH_INFO}?format=ical_comm&version=$version1&dioecesis=$dioecesis$iyear'>iCal with Commemorations</A>";
   }
 
   my $date1 = strictparam('date1');

--- a/web/cgi-bin/horas/kalendar.pl
+++ b/web/cgi-bin/horas/kalendar.pl
@@ -120,6 +120,9 @@ require "$Bin/kalendar/$mode.pl";
 if (strictparam('format') eq 'ical') {
   require "$Bin/kalendar/ical.pl";
   ical_output();
+} elsif (strictparam('format') eq 'ical_comm') {
+  require "$Bin/kalendar/ical.pl";
+  ical_comm_output();
 } else {
   html_output($kyear, $kmonth, $mode);
 }
@@ -218,6 +221,8 @@ sub html_output {
     my $iyear = $tyear != $kyear ? "&kyear=$kyear" : '';
     print
       "&nbsp;&nbsp;&nbsp;<A HREF='$ENV{PATH_INFO}?format=ical&version=$version1&dioecesis=$dioecesis$iyear'>iCal</A>";
+    print
+      "&nbsp;&nbsp;&nbsp;&nbsp;<A HREF='$ENV{PATH_INFO}?format=ical_comm&version=$version1&dioecesis=$dioecesis$iyear'>iCal with Commemorations</A>";
   }
 
   my $date1 = strictparam('date1');

--- a/web/cgi-bin/horas/kalendar/ical.pl
+++ b/web/cgi-bin/horas/kalendar/ical.pl
@@ -31,7 +31,7 @@ EOH
     my ($yday, $ymonth, $yyear) = ydays_to_date($cday, $kyear);
     my ($dtstart) = sprintf("%04i%02i%02i", $yyear, $ymonth, $yday);
     my $day = sprintf("%02i-%02i-%04i", $ymonth, $yday, $yyear);
-    my ($e) = ordo_entry($day, $version1, '', '', 'winneronly');
+    my ($e) = ordo_entry($day, $version1, $dioecesis, '', 'winneronly');
     $e = abbreviate_entry($e);
     my $uid = uuid();
     $output .= <<"EOE";
@@ -40,6 +40,52 @@ UID:$uid
 DTSTAMP:$dtstamp
 SUMMARY:$e
 DTSTART;VALUE=DATE:$dtstart
+END:VEVENT
+EOE
+  }
+  print "${output}END:VCALENDAR\n";
+}
+
+# prepare ical output
+sub ical_comm_output {
+  my ($output) = <<"EOH";
+Content-Type: text/calendar; charset=utf-8
+Content-Disposition: attachment; filename="$version1 - $kyear.ics"
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//divinumofficium.com//
+CALSCALE:GREGORIAN
+SOURCE:https://divinumofficium.com/cgi-bin/horas/kalendar.pl
+EOH
+
+  my ($to) = 365 + leapyear($kyear);
+  my (@date) = reverse((localtime(time()))[0 .. 5]);
+  $date[0] += 1900;
+  $date[1]++;
+  my ($dtstamp) = sprintf("%04i%02i%02iT%02i%02i%02i", @date);
+
+  for my $cday (1 .. $to) {
+    my ($yday, $ymonth, $yyear) = ydays_to_date($cday, $kyear);
+    my ($dtstart) = sprintf("%04i%02i%02i", $yyear, $ymonth, $yday);
+    my $day = sprintf("%02i-%02i-%04i", $ymonth, $yday, $yyear);
+    my ($e) = ordo_entry($day, $version1, $dioecesis, '', 'winnerupd');
+    my ($d) = ordo_entry($day, $version1, $dioecesis, '', 'comm');
+    $e = abbreviate_entry($e);
+    my $version1_url = $version1 =~ s/ /\%20/gr;
+    my $version1_uid = $version1 =~ s/ /-/gr;
+    my $d_html = format_ics_html($d);
+    $d = abbreviate_entry($d);
+    my $uid = uuid();
+    $output .= <<"EOE";
+BEGIN:VEVENT
+UID:$day-$version1_uid
+DTSTAMP:$dtstamp
+DTSTART;VALUE=DATE:$dtstart
+SUMMARY:$e
+DESCRIPTION:$d
+$d_html
+URL:https://divinumofficium.com/cgi-bin/horas/Pofficium.pl?date1=$day&version=$version1_url
 END:VEVENT
 EOE
   }
@@ -81,10 +127,33 @@ sub abbreviate_entry {
   s/ Ferial//;
   s/Feria major/Fer. maj./;
   s/Feria privilegiata/Fer. priv./;
+  s/Vigilia ?privilegiata/Vigil. priv./;
   s/post Octavam/post Oct./;
   s/Augusti/Aug./;
   s/(Septem|Octo|Novem|Decem)bris/${1}b./;
+  s/\&amp; /&/g;
+  s/\<.*?\>//g;
   $_;
+}
+
+# Splits the X-ALT-DESC line to be maximum of 75 characters long (ICS format requirement)
+sub format_ics_html {
+    my ($html_string) = @_;   
+    my $full_line = "X-ALT-DESC;FMTTYPE=text/html:" . $html_string;
+    
+    #  The first line can be up to 75 characters.
+    #  Subsequent lines can only be up to 74 characters + leading space 
+    my @folded_lines;
+    
+    if ($full_line =~ s/^(.{1,75})//) {
+        push @folded_lines, $1;
+    }
+    
+    while ($full_line =~ s/^(.{1,74})//) {
+        push @folded_lines, " " . $1;
+    }
+    
+    return join("\r\n", @folded_lines);
 }
 
 1;

--- a/web/cgi-bin/horas/kalendar/ical.pl
+++ b/web/cgi-bin/horas/kalendar/ical.pl
@@ -31,7 +31,7 @@ EOH
     my ($yday, $ymonth, $yyear) = ydays_to_date($cday, $kyear);
     my ($dtstart) = sprintf("%04i%02i%02i", $yyear, $ymonth, $yday);
     my $day = sprintf("%02i-%02i-%04i", $ymonth, $yday, $yyear);
-    my ($e) = ordo_entry($day, $version1, $dioecesis, '', 'winneronly');
+    my ($e) = ordo_entry($day, $version1, '', '', 'winneronly');
     $e = abbreviate_entry($e);
     my $uid = uuid();
     $output .= <<"EOE";
@@ -40,52 +40,6 @@ UID:$uid
 DTSTAMP:$dtstamp
 SUMMARY:$e
 DTSTART;VALUE=DATE:$dtstart
-END:VEVENT
-EOE
-  }
-  print "${output}END:VCALENDAR\n";
-}
-
-# prepare ical output
-sub ical_comm_output {
-  my ($output) = <<"EOH";
-Content-Type: text/calendar; charset=utf-8
-Content-Disposition: attachment; filename="$version1 - $kyear.ics"
-
-BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//divinumofficium.com//
-CALSCALE:GREGORIAN
-SOURCE:https://divinumofficium.com/cgi-bin/horas/kalendar.pl
-EOH
-
-  my ($to) = 365 + leapyear($kyear);
-  my (@date) = reverse((localtime(time()))[0 .. 5]);
-  $date[0] += 1900;
-  $date[1]++;
-  my ($dtstamp) = sprintf("%04i%02i%02iT%02i%02i%02i", @date);
-
-  for my $cday (1 .. $to) {
-    my ($yday, $ymonth, $yyear) = ydays_to_date($cday, $kyear);
-    my ($dtstart) = sprintf("%04i%02i%02i", $yyear, $ymonth, $yday);
-    my $day = sprintf("%02i-%02i-%04i", $ymonth, $yday, $yyear);
-    my ($e) = ordo_entry($day, $version1, $dioecesis, '', 'winnerupd');
-    my ($d) = ordo_entry($day, $version1, $dioecesis, '', 'comm');
-    $e = abbreviate_entry($e);
-    my $version1_url = $version1 =~ s/ /\%20/gr;
-    my $version1_uid = $version1 =~ s/ /-/gr;
-    my $d_html = format_ics_html($d);
-    $d = abbreviate_entry($d);
-    my $uid = uuid();
-    $output .= <<"EOE";
-BEGIN:VEVENT
-UID:$day-$version1_uid
-DTSTAMP:$dtstamp
-DTSTART;VALUE=DATE:$dtstart
-SUMMARY:$e
-DESCRIPTION:$d
-$d_html
-URL:https://divinumofficium.com/cgi-bin/horas/Pofficium.pl?date1=$day&version=$version1_url
 END:VEVENT
 EOE
   }
@@ -127,33 +81,10 @@ sub abbreviate_entry {
   s/ Ferial//;
   s/Feria major/Fer. maj./;
   s/Feria privilegiata/Fer. priv./;
-  s/Vigilia ?privilegiata/Vigil. priv./;
   s/post Octavam/post Oct./;
   s/Augusti/Aug./;
   s/(Septem|Octo|Novem|Decem)bris/${1}b./;
-  s/\&amp; /&/g;
-  s/\<.*?\>//g;
   $_;
-}
-
-# Splits the X-ALT-DESC line to be maximum of 75 characters long (ICS format requirement)
-sub format_ics_html {
-    my ($html_string) = @_;   
-    my $full_line = "X-ALT-DESC;FMTTYPE=text/html:" . $html_string;
-    
-    #  The first line can be up to 75 characters.
-    #  Subsequent lines can only be up to 74 characters + leading space 
-    my @folded_lines;
-    
-    if ($full_line =~ s/^(.{1,75})//) {
-        push @folded_lines, $1;
-    }
-    
-    while ($full_line =~ s/^(.{1,74})//) {
-        push @folded_lines, " " . $1;
-    }
-    
-    return join("\r\n", @folded_lines);
 }
 
 1;

--- a/web/cgi-bin/horas/kalendar/ical.pl
+++ b/web/cgi-bin/horas/kalendar/ical.pl
@@ -40,7 +40,6 @@ EOH
     my ($yday, $ymonth, $yyear) = ydays_to_date($cday, $kyear);
     my ($dtstart) = sprintf("%04i%02i%02i", $yyear, $ymonth, $yday);
     my $day = sprintf("%02i-%02i-%04i", $ymonth, $yday, $yyear);
-    my ($e) = ordo_entry($day, $version1, '', '', 'winneronly');
     my ($e) = ordo_entry($day, $version1, $dioecesis, '', 'winneronly');
 
     $e = abbreviate_entry($e);
@@ -56,6 +55,52 @@ EOE
   }
   print "${output}END:VCALENDAR\n";
 }
+
+# prepare ical output with commemorations
+sub ical_comm_output {
+  my ($output) = <<"EOH";
+Content-Type: text/calendar; charset=utf-8
+Content-Disposition: attachment; filename="$version1 - $kyear.ics"
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//divinumofficium.com//
+CALSCALE:GREGORIAN
+SOURCE:https://divinumofficium.com/cgi-bin/horas/kalendar.pl
+EOH
+
+  my ($to) = 365 + leapyear($kyear);
+  my (@date) = reverse((localtime(time()))[0 .. 5]);
+  $date[0] += 1900;
+  $date[1]++;
+  my ($dtstamp) = sprintf("%04i%02i%02iT%02i%02i%02i", @date);
+
+  for my $cday (1 .. $to) {
+    my ($yday, $ymonth, $yyear) = ydays_to_date($cday, $kyear);
+    my ($dtstart) = sprintf("%04i%02i%02i", $yyear, $ymonth, $yday);
+    my $day = sprintf("%02i-%02i-%04i", $ymonth, $yday, $yyear);
+    my ($e) = ordo_entry($day, $version1, $dioecesis, '', 'winnerupd');
+    my ($d) = ordo_entry($day, $version1, $dioecesis, '', 'comm');
+    $e = abbreviate_entry($e);
+    my $version1_url = $version1 =~ s/ /\%20/gr;
+    my $version1_uid = $version1 =~ s/ //gr;
+    my $d_html = format_ics_html($d);
+    $d = abbreviate_entry($d);
+    $output .= <<"EOE";
+BEGIN:VEVENT
+UID:$day-$version1_uid\@divinumofficium
+DTSTAMP:$dtstamp
+DTSTART;VALUE=DATE:$dtstart
+SUMMARY:$e
+DESCRIPTION:$d
+$d_html
+URL:https://divinumofficium.com/cgi-bin/horas/Pofficium.pl?date1=$day&version=$version1_url
+END:VEVENT
+EOE
+  }
+  print "${output}END:VCALENDAR\n";
+}
+
 
 # abbreviate entries for ical
 sub abbreviate_entry {
@@ -92,10 +137,33 @@ sub abbreviate_entry {
   s/ Ferial//;
   s/Feria major/Fer. maj./;
   s/Feria privilegiata/Fer. priv./;
+  s/Vigilia ?privilegiata/Vigil. priv./;
   s/post Octavam/post Oct./;
   s/Augusti/Aug./;
   s/(Septem|Octo|Novem|Decem)bris/${1}b./;
+  s/\&amp; /&/g;
+  s/\<.*?\>//g;
   $_;
+}
+
+# Splits the X-ALT-DESC line to be maximum of 75 characters long (ICS format requirement)
+sub format_ics_html {
+    my ($html_string) = @_;   
+    my $full_line = "X-ALT-DESC;FMTTYPE=text/html:" . $html_string;
+    
+    #  The first line can be up to 75 characters.
+    #  Subsequent lines can only be up to 74 characters + leading space 
+    my @folded_lines;
+    
+    if ($full_line =~ s/^(.{1,75})//) {
+        push @folded_lines, $1;
+    }
+    
+    while ($full_line =~ s/^(.{1,74})//) {
+        push @folded_lines, " " . $1;
+    }
+    
+    return join("\r\n", @folded_lines);
 }
 
 1;

--- a/web/cgi-bin/horas/kalendar/ordo.pl
+++ b/web/cgi-bin/horas/kalendar/ordo.pl
@@ -24,7 +24,8 @@ sub ordo_entry {
   setChantTone() if ($lang1 =~ /gabc/i);    # GABC: set ChantTone depending on the solemnity of the day
 
   my ($h1, $h2) = split(/\s*~\s*/, setheadline());
-  return "$h1, $h2" if $winneronly;         # finish here for ical
+  return "$h1, $h2" if $winneronly =~ /winneronly/;  # finish here for ical
+  return "$h1 ($h2)" if $winneronly =~ /winnerupd/;     # finish here for ical_comm
 
   my ($c1, $c2);
   $c1 = "<B>" . setfont(liturgical_color($h1), $h1) . "</B>" . setfont('1 maroon', "&ensp;$h2");
@@ -63,6 +64,8 @@ sub ordo_entry {
       last if ($version =~ /1960/ && $rank >= 5 || ($rank >= 4 && $winner{Rank} =~ /Feria|Sabbato/i));
     }
   }
+
+  return "$c2" if $winneronly =~ /comm/i; # finish here for ical_comm - comm
 
   $c2 =~ s/Hebdomadam/Hebd/i;
   $c2 =~ s/Quadragesima/Quadr/i;

--- a/web/cgi-bin/horas/kalendar/ordo.pl
+++ b/web/cgi-bin/horas/kalendar/ordo.pl
@@ -24,8 +24,7 @@ sub ordo_entry {
   setChantTone() if ($lang1 =~ /gabc/i);    # GABC: set ChantTone depending on the solemnity of the day
 
   my ($h1, $h2) = split(/\s*~\s*/, setheadline());
-  return "$h1, $h2" if $winneronly =~ /winneronly/;  # finish here for ical
-  return "$h1 ($h2)" if $winneronly =~ /winnerupd/;     # finish here for ical_comm
+  return "$h1, $h2" if $winneronly;         # finish here for ical
 
   my ($c1, $c2);
   $c1 = "<B>" . setfont(liturgical_color($h1), $h1) . "</B>" . setfont('1 maroon', "&ensp;$h2");
@@ -64,8 +63,6 @@ sub ordo_entry {
       last if ($version =~ /1960/ && $rank >= 5 || ($rank >= 4 && $winner{Rank} =~ /Feria|Sabbato/i));
     }
   }
-
-  return "$c2" if $winneronly =~ /comm/i; # finish here for ical_comm - comm
 
   $c2 =~ s/Hebdomadam/Hebd/i;
   $c2 =~ s/Quadragesima/Quadr/i;

--- a/web/cgi-bin/horas/kalendar/ordo.pl
+++ b/web/cgi-bin/horas/kalendar/ordo.pl
@@ -24,7 +24,8 @@ sub ordo_entry {
   setChantTone() if ($lang1 =~ /gabc/i);    # GABC: set ChantTone depending on the solemnity of the day
 
   my ($h1, $h2) = split(/\s*~\s*/, setheadline());
-  return "$h1, $h2" if $winneronly;         # finish here for ical
+  return "$h1, $h2" if $winneronly =~ /winneronly/;     # finish here for ical
+  return "$h1 ($h2)" if $winneronly =~ /winnerupd/;     # finish here for ical_comm
 
   my ($c1, $c2);
   $c1 = "<B>" . setfont(liturgical_color($h1), $h1) . "</B>" . setfont('1 maroon', "&ensp;$h2");
@@ -63,6 +64,8 @@ sub ordo_entry {
       last if ($version =~ /1960/ && $rank >= 5 || ($rank >= 4 && $winner{Rank} =~ /Feria|Sabbato/i));
     }
   }
+
+  return "$c2" if $winneronly =~ /comm/i; # finish here for ical_comm - comm
 
   $c2 =~ s/Hebdomadam/Hebd/i;
   $c2 =~ s/Quadragesima/Quadr/i;


### PR DESCRIPTION
Father Prior of our Cistercian Monastery asked me for a Cistercian - if possible - calendar in his phone. 

I looked at this version and after a basic fix, which @FAJ-Munich improved, I tried to include the commemorations in the calendar event text, with a possibility to display the HTML version and a fallback to pure text. 

Also, the UID for the Cistercian version exceeds the maximum allowed line length of 75 characters in the ICS format, therefore I made up something "short" enough, yet stable, in order to allow for calendar updates, if the ordo changes in the future.

I hope this won't be an issue! (and sorry for the mess with merge - revert etc. I didn't think to check for new PR's before my own).