### PR TITLE
Francais: Fix #5366

### DIFF
--- a/web/www/horas/Francais/Sancti/01-25.txt
+++ b/web/www/horas/Francais/Sancti/01-25.txt
@@ -72,7 +72,7 @@ A Damas, * l’ethnarque du roi Arétas voulut me prendre ; les frères me firen
 Trois fois j’ai été battu de verges, * une fois lapidé, trois fois j’ai fait naufrage, pour le nom du Christ.;;138
 
 [Commemoratio4]
-! Mémoire de S. Pierre Apôtre
+!Commémoraison de S. Pierre Apôtre
 (deinde dicuntur)
 Ant. Vous êtes le pasteur des brebis, Prince des Apôtres, à vous ont été confiées les clefs du royaume des deux.
 _

--- a/web/www/horas/Francais/Sancti/02-22.txt
+++ b/web/www/horas/Francais/Sancti/02-22.txt
@@ -164,8 +164,8 @@ R. Pour lui sacrifier une hostie de louange.
 @Commune/C4:Ant 3 summi Pontificis
 
 [Commemoratio4]
-!Mémoire de S. Paul Apôtre
-(se fait avant toutes les autres Mémoires )
+!Commémoraison de S. Paul Apôtre
+(deinde dicuntur)
 Ant. Saint Apôtre Paul, * prédicateur de la vérité et Docteur des Nations, intercédez pour nous, près de Dieu, qui vous a choisi.
 _
 V. Vous êtes un vase d’élection, saint Apôtre Paul.


### PR DESCRIPTION
close #5366

@dimon-CH-GE The issue comes from « Mémoire » not being recognized as the translatation for _Commemoratio_ in French `translate.txt` is given as « Commémoraison ».