### PR TITLE
Fix malformed scripture citations in English missa Tempora

### DIFF
--- a/web/www/missa/English/Tempora/Pasc0-0.txt
+++ b/web/www/missa/English/Tempora/Pasc0-0.txt
@@ -28,7 +28,7 @@ Alleluia, alleluia
 !Ps. 117:24; 117:1
 This is the day which the Lord hath made: let us rejoice and be glad in it. 
 V. Give praise unto the Lord, for He is good: for His mercy endureth for ever. Alleluia, alleluia. 
-!1 Cor. 5. 7
+!1 Cor. 5:7-8
 Christ our Pasch is immolated.
 
 [Sequentia]

--- a/web/www/missa/English/Tempora/Pent01-4.txt
+++ b/web/www/missa/English/Tempora/Pent01-4.txt
@@ -23,7 +23,7 @@ $Qui vivis
 
 [Lectio]
 Lesson from the first letter of St. Paul the Apostle to the Corinthians
-!1 Cor. 23-29.
+!1 Cor. 11:23-29.
 Brethren: I myself have received from the Lord - what I also delivered to you, - that the Lord Jesus, on the night in which He was betrayed, took bread, and giving thanks broke, and said, Take and eat. This is My Body which shall be given up for you; do this in remembrance of Me. In like manner also the cup, after He had supped, saying, This is the new covenant in My Blood; do this as often as you drink it, in remembrance of Me. For as often as you shall eat this Bread and drink the cup, you proclaim the death of the Lord, until He comes. Therefore whoever eats this Bread or drinks the cup of the Lord unworthily, will be guilty of the Body and the Blood of the Lord. But let a man prove himself, and so let him eat of that Bread and drink of the cup; for he who eats and drinks unworthily, without distinguishing the Body, eats and drinks judgment to himself.
 
 [Graduale]


### PR DESCRIPTION
Two citation formatting errors found in English missa Tempora files, discovered by comparing against the Latin source files.

## Changes

**`Pent01-4.txt` (Corpus Christi — Feast of the Body of Christ):**
- `!1 Cor. 23-29` → `!1 Cor. 11:23-29`
- Missing chapter number; Latin file correctly has `!1 Cor 11:23-29`

**`Pasc0-0.txt` (Easter Sunday):**
- `!1 Cor. 5. 7` → `!1 Cor. 5:7`
- Used periods instead of colon; Latin file correctly has `!1 Cor 5:7`