### PR TITLE
Káldi György's Hungarian Psalms translation

### DIFF
--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm1.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm1.txt
@@ -1,0 +1,7 @@
+1:1 Boldog ember, ki az istentelenek tanácsán nem jár, † és a bűnösök útján meg nem áll, * és a mirígy székében nem ül;
+1:2 Hanem az Úr törvényében telik kedve, * és éjjel-nappal az ő törvényében elmélkedik.
+1:3a És leszen mint a fa, mely vízfolyások mellé ültettetett, * mely gyümölcsét megadja idejében,
+1:3b És levele el nem hull; * és amit cselekszik, mind sikerül.
+1:4 Nem így az istentelenek, nem így; * hanem mint a por, melyet a szél elhány a föld színéről.
+1:5 Azért az istentelenek meg nem állhatnak az ítéletben; * sem a bűnösök az igazak gyülekezetében.
+1:6 Mert az Úr ismeri az igazak útját; * és az istentelenek útja elvész.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm10.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm10.txt
@@ -1,0 +1,8 @@
+10:2 Az Úrban bízom; † hogyan mondjátok lelkemnek: * Költözzél a hegyre, mint a veréb?
+10:3 Mert íme a bűnösök megvonták a kézíjat, † elkészítették nyilaikat a tegezben, * hogy lövöldözzék titkon az igaz szívűeket;
+10:4 Mert amiket te állítottál, elbontották; * de az igaz mit cselekedett?
+10:5a Az Úr az ő szent templomában, * az Úr széke mennyben vagyon;
+10:5b Szemei a szegényre néznek, * és szempillái vizsgálják az emberek fiait.
+10:6 Az Úr megvizsgálja az igazat és az istentelent; * ki pedig a gonoszságot szereti, lelkét gyűlöli.
+10:7 A bűnösökre tőröket hullat; * tűz és kénkő és viharok szele az ő kelyhük része.
+10:8 Mert az Úr igaz, és igazságot szeret, * és igazra néz az ő orcája.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm100.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm100.txt
@@ -1,0 +1,10 @@
+100:1 Irgalmasságot és ítéletet éneklek, * Uram, neked éneklek.
+100:2 Figyelni fogok a szeplőtelen útra, * mikor hozzám jössz;
+100:2 Szívem ártatlanságában fogok járni * az én házamnak közepette.
+100:3 Nem teszek szemeim elé igaztalan dolgot, * a törvényszegőket gyűlölöm.
+100:4 Nem fog ragaszkodni hozzám az álnok szív; * a tőlem elhajló gonosztevőnek nem leszek ismerője.
+100:5 Ki felebarátját titkon rágalmazza, * azt üldözőbe veszem;
+100:5 Kinek szeme kevély, szíve telhetetlen, * azzal nem eszem.
+100:6 Szemeim a föld hívein lesznek, hogy velem üljenek; * ki szeplőtelen úton jár, az fog szolgálni nekem.
+100:7 Nem lesz lakása házamban, ki kevélyen cselekszik; * s az igaztalanul szólónak szemeim előtt nem lesz maradása.
+100:8 Korán kiirtom a föld minden bűnösét, * s az Úr városából mind elvesztem a gonoszul cselekvőket.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm101.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm101.txt
@@ -1,0 +1,29 @@
+101:2 Uram, hallgasd meg imádságomat, * és az én kiáltásom jusson hozzád.
+101:3 Ne fordítsd el tőlem a te orcádat; * amely nap szorongattatom, hajtsd hozzám füledet;
+101:3 Amely nap segítségül hívlak téged, * azonnal hallgass meg engem.
+101:4 Mert mint a füst, elenyésznek az én napjaim, * és csontjaim mint a forgács elszáradnak.
+101:5 Levágattam, mint a széna, és szívem kiszáradott, * úgy hogy elfeledtem enni kenyeremet.
+101:6 Az én nyögésem szava miatt * csontom húsomhoz ragadott.
+101:7 Hasonló lettem a pusztaság pelikánjához; * olyan lettem, mint a bagoly az ő lakhelyén.
+101:8 Virrasztok * és olyan lettem, mint a magányos madár a háztetőn.
+101:9 Napestig gyaláznak engem az én ellenségeim; * és akik dicsértek engem, ellenem esküsznek.
+101:10 Mert a kenyeret hamuban eszem, * és italomat sírással vegyítem
+101:11 A te haragod és bosszankodásod miatt; * mert fölemelvén, levetettél engem.
+101:12 Napjaim mint az árnyék hanyatlanak, * és én mint a széna elszáradok.
+101:13 Te pedig, Uram, mindörökké megmaradsz, * és a te emlékezeted nemzedékről nemzedékre.
+101:14 Te fölkelvén, könyörülni fogsz Sionon; * mert ideje, hogy rajta könyörülj, mert eljött ideje.
+101:15 Mivel kedvesek szolgáidnak az ő kövei, * és romján sajnálkoznak.
+101:16 És a népek félni fogják a te nevedet, Uram, * és a föld minden királyai a te dicsőségedet.
+101:17 Mivelhogy az Úr fölépíti Siont, * és láttatni fog az ő dicsőségében,
+101:18 Az alázatosok imádságát tekintetbe veszi, * és nem veti meg azok könyörgését.
+101:19 Írassanak meg ezek a jövő nemzedéknek; * és a teremtendő nép dicsérni fogja az Urat;
+101:20 Mert letekintett az ő szent magasságából; * az Úr a mennyből a földre tekintett:
+101:21 Hogy meghallja a foglyok sóhajtásait, * és föloldja a megöltek fiait:
+101:22 Hogy hirdessék az Úr nevét Sionban, * és az ő dicséretét Jeruzsálemben,
+101:23 Midőn a népek és királyok egybegyűlnek, * az Úrnak szolgálandók.
+101:24 Erre felelt neki ő életereje javában: * Napjaim kevés számát jelentsd meg nekem.
+101:25 Ne szólíts ki engem napjaim felén; * a te esztendeid nemzedékről nemzedékre.
+101:26 Kezdetben, Uram, te alapítottad a földet, * és az egek kezeid alkotásai.
+101:27 Ezek elmúlnak, te pedig megmaradsz; * mind elavulnak, mint a ruha,
+101:28 És mint az öltözetet, elváltoztatod azokat, és elváltoznak; * te pedig ugyanaz vagy, és esztendeid nem fogynak el.
+101:29 Szolgáid fiainak lakásuk lesz nálad, * és ivadékuk megmarad mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm102.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm102.txt
@@ -1,0 +1,22 @@
+102:1 Áldjad, én lelkem, az Urat, * és minden ami bennem vagyon, az ő szent nevét.
+102:2 Áldjad, én lelkem, az Urat, * és ne feledd el semmi adományát;
+102:3 Ki megkegyelmez minden gonoszságodnak, * ki meggyógyítja minden betegségedet,
+102:4 Ki a veszedelemből kiszabadítja éltedet, * ki téged megkoronáz irgalmassággal és könyörülettel,
+102:5 Ki betölti jókkal kívánságodat, * hogy megújuljon ifjúságod, mint a sasé.
+102:6 Irgalmasságot cselekszik az Úr, * és ítéletet minden igaztalanul szenvedőnek.
+102:7 Kijelentette Mózesnek az ő utait, * Izrael fiainak az ő akaratát.
+102:8 Könyörülő és irgalmas az Úr, * hosszantűrő és igen irgalmas.
+102:9 Nem tart haragot örökké, * sem örökké nem fenyeget.
+102:10 Nem bűneink szerint cselekszik velünk, * és nem gonoszságaink szerint fizet nekünk;
+102:11 Mert amily magas az ég a föld felett, * oly erőssé teszi irgalmát az őt félőkön.
+102:12 Amily messze vagyon napkelet nyugattól, * annyira távolítja el tőlünk gonoszságainkat.
+102:13 Mint az atya könyörül fiain, úgy könyörül az Úr az őt félőkön; * mert ő ismeri alkatunkat,
+102:14 Megemlékezik, hogy mi por vagyunk, * az ember napjai, mint a széna; elhervad ő, mint a mezei virág;
+102:16 Melyen ha átmegy a szél, meg nem marad, * és többé helyét sem ismerik meg.
+102:17 Az Úr irgalmassága pedig öröktől van * és mindörökké az őt félőkön,
+102:17 És az ő igazsága a fiak fiain, * azokon, kik megtartják szövetségét,
+102:18 És megemlékeznek parancsairól, * hogy azokat cselekedjék.
+102:19 Az Úr a mennybe helyezte az ő székét, * és uralmának minden alá van vetve.
+102:20 Áldjátok az Urat minden angyalai, * hatalmas erejűek, az ő igéjének cselekvői, mihelyst beszéde hangját halljátok.
+102:21 Áldjátok az Urat minden erősei, * ti, szolgái, kik az ő akaratát cselekszitek.
+102:22 Áldjátok az Urat minden alkotásai; * az ő uralkodásának minden helyén áldjad, én lelkem, az Urat.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm103.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm103.txt
@@ -1,0 +1,36 @@
+103:1 Áldjad, én lelkem, az Urat; * Uram, Istenem, fölötte fönséges vagy,
+103:1 Dicsőségbe és ékességbe öltöztél; * világossággal mint köntössel körül vagy öltve,
+103:2 Kiterjesztvén az eget, mint a sátorfödelet; * ki befödöd vizekkel annak felső részeit,
+103:3 Ki a felhőt szekereddé teszed, * ki a szelek szárnyain jársz;
+103:4 Ki angyalaidat szélvésszé teszed, * és szolgáidat égető tűzzé;
+103:5 Ki a földet állandóságra alapítottad, * hogy nem fog ingadozni örökkön-örökké.
+103:6 A vízmélység öltözet gyanánt födte azt; * a hegyeken vizek állottak.
+103:7 A te feddésed előtt elfutottak; * mennydörgésed szavától megijedtek.
+103:8 A hegyek fölemelkedtek, a völgyek alászállottak * azon helyre, melyet nekik alapítottál.
+103:9 Határt vontál, melyet nem fognak átlépni, * s nem térnek vissza a földet elborítani.
+103:10 Ki forrásokat fakasztasz a völgyekben, * a hegyek között folynak a vizek.
+103:11 Iszik azokból minden mezei vad; * azok után lihegnek szomjúságukban a vadszamarak.
+103:12 Azok mellett lakoznak az égi madarak; * a kősziklák közül szózatot adnak.
+103:13 Ki megöntözöd a hegyeket onnan felülről; * a te műveid gyümölcséből megelégíttetik a föld.
+103:14 Ki szénát teremtesz a barmoknak, * és veteményt az emberek szolgálatára,
+103:14 Hogy kenyeret termessz a földből, * és bor vidámítsa föl az ember szívét;
+103:15 Hogy olajjal derítse föl orcáját, * és a kenyér erősítse meg az ember szívét.
+103:16 Jóllaknak a mező fái, és a Libanon cédrusai, melyeket ültetett, * ott fészkelnek a madarak,
+103:17 A gólya háza fő azok között, * a magas hegy a szarvasok, a kőszikla a sündisznók menedéke.
+103:19 A holdat időmértékül teremté; * a nap tudja lenyugvását.
+103:20 Sötétséget parancsolsz, és éj van; * mely alatt mind kimennek az erdei vadak,
+103:21 Az oroszlán ordító kölykei, hogy ragadozzanak, * és az Istentől maguknak eledelt keressenek.
+103:22 Fölkel a nap, és összegyűlnek, * és hajlékaikba helyezkednek.
+103:23 Kimegy az ember munkájára * és dolgára napestig.
+103:24 Mily igen fölségesek a te műveid, Uram! * Mindeneket bölcsességgel cselekedtél; mi a földet betölti, mind a te jószágod.
+103:25 Ez a nagy és tágas öblű tenger, * ott az úszók, melyeknek száma nincs.
+103:26 A kicsiny állatok a nagyokkal; * ott járnak a hajók.
+103:27 A cethal, melyet alkottál, hogy játsszék abban, * mindnyájan tőled várják, hogy eledelt adj nekik idejében.
+103:28 Te adván nekik, gyűjtenek; * fölnyitván kezedet, minden betelik jóval.
+103:29 De ha elfordítod arcodat, megrémülnek; * ha elveszed lélegzetüket, elfogynak, és a porba visszatérnek.
+103:30 Beléjük bocsátván leheletedet, fölélednek; * és megújítod a föld színét.
+103:31 Legyen az Úré a dicsőség mindörökké. * Az Úr örülni fog alkotásaiban;
+103:32 Ki letekint a földre, és megrendíti azt; * ki a hegyeket megérinti, és füstölögnek.
+103:33 Énekelni fogok az Úrnak életemben, * dicséretet mondok az én Istenemnek, valamíg leszek.
+103:34 Legyen kellemes neki az én beszédem; * én pedig az Úrban fogok gyönyörködni.
+103:35 Fogyjanak el a bűnösök a földről és a gonoszok, úgy hogy ne legyenek; * áldjad én lelkem az Urat.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm104.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm104.txt
@@ -1,0 +1,44 @@
+104:1 Adjatok hálát az Úrnak, és hívjátok segítségül az ő nevét; * hirdessétek a népek között cselekedeteit.
+104:2 Énekeljetek neki, zengedezzetek neki, * és beszéljétek el minden csodatettét.
+104:3 Dicsekedjetek az ő szent nevében, * vigadjon az Urat keresők szíve.
+104:4 Keressétek az Urat és erősödjetek meg; * keressétek az ő színét mindenkoron.
+104:5 Emlékezzetek meg csodáiról, melyeket cselekedett, * az ő jeleiről és szája ítéleteiről.
+104:6 Ábrahámnak, az ő szolgájának ivadéka; * Jákobnak, az ő választottjának fiai.
+104:7 Ő a mi Urunk, Istenünk, * ő ítéli az egész földet.
+104:8 Megemlékezik örökké az ő szövetségéről, * az igéről, melyet parancsolt ezer nemzedékig,
+104:9 Melyet szerzett Ábrahámmal; * és az ő esküjéről Izsákkal.
+104:10 És melyet Jákobnak rendelt parancsolatul, * és Izraelnek örök szövetségül,
+104:11 Mondván: Neked adom Kánaán földjét * örökségetek részéül.
+104:12 Mikor csekély számmal, * igen kevesen és jövevények voltak benne,
+104:13 És nemzettől nemzethez költöztek, * és egy országból más néphez,
+104:14 Nem engedé, hogy ember ártson nekik, * és megfenyíté érettük a királyokat.
+104:15 Ne illessétek az én fölkentjeimet, * és prófétáim ellen ne gonoszkodjatok.
+104:16 És éhséget hívott a földre, * és a kenyérnek minden botját eltöré.
+104:17 Férfit küldött eléjük; * József szolgául adatott el.
+104:18 Megalázták bilincsbe lábait, a vas áthatotta lelkét, * míg betelt az ő mondása.
+104:19 Az Úr szava fölvilágosította őt. * Elküldött a király, és föloldá őt; a népek fejedelme elbocsátá őt.
+104:21 Úrrá rendelé őt házán, * és fejedelemmé minden jószágán,
+104:22 Hogy oktassa fejedelmeit, mint önmagát, * és véneit tanítsa okosságra.
+104:23 És bement Izrael Egyiptomba; * és Jákob lakos lőn Kám földjén.
+104:24 És igen megszaporította népét, * erősebbé tette ellenségeinél.
+104:25 Elfordítá azok szívét, hogy gyűlöljék az ő népét, * és álnokságot cselekedjenek szolgáin.
+104:26 Elküldé Mózest, az ő szolgáját, * Áront, kit kiválasztott.
+104:27 Jeleinek és csodáinak igéit * adta nekik Kám földjén.
+104:28 Sötétséget küldött, és sötét lett; * és nem hagyta hiába beszédeit.
+104:29 Vérré változtatta azok vizeit, * és megölé halaikat.
+104:30 Békákat termett földjük, * az ő királyaik belházaiban is.
+104:31 Szólott, és mindenféle légy jöve, * és szúnyogok minden határaikban.
+104:32 Eső helyett jeget bocsátott, * és égető tüzet földjeikre.
+104:33 És elveré szőlőiket, és fügefáikat, * és összezúzta határaik fáját.
+104:34 Szólott, és sáska jöve és cserebogár, * melynek nem volt száma.
+104:35 És megemészte minden füvet az ő földjükön, * és megevé földjük minden gyümölcsét.
+104:36 És megölt minden elsőszülöttet földjükön, * minden munkájuk zsengéit.
+104:37 És kivitte őket ezüsttel és arannyal, * és nemzetségeikben nem volt beteg.
+104:38 Örült Egyiptom az ő elmenetükön; * mert rájuk szállt vala azok félelme.
+104:39 Felhőt terített ki oltalmukra, * és tüzet, hogy világítson nekik éjjel.
+104:40 Könyörögtek, és jött a fürj; * és mennyei kenyérrel elégítette meg őket.
+104:41 Megnyitotta a kősziklát, és víz ömlött ki, * a szárazon folyóvíz folyt.
+104:42 Mert megemlékezett az ő szent igéjéről, * melyet szolgájának, Ábrahámnak mondott.
+104:43 És kivezette népét örvendezéssel, * és választottait vigassággal.
+104:44 És nekik adá a nemzetek tartományait, * és a népek munkáit elfoglalták,
+104:45 Hogy igazságait megőrizzék, * és kövessék az ő törvényét.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm105.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm105.txt
@@ -1,0 +1,47 @@
+105:1 Adjatok hálát az Úrnak, mert jó; * mert örökkévaló az ő irgalmassága.
+105:2 Ki beszéli el az Úr nagy tetteit, * ki hirdeti minden dicséretét?
+105:3 Boldogok, akik megtartják az ítéletet, * és igazságot cselekszenek minden időben.
+105:4 Emlékezzél meg, Uram, rólunk népedhez való jókedvedből; * látogass meg minket a te szabadításoddal,
+105:5 Hogy lássuk választottaid jólétét, hogy vigadjunk néped vigasságában, * hogy dicsértessél a te örökségeddel.
+105:6 Vétkeztünk atyáinkkal, * igaztalanul cselekedtünk, gonoszságot tettünk.
+105:7 Atyáink Egyiptomban nem értették csodáidat, * nem emlékeztek meg a te irgalmad sokaságáról,
+105:7 És bosszantottak, menvén a tengerre, * a Vörös-tengerre.
+105:8 De megszabadította őket nevéért, * hogy kijelentse hatalmasságát.
+105:9 És megdorgálta a Vörös-tengert, és kiszáradt; * és átvivé őket a mélységeken, mint a pusztán.
+105:10 És kiszabadítá őket a gyűlölők kezéből, * és megmenté őket az ellenség kezéből.
+105:11 És a víz elborította üldözőiket; * egy sem maradt meg azok közül.
+105:12 Akkor hittek az ő igéinek, * és énekelték dicséretét.
+105:13 De hamar elfeledkeztek az ő tetteiről, * és nem vártak tanácsára,
+105:14 És kívánságra gerjedtek a pusztában, * és kísértették Istent a vizetlen helyen.
+105:15 És megadta nekik kérésüket, * és megelégíté lelküket.
+105:16 És bosszanták Mózest a táborban, * Áront, az Úr szentjét.
+105:17 Megnyílt a föld, és elnyelé Dátánt, * és elborítá Abiron csoportját.
+105:18 És tűz gyulladt ki gyülekezetükben; * és láng égette meg a bűnösöket.
+105:19 És borjút alkottak Hóreben, * és imádták a bálványt.
+105:20 És fölcserélték dicsőségüket * a szénátevő borjú hasonmásával.
+105:21 Elfeledték az Istent, ki megszabadította őket, * ki nagy dolgokat cselekedett Egyiptomban, csodálatosakat Kám földén, rettentőket a Vörös-tengeren.
+105:23 És kimondá, hogy elveszti őket, * ha Mózes az ő választottja nem állott volna a rés előtt,
+105:24 Hogy elfordítsa az ő haragját, hogy el ne veszítse őket. * És semminek tarták a kívánatos földet,
+105:25 Nem hittek az ő igéjének, és morgolódtak sátoraikban, * nem hallgattak az Úr szavára.
+105:26 És fölemelte kezét ellenük, * hogy leverje őket a pusztában,
+105:27 És hogy ivadékukat a nemzetek közé vesse, * és elszórja őket a tartományokba,
+105:28 És ők Beélfegor szolgálatára állottak, * és a holtak áldozatait ették,
+105:29 És bosszantották őt találmányaikkal; * és a romlás rajtuk megsokasodott.
+105:30 De elé állt Fineesz és engesztelést szerzett, * és megszűnt a csapás.
+105:31 És igazságul tulajdoníttatott neki, * nemzedékről nemzedékre mindörökké.
+105:32 És bosszantották őt az ellenmondás vizeinél, * és Mózes is bajba került miattuk; mert elkeserítették lelkét,
+105:33 És kétkedve szólt ajkaival. * Nem irtották ki a nemzeteket, melyekről nekik az Úr szólott.
+105:35 A nemzetek közé vegyültek, és megtanulták azok cselekedeteit, és szolgáltak azok bálványainak, * s ez botrányul lőn nekik.
+105:37 Fiaikat és leányaikat * az ördögöknek áldozták,
+105:38 És kiontották az ártatlan vért, * fiaik és leányaik vérét, kiket Kánaán bálványainak áldoztak.
+105:39 És a föld megfertőztetett vérrel, és undokká lett cselekedeteik által, * és találmányaikkal paráználkodtak.
+105:40 És az Úr haragra gerjedt népe ellen; * és megutálta örökségét.
+105:41 És a nemzetek kezeibe adta őket, * és azok uralkodtak rajtuk, kik gyűlölték őket.
+105:42 És nyomorgaták őket ellenségeik, és megaláztattak azok kezei alatt. * Sok ízben megszabadította őket:
+105:43 Ezek pedig bosszantották őt törekvéseik által, * és megaláztattak gonoszságaikban.
+105:44 És látta, midőn nyomorgattattak, * és meghallgatá könyörgésüket.
+105:45 És megemlékezett szövetségéről, * és megsajnálta őket irgalmának sokasága szerint.
+105:46 És könyörületre indította irántuk mindazokat, * kik foglyokká tették őket.
+105:47 Szabadíts meg minket, Urunk, Istenünk, * és gyűjts össze minket a nemzetek közül,
+105:47 Hogy hálát adjunk szent nevednek, * és dicsekedjünk a te dicséretedben.
+105:48 Áldott legyen Izrael Ura, Istene, öröktől fogva mindörökké; * és mondja az egész nép: Úgy legyen! Úgy legyen!

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm106.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm106.txt
@@ -1,0 +1,43 @@
+106:1 Adjatok hálát az Úrnak, mert jó; * mert örökkévaló az ő irgalmassága.
+106:2 Mondják meg ezt, kik megszabadíttattak az Úr által, kiket megszabadított az ellenség kezéből, * és egybegyűjtött a tartományokból,
+106:3 Napkeletről és nyugatról, * északról és a tenger felől.
+106:4 Tévelyegtek a pusztában a vizetlen helyen; * nem találtak utat lakásra való városhoz.
+106:5 Éhezvén és szomjúhozván, * lelkük elbágyadt bennük.
+106:6 De az Úrhoz kiáltottak, midőn szorongattattak, * és kiragadta őket szükségeikből,
+106:7 És egyenes útra vezette őket, * hogy lakásra való városba menjenek.
+106:8 Adjanak hálát az Úrnak irgalmáért, * és csodatetteiért az emberek fiai előtt,
+106:9 Mert megelégítette a sóvárgó lelket, * az éhező lelket megelégítette jókkal.
+106:10 Kik a sötétségben és a halál árnyékában ültek, * ínségben és vasra verve:
+106:11 Mert ellenszegültek az Isten igéinek, * és a Fölséges tanácsát megvetették.
+106:12 És szívük megaláztatott a sanyarúság alatt; * elfogyott erejük, és nem volt, ki megsegítse.
+106:13 De az Úrhoz kiáltottak, midőn szorongattattak, * és kiszabadítá őket szükségeikből,
+106:14 És kivezette őket a sötétségből és a halál árnyékából, * és bilincseiket szétszaggatta.
+106:15 Adjanak hálát az Úrnak irgalmáért * és csodatetteiért az emberek fiai előtt;
+106:16 Mert lerontotta a réz ajtókat, * és a vas zárakat összetörte,
+106:17 Fölemelé őket gonoszságuk útjáról; * mert igaztalanságaik miatt aláztattak meg.
+106:18 Lelkük minden eledelt megutált; * és a halál kapuihoz közelgettek.
+106:19 De az Úrhoz kiáltottak, midőn szorongattattak, * és kiszabadítá őket szükségeikből.
+106:20 Kibocsátotta az ő igéjét, és meggyógyítá őket, * és kiragadta őket veszedelmeikből.
+106:21 Adjanak hálát az Úrnak irgalmáért * és csodatetteiért az emberek fiai előtt,
+106:22 És áldozzanak dicséretáldozattal, * és hirdessék az ő tetteit örvendezéssel.
+106:23 Kik hajókon jártak a tengeren, * kereskedvén a sok vízen;
+106:24 Azok látták az Úr cselekedeteit, * és csodatetteit a mélységben.
+106:25 Szólt, és szélvész lőn, * és fölkeltek az ő habjai.
+106:26 Fölemelkedtek az égig, és leszálltak a mélységig; * az ő lelkük elepedt a veszélyekben.
+106:27 Szédültek és tántorogtak, mint a részeg, * és minden bölcsességük elenyészett.
+106:28 De az Úrhoz kiáltottak, midőn szorongattattak, * és kivitte őket szükségeikből.
+106:29 És szélvészét gyenge szellővé tette, * és lecsendesedtek az ő habjai.
+106:30 És örültek, hogy lecsendesedtek; * és elvezette őket óhajtásuk révpartjára.
+106:31 Adjanak hálát az Úrnak az ő irgalmáért, * csodatetteiért az emberek fiai előtt,
+106:32 És magasztalják őt a község gyülekezeteiben, * és a vének ülésében dicsérjék őt.
+106:33 A folyókat pusztává tette, * és a vizek forrásait szomjas helyekké,
+106:34 A termékeny földet sovánnyá * a benne lakók gonoszsága miatt.
+106:35 A pusztát tavakká tette, * és a víz nélküli földet vízforrásokká.
+106:36 És oda telepítette az éhezőket, * és lakásul várost építettek.
+106:37 És bevetették a szántóföldet, és szőlőket ültettek, * és a termés gyümölcsét nyerték.
+106:38 És megáldotta őket, és igen megsokasodtak, * és barmaikat nem kevesítette meg.
+106:39 Kevesen voltak * és nyomorgattattak a gonoszoktól szorongatással és fájdalommal.
+106:40 Gyalázattal boríttattak el a fejedelmek; * és tévelyegni hagyta őket a járatlan és út nélküli helyeken;
+106:41 Ámde kisegítette a szegényt a nyomorúságból, * és a családokat juhnyájakhoz tette hasonlókká.
+106:42 Látják ezt az igazak, és örvendenek, * és minden gonoszság befogja száját.
+106:43 Kicsoda bölcs, hogy fölfogja ezeket * és megértse az Úr irgalmasságait?

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm107.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm107.txt
@@ -1,0 +1,14 @@
+107:2 Kész az én szívem, Isten, kész az én szívem, * énekelni és zengeni az én dicsőségemben.
+107:3 Serkenj föl, dicsőségem, serkenj föl zsoltárom és hárfám! * Fölkelek korán reggel.
+107:4 Hálát adok neked, Uram, a népek között, * és dicséretet mondok neked a nemzetek között.
+107:5 Mert nagyobb az egeknél irgalmasságod, * és a felhőkig ér a te igazságod.
+107:6 Magasztaltassál föl az egek fölött, Isten, és a te dicsőséged az egész földön, * hogy megszabaduljanak kedvelteid.
+107:7 Szabadíts meg a te jobb kezeddel, és hallgass meg engem. * Isten szólott az ő szent helyén:
+107:8 Azért vigadni fogok; és fölosztom Szikemet, * és a sátorok völgyét fölmérem.
+107:9 Enyém Gálaád és enyém Manasszesz, * és Efraim fejem oltalma,
+107:10 Júda az én királyom. * Moáb reményem fazeka;
+107:10 Idumeára kinyújtom sarumat; * az idegenek barátaimmá lesznek.
+107:11 Ki visz engem az erős városba? * Ki visz engem Idumeáig?
+107:12 Nemde te, Isten, ki minket elvetettél? * És nem mégy-e ki, Isten, a mi seregeinkkel?
+107:13 Segíts ki minket a szorongatásból, * mert hiábavaló az ember segedelme.
+107:14 Isten által fejtünk ki majd erőt, * és ő megsemmisíti háborgatóinkat.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm108.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm108.txt
@@ -1,0 +1,30 @@
+108:2 Isten, ne hallgasd el az én dicséretemet, * mert a bűnös szája és az álnok szája rám nyílt.
+108:3 Álnok nyelvvel szólanak ellenem, és körülvesznek engem gyűlölséges beszédekkel, * és ok nélkül ostromolnak engem.
+108:4 Ahelyett, hogy szeretnének, rágalmaznak engem; * én pedig imádkozom.
+108:5 Rosszal fizetnek nekem a jóért, * és gyűlölséggel szeretetemért.
+108:6 Rendelj föléje bűnöst; * és az ellenség álljon jobbja felől.
+108:7 Mikor ítéltetik, kárhoztatva jöjjön ki; * és imádsága legyen bűnévé.
+108:8 Legyenek az ő napjai kevesek; * és tisztségét más nyerje el.
+108:9 Árvákká legyenek fiai, * és felesége özveggyé.
+108:10 Bujdosva tévelyegjenek fiai és kolduljanak, * és vettessenek ki lakhelyeikből.
+108:11 Az uzsorás kutassa föl minden jószágát; * és idegenek ragadják el szerzeményét.
+108:12 Ne legyen neki segítője, * s ne legyen, ki árváin könyörüljön.
+108:13 Vesszenek el szülöttei, * töröltessék el neve egy nemzedékben.
+108:14 Legyen emlékezetben atyáinak gonoszsága az Úr színe előtt, * és ne töröltessék el anyja vétke.
+108:15 Legyenek az Úr előtt mindenkoron, és emlékük vesszen el a földről; * azért, mivel nem gondolt arra, hogy irgalmasságot cselekedjék,
+108:17 És üldözte a szegény embert és nyomorultat, * és az elkeseredett szívűt öldökölte.
+108:18 Szerette az átkot, tehát jöjjön rá; * és nem akarta az áldást, távozzék hát tőle.
+108:18 És magára húzta az átkot, mint a ruházatot, * mely mint a víz, behatolt belsejébe, és mint az olaj, az ő csontjaiba.
+108:19 Legyen rajta, mint a ruházat, melybe öltözik, * és mint az öv, mellyel magát mindenkor körülövezi.
+108:20 Ez legyen jutalmuk az Úrtól, kik engem rágalmaznak, * és kik rosszat beszélnek lelkem ellen.
+108:21 De te, Uram, Uram, légy velem a te nevedért; * mert jóságos a te irgalmad.
+108:22 Szabadíts meg engem, mert nyomorult és szegény vagyok; * és szívem megháboríttatott.
+108:23 Mint az árnyék, mikor elhanyatlik, elenyészem, * és elűzetem, mint a sáskák.
+108:24 Térdeim elerőtlenedtek a böjttől; * és húsom elesett az olajhiány miatt.
+108:25 Gyalázattá lettem nekik; * látnak engem, és fejüket csóválják.
+108:26 Segíts engem, Uram, Istenem, * szabadíts meg engem a te irgalmasságod szerint;
+108:27 Hadd tudják meg, hogy a te kezed ez, * és te cselekedted ezt, Uram.
+108:28 Ők átkozni fognak, te megáldasz; * kik ellenem támadnak, megszégyenülnek: a te szolgád pedig vigadni fog.
+108:29 Öltözzenek szégyenbe, kik engem rágalmaznak; * és mint palásttal, födöztessenek be gyalázatukkal.
+108:30 Nagy hálát adok szájammal az Úrnak, * és a sokaság között dicsérem őt.
+108:31 Mert a szegénynek jobbja felől áll, * hogy lelkemet az üldözőktől megszabadítsa.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm109.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm109.txt
@@ -1,0 +1,8 @@
+109:1a Mondá az Úr az én Uramnak: * Ülj az én jobbomra,
+109:1b Míg ellenségeidet * lábaid zsámolyává teszem.
+109:2 A te hatalmad pálcáját elküldi az Úr Sionból. * Uralkodjál ellenségeidnek közepette.
+109:3 Nálad az uralom hatalmad napján a szentek fényességében; * méhemből a hajnalcsillag előtt szültelek téged.
+109:4 Megesküdött az Úr, és nem bánja meg: * Te pap vagy mindörökké Melkizedek rendje szerint.
+109:5 Az Úr jobbod felől * megrontja haragja napján a királyokat.
+109:6 Ítélni fog a nemzetek között, nagy romlást teszen, * soknak összezúzza fejét a földön.
+109:7 A patakból iszik az úton; * azért emeli magasra fejét.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm11.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm11.txt
@@ -1,0 +1,9 @@
+11:2 Szabadíts meg engem, Uram, mert fogynak a szentek; * mert az igazmondás megkevesedett az emberek fiainál.
+11:3 Hiúságokat szól ki-ki felebarátjának; * az álnok ajkak kettős szívvel szólanak.
+11:4 Veszítse el Isten mind az álnok ajkat * és a kérkedő nyelvet,
+11:5 Melyek mondják: Nyelvünket felmagasztaljuk, † ajkaink velünk vannak, * kicsoda a mi Urunk?
+11:6a A szűkölködők nyomorúsága és a szegények nyögése miatt * majd fölkelek, úgymond az Úr.
+11:6 Megszabadítom őket, * s bizalmat gerjesztek bennük.
+11:7 Az Úr beszédei tiszta beszédek; * tűzzel megpróbált, a földtől elválasztott, hétszer megtisztított ezüst.
+11:8 Te, Uram, megtartasz minket, és megőrzöl minket * e nemzedéktől mindörökké.
+11:9 Az istentelenek kerengenek; * a te magas végzésed szerint megsokasítottad az ily emberek fiait.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm110.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm110.txt
@@ -1,0 +1,10 @@
+110:1 Hálát adok neked, Uram, teljes szívemből * az igazak tanácsában és gyülekezetében.
+110:2 Nagyok az Úr cselekedetei, * tökéletesek egészen az ő akarata szerint.
+110:3 Dicséret és dicsőség az ő cselekedete, * és igazsága megmarad örökkön-örökké.
+110:4 Emléket szerzett csodatetteinek † az irgalmas és könyörülő Úr, * (5a) eledelt adott az őt félőknek.
+110:5b Szövetségéről megemlékezik mindörökké, * (6) cselekedeteinek hatalmát hirdeti az ő népének.
+110:7 Hogy nekik adta a pogányok örökségét. * Az ő kezeinek cselekedetei valóság és ítélet;
+110:8 Bizonyosak minden parancsai, † megerősítvék örökkön-örökre, * valóságban és igazságban lettek.
+110:9a Váltságot küldött az ő népének, * örökre szerzette szövetségét;
+110:9b (fejet hajtunk) Szent és rettenetes az ő neve, * a bölcsesség kezdete az Úr félelme.
+110:10b Jó értelműek mindazok, kik e szerint cselekszenek; * az ő dicsérete örökkön-örökké megmarad.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm111.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm111.txt
@@ -1,0 +1,9 @@
+111:1 Boldog férfiú, ki az Urat féli; * az ő parancsolataiban igen nagy kedve telik.
+111:2 Hatalmas lesz a földön ivadéka; * az igazak nemzedéke megáldatik.
+111:3 Dicsőség és gazdagság lesz házában; * és az ő igazsága örökkön-örökké megmarad.
+111:4 A sötétségben világosságot támaszt az igazaknak * az irgalmas és könyörülő és igaz.
+111:5 Boldog ember, ki könyörül és kölcsön ad, † az ő beszédei megállnak az ítéletben; * (6) mert nem tántorodik meg mindörökké.
+111:7a Örök emlékezetben lesz az igaz; * nem fél gonosz hír hallásától.
+111:7b Szíve kész az Úrban bízni, † (8) szíve megerősödött, * rendületlen, míg lenézheti ellenségeit.
+111:9 Bőven ad a szegényeknek; † igazsága megmarad örökkön-örökké, * az ő szarva fölemelkedik dicsőséggel.
+111:10 A gonosz látni fogja ezt, † és haragra gyúl; fogát csikorgatja, és eleped; * a bűnösök kívánsága elenyészik.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm112.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm112.txt
@@ -1,0 +1,8 @@
+112:1 Dicsérjétek, szolgák, az Urat; * dicsérjétek az Úr nevét.
+112:2 (fejet hajtunk) Legyen áldott az Úr neve, * most és mindörökké.
+112:3 Napkelettől nyugatig * dicsértessék az Úr neve.
+112:4 Magasztos az Úr minden nép fölött, * és az egek fölött az ő dicsősége.
+112:5 Kicsoda olyan, mint a mi Urunk, Istenünk, ki a magasságban lakik, * (6) és a mennyből a legkisebbre is letekint a földön?
+112:7 Fölemelvén a földről a nyomorultat, * és a szemétből fölmagasztalván a szegényt;
+112:8 Hogy a fejedelmekhez ültesse őt, * az ő népe fejedelmeihez;
+112:9 Ki a házban lakást ad a magtalannak, * mint fiakon örvendező anyának.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm113.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm113.txt
@@ -1,0 +1,27 @@
+113:1 Kijövén Izrael Egyiptomból, * Jákob háza az idegen nép közül,
+113:2 Lőn Júdea az ő szent helyévé, * Izrael az ő birodalmává.
+113:3 A tenger látta ezt, és futott; * a Jordán visszafordult.
+113:4 A hegyek szökdeltek, mint a kosok, * és a halmok, mint a juhok bárányai.
+113:5 Mi lelt téged, tenger, hogy futottál? * És téged, Jordán, hogy visszafordultál?
+113:6 És titeket, hegyek, hogy szökdeltetek, mint a kosok, * és ti, halmok, mint a juhok bárányai?
+113:7 Az Úr színe előtt megrendült a föld, * Jákob Istene előtt.
+113:8 Ki a sziklát tavakká változtatta, * és a kőszirtet vízforrásokká.
+113:9 Ne nekünk, Uram, ne nekünk, * hanem a te nevednek adj dicsőséget,
+113:10 A te irgalmad és igazságod miatt, * nehogy valaha mondják a pogányok: Hol vagyon az ő Istenük?
+113:11 Mert a mi Istenünk a mennyben vagyon; * amit akar, mindent végbevisz.
+113:12 A pogányok bálványai ezüst és arany, * emberi kezek alkotásai.
+113:13 Szájuk vagyon, és nem szólnak; * szemük vagyon, és nem látnak.
+113:14 Fülük vagyon, és nem hallanak; * orruk vagyon, és nem szagolnak.
+113:15 Kezeik vannak, és nem tapintanak; † lábaik vannak, és nem járnak; * nem kiáltanak torkukkal.
+113:16 Hasonlók legyenek hozzájuk, kik azokat csinálják, * és mind, kik azokban bíznak.
+113:17 Izrael háza az Úrban bízik; * ő segítőjük és oltalmazójuk.
+113:18 Áron háza az Úrban bízik; * ő segítőjük és oltalmazójuk.
+113:19 Kik az Urat félik, az Úrban bíznak; * ő segítőjük és oltalmazójuk.
+113:20a Az Úr megemlékezett rólunk, * és megáldott minket;
+113:20b Megáldotta Izrael házát, * megáldotta Áron házát.
+113:21 Megáldotta mind, kik félik az Urat, * a kicsinyeket a nagyokkal.
+113:22 Gyarapítson az Úr titeket, * titeket és fiaitokat.
+113:23 Áldottak legyetek ti az Úrtól, * ki a mennyet és földet teremtette.
+113:24 Az egek ege az Úré; * a földet pedig az emberek fiainak adta.
+113:25 Nem a holtak dicsérnek téged, Uram, * sem azok, kik a föld alá szállanak.
+113:26 Hanem mi, kik élünk, áldjuk az Urat, * mostantól és mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm114.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm114.txt
@@ -1,0 +1,9 @@
+114:1 Szeretem, mert az Úr meghallgatta * könyörgésem szavát;
+114:2 Mert hozzám hajtotta fülét, * azért segítségül hívom őt napjaimban.
+114:3a Körülvettek engem a halál gyötrelmei; * és a pokol veszedelmei elértek engem;
+114:3b Szorongatást és fájdalmat találtam; * (4a) és az Úr nevét segítségül hívtam:
+114:4b Ó Uram, szabadítsd meg az én lelkemet. ‡ (5) Irgalmas az Úr és igaz; * könyörül a mi Istenünk.
+114:6 A kicsinyek megőrizője az Úr; * én megaláztattam, és megszabadított engem.
+114:7 Térj vissza nyugalmadba, én lelkem, * mert az Úr jót tett veled;
+114:8 Mert megmentette lelkemet a haláltól, ‡ szemeimet a könnyhullatástól, * lábaimat az eséstől.
+114:9 Kedves leszek az Úr előtt * az élők tartományában.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm115.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm115.txt
@@ -1,0 +1,8 @@
+115:1 Hittem, s azért szólottam; * de igen megaláztattam.
+115:2 Mondtam elkeseredésemben: * Minden ember hazug.
+115:3 Mit adjak vissza az Úrnak * mindazokért, miket nekem adott?
+115:4 Az üdvösség kelyhét veszem, * és az Úr nevét segítségül hívom.
+115:5 Fogadásaimat az Úrnak teljesítem az ő egész népe előtt. * (6) Drágalátos az Úr színe előtt az ő szentjei halála.
+115:7a Ó Uram, mert én a te szolgád, * én a te szolgád, és szolgálód fia vagyok;
+115:7b Szétszakasztottad köteleimet. ‡ (8) Neked áldozok dicséretáldozattal, * és az Úr nevét segítségül hívom.
+115:9 Fogadásaimat az Úrnak teljesítem az ő egész népének színe előtt, * (10) az Úr házának tornácaiban, közepetted, Jeruzsálem.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm116.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm116.txt
@@ -1,0 +1,2 @@
+116:1 Dicsérjétek az Urat, minden nemzetek, * dicsérjétek őt, minden népek;
+116:2 Mert megerősödött rajtunk az ő irgalmassága, * és az Úr igaz volta mindörökké megmarad.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm117.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm117.txt
@@ -1,0 +1,29 @@
+117:1 Adjatok hálát az Úrnak, mert jó; * mert örökkévaló az ő irgalmassága.
+117:2 Mondja most Izrael: mert jó; * mert örökkévaló az ő irgalmassága.
+117:3 Mondja most Áron háza: * mert örökkévaló az ő irgalmassága.
+117:4 Mondják most, kik félik az Urat: * mert örökkévaló az ő irgalmassága.
+117:5 A szorultságban segítségül hívtam az Urat, * és meghallgatott az Úr, tágítván rajtam.
+117:6 Az Úr az én segítőm; * nem félek, bármit tegyen nekem az ember.
+117:7 Az Úr az én segítőm, * s én meglátom ezt ellenségeimen.
+117:8 Jobb az Úrban bízni, * mint az emberben bízni.
+117:9 Jobb az Úrban reményleni, * mint a fejedelmekben reményleni.
+117:10 Minden nemzet körülöttem járt: * de az Úr nevében bosszút állottam rajtuk.
+117:11 Körülvéve körülvettek engem: * de az Úr nevében bosszút állottam rajtuk.
+117:12 Körülvettek engem, mint a méhek, † és fölgerjedtek, mint a tűz a tövisben: * de az Úr nevében bosszút állottam rajtuk.
+117:13 Taszigáltak, s elhanyatlottam, hogy elessem: * de az Úr fönntartott engem.
+117:14 Az én erősségem és dicséretem az Úr; * mert ő lett nekem szabadulásom.
+117:15 Vigasság és szabadulás szava hangzik * az igazak hajlékaiban.
+117:16 Az Úr jobbja hatalmasan cselekedett; † az Úr jobbja fölmagasztalt engem, * az Úr jobbja hatalmasan cselekedett.
+117:17 Nem halok meg, hanem élni fogok, * és hirdetem az Úr cselekedeteit.
+117:18 Fenyítve fenyített engem az Úr; * de nem adott engem a halálnak.
+117:19 Nyissátok meg nekem az igazság kapuit, † bemenvén azokon, hálát fogok adni az Úrnak. * (20) Ez az Úr kapuja, az igazak mennek be azon.
+117:21 Hálát adok neked, mert meghallgattál engem, * és szabadulásomra lettél.
+117:22 A kő, melyet megvetettek az építők, * szegletkővé lőn.
+117:23 Az Úrtól lett ez, * és csodálatos a mi szemeink előtt.
+117:24 Ez a nap, melyet az Úr szerzett; * örvendezzünk és vigadjunk azon.
+117:25 Ó Uram, szabadíts meg engem; † ó Uram, adj jó előmenetelt. * (26a) Áldott, ki az Úr nevében jő;
+117:26b Áldunk titeket az Úr házából. * (27a) Isten az Úr, és megvilágosít minket.
+117:27b Tartsatok ünnepnapot lombos ágakkal * egész az oltár szarváig.
+117:28a Istenem vagy te, és hálát adok neked; * Istenem vagy te, és fölmagasztallak téged.
+117:28b Hálát adok neked, mert meghallgattál engem, * és szabadulásomra lettél.
+117:29 Adjatok hálát az Úrnak, mert jó; * mert örökkévaló az ő irgalmassága.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm118.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm118.txt
@@ -1,0 +1,176 @@
+118:1 (Alef) Boldogok, kiknek útjuk feddhetetlen, * kik az Úr törvényében járnak.
+118:2 Boldogok, kik az ő bizonyságait vizsgálják, * teljes szívükből keresik őt;
+118:3 Mert nem cselekszenek gonoszt, * kik az ő utain járnak.
+118:4 Te parancsoltad * rendeléseidet fölötte megtartatni.
+118:5 Bárcsak utaim * a te igazságaid megőrzésére lennének intézve!
+118:6 Akkor nem szégyenülök meg, * midőn szemmel tartom minden parancsodat.
+118:7 Hálát adok neked egyenes szívvel, * azért, hogy megtanultam a te igazságod ítéleteit.
+118:8 A te igazságaidat megőrzöm; * ne hagyj el soha engemet.
+118:9 (Bet) Mivel jobbítja meg útját az ifjú? * A te beszédeid megtartásával.
+118:10 Teljes szívemből kereslek téged; * ne hagyj eltévednem parancsaidtól.
+118:11 Szívembe rejtem a te beszédeidet, * hogy ne vétsek ellened.
+118:12 Áldott vagy te, Uram, * taníts meg engem igazságaidra.
+118:13 Ajkaimmal * hirdetem a te szád minden ítéletét.
+118:14 A te bizonyságaid útjában gyönyörködöm, * mint mindannyi gazdagságban.
+118:15 Parancsaidban gyakorlom magamat, * és vigyázok utaidra.
+118:16 A te igazságaidról elmélkedem; * nem feledem el beszédeidet.
+118:17 (Gimel) Tégy jót a te szolgáddal, adj nekem életet; * és megőrzöm beszédeidet.
+118:18 Nyisd meg szemeimet, * hogy szemlélhessem a csodákat törvényedben.
+118:19 Jövevény vagyok én a földön; * ne rejtsd el tőlem parancsaidat.
+118:20 Epedve óhajtja lelkem a te igazságaidat * minden időben.
+118:21 Megfedded a kevélyeket; * átkozottak, kik elhajolnak a te parancsaidtól.
+118:22 Vedd el rólam a gyalázatot és megvetést, * mivel a te bizonyságaidat keresem.
+118:23 Mert fejedelmek ülnek össze, és szólanak ellenem; * de a te szolgád igazságaidban gyakorolja magát;
+118:24 Mert bizonyságaid az én elmélkedésem, * és tanácsom a te igazságaid.
+118:25 (Dalet) A porhoz ragadt lelkem; * eleveníts meg engem a te igéd szerint.
+118:26 Elbeszélem utaimat, és meghallgatsz engem; * taníts meg engem a te igazságaidra.
+118:27 Oktass engem igazságaid útjára: * és gyakorolni fogom magamat csodatételeidben.
+118:28 Lelkem elbágyad az unatkozás miatt; * erősíts meg engem igéid által.
+118:29 A gonoszság útját távoztasd el tőlem, * és törvényed szerint könyörülj rajtam.
+118:30 Az igazság útját választottam, * nem feledem el ítéleteidet.
+118:31 Bizonyságaidhoz ragaszkodom, Uram, * ne hagyj megszégyenülnöm.
+118:32 Parancsaid útján futok, * ha kitágítod szívemet.
+118:33 (He) Taníts meg engem, Uram, a te igazságaid útjára; * és mindenkor azt fogom követni.
+118:34 Adj értelmet nekem, és vizsgálni fogom törvényedet, * és megőrzöm azt teljes szívemből.
+118:35 Vezess engem parancsaid ösvényére, * mert kedvelem azt.
+118:36 Hajtsd szívemet a te bizonyságaidra, * és ne a fösvénységre.
+118:37 Fordítsd el szemeimet, hogy ne lássanak hiúságot; * a te utadon engedj élnem.
+118:38 Teljesítsd szolgádnak beszédedet * a te félelmedről.
+118:39 Vedd el gyalázatomat, melytől tartok; * mert a te ítéleteid gyönyörűségesek.
+118:40 Íme óhajtom parancsaidat; * éltess engem igazságodban.
+118:41 (Vau) És jöjjön rám, Uram, a te irgalmasságod; * a te szabadításod beszéded szerint.
+118:42 Hogy felelhessek egy szót szidalmazóimnak; * mert bízom beszédeidben.
+118:43 És ne vedd el számból soha az igazság igéjét, * mert a te ítéleteidben igen bízom.
+118:44 És megtartom törvényedet mindenkoron, * örökké és mindörökkön-örökké.
+118:45 És tágas téren járok, * mert a te parancsaidat keresem.
+118:46 És szólok bizonyságaidról a királyok előtt; * és nem fogok megszégyenülni.
+118:47 És elmélkedem parancsaidról, * melyeket szeretek,
+118:48 És fölemelem kezemet parancsaid után, melyeket szeretek; * és gyakorlom magamat igazságaidban.
+118:49 (Zain) Emlékezzél meg szolgádnak tett igédről, * melyben nekem reménységet adtál.
+118:50 Ez vigasztal engem lealáztatásomban; * mert a te beszéded életet ad nekem.
+118:51 A kevélyek gonoszul cselekszenek mindenképpen: * de a te törvényedtől nem hajlok el.
+118:52 Megemlékezem, Uram, a te örök ítéleteidről, * és megvigasztalódom.
+118:53 Bosszankodás fog el engem * a te törvényedet elhagyó bűnösök miatt.
+118:54 Énekül lettek nekem a te igazságaid * zarándokságom helyén.
+118:55 Megemlékezem éjjel a te nevedről, Uram, * és megtartom törvényedet.
+118:56 Ez részem nekem, * hogy a te igazságaidat keressem.
+118:57 (Het) Mondom: Az én részem, Uram, * hogy megtartsam törvényedet.
+118:58 Könyörgök színed előtt teljes szívemből: * könyörülj rajtam a te igéd szerint.
+118:59 Gondolkodom utaimról, * és bizonyságaidra térítem lábaimat.
+118:60 Kész vagyok, és nem habozok * megtartani parancsaidat.
+118:61 A bűnösök kötelei körülfognak engem: * de a te törvényedet nem feledem el.
+118:62 Éjfélkor is fölkelek neked hálát adni * a te igazságod ítéleteiért.
+118:63 Társa vagyok én minden téged félőnek * és parancsaid megőrzőjének.
+118:64 A te irgalmasságoddal, Uram, teljes a föld; * taníts engem igazságaidra.
+118:65 (Tet) Jót tettél szolgáddal, Uram, * a te igéd szerint.
+118:66 Jóra és fegyelemre és tudományra taníts engem; * mert hiszek parancsaidnak.
+118:67 Mielőtt megaláztattam, vétkeztem; * de már megtartom beszédedet.
+118:68 Jó vagy te, * és jóvoltodból taníts engem igazságaidra.
+118:69 Megsokasodott rajtam a kevélyek gonoszsága; * én pedig teljes szívemből vizsgálom parancsaidat.
+118:70 Szívük megaludt, mint a tej; * én pedig törvényedben elmélkedem.
+118:71 Jó nekem, hogy megaláztál engem, * hogy megtanuljam igazságaidat.
+118:72 Jobb nekem a te szád törvénye * sok ezer aranynál és ezüstnél.
+118:73 (Jod) Kezeid teremtettek és alkottak engem; * adj értelmet nekem, hogy megtanuljam parancsaidat.
+118:74 Akik félnek téged, meglátva engem, vigadni fognak, * mert a te igéidben igen bízom.
+118:75 Megismerem, Uram, hogy igazság a te ítéleted, * és igaz voltodban aláztál meg engem.
+118:76 Legyen irgalmasságod vigasztalásomra, * a te szolgádhoz való igéd szerint.
+118:77 Jöjjenek rám a te könyörületeid, hogy éljek; * mert a te törvényed az én elmélkedésem.
+118:78 Szégyenüljenek meg a kevélyek, mert igaztalanul gonoszságot cselekedtek rajtam; * én pedig parancsaidban gyakorlom magamat.
+118:79 Térjenek hozzám a téged félők, * és akik tudják bizonyságaidat.
+118:80 Legyen szívem szeplőtelen a te igazságaidban, * hogy meg ne szégyenüljek.
+118:81 (Kaf) Segedelmedért eped lelkem; * és a te igédben fölötte bízom.
+118:82 Elbágyadnak szemeim ígéreteidért, * mondván: Mikor vigasztalsz meg engem?
+118:83 Mert olyanná lettem, mint a tömlő a zúzmarán; * a te igazságaidat nem feledtem el.
+118:84 Mennyi napja van még szolgádnak? * Mikor ítéled meg üldözőimet?
+118:85 Hiúságokat beszéltek nekem a gonoszok, * de nem mint a te törvényed.
+118:86 Minden parancsod igazság; * ok nélkül üldöztek engem, segíts rajtam.
+118:87 Csaknem megemésztettek engem a földön: * de én nem hagytam el parancsaidat.
+118:88 Irgalmasságod szerint éltess engem, * és megőrzöm a te szád bizonyságait.
+118:89 (Lamed) Uram, a te igéd * a mennyben örökké megmarad.
+118:90 Nemzedékről nemzedékre száll igazmondásod; * megalapítottad a földet, és megmarad.
+118:91 Rendelésedből megmarad a nap, * mert neked szolgálnak mindenek.
+118:92 Ha a te törvényed nem lett volna elmélkedésem, * talán már elvesztem volna lealáztatásomban.
+118:93 Örökké sem feledem el igazságaidat, * mert azok által éltetsz engem.
+118:94 Tied vagyok én, szabadíts meg engem; * mert a te igazságaidat keresem.
+118:95 Várnak rám a bűnösök, hogy elveszítsenek engem; * de én bizonyságaidra figyelmezek.
+118:96 Minden tökéletes dolognak is láttam végét; * de a te parancsod határtalan.
+118:97 (Mem) Mily igen szeretem, Uram, a te törvényedet; * egész nap elmélkedésem az.
+118:98 Ellenségeim fölött okossá tettél engem parancsoddal, * mely örökké velem vagyon.
+118:99 Minden tanítómnál értelmesebb vagyok, * mert a te bizonyságaid az én elmélkedésem.
+118:100 Bölcsebb vagyok a véneknél, * mert a te parancsaidat kerestem.
+118:101 Minden gonosz úttól eltiltom lábaimat, * hogy megtartsam igéidet.
+118:102 Ítéleteidtől nem hajlok el, * mert te adtál törvényt nekem.
+118:103 Mily édesek ínyemnek a te beszédeid, * a méz fölött számnak!
+118:104 Parancsaidból lettem értelmes, * azért gyűlölöm a gonoszság minden útját.
+118:105 (Nun) Szövétnek lábaimnak a te igéd, * és világosság ösvényeimnek.
+118:106 Megesküdtem és eltökéltem: * hogy megtartom igazságod ítéleteit.
+118:107 Egészen megaláztattam, Uram, * élessz föl engem a te igéd szerint.
+118:108 Az én szám önkéntes áldozatait vedd kedvesen, Uram, * és ítéleteidre taníts meg engem.
+118:109 Lelkem mindenkor kezeimben van, * de törvényedet nem feledtem el.
+118:110 A bűnösök tőrt vetettek nekem, * de nem tévelyedem el parancsaidtól.
+118:111 Örökségül bírom a te bizonyságaidat mindörökké, * mert azok szívem vigassága.
+118:112 Szívemet a te igazságaid megcselekvésére hajtom örökké, * a jutalomért.
+118:113 (Szamech) A gonoszokat gyűlölöm; * és a te törvényedet szeretem.
+118:114 Segítőm és oltalmazóm vagy te; * és igédben fölötte bízom.
+118:115 Távozzatok tőlem, gonosztevők, * mert én Istenem parancsait vizsgálom.
+118:116 Végy föl engem beszéded szerint, hogy éljek, * és ne szégyeníts meg engem várakozásomban.
+118:117 Segíts engem, és megszabadulok; * és igazságaidban elmélkedem mindenkoron.
+118:118 Megveted mind, akik eltávoznak ítéleteidtől, * mert csalárd az ő gondolatuk.
+118:119 Törvényszegőnek tartom a föld minden bűnösét, * azért szeretem a te bizonyságaidat.
+118:120 Szegezd át félelmeddel az én testemet, * mert félek a te ítéleteidtől.
+118:121 (Ain) Ítéletet és igazságot cselekszem; * ne adj át engem rágalmazóimnak.
+118:122 Segítsd szolgádat jóra, * hogy ne rágalmazzanak engem a kevélyek.
+118:123 Szemeim segedelmedért epednek, * és a te igazságod igéiért.
+118:124 Cselekedjél szolgáddal irgalmasságod szerint, * és taníts meg engem igazságaidra.
+118:125 A te szolgád vagyok én; * adj értelmet nekem, hogy tudjam bizonyságaidat.
+118:126 Ideje a cselekvésnek, Uram, * mert elhanyagolják törvényedet.
+118:127 Azért jobban szeretem parancsaidat * az aranynál és topáznál.
+118:128 Azért minden parancsodra igazodom, * minden gonosz utat gyűlölök.
+118:129 (Pe) Csodálandók a te bizonyságaid; * azért vizsgálja lelkem azokat.
+118:130 A te beszédeid fejtegetése megvilágosít, * és értelmet ad a kisdedeknek.
+118:131 Megnyitom számat és lélegzetet veszek, * mert óhajtom parancsaidat.
+118:132 Tekints rám, és könyörülj rajtam, * azok ítélete szerint, kik nevedet szeretik.
+118:133 Lépteimet igazgasd beszéded szerint, * és ne uralkodjék rajtam semmi igaztalanság.
+118:134 Ments meg engem az emberek rágalmaitól, * hogy megtarthassam parancsaidat.
+118:135 A te orcádat derítsd föl szolgád fölött; * és taníts meg engem igazságaidra.
+118:136 Vízomlások fakadnak szemeimből, * mivel nem tartották meg törvényedet.
+118:137 (Sáde) Igaz vagy, Uram, * és igaz a te ítéleted.
+118:138 Megparancsoltad igazságos bizonyságaidat, * igen a te igazságodat.
+118:139 Megemészt engem az én buzgalmam, * mert ellenségeim elfeledték igéidet.
+118:140 Fölötte tiszta a te beszéded, * és szolgád szereti azt.
+118:141 Kicsiny vagyok én és megvetett; * de igazságaidat nem feledem el.
+118:142 A te igazságod örökké igazság, * és törvényed igazmondás.
+118:143 Szorongatás és gyötrelem ért engem, * de parancsolataid elmélkedésem.
+118:144 A te bizonyságaid igazság mindörökké; * adj nekem értelmet, és élni fogok.
+118:145 (Kof) Teljes szívemből kiáltok, hallgass meg engem, Uram, * a te igazságaidat keresem.
+118:146 Hozzád kiáltok, szabadíts meg engem, * hogy megőrizzem parancsaidat.
+118:147 Megelőzöm a hajnalt, és kiáltok, * mert a te igéidben igen bízom.
+118:148 Szemeim fölnyílnak hozzád hajnal előtt, * hogy elmélkedjem beszédeidről.
+118:149 Hallgasd meg szómat, Uram, irgalmasságod szerint; * és ítéleted szerint éltess engem.
+118:150 Üldözőim közel vannak a gonoszsághoz, * törvényeidtől pedig messze távoztak.
+118:151 Közel vagy te, Uram, * és minden utad igazság.
+118:152 Kezdettől tudom bizonyságaidról: * hogy örökre alapítottad azokat.
+118:153 (Res) Lásd megaláztatásomat, és szabadíts meg engem, * mert törvényedet nem feledtem el.
+118:154 Ítéld meg ügyemet, és szabadíts meg engem; * a te igéd miatt éltess engem.
+118:155 A bűnösöktől távol van a szabadulás, * mert a te igazságaidat nem keresik.
+118:156 Sok a te irgalmasságod, Uram, * ítéleted szerint éltess engem.
+118:157 Sokan vannak üldözőim, kik szorongatnak engem; * de nem hajlok el bizonyságaidtól.
+118:158 Látom a törvényszegőket, és epekedem, * mert nem tartják meg beszédeidet.
+118:159 Lásd, Uram, hogy szeretem parancsaidat; * irgalmasságod szerint éltess engem.
+118:160 A te igéid alapja igazság; * örökkévaló a te igazságod minden ítélete.
+118:161 (Sin) A fejedelmek ok nélkül üldöznek engem; * de csak beszédeidtől fél az én szívem.
+118:162 Örvendek én beszédeiden, * mint aki sok zsákmányt talál.
+118:163 A gonoszságot gyűlölöm és utálom; * törvényedet pedig szeretem.
+118:164 Naponta hétszer dicsérlek téged, * az igazságosságot ítéleteidben.
+118:165 Sok békességük van törvényed szeretőinek, * és semmi sincs botrányukra.
+118:166 Várom, Uram, segedelmedet, * és szeretem parancsaidat.
+118:167 Lelkem megőrzi bizonyságaidat, * és azokat igen szereti.
+118:168 Megtartom parancsaidat és bizonyságaidat; * mert minden utam színed előtt vagyon.
+118:169 (Tau) Közelítsen, Uram, színed elé az én könyörgésem; * a te igéd szerint adj értelmet nekem.
+118:170 Jusson színed elé kérelmem; * a te beszéded szerint ments meg engem.
+118:171 Ajkaim dicsérettel fognak áradozni, * mikor engem igazságaidra tanítasz.
+118:172 Nyelvem mondja beszédedet; * mert minden parancsod igazság.
+118:173 Azon legyen kezed, hogy megszabadítson engem; * mert a te parancsaidat választottam.
+118:174 Óhajtom, Uram, segedelmedet; * és törvényed elmélkedésem.
+118:175 Él az én lelkem, és dicsér téged; * és ítéleteid megsegítenek engem.
+118:176 Eltévelyedtem, mint az elveszett juh; * keresd föl a te szolgádat, mert parancsaidat nem feledtem el.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm119.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm119.txt
@@ -1,0 +1,6 @@
+119:1 Az Úrhoz kiálték, midőn szorongattatám: * és meghallgata engem,
+119:2 Uram, szabadítsd meg lelkemet a csalárd ajkaktól * és az álnok nyelvtől.
+119:3 Mi adatik neked, vagy mi lesz jutalmad * az álnok nyelvért?
+119:4 Mely olyan, mint a hatalmasnak éles nyilai, * és pusztító széntűz.
+119:5 Jaj nekem, mert zarándokságom meghosszabbíttatott, † Kedár lakóival lakom, * (6) oly sokáig zarándok az én lelkem.
+119:7 A békegyűlölőkkel békességes vagyok; * mégis ha szólok nekik, ok nélkül ostromolnak engemet.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm12.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm12.txt
@@ -1,0 +1,6 @@
+12:1 Uram, meddig feledsz el engem egészen? * Meddig fordítod el tőlem orcádat?
+12:2 Meddig tartok még tanácsot lelkemben, * fájdalmat szívemben naponként?
+12:3 Meddig emelkedik föl ellenségem fölöttem? * (4a) Tekints rám, és hallgass meg engem, Uram, Istenem!
+12:4b Világosítsd meg szemeimet, hogy valaha el ne aludjam a halálban, * (5a) s valamikor ne mondja ellenségem: Hatalmat vettem rajta;
+12:5b Mert akik szorongatnak engem, örvendenek, ha megingattatom. * (6a) Én pedig irgalmasságodban bízom;
+12:6b Szívem örvend a te szabadításodban; † éneklek az Úrnak, ki jót tett velem, * és dicséretet mondok a fölséges Úr nevének.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm120.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm120.txt
@@ -1,0 +1,8 @@
+120:1 A hegyekre emelem szemeimet, * onnét jő segítség nekem.
+120:2 Az én segítségem az Úrtól van, * ki a mennyet és földet teremtette.
+120:3 Nem hagyja ingadozni lábadat, * és nem szunnyadoz, ki tégedet őriz.
+120:4 Íme nem szunnyad és nem alszik, * ki őrzi Izraelt.
+120:5 Az Úr őriz téged, az Úr a te oltalmad * jobb kezed felől.
+120:6 Nappal nem éget téged a nap, * sem éjjel a hold.
+120:7 Az Úr megőriz téged minden gonosztól, * őrizze meg az Úr lelkedet.
+120:8 Őrizzen az Úr jártodban és keltedben, * mostantól és mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm121.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm121.txt
@@ -1,0 +1,9 @@
+121:1 Vigadok, mikor azt mondják nekem: * Az Úr házába megyünk.
+121:2 Lábaink * tornácaidban állanak, Jeruzsálem!
+121:3 Jeruzsálem városul építtetett, * melynek közjavaiban mindenki részesül.
+121:4 Mert oda mennek föl a nemzetségek, az Úr nemzetségei, * Izrael bizonysága szerint hálát adni az Úr nevének.
+121:5 Mert ott vannak az ítélőszékek, * ott Dávid házának széke.
+121:6 Kérjétek, amik Jeruzsálem békességére vannak. * Legyen bőség szeretőidnek.
+121:7 Legyen béke a te erősségedben, * és bőség a te tornyaidban.
+121:8 Atyámfiaiért és barátaimért * békességet óhajtok neked.
+121:9 A mi Urunk, Istenünk házáért * jót kívánok neked.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm122.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm122.txt
@@ -1,0 +1,5 @@
+122:1 Hozzád emelem szemeimet, * ki a mennyekben lakol.
+122:2a Íme mint a szolgák szemei * uraik kezeire,
+122:2b Mint a szolgálók szemei asszonyaik kezeire: * úgy néznek szemeink a mi Urunkra, Istenünkre, míg könyörül rajtunk.
+122:3 Könyörülj rajtunk, Uram, könyörülj rajtunk; * mert igen elteltünk gyalázattal,
+122:4 Mert igen megtelt a mi lelkünk; * gyalázatul a gazdagoknak, és megvetésül a kevélyeknek.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm123.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm123.txt
@@ -1,0 +1,8 @@
+123:1 Ha az Úr velünk nem lett volna, mondja meg most Izrael; * (2a) ha az Úr velünk nem lett volna,
+123:2b Midőn ránk támadtak az emberek: * (3a) talán elevenen nyeltek volna el minket;
+123:3b Midőn az ő haragjuk ellenünk fölgerjedett, * (4) talán a víz nyelt volna el minket.
+123:5 Rohanó patakon ment volna keresztül a mi lelkünk, * talán ellenállhatatlan vízen ment volna át a mi lelkünk.
+123:6 Áldott legyen az Úr, * ki nem adott minket az ő fogaiknak martalékul.
+123:7a Lelkünk megmenekedett, mint a madár * a vadászok tőréből;
+123:7b A tőr elrontatott, és mi megszabadultunk.
+123:8 A mi segítségünk az Úr nevében van, * ki a mennyet és földet teremtette.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm124.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm124.txt
@@ -1,0 +1,5 @@
+124:1 Kik az Úrban bíznak, olyanok mint a Sion hegye; * nem fog ingadozni mindörökké, (2a) ki Jeruzsálemben lakik.
+124:2b Körötte hegyek vannak, ‡ és az Úr az ő népe körül * mostantól és mindörökké.
+124:3 Mert az Úr nem hagyja a bűnösök vesszejét az igazak sorsa fölött, * hogy az igazak hamisságra ne nyújtsák kezeiket.
+124:4 Tégy jót, Uram, a jókkal * és az igaz szívűekkel.
+124:5 A tekervényes utakra hajlókat pedig az Úr majd eljuttatja a gonosztevőkhöz. * Békesség legyen Izraelen!

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm125.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm125.txt
@@ -1,0 +1,8 @@
+125:1 Megfordítván az Úr Sion fogságát, * lettünk, mint a megvigasztaltak.
+125:2a Akkor szánk eltelt örömmel, * és nyelvünk vigassággal;
+125:2b Akkor mondák a nemzetek között: * Nagy dolgot cselekedett az Úr velük.
+125:3 Nagy dolgot cselekedett az Úr velünk: * azért örvendezzünk.
+125:4 Fordítsd meg a mi fogságunkat, * mint a patakot a déli tartományban.
+125:5 Akik könnyhullatással vetnek, * örvendezéssel aratnak.
+125:6a Menvén mentek és sírtak, * elvetvén magvaikat,
+125:6b Megjövén pedig, örvendezéssel jőnek, * hozván kévéiket.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm126.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm126.txt
@@ -1,0 +1,6 @@
+126:1a Ha az Úr nem építi a házat, * hiába munkálkodnak, kik azt építik;
+126:1b Ha az Úr nem őrzi a várost, * hiába vigyáz, ki azt őrzi.
+126:2a Hiába keltek föl virradat előtt; * hiába keltek föl pihenés után, kik a fájdalom kenyerét eszitek.
+126:2b Míg ellenben az Úr íme álmot ad az ő kedveltjeinek, * (3) örökséget a fiakban: mert az ő ajándéka a méh gyümölcse.
+126:4 Mint a nyilak a hatalmas kezében, * olyanok a száműzöttek fiai.
+126:5 Boldog a férfiú, kinek ilyenek után kívánsága betelt; * nem szégyenül meg, midőn ellenségeivel szól a kapuban.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm127.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm127.txt
@@ -1,0 +1,7 @@
+127:1 Boldogok mindnyájan, kik az Urat félik, * kik az ő utain járnak.
+127:2 Mivel kezeid munkáját eszed, * boldog vagy, és jól lesz dolgod.
+127:3a Feleséged, mint a termékeny szőlőtő, * házad falai között;
+127:3b Fiaid, mint az olajfa sarjadékai * asztalod körül.
+127:4 Íme így áldatik meg az ember, * ki az Urat féli.
+127:5 Áldjon meg téged az Úr Sionból, * és lássad Jeruzsálem javait életed minden napjaiban;
+127:6 És lássad fiaidnak fiait, * s a békességet Izraelen.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm128.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm128.txt
@@ -1,0 +1,7 @@
+128:1 Gyakorta ostromlottak engem ifjúságomtól; * mondja meg most Izrael,
+128:2 Gyakorta ostromoltak engem ifjúságomtól: * de semmit sem tehettek nekem.
+128:3 Hátamon kovácsoltak a bűnösök, * sokáig űzték gonoszságukat;
+128:4 De az igaz Úr megtöré a bűnösök nyakát. * (5) Szégyenüljenek meg és hátráljanak mindnyájan, kik Siont gyűlölik.
+128:6 Legyenek, mint a háztetők füve, * mely mielőtt kiszaggattatnék, elszárad;
+128:7 Mellyel az arató nem tölti meg kezét, * sem ölét a kévekötő,
+128:8 És hol nem mondják az átmenők: Az Úr áldása legyen rajtatok, * áldunk titeket az Úr nevében.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm129.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm129.txt
@@ -1,0 +1,8 @@
+129:1 A mélységekből kiáltok, Uram, hozzád, * (2a) Uram, hallgasd meg az én szómat,
+129:2b Legyenek füleid figyelmesek * az én könyörgésem szavára.
+129:3 Ha a vétkeket figyelembe veszed, Uram, * Uram, ki állhat meg előtted?
+129:4a De nálad vagyon a kegyelem, * és a te törvényedért reménylek benned, Uram.
+129:4b Remél az én lelkem az ő igéjéért. * (5) Az én lelkem az Úrban bízik.
+129:6 A reggeli vigyázattól éjjelig * bízzék Izrael az Úrban;
+129:7 Mert az Úrnál az irgalmasság, * és nála bőséges a megváltás.
+129:8 És ő megszabadítja Izraelt * minden gonoszságából.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm13.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm13.txt
@@ -1,0 +1,11 @@
+13:1a Mondá az esztelen szívében: * nincs Isten.
+13:1b Romlottak és utálatosak lettek törekvéseikben; * nincs, ki jót cselekedjék, egyetlen egy sincs.
+13:2 Az Úr a mennyből néz az emberek fiaira, * hogy lássa, ha van-e értelmes vagy Istent kereső.
+13:3a Mindnyájan elhajlottak, mindegyütt hasztalanokká lettek; * nincs, ki jót cselekedjék, egyetlen egy sincs.
+13:3b Nyílt sír az ő torkuk; † nyelvüket álnokul forgatják, * áspisok mérge vagyon ajkaik alatt.
+13:3c Szájuk tele átokkal és keserűséggel; * lábaik gyorsak a vérontásra.
+13:3d Romlás és szerencsétlenség vagyon utaikon, † és a békesség útját nem ismerik; * nincs az Isten félelme szemeik előtt.
+13:4 Vajon nincs-e értelem mindazokban, kik gonoszságot cselekszenek, * kik emésztik népemet, mint a falat kenyeret?
+13:5 Az Urat nem hívták segítségül, * ott remegtek félelemmel, hol nem volt félelem;
+13:6 Mert az Úr az igaz nemzetség között vagyon; † a szűkölködő tanácsát megszégyenítettétek, * mivel az Úr az ő reménysége.
+13:7 Ki ad Izraelnek Sionból szabadulást? * Mikor az Úr elfordítja népe fogságát, örülni fog Jákob és vigadni Izrael.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm130.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm130.txt
@@ -1,0 +1,5 @@
+130:1a Uram, nem fuvalkodott föl az én szívem, * sem szemeim föl nem emelkedtek;
+130:1b Sem nem jártam nagy * és fölöttem való csodálatos dolgokban.
+130:2a Ha alázatosan nem gondolkodtam, * hanem fölmagasztaltam lelkemet,
+130:2b Mint ki anyjától elválasztatott, * úgy legyen az én lelkemnek fizetése.
+130:3 Bízzék Izrael az Úrban * mostantól és örökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm131.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm131.txt
@@ -1,0 +1,19 @@
+131:1 Emlékezzél meg, Uram, Dávidról * és minden tűréséről,
+131:2 Amint megesküdött az Úrnak, * fogadást fogadott Jákob Istenének:
+131:3 Nem megyek be házam hajlékába, * nem hágok föl nyoszolyám ágyára;
+131:4 Álmot nem engedek szemeimnek, * és szempilláimnak szunnyadást,
+131:5 És nyugovást halántékaimnak: * míg helyet nem találok az Úrnak, hajlékot Jákob Istenének.
+131:6 Íme hallottunk róla Efratában; * föltaláltuk azt az erdő mezején.
+131:7 Menjünk be az ő hajlékába, * imádkozzunk ama helyen, hol az ő lábai állanak.
+131:8 Kelj föl, Uram, a te nyughelyedre, * te, és a te szentelésed szekrénye.
+131:9 Papjaid öltözzenek igazságba, * és a te szentjeid örvendezzenek.
+131:10 Dávidért, a te szolgádért, * ne utáld meg a te fölkented orcáját.
+131:11 Igazat esküdött az Úr Dávidnak, és ezt nem másítja meg: * Tested gyümölcséből ültetek a te székedre.
+131:12a Ha fiaid megtartják szövetségemet, * és e bizonyságaimat, melyekre megtanítom őket:
+131:12b Azok fiai is örökké * a te székeden fognak ülni.
+131:13 Mert az Úr választotta Siont, * lakhelyül választotta azt magának.
+131:14 Ez az én nyughelyem mindörökkön-örökké; * itt fogok lakni, mert ezt választottam.
+131:15 Özvegyeit áldva áldom meg, * és szegényeit megelégítem kenyérrel;
+131:16 Papjait felöltöztetem üdvösséggel, * és szentjei örvendve fognak örvendeni.
+131:17 Ott növesztek szarvat Dávidnak, * szövétneket gyújtok az én fölkentemnek.
+131:18 Ellenségeit gyalázatba öltöztetem, * őrajta pedig virágzani fog az én megszentelésem.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm132.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm132.txt
@@ -1,0 +1,4 @@
+132:1 Íme mily jó és mily gyönyörűséges * az atyafiaknak együtt lakniuk.
+132:2a Mint főn a kenet, * mely lefolyik a szakállra, Áron szakállára,
+132:2b Mely lefolyik ruhája szélére; * (3a) mint a Hermon harmata, mely leszáll Sion hegyére.
+132:3b Mert oda rendel az Úr áldást * és életet mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm133.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm133.txt
@@ -1,0 +1,4 @@
+133:1a Íme most áldjátok az Urat, * ti, az Úr minden szolgái,
+133:1b Kik az Úr házában állotok, * a mi Istenünk háza tornácaiban.
+133:2 Emeljétek föl éjjel kezeiteket a szent helyhez, * és áldjátok az Urat.
+133:3 Áldjon meg téged az Úr Sionból, * ki a mennyet és földet teremtette.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm134.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm134.txt
@@ -1,0 +1,21 @@
+134:1 Dicsérjétek az Úr nevét, * dicsérjétek szolgák, az Urat,
+134:2 Kik az Úr házában állotok, * a mi Istenünk háza tornácaiban.
+134:3 Dicsérjétek az Urat, mert jó az Úr; * dicséretet énekeljetek az ő nevének, mert gyönyörűséges.
+134:4 Mert Jákobot magának választá az Úr, * Izraelt birtokául.
+134:5 Mert én tudom, hogy az Úr nagy, * és a mi Istenünk minden istenek fölött van.
+134:6 Mindent, amit akar, az Úr megtesz a mennyben, a földön, * a tengerben és minden mélységben;
+134:7a Felhőket hoz elé a föld széléről, * a villámokat esővé teszi,
+134:7b A szeleket kibocsátja táraiból; * (8) ki megölte Egyiptom elsőszülöttjeit, embertől baromig;
+134:9 És jeleket és csodákat bocsátott reád, Egyiptom; * a fáraóra és minden szolgájára.
+134:10 Ki megvert sok nemzetet, * és megölt erős királyokat:
+134:11 Szehont, az amorreusok királyát, és Ógot, Básán királyát, * és Kánaán minden országát;
+134:12 És azok földjét örökségül adá, * örökségül népének, Izraelnek.
+134:13 Uram, a te neved örök; * Uram, a te emlékezeted nemzedékről nemzedékre.
+134:14 Mert az Úr megítéli népét, * és szolgáinak megkegyelmez.
+134:15 A pogányok bálványai ezüst és arany, * emberi kezek csinálmányai.
+134:16 Szájuk vagyon, és nem szólanak; * szemük vagyon, és nem látnak.
+134:17 Fülük vagyon, és nem hallanak; * és lehelet sincsen szájukban.
+134:18 Hasonlók legyenek hozzájuk, kik azokat csinálják; * és mindnyájan, kik azokban bíznak.
+134:19 Izrael háza, áldjátok az Urat; * Áron háza, áldjátok az Urat.
+134:20 Lévi háza, áldjátok az Urat; * kik az Urat félitek, áldjátok az Urat.
+134:21 Áldott legyen az Úr Sionból, * ki Jeruzsálemben lakik.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm135.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm135.txt
@@ -1,0 +1,27 @@
+135:1 Adjatok hálát az Úrnak, mert jó; * mert örökkévaló az ő irgalmassága.
+135:2 Adjatok hálát az istenek Istenének; * mert örökkévaló az ő irgalmassága.
+135:3 Adjatok hálát az urak Urának; * mert örökkévaló az ő irgalmassága.
+135:4 Ki nagy csodákat cselekszik egyedül; * mert örökkévaló az ő irgalmassága.
+135:5 Ki az egeket bölcsen teremtette; * mert örökkévaló az ő irgalmassága.
+135:6 Ki a földet megerősítette a vizek fölött; * mert örökkévaló az ő irgalmassága.
+135:7 Ki nagy világítókat teremtett; * mert örökkévaló az ő irgalmassága.
+135:8 A napot, hogy uralkodjék nappal; * mert örökkévaló az ő irgalmassága.
+135:9 A holdat és csillagokat, hogy uralkodjanak éjszaka; * mert örökkévaló az ő irgalmassága.
+135:10 Ki megverte Egyiptomot elsőszülöttjeivel; * mert örökkévaló az ő irgalmassága.
+135:11 Ki Izraelt közülük kihozta; * mert örökkévaló az ő irgalmassága.
+135:12 Hatalmas kézzel és kinyújtott karral; * mert örökkévaló az ő irgalmassága.
+135:13 Ki a Vörös-tengert részekre osztotta; * mert örökkévaló az ő irgalmassága.
+135:14 És átvezette Izraelt annak közepén; * mert örökkévaló az ő irgalmassága.
+135:15 És bevetette a fáraót és haderejét a Vörös-tengerbe; * mert örökkévaló az ő irgalmassága.
+135:16 Ki átvitte népét a pusztán; * mert örökkévaló az ő irgalmassága.
+135:17 Ki megverte a nagy királyokat; * mert örökkévaló az ő irgalmassága.
+135:18 És megölte az erős királyokat; * mert örökkévaló az ő irgalmassága.
+135:19 Szehont, az amorreusok királyát; * mert örökkévaló az ő irgalmassága.
+135:20 És Ógot, Básán királyát; * mert örökkévaló az ő irgalmassága.
+135:21 És azok földjét örökségül adta; * mert örökkévaló az ő irgalmassága.
+135:22 Örökségül szolgájának, Izraelnek; * mert örökkévaló az ő irgalmassága.
+135:23 Mivel a mi lealáztatásunkban megemlékezett rólunk; * mert örökkévaló az ő irgalmassága.
+135:24 És megszabadított minket ellenségeinktől; * mert örökkévaló az ő irgalmassága.
+135:25 Ki eledelt ad minden testnek; * mert örökkévaló az ő irgalmassága.
+135:26a Adjatok hálát az ég Istenének; * mert örökkévaló az ő irgalmassága.
+135:26b Adjatok hálát az urak Urának; * mert örökkévaló az ő irgalmassága.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm136.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm136.txt
@@ -1,0 +1,12 @@
+136:1 Babilon folyóvizei mellett, ott ültünk és sírtunk, * midőn Sionról emlékezénk.
+136:2 Benne a fűzfákra * függesztettük hangszereinket.
+136:3a Mert ott, kik elvittek és fogságban tartottak minket, * énekszót kívántak tőlünk;
+136:3b És kik elhurcoltak minket, mondák: * Zengjetek nekünk éneket Sion énekeiből.
+136:4 Hogyan énekeljük az Úr énekét * idegen földön?
+136:5 Ha elfeledkezem rólad, Jeruzsálem, * legyen elfeledve jobb kezem.
+136:6a Torkomhoz ragadjon nyelvem, * ha meg nem emlékezem rólad,
+136:6b Ha nem teszem Jeruzsálemet * fővigasságomnak.
+136:7a Emlékezzél meg, Uram, Edom fiairól * Jeruzsálem napján,
+136:7b Kik mondák: Pusztítsátok el, pusztítsátok el * azt alapjáig.
+136:8 Babilon ínséges leánya, * boldog, ki visszaadja neked fizetésedet, mellyel te nekünk fizettél.
+136:9 Boldog, ki megragadja * s a kősziklához csapja kisdedeidet.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm137.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm137.txt
@@ -1,0 +1,9 @@
+137:1a Hálát adok neked, Uram, teljes szívemből, * mert meghallgattad az én szám igéit;
+132:2b Az angyalok színe előtt éneklek neked, * imádkozom a te szent templomodban, és hálát adok nevednek
+132:3b A te irgalmadért és igazságodért; * mert fölmagasztaltad mindenek fölött a te szent nevedet.
+137:3 Amely napon segítségül hívlak tégedet, hallgass meg engem; * te gyarapítani fogod az erőt lelkemben.
+137:4 Adjanak hálát neked, Uram, a föld minden királyai, * mert szádnak minden beszédét hallották,
+137:5 És énekeljék meg az Úr utait; * mert nagy az Úr dicsősége.
+137:5 Mert fölséges az Úr, és letekint az alázatosokra, * s a magasakat távolról megismeri.
+137:7 Ha szorongatás közepette járok is, megtartasz engem életben, ‡ és ellenségeim haragjára kinyújtod kezedet, * és megszabadít engem a te jobbod.
+137:8 Az Úr megfizet érettem; ‡ Uram, a te irgalmasságod örökkévaló, * ne vesd meg a te kezeid alkotásait.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm138.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm138.txt
@@ -1,0 +1,23 @@
+138:1 Uram, te megvizsgáltál engem, és ismersz engem; * (2) te ismered fektemet és keltemet.
+138:3 Megérted távolról az én gondolataimat; * ösvényemet és nyughelyemet megvizsgáltad.
+138:4 És minden utamat eleve megláttad; * még nincs is a szó nyelvemen,
+138:5 íme, Uram, te tudsz mindent, a legújabbakat és régieket; * te alkottál engem, és rámtevéd a te kezedet.
+138:6 Csodálatos előttem ezen tudásod; * igen magas, és nem érhetem föl azt.
+138:7 Hova menjek a te lelked elől? * És hova fussak színed elől?
+138:8 Ha fölmegyek az égbe, te ott vagy; * ha leszállok a pokolba, jelen vagy.
+138:9 Ha szárnyaimul veszem is a hajnalt, * és a tenger végső határain lakom:
+138:10 oda is a te kezed visz engem, * és jobbod tart engem.
+138:11 És ha mondom: Talán a sötétség elföd engemet: * az éj napfényre hozza gyönyörűségemet;
+138:12 mert a sötétség nem homály előtted, † az éj, mint a nap, világos, * a sötétség úgy, mint a világosság.
+138:13 Mert hatalmadban vannak veséim; * anyám méhétől fogva te oltalmaztál engem.
+138:14 Hálát adok neked, hogy ily csodálatosan alkottál, ‡ bámulandók a te cselekedeteid, * és ezt lelkem igen elismeri.
+138:15 Nem volt eltitkolva csontom előtted, melyet rejtekben alkottál, * és az én valóm a föld ölében.
+138:16 Még tökéletlen voltam, már láttak szemeid, † és a te könyvedben be vannak írva mindenek, * a napok meghatározva, bár azokból még egy sincsen.
+138:17 Nekem pedig igen tiszteletre méltók a te barátaid, Isten, * uralmuk igen erős lett.
+138:18 Megszámlálnám őket, de számosabbak a fövenynél; * fölkeltem, és mégis veled vagyok.
+138:19 Te megölöd, Isten, a bűnösöket; * vérszopó férfiak, távozzatok tőlem.
+138:20 Mert azt mondjátok gondolatban: * Hiába foglalják el a te városaidat.
+138:21 Ne gyűlöljem-e, Uram, kik téged gyűlölnek? * És ne epekedjem-e a te ellenségeiden?
+138:22 Teljes gyűlölséggel gyűlölöm őket, * és nekem ellenségeimmé lettek.
+138:23 Vizsgálj meg engem, Isten, és ismerd meg szívemet; * vonj kérdőre engem, és nézzed ösvényeimet;
+138:24 és lássad, ha a gonoszság útján vagyok-e; * és vezess engem az örökkévaló úton.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm139.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm139.txt
@@ -1,0 +1,14 @@
+139:2 Ments meg engem, Uram, a rossz embertől; * a gonosz férfiútól ments meg engem.
+139:3 Kik rosszat gondolnak szívükben, * kik egész nap háborognak.
+139:4 Élesítik nyelvüket, mint a kígyó; * áspisok mérge van ajkaik alatt.
+139:5 Őrizz meg engem, Uram, a bűnös kezétől, * és a gonosz emberektől ments meg engem.
+139:5 Kik leejteni szándékoznak lábaimról, * tőrt rejtenek el nekem a kevélyek,
+139:6 És köteleket vonnak ki tőrül, * az út mellett gáncsot vetnek nekem;
+139:7 De mondom az Úrnak: Istenem vagy te; * hallgasd meg, Uram, könyörgésem szavát.
+139:8 Uram, Uram, én szabadulásom ereje, * te beárnyékozod fejemet a harc napján.
+139:9 Ne adj engem, Uram, akaratom ellen a bűnösnek; * ármánykodnak ellenem, ne hagyj el engem, netalán fölfuvalkodjanak.
+139:10 Fejük körülvesz engem, * ármányaik összessége és ajkaik gonoszsága elborítja őket.
+139:11 Égő szén hull rájuk, tűzbe veted őket; * a nyomorúságokat ki nem állják.
+139:12 A nyelveskedő férfiú meg nem áll a földön; * az igazságtalan férfiút veszedelembe ragadja a nyomorúság.
+139:13 Tudom, hogy az Úr ítéletet tesz a szűkölködőnek, * és bosszút áll a szegényekért.
+139:14 Az igazak pedig hálát adnak a te nevednek, * és az egyenes szívűek színed előtt laknak.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm14.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm14.txt
@@ -1,0 +1,7 @@
+14:1 Uram, ki fog lakni a te hajlékodban? * Vagy ki fog nyugodni szent hegyeden?
+14:2 Ki szennyfolt nélkül jár, * és igazságot cselekszik;
+14:3a Ki igazat szól szívében, * ki nem cselekszik álnokságot nyelvével;
+14:3b És felebarátjának rosszat nem teszen, * és gyalázást nem veszen be felebarátai ellen;
+14:4a Ki előtt semmivé lett a gonosztevő, * de ki az istenfélőket dicsőíti;
+14:4b Ki felebarátjának esküszik, és nem csalja meg; * (5a) ki pénzét uzsorára nem adja, és ajándékot az ártatlan ellen nem fogad el;
+14:5b Ki ezeket cselekszi, * nem ingattatik meg mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm140.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm140.txt
@@ -1,0 +1,11 @@
+140:1 Uram, tehozzád kiáltok, hallgass meg engem; * figyelj szavamra, mikor tehozzád kiáltok.
+140:2 Jusson imádságom, mint jó illatszer a te színed elé, * kezeim fölemelése, mint az esti áldozat.
+140:3 Tégy, Uram, számra őrizetet, * és körülvevő ajtót ajkaimra.
+140:4 Ne hagyd szívemet gonosz cselekedetekre hajlani, * hogy mentegessem bűneimet,
+140:4 Mint a gonosztevő emberek; * én nem veszek részt abban, mit ők választottak.
+140:5 Az igaz feddjen meg engem irgalmasságban, és dorgáljon engem; * de a bűnösök olaja ne kenje az én fejemet;
+140:6 Sőt még imádkozom is kívánságaik ellen. * Bíráik a kősziklákhoz vettetvén, elnyeletnek;
+140:7 Akkor elismerik, hogy igéim hathatósak. * Mint a föld göröngye széttöretik a földön,
+140:8 Elhányatnak csontjaink a sír mellett, * de mivelhogy, Uram, Uram, te rajtad vannak szemeim: tebenned bízom, el ne vedd életemet.
+140:9 Őrizz meg engem a tőrtől, melyet nekem vetettek, * és a gonosztevők botránykövétől.
+140:10 Az ő hálójába esnek a bűnösök, * én magam maradok, míg átmegyek.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm141.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm141.txt
@@ -1,0 +1,10 @@
+141:2 Szómmal az Úrhoz kiáltok, * szómmal az Úrnak könyörgök.
+141:3 Kiöntöm színe előtt imádságomat, * és szorongatásomat elbeszélem előtte.
+141:4 Mikor elcsügged bennem az én lelkem, * te ismered ösvényeimet.
+141:4 Ez úton, melyen járok, * tőrt rejtének el nekem.
+141:5 Jobbra tekintek, és nézek, * és nincs, ki megismerjen engem.
+141:5 Odaveszett tőlem a menekvés, * és nincs, ki fölkeresse lelkemet.
+141:6 Hozzád kiáltok, Uram, mondván: Te vagy reménységem, osztályrészem az élők földjén.
+141:7 Figyelmezz könyörgésemre, * mert igen megaláztattam;
+141:7 Szabadíts meg engem üldözőimtől, * mert erőt vettek rajtam.
+141:8 Vidd ki a tömlöcből lelkemet, hogy dicsérjem a te nevedet; * az igazak várnak rám, míg jót teszel velem.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm142.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm142.txt
@@ -1,0 +1,14 @@
+142:1 Uram, hallgasd meg imádságomat; vedd füleidbe esedezésemet igazmondásod szerint; * hallgass meg engem igazságod szerint,
+142:2 és ne szállj ítéletre szolgáddal; * mert egy élő sem igazul meg a te színed előtt,
+142:3a mert az ellenség üldözi lelkemet, * földig alázza életemet,
+142:3b sötétségbe helyez engem, mint a rég megholtakat. * (4) És lelkem szorongatásban vagyon, szívem megháborodott bennem.
+142:5 Megemlékezem a régi napokról, elmélkedem minden cselekedetedről; * kezeid alkotásairól elmélkedem.
+142:6 Kiterjesztem hozzád kezeimet; * lelkem eped érted, mint a vízért szomjazó föld.
+142:7a Hamar hallgass meg engem, Uram, * lelkem eleped;
+142:7b ne fordítsd el tőlem orcádat, * mert hasonló leszek a sírgödörbe menőkhöz.
+142:8a Add, hogy korán halljam irgalmasságodat; * mert tebenned bízom.
+142:8b Mutasd meg nekem az utat, melyen járjak; * mert hozzád emelem az én lelkemet.
+142:9 Ments meg engem ellenségeimtől, Uram, tehozzád folyamodom. * (10a) Taníts meg engem akaratodat cselekednem, mert Istenem vagy;
+142:10b a te jó lelked elvezet engem a biztos földre. * (11a) A te nevedért életet adsz nekem, Uram, igazságod szerint
+142:11b kiviszed lelkemet a szorongatásból; * (12a) és irgalmad szerint elveszted ellenségeimet,
+142:12b és elveszted mind, akik szorongatják lelkemet; * mert én a te szolgád vagyok.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm143.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm143.txt
@@ -1,0 +1,18 @@
+143:1 Áldott legyen az én Uram, Istenem, ki kezeimet harcra tanítja, * és ujjamat hadakozásra.
+143:2 Irgalmasságom és menedékem ő, * gyámolom és szabadítóm;
+143:2 Oltalmazóm ő, és benne bízom, * ki alám veti népemet.
+143:3 Uram, mi az ember, hogy magadat tőle megismerteted? * Vagy az ember fia, hogy gondolsz vele?
+143:4 Az ember hasonló a hiúsághoz, * napjai, mint az árnyék, elmúlnak.
+143:5 Uram, hajtsd meg a te egeidet, és szállj alá; * illesd meg a hegyeket, hogy füstölögjenek.
+143:6 Tündököltesd a villámlást, és szórd széjjel őket; * bocsásd ki nyilaidat, és zavard meg őket.
+143:7 Nyújtsd ki kezedet a magasságból, ments meg engem és szabadíts ki a sok vizekből, * az idegen fiak kezéből.
+143:8 Kiknek szája hiúságot beszél, * és jobb kezük gonoszság jobbja.
+143:9 Isten, új éneket éneklek neked, * a tízhúros hárfán zengek neked;
+143:10 Ki megszabadítod a királyokat, * ki megmentetted Dávid szolgádat a gonoszok kardjától; ments meg engem,
+143:11 És ragadj ki az idegen fiak kezéből, kiknek szája hiúságot beszél, * és jobb kezük gonoszság jobbja.
+143:12 Kiknek fiai mint az új ültetvények * ifjúságukban;
+143:12 Leányaik fölékesítvék, * felcsinosítvák köröskörül a templom hasonlatosságára;
+143:13 Tárházaik rakvák, * egyre másra halmozottan;
+143:13 Juhaik tenyészők, s nagy számmal kijárók; * teheneik kövérek;
+143:14 Nincs a kerítésen romlás, sem átjárás, * sem kiáltás utcáikon.
+143:15 Boldognak mondják a népet, melynél ezek vannak; * boldog a nép, melynek az Úr az ő Istene.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm144.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm144.txt
@@ -1,0 +1,22 @@
+144:1 Magasztallak téged, Istenem, királyom, * és áldom a te nevedet örökké, és mindörökkön-örökké.
+144:2 Mindennap áldlak téged, * és dicsérem a te nevedet örökké és mindörökkön-örökké.
+144:3 Nagy az Úr, és igen nagy dicséretre méltó; * és az ő nagyvoltának nincs határa.
+144:4 Nemzedék nemzedéknek fogja dicsérni tetteidet, * és hirdetni hatalmasságodat.
+144:5 Elmondják a te szentséged fölséges dicsőségét, * és csodáidat elbeszélik;
+144:6 Elmondják a te rettenetes hatalmad erejét, * és nagyvoltodat elbeszélik;
+144:7 Áradozni fognak, a te bőséges gyönyörűségedről emlékezvén, * és örvendezni igazságodon.
+144:8 Könyörülő és irgalmas az Úr, * hosszantűrő és igen irgalmas.
+144:9 Édes az Úr mindeneknek, * és könyörületessége minden művei fölött.
+144:10 Adjon hálát neked, Uram, minden alkotásod, * és a te szentjeid áldjanak téged.
+144:11 Ők országod dicsőségét hirdetik, * és hatalmasságodat beszélik,
+144:12 Hogy tudtul adják az emberek fiainak hatalmadat, * és országod fölséges dicsőségét.
+144:13a A te országod örökkévaló ország, * és uralkodásod minden nemzedékről nemzedékre száll.
+144:13b Hű az Úr minden igéjében, * és szent minden cselekedetében.
+144:14 Fölemeli az Úr mind, akik elesnek, * és föltámaszt minden levertet.
+144:15 Mindenek szemei tebenned bíznak, Uram, * és te adsz eledelt azoknak alkalmas időben.
+144:16 Fölnyitod kezeidet, * és betöltesz minden élő teremtményt áldással.
+144:17 Igazságos az Úr minden utaiban, * és szent minden cselekedetében.
+144:18 Közel van az Úr mindazokhoz, kik őt segítségül hívják, * mindazokhoz, kik őt segítségül hívják igazságban.
+144:19 Az őt félők akaratát megcselekszi, ‡ és könyörgésüket meghallgatja, * és megszabadítja őket.
+144:20 Megőrzi az Úr mindazokat, kik őt szeretik, * és elveszít minden bűnöst.
+144:21 Az Úr dicséretét beszélje szám, * és áldja minden test az ő szent nevét örökké és mindörökkön-örökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm145.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm145.txt
@@ -1,0 +1,9 @@
+145:2a Dicsérd, én lelkem, az Urat, † dicsérem az Urat életemben, * dicséretet mondok az én Istenemnek, valamíg leszek.
+145:2b Ne bízzatok a fejedelmekben, * (3) az emberek fiaiban, kik nem segíthetnek.
+145:4 Kimegyen lelkük, és visszatérnek földjükbe; * azon a napon elvész minden gondolatuk.
+145:5 Boldog, akinek segítője Jákob Istene, † és reménysége az ő Urában, Istenében van, * (6) ki az eget és a földet teremtette, a tengert és mindazt, mi azokban vagyon;
+145:7a Ki az igazmondást örökké megtartja, † ítéletet tesz a méltatlanul szenvedőknek, * eledelt ad az éhezőknek.
+145:7b Az Úr föloldja a foglyokat, * (8a) az Úr megvilágosítja a vakokat,
+145:8b Az Úr fölemeli a leverteket, * az Úr szereti az igazakat.
+145:9 Az Úr megőrzi a jövevényeket, † az árvát és az özvegyet fölfogja, * és a bűnösök utait elveszíti.
+145:10 Az Úr országol mindörökké, a te Istened, Sion, * nemzedékről nemzedékre.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm146.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm146.txt
@@ -1,0 +1,12 @@
+146:1 Dicsérjétek az Urat, mert jó a dicséret; * a mi Istenünknek gyönyörű és illendő dicsérete legyen.
+146:2 Fölépítvén az Úr Jeruzsálemet, * Izraelnek elszéledettjeit egybegyűjti.
+146:3 Meggyógyítja a töredelmes szívűeket, * és bekötözi azok sebeit.
+146:4 Megszámlálja a csillagok sokaságát, * és mindegyiket nevén szólítja.
+146:5 Nagy a mi Urunk, és nagy az ő ereje, * és bölcsességének nincsen száma.
+146:6 A szelídeket fölfogja az Úr, * a bűnösöket pedig földig alázza.
+146:7 Énekeljetek az Úrnak hálaadással, * zengjetek hárfán a mi Istenünknek,
+146:8a Ki beborítja az eget felhőkkel, * és a földnek esőt készít.
+146:8b Ki a hegyeken szénát teremt * és füvet az emberek szolgálatára.
+146:9 Ki megadja élelmüket a barmoknak * és a hozzá kiáltó hollófiaknak.
+146:10 Nem a ló erősségében telik kedve, * sem a férfiú lábszáraiban gyönyörködése.
+146:11 Az Úr az őt félőkben gyönyörködik, * és azokban, kik az ő irgalmasságában bíznak.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm147.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm147.txt
@@ -1,0 +1,9 @@
+147:1 Dicsérd, Jeruzsálem, az Urat; * dicsérd, Sion, a te Istenedet.
+147:2 Mert megerősítette kapuidnak zárait, * benned megáldotta fiaidat.
+147:3 Ki békéssé tette határaidat, * és a búza javával elégít meg téged.
+147:4 Ki elküldi szózatát a földre; * sebesen fut az ő beszéde.
+147:5 Ki a havat, mint a gyapjat adja, * a ködöt, mint a hamvat hinti.
+147:6 Jegét darabonként ereszti; * ki tűrheti el annak hidegségét?
+147:7 Elküldi ismét az ő igéjét, és fölolvasztja azokat; * az ő szele fúj, és vizek folynak.
+147:8 Ki igéjét Jákobnak hirdeti, * rendeléseit és törvényeit Izraelnek.
+147:9 Nem cselekedett így semmi más nemzettel, * és azoknak nem jelentette ki ítéleteit.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm148.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm148.txt
@@ -1,0 +1,14 @@
+148:1 Dicsérjétek az Urat a mennyekben, * dicsérjétek őt a magasságban.
+148:2 Dicsérjétek őt, minden angyalai; * dicsérjétek őt, minden seregei.
+148:3 Dicsérjétek őt, nap és hold; * dicsérjétek őt, minden ragyogó csillagok.
+148:4 Dicsérjétek őt, egeknek egei, * és minden vizek, melyek az egekben fölül vannak, dicsérjék az Úr nevét.
+148:5 Mert ő szólt, és lettek; * parancsolt, és előtermettek.
+148:6 Megállapítá azokat örökre, és mindörökkön-örökre * parancsot adott, s ez el nem múlik.
+148:7 Dicsérjétek az Urat a földön, * szörnyetegek, és minden örvények.
+148:8 Tűz, jégeső, hó, jég, forgószél, * melyek az ő igéjét cselekszik.
+148:9 Hegyek és minden halmok, * gyümölcsfák és minden cédrusok.
+148:10 Vadállatok és minden barmok, * kígyók és szárnyas állatok.
+148:11 Föld királyai és minden népek, * fejedelmek és a föld minden bírái.
+148:12 Ifjak és szüzek, † vének az ifjakkal, dicsérjétek az Úr nevét: * (13) mert csak az ő neve magasztos.
+148:14a Az ő dicsérete ég és föld felett van; * és ő fölemeli népe szarvát.
+148:14b Dicséret minden szentjeinek, * Izrael fiainak, a hozzá közelálló népnek.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm149.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm149.txt
@@ -1,0 +1,9 @@
+149:1 Énekeljetek az Úrnak új éneket, * legyen dicsérete a szentek gyülekezetében.
+149:2 Örvendjen Izrael abban, ki őt teremtette, * és Sion fiai vigadjanak királyukban.
+149:3 Dicsérjék az ő nevét énekkarban, * dobbal és hárfával zengjenek neki;
+149:4 Mert az Úr gyönyörködik népében, * és fölmagasztalja a szelídeket szabadulásra.
+149:5 A szentek örvendeznek a dicsőségben; * vigadnak nyughelyeiken.
+149:6 Isten magasztalása van szájukban, * és kétélű kard kezeikben,
+149:7 Hogy bosszút álljanak a nemzeteken, * megfeddjék a népeket;
+149:8 Hogy azok királyait láncokra verjék, * és nemeseit vasbilincsekre;
+149:9 Hogy a megírt ítélet szerint cselekedjenek velük. * Ez dicsősége az ő minden szentjeinek.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm15.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm15.txt
@@ -1,0 +1,11 @@
+15:1 Tarts meg engem, Uram, mert benned bíztam. ‡  (2) Mondám az Úrnak: Én Istenem vagy te, * azért javaimra nincs szükséged.
+15:3 A szentekhez, kik az ő földjén vannak, * irányozta csodálatosan minden hajlandóságomat.
+15:4a Megsokasodott az ő ínségük; * azután siettek.
+15:4b Nem hívom egybe gyülekezetüket véráldozatokra, * sem nevüket nem említem ajkaimmal.
+15:5 Az Úr az én örökségem és kelyhem része; * te vagy, ki visszaadod nekem örökségemet.
+15:6 A sorskötél nekem jelesre esett; * mert jeles örökség jutott nekem.
+15:7 Áldom az Urat, ki értelmet adott nekem; * még éjjel is erre intenek engem veséim.
+15:8 Szemem előtt viselem az Urat mindenkoron; * mert jobbomon vagyon, hogy ne ingadozzak.
+15:9 Ezért örvend szívem és vigad nyelvem; * azonfölül testem is reményben fog nyugodni;
+15:10 Mert lelkemet nem hagyod pokolban, * és nem engeded, hogy a te szented rothadást lásson.
+15:11 Megismertetted velem az élet utait, † betöltesz engem örömmel, a te orcáddal, * jobbodnál mindvégig gyönyörűség vagyon.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm150.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm150.txt
@@ -1,0 +1,5 @@
+150:1 Dicsérjétek az Urat az ő szentjeiben; * dicsérjétek őt az ég erős boltozatában.
+150:2 Dicsérjétek őt hatalmasságában; * dicsérjétek őt nagyvoltának sokasága szerint.
+150:3 Dicsérjétek őt harsonaszóval; * dicsérjétek őt hárfán és citerán.
+150:4 Dicsérjétek őt dobbal és énekkarban; * dicsérjétek őt húrokon és hangszereken.
+150:5 Dicsérjétek őt hangos szavú cimbalmokon, † dicsérjétek őt a vigasság cimbalmain. * (6)  Minden lélek dicsérje az Urat.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm16.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm16.txt
@@ -1,0 +1,17 @@
+16:1a Hallgasd meg, Uram, igazságomat, * figyelmezz könyörgésemre.
+16:1b Vedd füleidbe imádságomat * az álnokság nélküli ajkakból.
+16:2 Tőled jöjjön ítéletem; * a te szemeid lássák az igazságot.
+16:3 Megvizsgáltad szívemet és meglátogattad éjjel; * tűzzel próbáltál meg engem, és gonoszság nem találtatott bennem.
+16:4 Hogy szájam ne beszélje az emberek cselekedeteit, * kemény utakon maradtam a te ajkaid igéi miatt.
+16:5 Erősítsd meg lépéseimet a te ösvényeiden, * hogy ne ingadozzanak lábaim.
+16:6 Én kiáltottam, mert meghallgatsz engem, Isten; * hajtsd hozzám füledet, és hallgasd meg beszédemet.
+16:7 Mutasd meg csodálatos irgalmadat, * ki megszabadítod a benned bízókat.
+16:8a A jobbod ellen állóktól őrizz meg engem, * mint szemed fényét;
+16:8b Szárnyaid árnyéka alatt oltalmazz meg engem, * (9a) az istentelenek orcájától, kik engem nyomorgatnak.
+16:9b Ellenségeim körülvették lelkemet, † (10) bezárták szívüket; * szájuk kevélységet szólott.
+16:11 Megvetvén engem, most körülvettek; * elvégezték, hogy szemeiket földre sütik;
+16:12 Körülfogtak engem, mint a ragadományra készült oroszlán; * és mint a rejtekben lakó oroszlánkölyök.
+16:13 Kelj föl, Uram, vedd elejét és ejtsd meg őt; * ragadd ki lelkemet az istentelentől, (14a) a te kezed ellenségeitől.
+16:14b Uram, a kevesektől a földön válaszd el őket életükben. * Elrejtett kincseiddel betelt hasuk;
+16:14c Bővelkednek magzatokkal, * s amijük fennmarad, kisdedeiknek hagyják.
+16:15 Én pedig igazságban jelenek meg színed előtt; * megelégszem, mikor meg fog jelenni a te dicsőséged.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm17.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm17.txt
@@ -1,0 +1,54 @@
+17:2 Szeretlek téged, Uram, én erősségem. * (3a) Az Úr az én erősségem, oltalmam és szabadítóm;
+17:3b Istenem az én segítőm, * és benne bízom;
+17:3c Én oltalmazóm, és szabadulásom szarva * és pártfogóm.
+17:4 Dicsérve segítségül hívom az Urat, * és ellenségeimtől megszabadulok.
+17:5 Körülvettek engem a halál fájdalmai, * és a gonoszság árjai megháborítottak engem.
+17:6 A pokol fájdalmai megkörnyeztek engem; * elővettek a halál tőrei.
+17:7a Szorultságomban segítségül hívtam az Urat, * és az én Istenemhez kiáltottam:
+17:7b És meghallgatá szómat az ő szent templomából; * és színe előtt való kiáltásom füleibe jutott.
+17:8 Megindult és megrendült a föld, * a hegyek alapjai megrázkódtak és ingadoztak, mert haragudott rájuk.
+17:9 Füst ment föl az ő haragjában, † és tűz gyulladott orcájától; * a holtszenek meggyulladtak attól.
+17:10 Meghajtotta az egeket, és leszállott; * és homály volt lábai alatt.
+17:11 És a kerubok fölé ment, és szállott, * röpült a szelek szárnyain.
+17:12 Rejtekévé tette a sötétséget, † körüle sátorává * a sötétes vizet az ég felhőiben.
+17:13 A színe előtti villogástól szakadoztak a felhők, * a jégeső és parázstűz.
+17:14 És az Úr dörgött az égből, † és a Fölséges szózatát adta, * jégesőt és parázstüzet.
+17:15 És kibocsátá nyilait, és elszéleszté őket, * a villámokat megsokasította, és megzavará őket.
+17:16a És meglátszottak a vizek forrásai, * s fölfedettek a földkerekség alapjai
+17:16b A te dorgálásodtól, Uram, * a te haragod szelének fúvásától.
+17:17 Elküldött a magasból, és felvőn engem, * és felvona engem a sok vízből.
+17:18 Megmentett engem igen erős elleneimtől, † és azoktól, kik engem gyűlöltek; * mert hatalmat vettek rajtam.
+17:19 Megelőztek nyomorúságom napján; * és az Úr lőn oltalmam.
+17:20 És kivezetett engem a térségre; * megszabadított, mert kedvelt engem.
+17:21 És az Úr megfizet nekem igazságom szerint, * és kezeim tisztasága szerint fog jutalmazni engem;
+17:22 Mert megőriztem az Úr utait, * és istentelenül nem cselekedtem Istenem ellen.
+17:23 Mivel minden ítélete szemem előtt vagyon, * és az ő igazságát nem taszítottam el magamtól.
+17:24 És ártatlan leszek előtte, * és őrizkedni fogok gonoszságomtól.
+17:25 És az Úr megfizet nekem igazságom szerint, * és kezeim tisztasága szerint az ő szemei láttára.
+17:26 A szenttel szent leszel, * és az ártatlan férfiúval ártatlan leszel.
+17:27 A választottal választott leszel, * és az elvetemülttel elvetemedel.
+17:28 Mert te az alázatos népet megmented, * és a kevélyek szemeit megalázod.
+17:29 Mert te, Uram, megvilágosítod szövétnekemet; * én Istenem, világosítsd meg sötétségemet.
+17:30 Mert teáltalad menekedem meg a kísértettől, * és Istenemmel átmegyek a kőfalon.
+17:31 Az én Istenem útja fertőzetlen; † az Úr beszédei tűzzel megpróbáltattak; * ő minden benne bízónak oltalmazója.
+17:32 Mert kicsoda Isten az Úron kívül? * Vagy kicsoda Isten a mi Istenünkön kívül?
+17:33 Isten az, ki körülvett engem erősséggel, * és feddhetetlenné tette utamat;
+17:34 Ki olyanokká tette lábaimat, mint a szarvasokéi, * és magas helyre állított engem;
+17:35 Ki harcra tanítja kezeimet, * és karjaimat olyanokká tette, mint a rézíjat.
+17:36a És nekem adtad szabadításod oltalmát, * és jobbod fölemelt engem;
+17:36b És fegyelmed végre megigazított engem, * és fegyelmed megtanít engem.
+17:37 Tért adtál lépéseimnek alattam; * és nem erőtlenedtek el lábaim.
+17:38 Űzőbe veszem ellenségeimet, és megfogom őket, * és nem térek vissza, míg el nem fogynak.
+17:39 Összetöröm őket, és föl nem kelhetnek; * lábaim alá fognak esni.
+17:40 Felöveztél engem erősséggel a harcra, * és alám vetetted az ellenem támadókat.
+17:41 Elleneimmel hátat fordíttattál nekem, * és gyűlölőimet elvesztetted.
+17:42 Kiáltottak, és nem volt, ki megszabadítsa, az Úrhoz (kiáltottak), * és nem hallgatta meg őket.
+17:43 És összetöröm őket, mint a port szélnek eresztem, * mint az utcák sarát eltiprom őket.
+17:44 Megmentesz engem a nép ellenmondásaitól; * nemzetek fejévé rendelsz engem.
+17:45 A nép, melyet nem ismertem, szolgál nekem; * hallván füle, engedelmeskedett nekem.
+17:46 Az idegen fiak hazudtak nekem, * az idegen fiak megrögzöttek, és elsántikáltak ösvényeikről.
+17:47 Él az Úr, és áldott legyen az én Istenem, * és magasztaltassék föl az én szabadulásom Istene.
+17:48 Isten, ki bosszúállást adsz nekem, a népeket alám veted, * én szabadítóm haragos ellenségeimtől;
+17:49 Az ellenem támadók fölött felmagasztalsz engem, * az igaztalan férfiútól megmentesz engem.
+17:50 Azért hálát adok neked, Uram, a népek között, * és a te nevednek dicséretet mondok;
+17:51 Ki magasztossá tette az ő királya szabadulását, † és irgalmasságot cselekedett fölkentjével, Dáviddal, * és az ő ivadékával mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm18.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm18.txt
@@ -1,0 +1,16 @@
+18:2 Az egek beszélik Isten dicsőségét, * és az ő kezei alkotmányát hirdeti az égboltozat.
+18:3 Ezt beszéli a nap a jövő napnak, * erre tanítja az éj a jövő éjt.
+18:4 Nincs nyelv, sem beszéd, * melyen nem hallatnék az ő szavuk;
+18:5 Egész földre elhat az ő szózatuk, * és a földkerekség határaira igéjük.
+18:6a Az egekben vagyon helyezve a nap sátora, * melyből, mint a vőlegény az ő terméből, kilépvén,
+18:6b Örömmel futja pályáját, mint a hős. * (7a) Kijövete az ég egyik véghatárától,
+18:7b És járása másik végéig, * és nincs, ki elrejtse magát hevétől.
+18:8 Az Úr törvénye hiba nélkül való, lelkeket térítő; * az Úr bizonyságtétele hű, bölcsességet adó a kisdedeknek.
+18:9 Az Úr rendelései egyenesek, szíveket vigasztalók; * az Úr parancsa világos, megvilágosítja a szemeket.
+18:10 Az Úr félelme szent, megmaradó örökkön-örökké, * az Úr ítéletei igazak, igazolvák önmagukban.
+18:11 Kívánatosabbak az aranynál és sok drágakőnél, * és édesebbek a színméznél és a lépesméznél.
+18:12 A te szolgád meg is tartja azokat, * megtartásukban sok a jutalom.
+18:13 De a vétkeket ki veszi észre? † Az én titkos bűneimtől tisztíts meg engem, * (14a) és az idegenektől szabadítsd meg szolgádat.
+18:14b Ha nem uralkodnak rajtam, akkor hiba nélkül leszek, * és nagy vétkektől tisztulok meg.
+18:15a És kedvesek lesznek az én szám beszédei, * és szívem elmélkedése előtted lesz mindenkoron,
+18:15b Uram, én segítőm * és megváltóm.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm19.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm19.txt
@@ -1,0 +1,10 @@
+19:2 Hallgasson meg téged az Úr a szorongatás napján, * oltalmazzon meg téged Jákob Istenének neve.
+19:3 Küldjön neked segítséget a szenthelyről; * és Sionból védelmezzen téged.
+19:4 Emlékezzék meg minden áldozatodról; * és a te égőáldozatod legyen kövér.
+19:5 Cselekedjék veled szíved szerint, * és minden szándékodat teljesítse.
+19:6 Örvendeni fogunk szabadulásodban, * és a mi Istenünk nevében dicsekedni.
+19:7a Teljesítse az Úr minden kérésedet. * Most tudom, hogy az Úr megsegítette az ő fölkentjét;
+19:7b Meghallgatja őt szent egéből, * mert jobbja segélye hatalmas.
+19:8 Ezek a szekerekben és amazok a lovakban, * mi pedig a mi Urunk Istenünk nevében keresünk segítséget.
+19:9 Ők megkötöztetnek és elesnek: * mi pedig fölkelünk és fölemeltetünk.
+19:10 Uram, tartsd meg a királyt; * és hallgass meg minket azon a napon, melyen segítségül hívunk téged.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm2.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm2.txt
@@ -1,0 +1,13 @@
+2:1 Miért agyarkodnak a pogányok, * s gondolnak a népek hiúságokat?
+2:2 Fölállanak a föld királyai, és a fejedelmek egybegyűlnek * az Úr ellen és az ő fölkentje ellen.
+2:3 Szaggassuk el köteleiket, * és rázzuk le magunkról igájukat!
+2:4 A mennyekben lakó kineveti őket, * és az Úr kigúnyolja őket.
+2:5 Akkor szól nekik haragjában, * és búsulásában megháborítja őket.
+2:6 Én pedig királlyá rendeltettem tőle Sionon, az ő szent hegyén, * és parancsát hirdetem.
+2:7 Az Úr mondá nekem: * Fiam vagy te, én ma szültelek téged.
+2:8 Kérjed tőlem, és neked adom a pogányokat örökségül, * és birtokul a föld határait.
+2:9 Vasvesszővel fogod őket kormányozni, * s mint a cserépedényt, összetöröd őket.
+2:10 És most, királyok, okuljatok; * tanuljatok, kik a földet ítélitek.
+2:11 Szolgáljatok az Úrnak félelemmel, * és örvendezzetek neki rettegéssel.
+2:12 Fogadjátok el a fegyelmet, nehogy valamikor megharagudjék az Úr, * és elvesszetek az igaz útról;
+2:13 Mikor hirtelen fölgerjed az ő haragja, * boldogok mindnyájan, kik benne bíznak.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm20.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm20.txt
@@ -1,0 +1,13 @@
+20:2 Uram, a te erődben vigad a király, * és szabadításodon fölötte igen örvendez.
+20:3 Szíve kívánságát megadtad neki, * és ajkai óhajtását nem tagadtad meg tőle.
+20:4 Mert megelőzted őt az édesség áldásaival; * fejére koronát tettél drágakőből.
+20:5 Életet kért tőled, * és napok hosszaságát adtad neki örökké, és mindörökkön-örökké.
+20:6 Nagy az ő dicsősége a te szabadításodban; * dicsőséget és nagy ékességet teszel rája.
+20:7 Mert áldássá teszed őt mindörökkön-örökké; * megvigasztalod őt a te színed örömével.
+20:8 Mert a király az Úrban bízik; * és a Fölségesnek irgalmában nem fog ingadozni.
+20:9 Találja meg kezed minden ellenségedet; * a te jobbod találja meg mind, akik téged gyűlölnek.
+20:10 Hasonlókká teszed őket a tüzes kemencéhez megjelenésed idején; * az Úr megháborítja őket haragjában, és tűz emészti meg őket.
+20:11 Gyümölcsüket a földről elveszted, * és ivadékukat az emberek fiai közül.
+20:12 Mert gonoszt végeztek ellened; * tanácsokat gondoltak, melyeket véghez nem vihettek.
+20:13 Mert hátat fordítani kényszeríted őket, * orcájukra igazítván hátrahagyott nyilaidat.
+20:14 Magasztaltassál föl, Uram, a te erődben, * hogy énekeljük és zengjük erődet.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm21.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm21.txt
@@ -1,0 +1,34 @@
+21:2 Istenem, én Istenem, tekints rám; miért hagytál el engem? * Szabadulásomat eltávolítják vétkeim kiáltásai.
+21:3 Én Istenem, napestig kiáltok, és nem hallgatsz meg; * és éjjel, és nem hasztalanul-e rám nézve?
+21:4 Te pedig a szent helyen lakol, * Izrael dicsérete!
+21:5 Tebenned bíztak atyáink; * bíztak, és megszabadítottad őket.
+21:6 Hozzád kiáltottak, és megszabadultak; * tebenned bíztak, és meg nem szégyenültek.
+21:7 Én pedig féreg vagyok, és nem ember; * emberek gyalázata és a nép megvetése.
+21:8 Mindnyájan, kik látnak engem, kigúnyolnak engem, * félrevonják ajkukat, és fejüket hajtogatják.
+21:9 Az Úrban bízott, mentse meg őt, * szabadítsa meg őt, mert kedveli őt.
+21:10 Mert te vagy, ki engem kivontál a méhből; * én reménységem anyám emlőjétől. Hozzád utasíttattam a méhtől fogva;
+21:11 Én Istenem vagy te anyám méhétől. * Ne távozzál el tőlem,
+21:12 Mert a szorongatás közel vagyon; * mivel nincs, ki segítsen.
+21:13 Sok tulok vett engem körül; * kövér bikák környeztek meg engem;
+21:14 Rám tátották szájukat, * mint a ragadozó és ordító oroszlán.
+21:15 Mint a víz, kiöntettem, * minden csontom elvált.
+21:15 Mint a megolvadt viasz, olyan lett szívem * testem belsejében.
+21:16 Erőm kiszáradt, mint a cserép, és nyelvem ínyemhez ragadt; * és a halál porába vittél engem.
+21:17 Mert körülvett engem a sok eb; * a gonoszok gyülekezete körülkerített engem.
+21:17 Átlyuggatták kezeimet és lábaimat, * megszámlálták minden csontomat;
+21:18 Ők pedig néztek és szemléltek engem, * elosztották maguk közt ruháimat, és öltönyömre sorsot vetettek.
+21:20 De te, Uram, ne távoztasd el tőlem segítségedet, * figyelj az én oltalmamra.
+21:21 Mentsd meg, ó Isten, lelkemet a fegyvertől; * és egyetlenemet az eb kezéből.
+21:22 Szabadíts meg engem az oroszlán szájából; * engem, lealázottat, az egyszarvúak szarvaitól.
+21:23 Hirdetni fogom nevedet atyámfiainak, * a gyülekezetnek közepette dicsérlek téged.
+21:24 Kik félitek az Urat, dicsérjétek őt; * Jákob minden ivadéka, dicsőítsétek őt.
+21:25 Félje őt Izrael minden ivadéka; * mert nem utálta és nem vetette meg a szegény könyörgését,
+21:25 Orcáját sem fordította el tőlem; * mikor kiáltottam hozzája, meghallgatott engem.
+21:26 Nálad vagyon dicséretem a nagy gyülekezetben; * fogadásaimat beteljesítem a téged félők színe előtt.
+21:27 Enni fognak a szegények, és megelégszenek, és dicsérik az Urat, kik őt keresik; * szíveik élni fognak örökkön-örökké.
+21:28 Megemlékezik és megtér az Úrhoz * a föld minden határa;
+21:28 És imádkozni fog az ő színe előtt * a pogányok minden nemzetsége.
+21:29 Mert az Úré az ország; * és ő uralkodni fog a pogányokon.
+21:30 Esznek és imádják őt a föld minden kövérei; * az ő színe előtt leborulnak mindnyájan, kik a földbe mennek.
+21:31 És az én lelkem neki él, * és ivadékom neki fog szolgálni.
+21:32 Az Úrról fog neveztetni a következő nemzedék; * és az egek hirdetni fogják az ő igazságát a népnek, mely születik, melyet az Úr teremtett.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm210.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm210.txt
@@ -1,0 +1,21 @@
+(A_három_ifjú Éneke * Dán 3:57-88,56)
+3:57 Áldjátok, az Úr minden alkotásai, az Urat, * dicsérjétek és magasztaljátok őt mindörökké.
+3:58 Áldjátok, az Úr angyalai, az Urat; * áldjátok, egek, az Urat.
+3:59 Áldjátok, minden egek fölötti vizek, az Urat; * áldjátok, az Úr minden erősségei, az Urat.
+3:60 Áldjátok, nap és hold, az Urat; * áldjátok, égi csillagok, az Urat.
+3:61 Áldjátok, minden záporeső és harmat, az Urat; * áldjátok, Isten minden szelei, az Urat.
+3:62 Áldjátok, tűz és hőség, az Urat; * áldjátok, hideg és hőség, az Urat.
+3:63 Áldjátok, harmat és zúzmara, az Urat; * áldjátok, fagy és hideg, az Urat.
+3:64 Áldjátok, jég és hó, az Urat; * áldjátok, éjek és napok, az Urat.
+3:65 Áldjátok, világosság és sötétség, az Urat; * áldjátok, villámok és felhők, az Urat.
+3:66 Áldja, a föld, az Urat, * dicsérje és magasztalja őt mindörökké.
+3:67 Áldjátok, hegyek és halmok, az Urat; * áldjátok, minden földi termények, az Urat.
+3:68 Áldjátok, kútforrások, az Urat; * áldjátok, tengerek és folyóvizek, az Urat.
+3:69 Áldjátok, cethalak és a vizekben úszó minden állatok, az Urat; * áldjátok, minden égi madarak az Urat.
+3:70 Áldjátok, minden vadak és barmok, az Urat; * áldjátok, emberek fiai, az Urat.
+3:71 Áldja, Izrael, az Urat, * dicsérje és magasztalja őt mindörökké.
+3:72 Áldjátok, az Úr papjai, az Urat; * áldjátok, az Úr szolgái, az Urat.
+3:73 Áldjátok, igazak szívei és lelkei, az Urat; * áldjátok, szentek és alázatos szívűek, az Urat.
+3:74 Áldjátok, Ananiás, Azariás, Misael, az Urat, * dicsérjétek és magasztaljátok őt mindörökké.
+3:75 (Fejet hajtunk:) Áldjuk az Atyát és Fiút a Szentlélekkel együtt, * dicsérjük és magasztaljuk őt mindörökké.
+3:56 Áldott vagy, Urunk, az ég erősségében; dicséretes és dicsőséges és magasztos mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm211.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm211.txt
@@ -1,0 +1,8 @@
+(Dávid Éneke * 1Krón 29:10-16)
+29:10 Áldott vagy, atyánk, Izrael Ura, Istene, * öröktől fogva mindörökké.
+29:11 Tied, Uram, a fölség és hatalom, * a dicsőség és győzelem;
+29:12 És dicséret neked:;  mert minden, ami az égben és földön van, tied;
+29:13 Tied, Uram, az ország, * és te minden fejedelmek fölött vagy.
+29:14 Tied a gazdagság és tied a dicsőség; * te mindeneken uralkodol,
+29:15 Kezedben az erő és hatalom; * kezedben a nagyság és mindenek birodalma.
+29:16 Most azért, mi Istenünk, hálát adunk neked, * és dicsérjük a te dicsőséges nevedet.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm212.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm212.txt
@@ -1,0 +1,12 @@
+(Tóbiás Éneke * Tób 13:1-11)
+13:1 Nagy vagy, Uram, örökké, * és országod minden időben tart;
+13:2 Mert te megostorozol és meggyógyítasz, leviszel az alvilágba és visszahozol; * és nincs aki elfusson kezedből.
+13:3 Adjatok hálát az Úrnak, Izrael fiai, * és a pogányok színe előtt dicsérjétek őt;
+13:4 Mert azért oszlatott el titeket a pogányok közé, kik őt nem ismerik, * hogy ti hirdessétek az ő csodatetteit,
+13:5 És tudtul adjátok nekik, * hogy nincs más mindenható Isten őkívüle.
+13:6 Ő ostorozott meg minket a mi gonoszságunkért, * és ő szabadít meg minket irgalmasságáért.
+13:7 Tekintsétek tehát, amiket velünk cselekedett, s félelemmel és rettegéssel adjatok hálát neki, * és az örökkévaló királyt magasztaljátok tetteitek által.
+13:8 Én pedig fogságom földjén hálát adok neki; * mert megmutatta fölségét a bűnös nemzeten.
+13:9 Térjetek meg tehát, bűnösök, és cselekedjetek igazságot az Isten előtt, * elhívén, hogy irgalmasságát fogja cselekedni veletek.
+13:10 Én pedig és az én lelkem * őbenne vigadunk.
+13:11 Áldjátok az Urat, minden választottjai, * legyenek örvendetes napjaitok, és adjatok hálát neki.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm213.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm213.txt
@@ -1,0 +1,9 @@
+(Judit Éneke * Jud 16:15-22)
+16:15 Dicséretet énekeljünk az Úrnak, * új dicséretet énekeljünk a mi Istenünknek.
+16:16 Adonai, Uram, nagy vagy te és hatalmas a te erődben, * és akit senki meg nem győzhet.
+16:17 Neked szolgáljon minden teremtményed; * mert mondottad, és lőnek;
+16:18 Kibocsátottad lélegzetedet, és létre jövének; * és nincs, ki ellenálljon a te szódnak.
+16:19 A hegyek alapjukból megindulnak a vizekkel; * a kősziklák, mint a viasz, megolvadnak színed előtt.
+16:20 Akik pedig félnek téged, * nagyok lesznek nálad mindenekben.
+16:21 Jaj az én nemzetem ellen föltámadó népnek, mert a mindenható Úr bosszút áll rajtuk, * az ítélet napján meglátogatja őket.
+16:22 Mert tüzet ad és férgeket az ő testükbe, * hogy égettessenek és érezzék mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm214.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm214.txt
@@ -1,0 +1,10 @@
+(Jeremiás Éneke * Jer 31:10-18)
+31:10 Halljátok az Úr igéjét, nemzetek, * és hirdessétek a távollevő szigetekben,
+31:11 És mondjátok: Aki elszélesztette Izraelt, összegyűjti őt, * és megőrzi, mint nyáját a pásztor.
+31:12 Mert az Úr megváltja Jákobot, * és megszabadítja őt a hatalmasabb kezéből.
+31:13 És eljőnek és dicséretet mondanak Sion hegyén, * és egybegyűlnek az Úr javaira,
+31:14 A gabonára és borra és olajra, * a barmok és csordák szaporodására;
+31:15 És leszen az ő lelkük, mint a megöntözött kert, * és többé nem éheznek.
+31:16 Akkor a szűz örvendezni fog az énekkarban, * az ifjak és vének egyetemben;
+31:17 Az ő siralmukat örömre fordítom, * és megvigasztalom őket, és fölvidítom búsongásukból.
+31:18 És elárasztom a papok lelkét kövérséggel; * és az én népem eltelik javaimmal.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm215.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm215.txt
@@ -1,0 +1,17 @@
+(Izajás Éneke * Iz 45:15-30)
+45:15 Bizonyára te elrejtett Isten vagy, * Izrael üdvözítő Istene.
+45:16 Megszégyenülnek és megpirulnak mindnyájan, * gyalázatra jutnak egyetemben a tévelyképek alkotói.
+45:17 Izrael pedig megszabadul az Úrban örök szabadulással; * nem szégyenültök és nem pirultok meg mindörökkön-örökké.
+45:18 Mert ezeket mondja az Úr, az egek teremtője, * önmaga a földnek alkotó Istene, és annak képzője, önmaga annak teremtője;
+45:19 Nem hiába teremtette azt, lakóhelyül alkotta azt; * Én vagyok az Úr, és nincs más.
+45:20 Nem rejtekben szólottam * a föld sötét helyén;
+45:21 Nem mondottam Jákob ivadékának: Hiába kérdeztek engem; Én vagyok az Úr, igazságot szóló, igazat hirdető.
+45:22 Gyűljetek egybe, jöjjetek és járuljatok elé mind együtt, * kik megszabadultatok a pogányok közül,
+45:23 Tudatlanok, akik faragott fájukat fölemelik, * és könyörögnek oly istenhez, ki nem szabadító.
+45:24 Hirdessétek, és jöjjetek elé, és tanácskozzatok együtt. * Ki hallatta ezt kezdettől, régtől fogva ki mondta ezt meg előre?
+45:25 Nem én-e, az Úr? És nincs több Isten nálamnál, * igaz és szabadító Isten nincs énkívülem.
+45:26 Térjetek hozzám, és megszabadultok, föld minden határai; * mert én vagyok az Isten, és nincs más.
+45:27 Saját magamra esküdtem, igazság igéje megyen ki számból, * és nem tér vissza:
+45:28 Hogy nekem hajol meg minden térd, * és esküszik minden nyelv.
+45:29 Azért fogják mondani: Az Úrban van az én igazságom és uralmam; * hozzá fognak jőni, és megszégyenülnek mindnyájan, kik ellene tusakodnak.
+45:30 Az Úrban igazul meg és dicsértetik * Izrael minden ivadéka.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm216.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm216.txt
@@ -1,0 +1,17 @@
+(Jézus,_Sirák_fia Éneke * Sir 36:1-16)
+36:1 Könyörülj rajtunk, mindenek Istene, és tekints ránk, * és mutasd meg nekünk könyörületed világosságát;
+36:2 És bocsásd félelmedet a népekre, * kik téged nem keresnek,
+36:3 Hadd ismerjék meg, hogy nincs Isten, hanem csak te, * és beszéljék a te nagy dolgaidat.
+36:4 Emeld föl kezedet az idegen népekre, * hogy lássák hatalmasságodat.
+36:5 Hogy amint szemük előtt megszenteltetel mibennünk, * úgy a mi szemünk előtt magasztaltassál föl őbennük,
+36:6 Hadd ismerjenek meg téged, mint mi is megismertünk, * hogy nincs Isten tekívüled, Uram.
+36:7 Újítsd meg a jeleket, és ismételd a csodákat. * Dicsőítsd meg kezedet és jobb karodat.
+36:8 Indítsd föl búsulásodat, és öntsd ki haragodat. * Vedd el az ellenkezőt, és fenyítsd meg az ellenséget.
+36:9 Siettesd az időt, és emlékezzél meg a végről, * hogy hirdessék a te csodáidat.
+36:10 A harag lángjától emésztessék meg, aki megszabadul, és akik gonoszul bánnak népeddel, találjanak veszedelmet.
+36:11 Rontsd meg fejüket az ellenséges fejedelmeknek, * kik azt mondják: Nincs más mikívülünk.
+36:12 Gyűjtsd össze Jákob minden nemzetségét, hadd ismerjék meg, hogy nincs Isten, hanem csak te, * és beszéljék a te nagy dolgaidat;
+36:13 Hogy örökségül bírjad őket, * mint kezdetben.
+36:14 Könyörülj népeden, mely nevedről hívatik, * és Izraelen, kit hasonlóvá tettél elsőszülöttedhez.
+36:15 Könyörülj szentélyed városán, Jeruzsálemen, * a te nyugodalmad városán.
+36:16 Töltsd meg Siont a te kimondhatatlan igéiddel, * és dicsőségeddel a te népedet.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm22.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm22.txt
@@ -1,0 +1,9 @@
+22:1 Az Úr igazgat engem, és semmi híjával nem leszek; * a legelés helyére fektetett engem;
+22:2 A megújulás vize mellett nevelt engem; * lelkemet megtérítette,
+22:3 Az igazság ösvényein hordozott engem * az ő nevéért.
+22:4 Mert ha a halál árnyéka közepette járok is, nem félek a rosszaktól: * mivel te velem vagy.
+22:4 A te vessződ és botod, * azok vigasztaltak engem.
+22:5 Asztalt készítettél előttem * azok ellen, kik engem szorongatnak.
+22:5 Megkented olajjal fejemet; * és az én kedvet adó poharam mely jeles!
+22:6 És a te irgalmasságod követ engem * életem teljes napjaiban;
+22:6 Hogy az Úr házában lakjam * hosszú ideig.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm220.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm220.txt
@@ -1,0 +1,8 @@
+(A_három_ifjú Éneke * Dán 3:52-57)
+3:52 Áldott vagy, Uram, atyáink Istene, * dicséretes és dicsőséges és magasztos mindörökké;
+3:53 És áldott a te dicsőséged szent neved, * dicséretes és magasztos mindörökké.
+3:54 Áldott vagy te dicsőséged szent templomában, * fölötte dicséretes és fölötte dicsőséges mindörökké.
+3:55 Áldott vagy te országod királyi székében, * fölötte dicséretes és fölötte magasztos mindörökké.
+3:56 Áldott vagy te, ki átlátod a mélységeket, és a kerubokon ülsz, * dicséretes és magasztos mindörökké.
+3:57 Áldott vagy az ég erősségében, * dicséretes és dicsőséges mindörökké.
+3:58 Áldjátok, az Úr minden alkotásai, az Urat, * dicsérjétek és magasztaljátok őt mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm221.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm221.txt
@@ -1,0 +1,8 @@
+(Izajás Éneke * Iz 12:1-7)
+12:1 Hálát adok neked, Uram, mert haragudtál rám, * de elfordult a te haragod, és megvigasztaltál engem.
+12:2 Íme Isten az én szabadítóm, * bizodalmam vagyon, és nem félek;
+12:3 Mert az én erősségem és dicséretem az Úr, * és szabadulásomra lett nekem.
+12:4 Örömmel merítek vizet az üdvözítő kútforrásaiból, * és mondjátok azon a napon: Adjatok hálát az Úrnak, és hívjátok segítségül a Ő nevét;
+12:5 Nyilatkoztassátok ki a népek között az ő találmányait, * és emlékezzetek meg, hogy fölséges az ő neve.
+12:6 Énekeljetek az Úrnak, mert nagy dolgokat cselekedett; * hirdessétek ezt az egész földön.
+12:7 Örvendezz és dicsérd, Sion lakossága, * mert nagy Izrael Szentje közepetted.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm222.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm222.txt
@@ -1,0 +1,16 @@
+(Ezekiás Éneke * Iz 38:10-24)
+38:10 Én mondám: Az én napjaim közepén * megyek az alvilág kapuihoz,
+38:11 Keresve esztendeim maradványát * mondám: Nem látom az Úr Istent az élők földjén;
+38:12 Nem látok többé embert * és nyugalomban lakót.
+38:13 Életem elvétetik, és összegöngyöltetik, * mint a pásztorok sátora;
+38:14 Elmetszetik, mint a szövőtől, életem; még mikor kezdeném, elmetsz engem; * reggeltől estig végemre jársz.
+38:15 Bíztam a reggelhez, * és mint az oroszlán, úgy összetörte csontjaimat;
+38:16 Reggeltől estig végemre jársz, * mint a fecskefióka, úgy kiáltok; nyögök, mint a galamb;
+38:17 Meggyengültek szemeim, * nézvén a magasba.
+38:18 Uram, erőszakot szenvedek, fogd fel ügyemet. * Mit mondjak, vagy mit felel nekem ő, holott maga cselekedte?
+38:19 Átgondolom előtted minden esztendőmet * lelkem keserűségében.
+38:20 Uram, ha így kell élni, és ilyenekben áll az én lelkem élete, megfeddhetsz engem, és megeleveníthetsz engem. * Íme békességemül lett legkeservesebb keserűségem;
+38:21 Te megszabadítottad lelkemet, hogy el ne vesszen, * hátad mögé vetetted minden bűnömet.
+38:22 Mert nem az alvilág teszen rólad vallást, sem a halál nem dicsér téged; * nem várnak, kik a sírgödörbe leszállnak, a te hűségedre;
+38:23 Az élő, az élő teszen rólad vallást, mint én is ma; * az atya a fiaknak adja tudtul a te hűségedet.
+38:24 Uram, szabadíts meg engem, * és zsoltárainkat énekelni fogjuk életünk teljes napjain az Úr házában.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm223.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm223.txt
@@ -1,0 +1,17 @@
+(Anna Éneke * 1Sám 2:1-16)
+2:1 Örvend az én szívem az Úrban, * és szarvam fölmagasztaltatott Istenemben;
+2:2 Megnyílik, szájam ellenségeimre; * mert vigadok szabadításodban.
+2:3 Nincs oly szent, mint az Úr; mert nincs is más kívüled, * és nincs oly erős, mint a mi Istenünk.
+2:4 Ne szaporítsatok kevély szókat, * dicsekedvén:
+2:5 Távozzanak el a régiek szájatokból; mert tudományok Istene az Úr, * és előtte tárvák a gondolatok.
+2:6 Az erősök kézíja meggyőzetett, * és az erőtlenek felöveztettek erősséggel.
+2:7 Kik azelőtt jóllaktak, kenyérért bérbe adták magukat, * és az éhezők megelégíttettek;
+2:8 Sőt a magtalan is sokat szült, * és kinek sok fia vala, megerőtlenedett.
+2:9 Az Úr öl és elevenít, * levisz a poklokra és visszahoz.
+2:10 Az Úr szegénnyé tesz és gazdagít, * megaláz és fölemel.
+2:11 Felkölti a porból a szűkölködőt, * és a szemétből fölemeli a szegényt,
+2:12 Hogy a fejedelmekkel üljön, * és a dicsőség székét bírja.
+2:13 Mert az Úréi a föld sarkai, * és azokra helyezte a világot.
+2:14 Szentjeinek lábait megőrzi, és az istentelenek a sötétben elnémulnak; * mert nem a maga erősségében erős a férfiú.
+2:15 Az Urat rettegik ellenségei, * és rájuk dörög az egekben;
+2:16 Az Úr megítéli a föld határait, és uralmat ad királyának, * és fölkentjének szarvát fölemeli.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm224.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm224.txt
@@ -1,0 +1,23 @@
+(Mózes Éneke * Kiv 15:1-22)
+15:1 Énekeljünk az Úrnak, mert dicsőségesen fölmagasztaltatott, * a lovat és rajta ülőt levetette a tengerbe.
+15:2 Az én erősségem és dicséretem az Úr, * mert nekem szabadulásomra lőn;
+15:3 Ő az én Istenem, és dicsőítem őt; * az én atyám Istene, és felmagasztalom őt.
+15:4 Az Úr mint a hadakozó férfiú, az ő neve: Mindenható. * A fáraó szekereit és seregét a tengerbe vetette;
+15:5 Az ő válogatott fejedelmei elmerültek a Vörös-tengerben. * A mélység elborította őket, alászállottak a fenékre, mint a kő.
+15:6 A te jobbod, Uram, fölmagasztaltatott erősségben; jobbod, Uram, megverte az ellenséget. * És a te dicsőséged teljességében megbuktattad ellenségeidet;
+15:7 Megeresztetted haragodat, mely megemésztette őket, mint a tarlót. * És haragod lehelete által összegyűltek a vizek;
+15:8 Megálla a folyóvíz, * az örvények összegyűltek a tenger közepén.
+15:9 Mondá az ellenség: Űzőbe veszem és megfogom őket, * fölosztom a ragadományt, és lelkem bételik;
+15:10 Kivonom kardomat, * megöli őket az én kezem.
+15:11 Ekkor fúva szeled, és a tenger elborítá őket; * elmerülének, mint az ón a sebes vizekben.
+15:12 Ki hasonló hozzád, Uram, az erősek között? * Ki hasonló hozzád, s oly dicső a szentségben, oly rettenetes és dicsérendő, oly csodatévő?
+15:13 Kinyújtottad kezedet, és a föld elnyelé őket. * Vezére voltál irgalmasságodban a népnek, melyet megszabadítottál;
+15:14 És hordoztad őt erősségeddel * a te szent lakhelyedre.
+15:15 Fölkelének a népek, és haraguvának; * fájdalom fogá körül Filisztea lakóit.
+15:16 Akkor megháborodának Edom fejedelmei, Moáb erőseit körülfogá a rettegés, * Kánaán minden lakói megmerevedének.
+15:17 Rohanjon rájuk félelem és rettegés *  karod erejével;
+15:18 Legyenek mozdulatlanok, mint a kő, míg néped átmegy, Uram, * míg átmegy ezen te néped, melyet szerzettél.
+15:19 Beviszed őket, és örökséged hegyére ülteted, * a te erősséges lakhelyedre, melyet alkottál Uram,
+15:20 A te szentélyed az, Uram, melyet kezeid megerősítettek. * Az Úr uralkodik örökké és mindenkoron.
+15:21 Mert a fáraó beméne lovaival, szekereivel és lovagjaival a tengerbe; * és az Úr visszahozá rájuk a tenger vizeit;
+15:22 Izrael fiai pedig szárazon járának * annak közepén.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm225.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm225.txt
@@ -1,0 +1,33 @@
+(Habakuk Éneke * Hab 3:2-19)
+3:2a Uram, hallottam amit hirdettél, * és féltem.
+3:2b Uram, a te munkádat * az esztendők folytán újítsd meg;
+3:2c Az esztendők folytán jelentsd ki azt, * és mikor megharagszol, az irgalmasságról emlékezzél meg.
+3:3a Az Isten eljő dél felől, * és a Szent a Fárán hegyéről;
+3:3b Dicsősége elborítja az egeket, * és dicséretével teljes a föld.
+3:4a Az ő fényessége, mint a világosság; * szarvakat tart kezében;
+3:4b Ott van elrejtve erőssége, * (5a) orcája előtt megyen a halál;
+3:5b És a gonosz jár lábai előtt, * (6a) megáll és megméri a földet;
+3:6b Széttekint, és szétszórja a nemzeteket; * összeomlanak a világ hegyei,
+3:6c Lesüllyednek a világ halmai * az ő örökkévaló léptei alatt.
+3:7 A gonoszság miatt látom reszketni Etiópia sátorait * s Mádián földjének bőrhajlékait.
+3:8a Vajon a folyóvizek ellen haragudtál-e meg, Uram? * A folyóvizek ellen van-e a te búsulásod, vagy a tenger ellen a te bosszankodásod?
+3:8b Ki felülsz lovaidra * és szekereidre, hogy megszabadíts.
+3:9a Felvonván felvonod kézíjadat, * amint megesküdtél a nemzetségeknek;
+3:9b A földből folyóvizeket hasítasz, † (10a) látnak téged, és megrendülnek a hegyek; * a vizek árja özönlik;
+3:10b A mélység szózatát adja, * a magasság fölemeli kezeit.
+3:11 A nap és hold megállanak hajlékukban, * a te nyilaid csillámánál mennek ők, és villogó dárdád fényénél.
+3:12 Búsulásodban eltapodod a földet; * haragodban elrémíted a nemzeteket.
+3:13a Te kijössz néped szabadítására, * szabadításra a te fölkenteddel;
+3:13b Megvered az istentelen házában a főt, * tetőtől talpig megmezteleníted.
+3:14a Megátkozod királyi pálcáját, † az ő hadakozóinak fejét, * kik forgószél gyanánt jöttek engem elveszteni.
+3:14b Öröm nekik * a szegényt elnyelni rejtekben.
+3:15 Utat nyitsz lovaidnak a tengeren, * a nagy vizek iszapjában.
+3:16a Hallottam ezt, és megháborodott az én belsőm; * a szózat miatt reszkettek ajkaim.
+3:16b Induljon a korhadás csontjaimba, * és alattam fakadjon ki,
+3:16c Hogy nyugodjam a szorongatás napján, * hogy fölmenjek a mi felövezett népünkhöz.
+3:17a Mert a fügefa nem fog virágzani, * és nem leszen termés a szőlőkben;
+3:17b Megcsal az olajfa gyümölcse, * és a szántóföldek nem teremnek élelmet;
+3:17c Az akolból kivesz a juh, * és nem lesz barom a jászoloknál.
+3:18 Én pedig az Úrban örülök, * és vigadok az én üdvözítő Istenemben.
+3:19a Az Úr Isten az én erősségem, * és lábaimat olyanokká teszi, mint a szarvasokéi;
+3:19b Ő, a győző, magas helyekre visz engem, * zsoltározva énekelőt.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm226.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm226.txt
@@ -1,0 +1,66 @@
+(Mózes Éneke * MTörv 32:1-65)
+32:1 Halljátok, egek, amiket szólok, * hallja a föld szájam igéit.
+32:2 Folyjon össze, mint az eső, az én tanításom; * hulljon, mint a harmat, az én szólásom,
+32:3 Mint a záporeső a füvön, és mint a csöppek a pázsiton. * Mert az Úr nevét segítségül hívom;
+32:4 Adjatok dicsőséget Istenünknek. * Az Isten cselekedetei tökéletesek, és minden utai igazságosak;
+32:5 Az Isten hű, és minden hamisság nélkül igaz és tökéletes. * Vétkeztek ellene, kik már nem fiai, undokságok által,
+32:6 A gonosz és elfordult nemzedék. * Ezekkel fizetsz-e az Úrnak, bolond és esztelen nép?
+32:7 Vajon nem atyád-e ő, * ki bírt téged és alkotott és teremtett?
+32:8 Emlékezzél a régi napokról, * gondolj át minden nemzedéket;
+32:9 Kérdezd meg atyádat, és tudtodra adja, * elődeidet, és megmondják neked.
+32:10 Mikor a Fölséges elosztá a nemzeteket, * mikor elkülöníté Ádám fiait,
+32:11 Akkor állapítá meg a népek határait * Izrael fiainak száma szerint.
+32:12 Az Úr része pedig az ő népe, * Jákob az ő örökségének kötele.
+32:13 A puszta földön találá őt, * az iszonyodás és kietlen pusztaság helyén;
+32:14 Körülhordozá őt és tanítá, * és mint szeme fényét őrizé.
+32:15 Mint a sas röpülésre izgatván fiait * és felettük repesvén,
+32:16 Kiterjeszté szárnyait, és fölvevé őt, * és vállain hordozá.
+32:17 Az Úr egyedül vala vezére, * és nem vala idegen Isten vele.
+32:18 Magas földre helyezé őt, * hogy egye a föld gyümölcsét,
+32:19 Hogy mézet szívjon a kősziklából, * és olajat a kemény szirtből,
+32:20 A csordákból vajat és a juhokból tejet, * a bárányoknak, és Básán fiai kosainak kövérségével,
+32:21 És bakokat a búza velejével; * és igya a szőlő legtisztább vérét.
+32:22 De meghízék a szerelmes és hátra ruga; * meghízván, megkövéredvén, eltelvén,
+32:23 Elhagyá alkotó Istenét, * és eltávozék üdvözítő Istenétől.
+32:24 Idegen istenekkel bosszanták őt, * és utálatossággal haragra indíták.
+32:25 Az ördögöknek áldozának, és nem az Istennek, * az isteneknek, kiket nem ismertek,
+32:26 Az újaknak, és nem rég jötteknek, * kiket atyáik nem tiszteltek.
+32:27 Az Istent, ki téged alkotott vala, elhagyád, * és teremtő Uradról elfeledkezél.
+32:28 Látta az Úr, és haragra gerjede, * mert bosszantották őt fiai és leányai.
+32:29 És mondá: Elrejtem orcámat előlük, * és meglátom, mi lesz végük;
+32:30 Mert elfordult nemzedék ez, * és hűtlen fiak.
+32:31 Ők engem azzal bosszantottak, aki nem vala Isten, * és haragra indítottak hiúságaikban;
+32:32 Én is azzal bosszantom őket, aki nem népem, * és a bolond nemzet által ingerlem őket.
+32:33 Lángoló tűz az én haragom, * és égni fog mind a pokol fenekéig;
+32:34 És megemészti a földet termésével együtt, * és a hegyek alapjait megégeti.
+32:35 Veszélyeket halmozok rájuk, * és nyilaimat rajtuk fogyasztom.
+32:36 Éhséggel fognak megemésztetni, * és a madarak eszik meg őket keserűséges harapással;
+32:37 A vadak fogait bocsátom rájuk, * a földön csúszók és kígyók dühösségével.
+32:38 Kívül fegyver pusztítja őket, és belül rettegés, * ifjat úgy mint a szüzet, csecsemőt a vén emberrel együtt.
+32:39 Mondám: Hol vannak? * Megszüntetem az embereknél emlékezetüket.
+32:40 De az ellenségek haragja miatt elhalasztám, * nehogy kevélykedjenek ellenségei,
+32:41 És mondják: A mi hatalmas kezünk, és nem az Úr * cselekedte mindezeket.
+32:42 Tanács és okosság nélkül való nemzet. * Bárcsak eszesek volnának, és értenének, és végükről gondoskodnának!
+32:43 Miképp kergethetne egy ezret, * és szalaszthatna meg kettő tízezret?
+32:44 Nemde úgy, hogy Istenük eladta őket, * és az Úr bekerítette őket?
+32:45 Mert nem olyan a mi Istenünk, mint azok istenei, * s ebben ellenségeink is bíráink.
+32:46 A szodomaiak szőlejéből való az ő szőlejük, * és Gomorra telkeiről;
+32:47 Szőlejük epeszőlő, * és gerezdjeik igen keserűek.
+32:48 Sárkányok epéje az ő boruk, * és áspisok gyógyíthatatlan mérge.
+32:49 Nemde el vannak ezek téve nálam, * és bepecsételve kincseim között?
+32:50 Enyém a bosszúállás, én megfizetek annak idején, * hogy lábuk elcsuszamodjék;
+32:51 Közel van a veszedelem napja, * és az idők sietve elérkeznek.
+32:52 Az Úr megítéli népét, * és könyörül majd szolgáin;
+32:53 Látni fogja, hogy megerőtlenül a kéz, * és a bezárkózottak is elfogytak, s a megmaradtak is fölemésztettek.
+32:54 És mondani fogja: Hol vannak az ő isteneik, * kikben bizodalmuk volt?
+32:55 Kiknek áldozataik kövérét ették, * és italáldozataik borát itták.
+32:56 Keljenek föl, és segítsenek titeket, * és szükségetekben oltalmazzanak.
+32:57 Lássátok, hogy egyedül én vagyok, * és nincs kívülem más Isten;
+32:58 Én ölök és elevenítek, sebesítek és gyógyítok, * és nincs, ki kezemből kiszabadíthasson.
+32:59 Fölemelem az égre kezemet, és mondom: * Élek én mindörökké.
+32:60 Ha megélesítem kardomat, mint a villámlást, * és kezem ítélethez fog,
+32:61 Bosszúmat töltöm ellenségeimen, * és azoknak, kik engem gyűlölnek, megfizetek.
+32:62 Megrészegítem nyilaimat vérrel, * és kardom jóllakik hússal,
+32:63 A megöltek és foglyok vérével, * a mezítelen fejű ellenségek vérével.
+32:64 Dicsérjétek, nemzetek, az ő népét, * mert szolgáinak vérét megtorolja,
+32:65 És bosszút áll azok ellenségein, * és kegyelmes lesz az ő népe földjéhez.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm23.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm23.txt
@@ -1,0 +1,10 @@
+23:1 Az Úré a föld és annak teljessége; * a föld kereksége, és mindnyájan, kik benne laknak.
+23:2 Mert ő tengerekre alapította azt; * és folyóvizekre állította azt.
+23:3 Ki megy föl az Úr hegyére? * Vagy ki fog állani az ő szent helyén?
+23:4 Az ártatlan kezű s a tiszta szívű, * ki lelkét nem adta hiúságra, sem álnoksággal nem esküdött felebarátjának;
+23:5 Az veszen áldást az Úrtól, * és irgalmat az ő szabadító Istenétől.
+23:6 Ez az őt keresők nemzetsége, * kik Jákob Istene orcáját keresik.
+23:7 Emeljétek föl, fejedelmek, a ti kapuitokat, és emelkedjetek föl, örök ajtók, * hogy bemenjen a dicsőség királya.
+23:8 Ki ez a dicsőség királya? * Az erős és hatalmas Úr, a hatalmas Úr a harcon.
+23:9 Emeljétek föl, fejedelmek, a ti kapuitokat, és emelkedjetek föl, örök ajtók, * hogy bemenjen a dicsőség királya.
+23:10 Ki ez a dicsőség királya? * A seregek Ura, ő a dicsőség királya.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm231.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm231.txt
@@ -1,0 +1,13 @@
+(Zakariás Éneke * Lk 1:68-79)
+1:68 Áldott + az Úr, Izraelnek Istene, * mert meglátogatta és megváltotta az ő népét.
+1:69 És fölemelte nekünk az üdvösség szarvát, * Dávidnak, az ő szolgájának házában;
+1:70 Amint ígért az ő szent prófétái szája által * elejétől fogva
+1:71 Szabadulást a mi ellenségeinktől * és mindazok kezéből, kik gyűlöltek minket;
+1:72 Irgalmasságot cselekedvén atyáinkkal, * és megemlékezvén az ő szent szövetségéről,
+1:73 Az esküről, mellyel megesküdött atyánknak, Ábrahámnak, * hogy megadja nekünk,
+1:74 Hogy ellenségeink kezéből megszabadulván, * félelem nélkül szolgáljunk neki,
+1:75 Szentségben és igazságban őelőtte * minden napjainkban.
+1:76 És te, gyermek, a Magasságbeli prófétájának fogsz hívatni; * mert az Úr színe előtt jársz majd, elkészítendő az ő utait;
+1:77 Hogy az üdvösség tudományát közöld népével, * az ő bűneik bocsánatára,
+1:78 A mi Istenünk nagy irgalmassága által, * mellyel meglátogatott minket a magasságból támadó;
+1:79 Hogy megvilágosítsa azokat, kik sötétségben s a halál árnyékában ülnek, * és lábainkat a békesség útjára igazgassa.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm232.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm232.txt
@@ -1,0 +1,11 @@
+(A Boldogságos Szűz Mária éneke * Lk 1:46-55)
+1:46 Magasztalja + * az én lelkem az Urat,
+1:47 És örvendez lelkem * az én üdvözítő Istenemben.
+1:48 Mert megtekintette szolgálójának alázatosságát; * íme mostantól boldognak hirdet engem minden nemzedék.
+1:49 Mert nagy dolgokat cselekedett nekem a Hatalmas, * kinek szent az ő neve.
+1:50 És az ő irgalmassága nemzedékről nemzedékre száll * az őt félőkön.
+1:51 Hatalmas dolgot cselekedett az ő karjával, * elszélesztette a szívük szándékában kevélykedőket.
+1:52 Levetette a hatalmasokat a fejedelmi székből, * és felmagasztalta az alázatosokat.
+1:53 Az éhezőket betöltötte jókkal, * és a gazdagokat üresen bocsátá.
+1:54 Oltalmába vette Izraelt, az ő szolgáját, * megemlékezvén irgalmasságáról;
+1:55 Amint szólott atyáinknak, * Ábrahámnak és az ő ivadékának örökre.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm233.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm233.txt
@@ -1,0 +1,5 @@
+(Simeon Éneke * Lk 2:29-32)
+2:29 Most bocsátod + el, Uram, szolgádat * a te igéd szerint békességben;
+2:30 Mert látták szemeim * a te üdvösségedet,
+2:31 Kit rendeltél * minden népek színe elé,
+2:32 Világosságul a pogányok megvilágosítására, * és dicsőségül a te népednek, Izraelnek.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm234.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm234.txt
@@ -1,0 +1,41 @@
+(Quicumque Kantikum * Atanáz-féle hitvallás)
+Aki Üdvözülni akar, * mindenekelőtt szükséges, hogy a katolikus hitet tartsa;
+Melyet Ha valaki épen és felbonthatatlanul nem tart, * kétségkívül örökre elvész.
+Ez Pedig a katolikus hit: * hogy tiszteljünk egy Istent a Szent Háromságban és Szent Háromságot az egyességben;
+Sem A személyeket egybe nem elegyítvén, * sem a természetet el nem választván.
+Mert Más az Atyának személye, más a Fiúé, * más a Szentléleké;
+De Az Atyának és Fiúnak és Szentléleknek egy az istensége, * egyenlő a dicsősége, egyenlőképpen örökkévaló a felsége.
+Amilyen Az Atya, olyan a Fiú, * olyan a Szentlélek.
+Nem-teremtett Az Atya, nem-teremtett a Fiú, * nem-teremtett a Szentlélek.
+Mérhetetlen Az Atya, mérhetetlen a Fiú, * mérhetetlen a Szentlélek.
+Örökkévaló Az Atya, örökkévaló a Fiú, * örökkévaló a Szentlélek;
+És Mindazonáltal nem három örökkévaló, * hanem egy örökkévaló;
+Miképpen Nem három nem-teremtett, sem három mérhetetlen, * hanem egy nem-teremtett és egy mérhetetlen.
+Hasonlóképpen: Mindenható az Atya, mindenható a Fiú, * mindenható a Szentlélek;
+És Mindazonáltal: nem hárman a mindenhatók, * hanem egy a mindenható.
+Azonképpen: Isten az Atya, Isten a Fiú, * Isten a Szentlélek;
+És Mindazonáltal: nem hárman istenek, * hanem egy az Isten.
+Azonképpen: Úr az Atya, Úr a Fiú, * Úr a Szentlélek;
+És Mindazonáltal: nem három úr, * hanem egy Úr;
+Mert Miképpen a keresztényi igazság kényszerít, hogy külön mindenik személyt Istennek és Úrnak valljuk, * úgy a katolikus isteni tudomány tiltja, hogy három istent vagy három urat mondjunk.
+Az Atya senkitől sem alkottatott, * sem teremtetett, sem született.
+A Fiú csak az Atyától vagyon: * nem alkottatott, sem teremtetett, hanem született.
+A Szentlélek az Atyától és a Fiútól vagyon: * nem alkottatott, sem teremtetett, sem született, hanem származott.
+Egy Azért az Atya, és nem hárman vannak atyák, egy a Fiú, nem hárman vannak Fiúk, * egy a Szentlélek, nem hárman vannak a lelkek;
+És Ebben a Szent Háromságban semmi sincs elébb vagy utóbb, sem nagyobb és kisebb, * hanem a három személy egyenlőképpen örökkévaló és egymáshoz képest egyenlő.
+Úgy, Hogy amint előbb mondtuk: * mindenikben az egység a háromságban, és a háromság az egységben tisztelendő legyen.
+Aki Azért üdvözülni akar, * ilyen értelemben gondolkodjék a Szentháromságról;
+De Szükséges az örök üdvösséghez az is, * hogy igaz hittel higgyen Urunk, Jézus Krisztus megtestesüléséről is.
+Ez Azért az igaz hit: hogy higgyük és valljuk, * hogy a mi Urunk, Jézus Krisztus Istennek Fia, Isten és ember.
+Isten: Időnek előtte, az Atyának lényegi valójából született, * és ember: az anyának valójából időben született.
+Tökéletes Isten, tökéletes ember: * értelmes lélekből és emberi testből áll.
+Egyenlő Az Atyával istensége szerint, * kisebb az Atyánál embersége szerint;
+Noha Isten és ember, * mindazonáltal nem kettő, hanem csak egy a Krisztus.
+Egy Pedig: nem az istenségnek testté változásával, * hanem az emberi természetnek Istenhez való felvételével.
+Egy Nem a természeteknek egybeelegyítése által, * hanem az egy személyben való egysége által.
+Mert Miképpen az értelemmel bíró lélek és test egy ember, * úgy az Isten és ember: egy Krisztus.
+Ő Üdvösségünkért szenvedett, poklokra szállott, * harmadnapra halottaiból feltámadott.
+Felment A mennyekbe, ül a mindenható Atyaistennek jobbján, * onnan leszen eljövendő ítélni eleveneket és holtakat;
+Kinek Eljövetelére minden embernek fel kell kelni testükkel együtt, * és számot kell adni tulajdon cselekedeteikről;
+És Akik jót cselekedtek, örök életre mennek, * akik pedig gonoszt, örök tűzre.
+Ez A katolikus hit, * melyet ha valaki híven és állhatatosan nem hisz, üdvösségre nem juthat.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm24.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm24.txt
@@ -1,0 +1,23 @@
+24:1 Tehozzád emelem föl, Uram, lelkemet; * én Istenem, tebenned bízom, meg ne piruljak,
+24:3 És ne nevessenek ki engem az én ellenségeim; * mert mindazok, kik téged várnak, meg nem szégyenülnek.
+24:4 Szégyenüljenek meg mindnyájan, kik gonoszságot cselekszenek * oktalanul.
+24:4 A te utaidat, Uram, mutasd meg nekem, * és ösvényeidre taníts meg engem.
+24:5 Vezess engem igazságod szerint, taníts engem; * mert te vagy az én üdvözítő Istenem, és egész nap téged vártalak.
+24:6 Emlékezzél meg, Uram, könyörületedről * és irgalmadról, melyek öröktől valók.
+24:7 Ifjúságom vétkeiről * és tudatlanságaimról ne emlékezzél meg.
+24:7 Irgalmad szerint emlékezzél meg rólam; * a te jóvoltodért, Uram!
+24:8 Jóságos és igazságos az Úr: * azért fog adni törvényt az útban tévedezőknek;
+24:9 Az engedelmeseket vezérli az ítéletben, * a szelídeket megtanítja utaira.
+24:10 Az Úr minden útja irgalom és igazság * azoknak, kik szövetségét és bizonyságtételeit megtartják.
+24:11 A te nevedért, Uram, kegyelmezz bűnömnek; * mert sok az.
+24:12 Kicsoda az ember, ki az Urat féli? * Törvényt szabott annak az úton, melyet válasszon.
+24:13 Annak lelke a jóban megmarad, * és ivadéka örökleni fogja a földet.
+24:14 Az Úr erőssége az őt félőknek; * és az ő szövetsége, hogy kinyilatkoztassék nekik.
+24:15 Szemeim mindenkor az Úron vannak; * mert lábaimat ő vonja ki a tőrből.
+24:16 Tekints rám és könyörülj rajtam; * mert én egyes és szegény vagyok.
+24:17 Szívem szorongatásai megsokasodtak; * szükségeimből ments ki engem.
+24:18 Nézd lealáztatásomat és gyötrelmemet; * és bocsásd meg minden vétkemet.
+24:19 Tekintsd ellenségeimet, * mert megsokasodtak, és igaztalan gyűlölséggel gyűlölnek engem.
+24:20 Őrizd meg lelkemet, és ments ki engem; * nem pirulok meg, mert benned bíztam.
+24:21 Az ártatlanok és igazak hozzám ragaszkodnak, * mert téged vártalak.
+24:22 Szabadítsd meg, Isten, Izraelt * minden szorongatásából.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm240.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm240.txt
@@ -1,0 +1,9 @@
+(Izajás Éneke * Iz 40:10-17)
+40:10 Íme az Úr Isten eljön erősséggel, és az ő karja uralkodni fog; íme az ő jutalma vele van, és munkája őelőtte.
+40:11 Mint a pásztor, úgy legelteti ő nyáját, karjára gyűjti a bárányokat, és ölébe fölemeli, az ellőket maga hordozza.
+40:12 Ki mérte meg marokkal a vizeket? És ki mérte meg az egeket arasszal? Ki tartotta föl három ujjal a föld nehézségét? És ki mérte meg fontban a hegyeket, és a halmokat mérlegben?
+40:13 Ki segítette az Úr lelkét? Vagy ki volt az ő tanácsosa, és ki oktatta őt?
+40:14 Kivel tartott tanácsot, és ki igazgatta és tanította őt az igazság ösvényére, és oktatta őt a tudományra, és az okosság útját ki mutatta meg neki?
+40:15 Íme a népek, mint csöpp a vederben, és mint a mérleg nyelve; íme a szigetek, mint csekély por.
+40:16 És a Libanon nem elég gyújtásra, és annak állatai nem elegendők égőáldozatra.
+40:17 Minden nemzetek, mintha nem volnának, úgy vannak előtte, és semmi és hiábavalóság gyanánt tartja azokat.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm241.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm241.txt
@@ -1,0 +1,8 @@
+(Izajás Éneke * Iz 42:10-16)
+42:10 Énekeljetek az Úrnak új éneket, az ő dicsérete a föld végső határairól; kik a tengeren jártok, és mi abban vagyon, szigetek, és azok lakói!
+42:11 Emelkedjék föl a puszta és annak városai, hol Kedár házakban lakik; mondjatok dicséretet, kősziklán lakók; a hegyek tetejéről kiáltsanak.
+42:12 Dicsőséget adjanak az Úrnak, és dicséretét hirdessék a szigetekben.
+42:13 Az Úr, mint hős kimegyen, mint hadakozó férfiú, fölindítja hevét, üvölt és kiált; és erőt vesz ellenségein.
+42:14 Én mindenkor hallgattam, veszteg voltam, tűrtem; (de most) szólok, mint a szülő, pusztítok és elnyelek egyetemben.
+42:15 Elpusztítom a hegyeket és halmokat, s azok minden füvét megszárasztom; és a folyóvizeket szigetekké teszem, és a tavakat kiszárasztom.
+42:16 És a vakokat oly útra viszem, melyet nem ismernek, és oly ösvényeken jártatom őket, melyekről nem tudtak, a sötétséget előttük világossággá teszem, és a göröngyösöket egyenesekké; ezeket cselekszem velük, és nem hagyom el őket.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm242.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm242.txt
@@ -1,0 +1,8 @@
+(Izajás Éneke * Iz 49:7-13)
+49:7 Ezeket mondja az Úr, Izrael megváltója, az ő Szentje, a megvetett léleknek, a megutált nemzetnek, az urak szolgájának: Meglátnak a királyok és fölkelnek a fejedelmek, és hódolni fognak az Úrért, mert ő hű, és Izrael Szentjéért, ki téged választott.
+49:8 Ezeket mondja az Úr: A kegyelemidőben meghallgatlak téged, és a szabadítás napján megsegítelek, és megtartalak, és a népnek szövetségül adlak téged, hogy fölállítsd az országot és birtokba vedd az elpusztult örökségeket,
+49:9 Hogy azoknak, kik fogva vannak, mondjad: Menjetek ki; és azoknak, kik a sötétségben vannak: Jöjjetek napfényre. Az utakon fognak legeltetni, és minden síkságon az ő legelőjük;
+49:10 Nem éheznek és nem szomjúhoznak, és nem süti őket a hőség és a nap; mert a rajtuk könyörülő vezérli, és a vizek forrásainál itatja őket.
+49:11 És minden hegyemet úttá teszem, és ösvényeim fölemeltetnek.
+49:12 Íme ezek messziről jőnek, és íme amazok északról és a tenger felől, és ezek a déli földről.
+49:13 Mondjatok dicséretet, egek, és vigadj, föld; zengjetek dicséretet, hegyek, mert az Úr megvigasztalta népét, és könyörül az ő szegényein.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm243.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm243.txt
@@ -1,0 +1,6 @@
+(Izajás Éneke * Iz 63:1-5)
+63:1 Kicsoda ez, ki Edomból jő, megfestett ruhákban Boszrából? Ez az ékes az ő köntösében, járván erejének teljességében? Én vagyok, ki igazságot szólok, és oltalomul kelek a megszabadításra.
+63:2 Miért vörös tehát a te öltözeted, és ruháid, mint a sajtóban nyomóké?
+63:3 A sajtót egyedül tapostam, és a nemzetek közül senki sincs velem; összetapodtam őket búsulásomban, és eltiportam őket haragomban, és az ő vérük ruházatomra freccsent, és minden öltözetemet megrútítottam.
+63:4 Mert szívemben a bosszúállás napja, az én megszabadításom esztendeje eljött.
+63:5 Körültekinték, és nem vala segítő; kerestem, és nem volt, ki megsegítsen; és megszabadított engem az én karom, és haragom megsegített engem.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm244.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm244.txt
@@ -1,0 +1,7 @@
+(Ozeás Éneke * Oz 6:1-6)
+6:1 Az ő szorongásukban reggel fölkelnek énhozzám: Jertek és térjünk az Úrhoz:
+6:2 Mert ő fogott meg és kiszabadít minket; megver és megorvosol minket.
+6:3 Megelevenít két nap múlva, harmadnapon feltámaszt minket, és élni fogunk az ő színe előtt. Megtudjuk és utána leszünk, hogy megismerjük az Urat; mint a hajnal, készül az ő kijövetele, és hozzánk jő, mint az őszi és tavaszi eső a földre.
+6:4 Mit cselekedjem neked, Efraim? Mit cselekedjem neked, Júda? A ti irgalmasságotok, mint a reggeli felhő, és mint a harmat, mely korán elenyészik.
+6:5 Azért gyalulom őket a próféták által, öldöklöm őket az én szám igéivel; és a te ítéleteid előtűnnek, mint a világosság.
+6:6 Mert irgalmasságot kívánok én, és nem áldozatot; és az Isten ismeretét inkább, mint az égőáldozatokat.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm245.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm245.txt
@@ -1,0 +1,7 @@
+(Szofoniás Éneke * Szof 3:8-13)
+3:8 Azért várj engemet, úgymond az Úr, fölkelésem napjáig jövendőre; mert az én végzésem, hogy egybegyűjtsem a nemzeteket, és összeszedjem az országokat; és kiöntsem azokra bosszankodásomat, búsulásom minden haragját; mert az én haragom tüze megemészti az egész földet.
+3:9 Akkor adok azután a népeknek tisztult ajkat, hogy mindnyájan segítségül hívják az Úr nevét, és egybevetett vállal szolgáljanak neki.
+3:10 Etiópia folyóvizein túl, onnan könyörögnek hozzám az én elszélesztett fiaim, s ajándékot hoznak nekem.
+3:11 Azon a napon nem szégyenülsz meg semmi találmányaid miatt, melyekkel vétkeztél ellenem; mert akkor elveszem közüled, kik nagyságodról kérkedve szólottak; s te nem fogsz többé kevélykedni az én szent hegyemen.
+3:12 És meghagyom közötted a szegény és szűkölködő népet, mely bízni fog az Úr nevében.
+3:13 Izrael maradékai nem cselekszenek gonoszt, és nem szólnak hazugságot, és nem találtatik szájukban álnok nyelv; mert ők legeltetni fognak és lefeküdnek, és nem leszen, ki fölrettentse őket.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm246.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm246.txt
@@ -1,0 +1,7 @@
+(Habakuk Éneke * Hab 3:1-6)
+3:1 Habakuk próféta imádsága a tudatlanság vétkeiért.
+3:2 Uram, hallottam amit hirdettél, és féltem. Uram, a te munkádat az esztendők folytán újítsd meg; az esztendők folytán jelentsd ki azt, és mikor megharagszol, az irgalmasságról emlékezzél meg.
+3:3 Az Isten eljő dél felől, és a Szent a Fárán hegyéről; dicsősége elborítja az egeket, és dicséretével teljes a föld.
+3:4 Az ő fényessége, mint a világosság; szarvakat tart kezében; ott van elrejtve erőssége.
+3:5 Orcája előtt megyen a halál; és a gonosz jár lábai előtt.
+3:6 Megáll és megméri a földet; széttekint, és szétszórja a nemzeteket; összeomlanak a világ hegyei, lesüllyednek a világ halmai az ő örökkévaló léptei alatt.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm247.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm247.txt
@@ -1,0 +1,7 @@
+(Habakuk Éneke * Hab 3:7-12)
+3:7 A gonoszság miatt látom reszketni Etiópia sátorait s Mádián földjének bőrhajlékait.
+3:8 Vajon a folyóvizek ellen haragudtál-e meg, Uram? A folyóvizek ellen van-e a te búsulásod, vagy a tenger ellen a te bosszankodásod? Ki felülsz lovaidra és szekereidre, hogy megszabadíts.
+3:9 Felvonván felvonod kézíjadat, amint megesküdtél a nemzetségeknek; a földből folyóvizeket hasítasz.
+3:10 Látnak téged, és megrendülnek a hegyek; a vizek árja özönlik; a mélység szózatát adja, a magasság fölemeli kezeit.
+3:11 A nap és hold megállanak hajlékukban, a te nyilaid csillámánál mennek ők, és villogó dárdád fényénél.
+3:12 Búsulásodban eltapodod a földet; haragodban elrémíted a nemzeteket.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm248.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm248.txt
@@ -1,0 +1,8 @@
+(Habakuk Éneke * Hab 3:13-19)
+3:13 Te kijössz néped szabadítására, szabadításra a te fölkenteddel; megvered az istentelen házában a főt, tetőtől talpig megmezteleníted.
+3:14 Megátkozod királyi pálcáját, az ő hadakozóinak fejét, kik forgószél gyanánt jöttek engem elveszteni. Öröm nekik a szegényt elnyelni rejtekben.
+3:15 Utat nyitsz lovaidnak a tengeren, a nagy vizek iszapjában.
+3:16 Hallottam ezt, és megháborodott az én belsőm; a szózat miatt reszkettek ajkaim. Induljon a korhadás csontjaimba, és alattam fakadjon ki, hogy nyugodjam a szorongatás napján, hogy fölmenjek a mi felövezett népünkhöz.
+3:17 Mert a fügefa nem fog virágzani, és nem leszen termés a szőlőkben; megcsal az olajfa gyümölcse, és a szántóföldek nem teremnek élelmet; az akolból kivesz a juh, és nem lesz barom a jászoloknál.
+3:18 Én pedig az Úrban örülök és vigadok az én üdvözítő Istenemben.
+3:19 Az Úr Isten az én erősségem, és lábaimat olyanokká teszi, mint a szarvasokéi; ő, a győző, magas helyekre visz engem, zsoltározva énekelőt.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm249.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm249.txt
@@ -1,0 +1,6 @@
+(Jézus,_Sirák_fia Éneke * Sir 39:17-21)
+39:17 Ő szól, és ezt mondja: Halljatok engem, isteni nemzedék, és mint a vízfolyások mellé ültetett rózsa, nyíljatok.
+39:18 Mint a Libanonnak, legyen gyönyörűséges illatotok.
+39:19 Virágozzatok, mint a liliom, és illatozzatok kedvesen, és dicsérjétek énekkel, és áldjátok az Urat műveiben.
+39:20 Magasztaljátok nevét, és adjatok hálát neki ajkaitok szózatával és ajkaitok énekével és citerákkal, és így szóljatok a hálaadásban:
+39:21 Az Úr minden műve igen jó.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm25.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm25.txt
@@ -1,0 +1,12 @@
+25:1 Ítélj meg engem, Uram, mert én ártatlanságomban jártam; * és az Úrban bízván, nem fogok lankadni.
+25:2 Próbálj meg engem, Uram, és kísérts meg engem; * égesd veséimet és szívemet.
+25:3 Mert a te irgalmasságod szemeim előtt vagyon; * és gyönyörködöm igazságodban.
+25:4 Nem ültem a hiúság gyülekezetében; * és a gonosztevőkkel nem járok.
+25:5 Gyűlöltem a gonosztevők gyülekezetét; * és az istentelenekkel nem ülök.
+25:6 Megmosom kezeimet az ártatlanokkal, * és körülveszem, Uram, a te oltárodat.
+25:7 Hogy halljam a dicséret szózatát, * és elbeszéljem minden csodádat.
+25:8 Uram, szeretem a te házad ékességét, * és a te dicsőséged lakhelyét.
+25:9 Isten, ne veszítsd el az istentelenekkel az én lelkemet, * és a vérszopó férfiakkal életemet,
+25:10 Kiknek kezeikben gonoszság vagyon, * jobb kezük tele ajándékokkal.
+25:11 Én pedig ártatlanságomban jártam; * válts meg engem, és irgalmazz nekem.
+25:12 Az én lábam egyenesen állott; * a gyülekezetekben áldalak téged, Uram!

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm250.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm250.txt
@@ -1,0 +1,6 @@
+(Izajás Éneke * Iz 61:10-11; 62:1-3)
+61:10 Örülve örülök az Úrban, és örvendez lelkem az én Istenemben; mert az üdvösség ruházatába öltöztetett, és az igazság öltözetével környezett meg engem, mint koronával fölékesített vőlegényt, és mint függőivel fölcsinosított menyasszonyt.
+61:11 Mert valamint a föld megtermi sarjadékát, és a kert kifejleszti magvát: úgy neveli az Úr Isten az igazságot és dicséretet minden nemzet előtt.
+62:1 Sionért nem hallgatok, és Jeruzsálemért nem nyugszom, mígnem eléjő, mint a fényesség, az ő igaza, és üdvözítője égni fog, mint a lámpa.
+62:2 És meglátják a népek a te igazadat, és mind a királyok a te dicsőidet, és új néven hívatol, melyet az Úr szája fog nevezni.
+62:3 És dicsőség koronája leszel az Úr kezében, és királyi korona a te Istened kezében.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm251.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm251.txt
@@ -1,0 +1,5 @@
+(Izajás Éneke * Iz 62:4-7)
+62:4 Nem hívatol többé elhagyottnak, és földed nem neveztetik többé pusztának; hanem hívatni fogsz, benned telt akaratomnak, és a te földed, lakottnak; mert az Úrnak kedve telik benned, és földedet lakni fogják.
+62:5 Mert mint az ifjú lakik benned a szűzzel, úgy laknak benned fiaid; és mint a vőlegény örül menyasszonyán, úgy örül rajtad a te Istened.
+62:6 A te kőfalaidra, Jeruzsálem, őröket rendeltem; egész nap és egész éjjel soha nem hallgatnak. Kik megemlékeztek az Úrról, ne hallgassatok,
+62:7 És ne hagyjatok föl vele, mígnem megerősíti, s mígnem dicséretessé teszi Jeruzsálemet a földön.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm253.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm253.txt
@@ -1,0 +1,5 @@
+(Izajás Éneke * Iz 61:6-9)
+61:6 Ti pedig az Úr papjainak hívattok; a mi Istenünk szolgái, ezt mondják nektek; a pogányok erejét fogjátok enni, és dicsőségükben büszkélkedtek.
+61:7 A ti kettős gyalázatotokért és pirulásotokért kettős örökségnek fogtok örvendeni; bizonyára kettős részt nyertek földeteken, s örök vigasságotok leszen.
+61:8 Mert én, az Úr, szeretem az ítéletet, és gyűlölöm a ragadományt az égőáldozatban is; és munkátokat igazán megjutalmazom, és örök szövetséget kötök veletek.
+61:9 És ismerve lesz a nemzetek között ivadékotok, és csemetétek a népek között; mindnyájan, kik látják, megismerik őket, hogy ez azon ivadék, melyet megáldott az Úr.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm254.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm254.txt
@@ -1,0 +1,4 @@
+(Bölcsesség Éneke * Bölcs 3:7-9)
+3:7 Fényleni fognak az igazak, és mint a szikrák a nádasban ide s tova futkosnak.
+3:8 Ítélni fogják a nemzeteket, és uralkodnak a népeken, és az ő Uruk országlani fog mindörökké.
+3:9 Akik őbenne bíznak, megértik az igazságot, és a hívek szeretetben engedelmeskednek neki; mert ajándék és béke jut az ő választottainak.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm255.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm255.txt
@@ -1,0 +1,6 @@
+(Bölcsesség Éneke * Bölcs 10:17-21)
+10:17 És az igazak munkáinak megadta jutalmát, és csodálatos utakon hordozta őket, és nekik árnyékul volt nappal, és éjszaka csillagok világául;
+10:18 Átvitte őket a Vörös-tengeren, és átköltöztette az igen nagy vízen.
+10:19 Ellenségeiket pedig a tengerbe merítette, és őket kihozta az örvények mélységéből. Azért az igazak elvitték az istentelenek ragadományait,
+10:20 És megénekelték, Uram, a te szent nevedet, és a te győzedelmes kezedet egyhangúlag dicsérték;
+10:21 Mert a bölcsesség megnyitotta a némák száját, és a gyermekek nyelvét ékesszólókká tette.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm256.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm256.txt
@@ -1,0 +1,5 @@
+(Jézus,_Sirák_fia Éneke * Sir 14:22;15:3-4;15:6)
+14:22 Boldog férfiú, ki a bölcsességben marad, és ki az igazságról magára nézve elmélkedik, és a mindentlátó Istenről elméjében gondolkodik.
+15:3 Élteti őt az élet és értelem kenyerével, és az üdvös bölcsesség vizével itatja őt, és megerősödik benne, és el nem hajol,
+15:4 És megtartja őt, és nem szégyenül meg, és fölmagasztalja őt felebarátainál,
+15:6 Vigasságot és örvendezést halmoz rája, és örök nevet ad neki örökségül.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm257.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm257.txt
@@ -1,0 +1,3 @@
+(Jeremiás Éneke * Jer 17:7-8)
+17:7 Áldott ember, ki az Úrban bízik, és kinek bizalma az Úr.
+17:8 Leszen ő, mint a víz mellé ültetett fa, mely nedvességre ereszti gyökereit; és nem fél, midőn eljő a hőség, és levele zöldelleni fog, és szárazság idején nem lesz aggodalma, és soha nem szűnik meg gyümölcsöt teremni.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm258.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm258.txt
@@ -1,0 +1,5 @@
+(Jézus,_Sirák_fia Éneke * Sir 31:8-11)
+31:8 Boldog a gazdag, ki hiba nélkül találtatott, és ki az arany után nem járt, és nem bízott a pénzben és kincsekben.
+31:9 Kicsoda ez? És dicsérni fogjuk őt, mert csoda dolgokat cselekedett életében.
+31:10 Ki megpróbáltatott abban, és tökéletes maradt, örök dicsősége leszen; ki vétkezhetett, és nem vétkezett; gonoszat cselekedhetett, és nem cselekedett;
+31:11 Azért biztosítvák javai az Úrban, és alamizsnáit beszéli a szentek egész gyülekezete.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm259.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm259.txt
@@ -1,0 +1,7 @@
+(Bölcsesség Éneke * Bölcs 3:1-6)
+3:1 Az igazak lelkei pedig az Isten kezében vannak, és a halál gyötrelme nem éri őket.
+3:2 Az esztelenek szemeiben meghalni látszanak, és kimúlásuk gyötrelemnek tartatik,
+3:3 És tőlünk való elmenetelük veszedelemnek; ők pedig békességben vannak.
+3:4 És ha az emberek előtt kínokat szenvedtek is, az ő reményük halhatatlansággal teljes.
+3:5 Kevésben gyötörtetve, sokban jól helyeztetnek el; mert az Isten megkísértette őket, és magához méltóknak találta.
+3:6 Mint aranyat a kemencében, megpróbálta őket, és mint az égőáldozatot, úgy fogadja őket, és annak idején tekintet leszen rájuk.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm26.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm26.txt
@@ -1,0 +1,20 @@
+26:1 Az Úr világosságom és szabadulásom, * kitől féljek?
+26:1 Az Úr életem oltalmazója, * kitől remegjek?
+26:2 Midőn ellenem közelednek a gonoszok, * hogy egyék húsomat,
+26:2 Ellenségeim, kik engem szorongatnak, * maguk meggyengülnek és elesnek.
+26:3 Ha tábor áll ellenem, * nem fél szívem.
+26:3 Ha harc támad ellenem, * én akkor is bízom.
+26:4 Egyet kértem az Úrtól, ismét azért esdeklek, * hogy az Úr házában lakjam életem teljes napjaiban;
+26:4 Hogy lássam az Úr gyönyörűségét, * és látogassam az ő templomát.
+26:5 Mert elrejtett engem az ő hajlékában, * a veszedelem napján megoltalmazott engem hajléka rejtekében,
+26:6 Kősziklára emelt föl engem. * És most fölemelte fejemet ellenségeim fölé.
+26:6 Körüljártam, és örömáldozatot áldoztam az ő hajlékában; * énekelni fogok és dicséretet mondok az Úrnak.
+26:7 Hallgasd meg, Uram, szómat, mellyel hozzád kiáltottam; * könyörülj rajtam és hallgass meg engem.
+26:8 Neked szólott szívem, az én orcám téged keresett; * a te orcádat keresem, Uram!
+26:9 Ne fordítsd el tőlem orcádat; * ne térj el szolgádtól haragodban.
+26:9 Légy segítőm; * ne hagyj el engem, és ne vess meg engem, én üdvözítő Istenem!
+26:10 Mert atyám és anyám elhagytak engem: * az Úr pedig fölvesz engem.
+26:11 Törvényt adj nekem, Uram, a te utadra; * és igazíts engem igaz ösvényre elleneim miatt.
+26:12 Ne adj engem szorongatóim akaratának: * mert hamis tanúk támadtak ellenem, és a gonoszság önmaga ellen hazudott.
+26:13 Hiszem, hogy meglátom az Úr javait * az élők földén.
+26:14 Várjad az Urat, cselekedjél férfiasan; * szíved legyen erős, és remélj az Úrban.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm260.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm260.txt
@@ -1,0 +1,9 @@
+(Tóbiás Éneke * Tób 13:10-17)
+13:10 Áldjátok az Urat, minden ő választottjai, legyenek örvendetes napjaitok, és adjatok hálát neki.
+13:11 Isten városa, Jeruzsálem, megfenyített téged az Úr a te kezeid cselekedeteiért.
+13:12 Adj hálát az Úrnak javaidért, és áldjad az örökkévaló Istent, hogy ismét benned építse föl hajlékát, és visszahívja hozzád mind a foglyokat, és örülj mindörökkön-örökké.
+13:13 Fényes világossággal fogsz tündökleni, és a föld minden határai hódolnak neked.
+13:14 A nemzetek messziről jőnek hozzád, és ajándékokat hozván, imádni fogják benned az Urat, és földedet szentnek tartják;
+13:15 Mert a nagy nevet fogják segítségül hívni benned.
+13:16 Átkozottak lesznek, akik megvetnek téged, és elkárhoznak mind, akik káromolnak; és áldottak lesznek, akik téged építenek.
+13:17 Te pedig örvendeni fogsz fiaidban, mert mindnyájan megáldatnak, és az Úrhoz gyülekeznek.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm261.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm261.txt
@@ -1,0 +1,3 @@
+(Izajás Éneke * Iz 2:2-3)
+2:2 És az utolsó napokban az Úr házának hegye a hegyek tetején fog állani, és fölemelkedik a halmok fölött, és ahhoz gyűlnek minden nemzetek.
+2:3 És elmegyen sok nép, és azt mondja: Jertek, menjünk föl az Úr hegyére, és Jákob Istene házához, s ő megtanít minket utaira, és ösvényein fogunk járni; mert Sionból megyen ki a törvény, és az Úr igéje Jeruzsálemből.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm262.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm262.txt
@@ -1,0 +1,7 @@
+(Jeremiás Éneke * Jer 7:2-7)
+7:2 Állj az Úr háza kapujában, és hirdesd ott ez igét, és mondjad: Halljátok az Úr igéjét, egész Júda, kik bementek e kapukon, hogy imádjátok az Urat.
+7:3 Ezeket mondja a seregek Ura, Izrael Istene: Jobbítsátok meg utaitokat és törekvéseteket, és veletek lakom e helyen.
+7:4 Ne bízzatok a hazugság igéiben, mondván: Az Úr temploma, az Úr temploma, az Úr temploma ez!
+7:5 Mert ha jóra irányozzátok utaitokat és törekvéseteket, ha ítéletet tesztek a férfiú és atyjafia között,
+7:6 A jövevényen és árván és özvegyen nem tesztek törvénytelenséget, sem ártatlan vért nem ontotok e helyen, és nem jártok idegen istenek után a magatok veszedelmére:
+7:7 Veletek lakom e helyen, a földön, melyet atyáitoknak adtam mindörökkön-örökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm263.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm263.txt
@@ -1,0 +1,7 @@
+(Izajás Éneke * Iz 9:2-7)
+9:2 A nép, mely sötétségben jár vala, nagy világosságot láta, a halálárnyék tartományában lakóknak világosság támada.
+9:3 Sokasítottad a népet, de nem gyarapítád örömét; hanem vigadni fognak előtted, mint a kik vigadnak aratáskor, mint örvendenek a győzedelmesek a nyert zsákmánynak, midőn osztják a ragadományokat.
+9:4 Mert az ő terhe igáját, és válla vesszejét, és zsarnoka fejedelmi pálcáját összetöréd, mint Mádián napján.
+9:5 Mert minden erőszakos és zenebonával járó prédálás, és a vérbe kevert ruházat égetésre lesz a tűznek eleségül.
+9:6 Mert kisded született nekünk, és fiú adatott nekünk, kinek vállán vagyon a fejedelemség; és hívatik az ő neve csodálatosnak, tanácsadónak, Istennek, erősnek, a jövendőség atyjának, békesség fejedelmének.
+9:7 Gyarapodni fog birodalma, és a békességnek nem lesz vége; Dávid királyi székén és az ő országában ül, hogy megerősítse azt és megszilárdítsa az ítélet és igazság által mostantól és mindörökké. A seregek Urának buzgósága míveli ezt.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm264.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm264.txt
@@ -1,0 +1,13 @@
+(Izajás Éneke * Iz 26:1-12)
+26:1 A mi erősségünk városa Sion, a szabadító, kőfalul helyeztetik abban és bástyául.
+26:2 Nyissátok meg a kapukat, és menjen be az igaz nép, az igazság megőrzője.
+26:3 A régi tévelygés elmúlt; megtartod a békességet, a békességet, mert tebenned bíztunk.
+26:4 Bíztatok az Úrban örök időktől, és az erős Úr Istenben mindörökké.
+26:5 Mert meghajtja a magasban lakókat; a magas várost megalázza, megalázza azt földig, levonja mind a porig.
+26:6 Letapodja azt a láb, a szegény lábai, a szűkölködők lépései.
+26:7 Az igaz ösvénye egyenes, egyenes járású az igaz útja.
+26:8 A te ítéleteid ösvényén várunk téged, Uram, a te neved és emlékezeted a lélek kívánsága;
+26:9 Az én lelkem kíván téged éjjel, de szellememmel is belsőmben már reggel hozzád ébredek; mert midőn végrehajtod ítéleteidet a földön, igazságot tanulnak a föld kerekségének lakói.
+26:10 Ha könyörülünk az istentelenen, nem tanul igazságot; a szentek földjén gonosz dolgokat cselekszik, és nem fogja látni az Úr dicsőségét.
+26:11 Uram, fölemelve a te kezed, és nem látják; lássák, és szégyenüljenek meg a nép irigyei, és tűz eméssze meg ellenségeidet.
+26:12 Uram, te békességet adsz nekünk, mert minden dolgunkat megcselekszed helyettünk.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm265.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm265.txt
@@ -1,0 +1,8 @@
+(Izajás Éneke * Iz 66:10-16)
+66:10 Vigadjatok Jeruzsálemmel, és örvendezzetek benne mindnyájan, kik őt szeretitek; örüljetek vele örömmel mindnyájan, kik rajta bánkódtok,
+66:11 Hogy szopjatok és beteljetek az ő vigasztalása emlőjétől; hogy fejjetek, és gyönyörűséggel bővelkedjetek az ő mindennemű dicsőségével.
+66:12 Mert ezeket mondja az Úr: Íme én rája térítem a békességet, mint a folyóvizet, és mint megáradt patakot a pogányok dicsőségét; és szopni fogtok és ölben hordoztatni, és térdeken hízelkednek nektek.
+66:13 Mint kinek anyja hízeleg, úgy vigasztallak én titeket és Jeruzsálemben megvigasztaltattok.
+66:14 Meglátjátok, és örülni fog szívetek, és csontjaitok mint a fű megifjodnak, és megismertetik az Úr keze az ő szolgáin, és haragja ellenségein.
+66:15 Mert íme az Úr tűzben jő el, és mint forgószél az ő szekerei, hogy megfizessen haragja búsulásában, és dorgáljon a tűz lángjában.
+66:16 Mert az Úr tűz által fog ítélni, és az ő fegyverével minden testet, és sokan lesznek az Úrtól megöltek.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm266.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm266.txt
@@ -1,0 +1,10 @@
+(Izajás Éneke * Iz 33:2-10)
+33:2 Uram, könyörülj rajtunk, mert téged várunk; légy a mi karunk reggel, és szabadulásunk a szorongatás idején.
+33:3 Az angyal szava elől futnak a népek, és midőn te fölemelkedel, elszélednek a nemzetek.
+33:4 És egybegyűjtetnek ragadományaitok, mint összeszedetik a cserebogár, mint midőn eltelnek a vermek azzal.
+33:5 Fölséges az Úr, mert a magasságban lakik; betölti Siont ítélettel és igazsággal.
+33:6 És hit leszen a te idődben, az üdvösség gazdagságai, a bölcsesség és tudomány; az Úr félelme, az az ő kincse.
+33:7 Íme a látók kiáltanak ott kinn, a békesség angyalai keservesen sírnak.
+33:8 Elpusztultak az utak, megszűnt a járókelő az ösvényen; fölbontatott a szövetség, megvetette a városokat, semminek tartotta az embereket.
+33:9 Sír és elhervad a föld; megszégyenülten áll a Libanon és megrútulva, és Sáron olyan lett, mint a puszta, és összerontatott Básán és Kármel.
+33:10 Majd fölkelek, úgymond az Úr; majd megdicsőíttetem, majd fölmagasztaltatom.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm267.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm267.txt
@@ -1,0 +1,7 @@
+(Izajás Éneke * Iz 33:13-18)
+33:13 Halljátok, kik távol vagytok, amiket cselekedtem, és ismerjétek meg, szomszédok, az én erősségemet.
+33:14 Megrettennek Sionban a bűnösök, reszketés fogja el a képmutatókat: Ki lakhatik közületek az emésztő tűzzel? Ki lakik közületek az örök égéssel?
+33:15 Aki igazságban jár, és igazat szól, ki megveti az erőszakoskodással járó fösvénységet, és leráz kezéről minden ajándékot, ki bedugja füleit, hogy vért ne halljon, és behunyja szemeit, hogy gonoszt ne lásson,
+33:16 Ez fog lakni a magasságban, kősziklák erőssége az ő védhelye; kenyere megadatik neki, és vize nem apad el.
+33:17 A királyt ékességében látják annak szemei, látják a földet messzire.
+33:18 Akkor szíved megemlékezik a félelemről. Hol vagyon az írástudó? Hol a törvény igéinek méregetője? Hol a kisdedek tanítója?

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm268.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm268.txt
@@ -1,0 +1,7 @@
+(Jézus,_Sirák_fia Éneke * Sir 36:14-19)
+36:14 Könyörülj népeden, mely nevedről hívatik, és Izraelen, kit hasonlóvá tettél elsőszülöttedhez.
+36:15 Könyörülj szentélyed városán, Jeruzsálemen, a te nyugodalmad városán.
+36:16 Töltsd meg Siont a te kimondhatatlan igéiddel, és dicsőségeddel a te népedet.
+36:17 Tégy bizonyságot azokról, kik kezdettől teremtményeid, és támaszd föl a jövendöléseket, melyeket nevedben az előbbi próféták mondottak.
+36:18 Adj jutalmat a téged váróknak, hogy prófétáid igazmondóknak találtassanak; és hallgasd meg szolgáid imádságait,
+36:19 Áron áldása szerint, a te néped felől; és vezérelj minket az igazság útjára, és tudják meg mindnyájan, kik a földet lakják, hogy te vagy az örökkévalóságon átlátó Isten.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm27.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm27.txt
@@ -1,0 +1,12 @@
+27:1 Hozzád kiáltok, Uram, én Istenem, ne légy hallgatag irántam; * netalán, ha hallgatsz, hasonló legyek a sírgödörbe lemenőkhöz.
+27:2 Hallgasd meg, Uram, könyörgésem szavát, mikor imádkozom tehozzád; * mikor kezeimet fölemelem a te szent templomodhoz.
+27:3 Ne ragadj el engem együtt a bűnösökkel, * és a gonosztevőkkel ne veszíts el engem,
+27:3 Kik békességet szólanak felebarátjukkal, * szívükben pedig gonosz vagyon.
+27:4 Fizess meg nekik cselekedeteik szerint, * és találmányaik gonoszsága szerint.
+27:4 Kezeik cselekedetei szerint fizess nekik, * add vissza nekik a kölcsönt.
+27:5 Mert nem ismerték az Úr cselekedeteit, és az ő kezei munkáit; * lerontod őket, és nem építed föl őket.
+27:6 Áldott legyen az Úr, * mert meghallgatta könyörgésem szavát.
+27:7 Az Úr az én segítőm és oltalmazóm; * benne bízott szívem, és megsegíttettem.
+27:7 És testem újra virágzó lett; * és készakaratommal adok hálát neki.
+27:8 Az Úr népének erőssége, * és oltalmazója az ő fölkentje üdvének.
+27:9 Tartsd meg, Uram, a te népedet, és áldd meg örökségedet; * és igazgasd őket és magasztald fel őket mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm28.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm28.txt
@@ -1,0 +1,10 @@
+28:1 Hozzatok az Úrnak, Isten fiai, * hozzatok az Úrnak fiatal kosokat.
+28:2 Hozzatok az Úrnak dicsőséget és tiszteletet, hozzatok az Úr nevének dicsőséget; * imádjátok az Urat az ő szent tornácában.
+28:3 Az Úr szava a vizeken, a fölség Istene mennydörög; * az Úr a sok víz fölött.
+28:4 Az Úr szava erőben, * az Úr szava dicsőségben jő.
+28:5 Az Úr szava összetöri a cédrusokat; * az Úr összetöri a Libanon cédrusait;
+28:6 És szökdelteti azokat, mint a borjút, a Libanont, * mint az egyszarvúak fiát.
+28:7 Az Úr szava szétvágja a tűz lángját. * Az Úr szava megrendíti a pusztát; és az Úr megmozdítja Kádes pusztáját.
+28:9 Az Úr szava vajúdásba hozza a szarvasokat, és megritkítja a sűrűket, * és az ő templomában mindnyájan dicsőséget mondanak.
+28:10 Az Úr a vízözön felett uralkodik, * és az Úr, mint király, örökké fog ülni.
+28:11 Az Úr erőt ad népének; * az Úr megáldja népét békességben.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm29.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm29.txt
@@ -1,0 +1,15 @@
+29:2 Magasztallak téged, Uram, mert fölemeltél engem, * és nem hagytad örülni ellenségeimet fölöttem.
+29:3 Uram, Istenem, hozzád kiáltottam, * és meggyógyítottál engem.
+29:4 Uram, kihoztad a pokolból lelkemet; * kiszabadítottál engem a sírgödörbe menők közül.
+29:5 Zengjetek az Úrnak ti, az ő szentjei, * és áldjátok az ő szentsége emlékezetét.
+29:6 Mert büntetés van bosszankodásában, * és élet az ő jóakaratában.
+29:6 Este betér a sírás, * és reggel az öröm.
+29:7 Én pedig mondtam bővelkedésemben: * Nem fogok ingani mindörökké!
+29:8 Mert, Uram, te jóvoltod szerint * erőt adtál dicsőségemnek.
+29:8 De elfordítottad tőlem orcádat, * és megháborodtam.
+29:9 Hozzád kiáltottam, Uram, * és Istenemnek könyörögtem.
+29:10 Mi haszna az én véremnek, * ha rothadásba leszállok?
+29:10 Vajon a por fog-e áldani téged, * vagy hirdetni fogja-e igazságodat?
+29:11 Hallotta az Úr, és könyörült rajtam; * az Úr segítőm lett.
+29:12 Sírásomat örömre fordítottad nekem; * elszaggattad szőrzsákomat, és körülvettél engem vigassággal,
+29:13 Hogy énekeljen neked az én dicsőségem, és ne szomoríttassam meg; * Uram, Istenem, hálát adok neked mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm3.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm3.txt
@@ -1,0 +1,8 @@
+3:2 Uram, mennyire megsokasodtak, kik engem szorongatnak. * Sokan támadnak ellenem.
+3:3 Sokan mondják lelkemnek: * Nincs neki szabadulása az ő Istenében.
+3:4 Te pedig, Uram, az én oltalmazóm vagy; * az én dicsőségem, ki fölemeled fejemet.
+3:5 Szómmal az Úrhoz kiáltottam; * és meghallgatott engem az ő szent hegyéről.
+3:6 Én szenderegtem, és mély álomban voltam, * és fölkeltem; mert az Úr megtartott engem.
+3:7 Nem félek az engem környező nép ezreitől; * kelj föl, Uram, szabadíts meg engem, én Istenem!
+3:8 Mert te verted meg mind, kik ok nélkül ellenkeztek velem; * a bűnösök fogait összetörted.
+3:9 Az Úré a szabadítás, * és népeden a te áldásod.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm30.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm30.txt
@@ -1,0 +1,31 @@
+30:2 Tebenned bízom, Uram, ne szégyenüljek meg mindörökké; * a te igazságod szerint szabadíts meg engem.
+30:3 Hajtsd hozzám füledet, * siess, hogy kiragadj engem.
+30:3 Légy nekem oltalmazó Istenem és menedékházam, * hogy megszabadíts engem.
+30:4 Mert erősségem és oltalmam vagy te; * és a te nevedért vezérleni és táplálni fogsz engem;
+30:5 Kiveszel engem a tőrből, melyet elrejtettek nekem; * mert te vagy oltalmazóm.
+30:6 Kezeidbe ajánlom lelkemet; * megváltottál engem Uram, igazságnak Istene!
+30:7 Gyűlölöd a hiúság hiábavaló * követőit;
+30:7 Én pedig az Úrban bíztam. * Örvendezek és vigadok a te irgalmasságodban;
+30:8 Mert megtekintetted lealáztatásomat, * kiszabadítottad lelkemet a szükségből.
+30:9 És nem rekesztettél engem az ellenség kezeibe, * tágas helyre állítottad lábaimat.
+30:10 Könyörülj rajtam, Uram, mert szorongattatom; * megzavarodott a búsulásban szemem, lelkem és testem.
+30:11 Mert elfogyatkozott életem a fájdalomban, * és esztendeim a fohászkodásokban.
+30:11 Erőm az ínségben elgyengült, * és csontjaim megrendültek.
+30:12 Minden ellenségem fölött nagy gyalázatává lettem szomszédaimnak, * és félelmévé ismerőimnek.
+30:12 Akik láttak engem künn, futottak tőlem. * Feledésbe mentem a szívben, mint a megholt;
+30:13 Olyanná lettem, mint az összetört edény; * mert sok körüllakó szidalmazását hallottam;
+30:14 Midőn egybegyűlve ellenem tanácskoztak, * hogy elvegyék életemet.
+30:15 Én pedig tebenned bíztam, Uram, * s mondtam: Te vagy az én Istenem! Kezeidben az én sorsom.
+30:16 Ments meg engem ellenségeim kezéből * és üldözőimtől.
+30:17 Világítson orcád a te szolgádra, szabadíts meg engem irgalmad által. * Uram, ne szégyenüljek meg, mert segítségül hívtalak téged.
+30:18 Szégyenüljenek meg az istentelenek, és vitessenek pokolba; * némuljanak meg a csalárd ajkak,
+30:19 Melyek az igaz ellen hamisságot szólanak * kevélységgel és megvetéssel.
+30:20 Mily nagy, Uram, a te édességed sokasága, * melyet fönntartottál a téged félőknek;
+30:20 Melyet megadsz azoknak, kik benned bíznak * az emberek fiainak színe előtt.
+30:21 Elrejted őket orcád rejtekében * az emberek háborgatása elől.
+30:21 Megoltalmazod őket hajlékodban * a nyelvek ellenmondásától.
+30:22 Áldott legyen az Úr: * mert csodálatossá tette irgalmasságát irántam az erős városban.
+30:23 Én ugyan mondtam elmém elragadtatásában: * Elvettettem szemeid elől.
+30:23 Azonban te meghallgattad imádságom szavát, * midőn hozzád kiáltottam.
+30:24 Szeressétek az Urat, minden szentjei, * mert igazságot keres az Úr, és bőségesen megfizet a kevélyen cselekvőknek.
+30:25 Cselekedjetek férfiasan, és erősítsétek meg szíveteket * mindnyájan, kik az Úrban bíztok.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm31.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm31.txt
@@ -1,0 +1,14 @@
+31:1 Boldogok, kiknek megbocsáttattak gonoszságaik, * és kiknek bűneik elfödöztettek.
+31:2 Boldog a férfiú, kinek az Úr nem számítja be a bűnt, * és kinek lelkében nincs álnokság.
+31:3 Mivel hallgattam, megavultak csontjaim * egész napi kiáltásomban.
+31:4 Mert éjjel és nappal megnehezedett rajtam kezed; * megtértem nyomorúságomban, midőn a tövis szurdalt.
+31:5 Vétkemet megvallottam neked; * és hamisságomat nem titkoltam el.
+31:5 Mondtam: Megvallom magam ellen hamisságomat az Úrnak; * és te megbocsátottad bűnöm istentelenségét.
+31:6 Ezért könyörögjön neked minden szent * alkalmas időben;
+31:6 És a nagy vizek áradása * nem fog hozzá közeledni.
+31:7 Te vagy menedékem a szorongatástól, mely körülvett engem; * te, én örvendezésem, ragadj ki az engem környezőktől.
+31:8 Értelmet adok neked és megtanítlak téged az útra, melyen járj; * és rajtad lesznek szemeim.
+31:9 Ne legyetek mint a ló és az öszvér, * melyeknek nincs értelmük.
+31:9 Fékkel és zabolával szorítsd meg azok állát, * kik hozzád nem közelednek.
+31:10 Sok a bűnös ostora; * de az Úrban bízót irgalom veszi körül.
+31:11 Vigadjatok az Úrban és örvendjetek, igazak, * és dicsekedjetek mindnyájan, egyenes szívűek!

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm32.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm32.txt
@@ -1,0 +1,22 @@
+32:1 Örvendjetek igazak az Úrban, * jámborokhoz illik a dicséret.
+32:2 Dicsérjétek az Urat citerával; * zengjetek neki tízhúrú hárfákon.
+32:3 Énekeljetek neki új éneket; * jól énekeljetek neki örömkiáltással.
+32:4 Mert az Úr igéje igaz, * és minden cselekedete hűség.
+32:5 Szereti az irgalmasságot és ítéletet; * az Úr irgalmával tele a föld.
+32:6 Az Úr igéje által erősíttettek meg az egek; * és szája lélegzete által azok minden ereje.
+32:7 Mintegy tömlőbe összegyűjti a tenger vizeit; * tárakba teszi a vízmélységeket.
+32:8 Félje az Urat az egész föld; * sőt remegjen tőle e világ minden lakója.
+32:9 Mert ő szólt, és lettek; * ő parancsolt, és létrejöttek.
+32:10 Az Úr fölforgatja a pogányok tanácsait, * elveti a népek gondolatait, és elveti a fejedelmek tanácsait.
+32:11 Az Úr tanácsa pedig örökké megmarad; * az ő szíve gondolatai nemzedékről nemzedékre.
+32:12 Boldog nemzet, melynek Istene az Úr; * a nép, melyet magának örökségül választott.
+32:13 A mennyből letekint az Úr; * és látja mind az emberek fiait.
+32:14 Elkészített lakhelyéből * letekint mindazokra, kik a földet lakják.
+32:15 Ő, ki egyenként alkotta azok szíveit, * és ki átlátja minden cselekedetüket.
+32:16 Nem szabadul meg a király nagy erő által, * és az óriás nem szabadul meg ereje nagyságában.
+32:17 Csalárd a ló a szabadításra; * ereje bőségében sem ment meg.
+32:18 Íme az Úr szemei az őt félőkön; * és azokon, kik az ő irgalmában bíznak,
+32:19 Hogy a haláltól megmentse lelkeiket, * és táplálja őket az éhségben.
+32:20 A mi lelkünk az Urat várja; * mert ő segítőnk és oltalmazónk.
+32:21 Mert szívünk benne örvend, * és az ő szent nevében bízunk.
+32:22 Legyen rajtunk, Uram, a te irgalmad, * amint tebenned bízunk.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm33.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm33.txt
@@ -1,0 +1,22 @@
+33:2 Áldom az Urat minden időben; * az ő dicsérete számban lesz mindenkoron.
+33:3 Az Úrban dicsekedik az én lelkem; * hallják meg ezt a szelídek, és vigadjanak.
+33:4 Magasztaljátok az Urat velem; * és dicsőítsük az ő nevét egyetemben.
+33:5 Kerestem az Urat, és meghallgatott engem, * és minden szorongásomból megmentett engem.
+33:6 Járuljatok hozzája és megvilágosodtok, * és orcátok nem szégyenül meg.
+33:7 Ez a szegény kiáltott, és az Úr meghallgatta őt, * és minden szorongásából kiszabadította őt.
+33:8 Az Úr angyala az őt félők körül lakozik, * és megmenti őket.
+33:9 Ízleljétek és lássátok, mily édes az Úr; * boldog ember, ki őbenne bízik.
+33:10 Féljétek az Urat, minden szentjei, * mert nincs fogyatkozásuk az őt félőknek.
+33:11 A gazdagok szűkölködtek és éheztek; * de kik az Urat keresik, semmi jóban meg nem fogyatkoznak.
+33:12 Jöjjetek, fiaim, halljatok engem, * az Úr félelmére tanítlak titeket.
+33:13 Ki az az ember, ki életet óhajt, * és jó napokat szeret látni?
+33:14 Tiltsd el nyelvedet a gonosztól, * és ajkaid ne szóljanak csalárdságot.
+33:15 Távozzál a gonosztól, és cselekedjél jót; * keresd a békét és kövesd azt.
+33:16 Az Úr szemei az igazakon, * és fülei azok könyörgésein.
+33:17 Az Úr orcája pedig a gonosztevőkön van, * hogy elveszítse a földről azok emlékezetét.
+33:18 Az igazak kiáltottak, és az Úr meghallgatta őket, * és minden szorongásukból kiszabadította őket.
+33:19 Közel van az Úr azokhoz, kik töredelmes szívűek, * és az alázatos lelkűeket megsegíti.
+33:20 Sok az igazak szorongása, * de mindazokból kiszabadítja őket az Úr.
+33:21 Az Úr megőrzi minden csontjukat, * egy sem törik el azok közül.
+33:22 A bűnösök halála igen gonosz; * és kik gyűlölik az igazat, vétkeznek.
+33:23 Az Úr megváltja szolgái lelkeit; * és mindazok, kik benne bíznak, nem vétkeznek.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm34.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm34.txt
@@ -1,0 +1,32 @@
+34:1 Ítéld meg, Uram, a nekem ártókat, * győzd meg az ellenem harcolókat.
+34:2 Ragadj fegyvert és pajzsot; * és kelj föl segítségemre.
+34:3 Vond ki a kardod, és rekeszd el azokat, kik engem üldöznek; * mondjad lelkemnek: Én vagyok a te szabadulásod.
+34:4 Szégyenüljenek és piruljanak meg, * kik lelkemet keresik.
+34:4 Térjenek hátra és szégyenüljenek meg, * kik nekem rosszakat gondolnak;
+34:5 Legyenek, mint a por a szél előtt; * és az Úr angyala szorongassa őket.
+34:6 Útjuk legyen sötét és sikamlós; * és az Úr angyala üldözze őket.
+34:7 Mert ok nélkül rejtették el nekem tőrük veszedelmét, * ok nélkül pirongatták lelkemet.
+34:8 Jöjjön rá a tőr, melyet nem vesz észre, és a háló, melyet elrejtett, fogja meg őt; * és ugyanazon tőrbe essék.
+34:9 Az én lelkem pedig örvendeni fog az Úrban, * és gyönyörködni szabadításában.
+34:10 Minden csontom mondani fogja: * Uram, ki hasonló hozzád?
+34:10 Ki megszabadítod a szegényt a nálánál erősebbek kezéből, * a szűkölködőt és szegényt az őt kirablóktól.
+34:11 Hamis tanúk támadván, * kérdeztek, miről mit sem tudtam.
+34:12 Jóért rosszal fizettek nekem, * elhagyatottsággal lelkemnek.
+34:13 Én pedig, midőn engem bántottak, * szőrzsákba öltöztem.
+34:13 Böjttel aláztam meg lelkemet; * és imádságom keblembe visszatért.
+34:14 Mint felebarátunknak és mint atyánkfiának, úgy kedveskedtem nekik; * mint gyászoló és megszomorodott, úgy megalázódtam.
+34:15 És ők vigadtak ellenem, és egybegyűltek; * összegyűjtettek rám az ostorok, s én nem tudtam.
+34:16 Elszéledtek, de nem bánkódtak, kísértettek engem, csúfolással csúfoltak engem, * és csikorgatták rám fogaikat.
+34:17 Uram, mikor tekintesz meg? * Szabadítsd ki lelkemet az ő gonoszságukból, az oroszlánok közül egyetlenemet.
+34:18 Hálát adok neked a nagy gyülekezetben, * a sok nép között dicsérni foglak téged.
+34:19 Ne örüljenek rajtam, kik igaztalanul ellenkeznek velem; * kik ok nélkül gyűlölnek engem, és hunyorgatnak szemeikkel.
+34:20 Mert habár nekem békességesen szóltak is, * de a föld haragjában szólván, álnokságot gondoltak.
+34:21 És föltátották rám szájukat * és mondák: Ehe, ehe, látták szemeink.
+34:22 Láttál, Uram, ne hallgass; * Uram, ne távozzál el tőlem.
+34:23 Kelj föl, és figyelj ítéletemre, * én Istenem és Uram, az én ügyemre.
+34:24 Ítélj meg engem igazságod szerint, én Uram, Istenem, * hogy ne örüljenek rajtam.
+34:25 Hogy ne mondják szíveikben: Öröm, öröm a mi lelkünknek! * S ne mondják: Elnyeltük őt!
+34:26 Piruljanak és szégyenüljenek meg mindnyájan, * kik az én bajaimon örvendenek.
+34:26 Gyalázattal és szégyennel boríttassanak be, * kik kevélyen szólnak ellenem.
+34:27 Örvendezzenek és vigadjanak, kik az én igazságomat kedvelik; * és mondják mindenkor: Magasztaltassék az Úr, kik az ő szolgája békességét szeretik.
+34:28 És nyelvem hirdetni fogja igazságodat, * egész nap a te dicséretedet.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm35.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm35.txt
@@ -1,0 +1,13 @@
+35:2 Mondá az igaztalan önmagában, hogy vétkezzék: * Nincs az Isten félelme az ő szemei előtt.
+35:3 Mert álnokul cselekszik az ő színe előtt; * nehogy gonoszsága föltaláltassék és gyűlöltessék.
+35:4 Az ő szája igéi gonoszság és álnokság; * nem akar érteni, hogy jól cselekedjék.
+35:5 Hamisságot gondol ágyában; * megáll minden nem jó úton, a gonoszságot pedig nem gyűlöli.
+35:6 Uram, a te irgalmasságod az égig ér, * és igaz voltod a felhőkig.
+35:7 A te igazságod, mint az Isten hegyei; * ítéleteid nagy mélység;
+35:7 Az embereket és barmokat megtartod, Uram. * Mily sokféle a te irgalmasságod, Istenem!
+35:8 Azért az emberek fiai * szárnyaid árnyékában bíznak.
+35:9 Megrészegülnek a te házad bőségétől; * és gyönyörűséged patakjából itatod őket.
+35:10 Mert nálad vagyon az élet kútfeje; * és a te világosságoddal látunk világosságot.
+35:11 Terjeszd ki irgalmadat a téged ismerőkre, * és igazságodat azokra, kik igaz szívvel vannak.
+35:12 Ne jöjjön rám a kevélység lába; * és a bűnös keze ne mozdítson meg engem.
+35:13 Ott esnek el, kik gonoszságot cselekesznek; * kiűzetnek és meg nem állhatnak.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm36.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm36.txt
@@ -1,0 +1,42 @@
+36:1 Ne bosszankodjál a gonosztevőkre, * ne irigykedjél a hamisságot cselekvőkre.
+36:2 Mert mint a fű, hamar elszáradnak, * és mint a zöld paréj, hamar elhullnak.
+36:3 Bízzál az Úrban, és cselekedjél jót; * lakjál a földön, és annak gazdagságaival tápláltatni fogsz.
+36:4 Gyönyörködjél az Úrban, * és megadja neked szíved kívánságait.
+36:5 Nyilatkoztasd ki az Úrnak utadat, és bízzál benne: * és ő megcselekszi.
+36:6 És világosságra hozza igazságodat, és ítéletedet déli fényre. * Hódolj az Úrnak, és könyörögj neki.
+36:7 Ne bosszankodjál arra, ki szerencsés az ő útjában, * a gonoszt cselekvő emberre.
+36:8 Szűnj meg a haragtól, és hagyd el a búsulást; * ne bosszankodjál, hogy rosszat is cselekedjél.
+36:9 Mert akik gonoszt cselekszenek, kiirtatnak; * akik pedig az Urat várják, azok fogják a földet örökleni.
+36:10 Még egy kissé, és nem lesz a bűnös; * keresed helyét, és nem találod.
+36:11 A szelídek pedig örökleni fogják a földet, * és gyönyörködnek a béke sokaságában.
+36:12 Az igazra vigyáz a bűnös, * és fogait csikorgatja rája.
+36:13 Az Úr pedig kineveti őt, * mert látja, hogy eljő napja.
+36:14 Kardot húznak a bűnösök, * megvonják kézívüket,
+36:14 Hogy elejtsék a szegényt és szűkölködőt, * hogy megöljék az igaz szívűeket.
+36:15 De fegyverük hasson szívükbe, * és kézívük töressék el.
+36:16 Jobb az igaznak a kevés * a bűnösök sok gazdagságánál.
+36:17 Mert a bűnösök karjai eltöretnek; * az igazakat pedig megerősíti az Úr.
+36:18 Az Úr ismeri az ártatlanok napjait; * és örökségük megmarad mindörökké.
+36:19 Nem szégyenülnek meg a gonosz időben, és az éhség napján megelégíttetnek; * mert a bűnösök elvesznek.
+36:20 És az Úr ellenségei mihelyt megtiszteltetnek és fölmagasztaltatnak, * elfogyván, mint a füst, elfogynak.
+36:21 Kölcsön vesz a bűnös, és nem fizeti meg; * az igaz pedig könyörül és adakozik.
+36:22 Mert az őt áldók a földet örökleni fogják; * az őt átkozók pedig elvesznek.
+36:23 Az Úrtól igazgattatnak az ember lépései, * és útját kedveli.
+36:24 Mikor elesik, nem sérül meg, * mert az Úr alája teszi kezét.
+36:25 Ifjú voltam és megöregedtem: * de nem láttam, hogy az igaz elhagyatott, sem hogy az ő ivadéka kenyeret kéregetett volna.
+36:26 Napestig könyörül és kölcsön ad; * és ivadéka áldásban leszen.
+36:27 Távozzál a gonosztól, és cselekedjél jót, * és megmaradsz örökkön-örökké.
+36:28 Mert az Úr szereti az igazat, és nem hagyja el az ő szentjeit, * mindörökké megtartatnak;
+36:28 Az igazságtalanok megbüntettetnek, * és az istentelenek ivadéka elvész.
+36:29 Az igazak pedig örökleni fogják a földet, * és azon laknak mindörökkön-örökké.
+36:30 Az igaz szája bölcsességet szól, * és nyelve igazat beszél.
+36:31 Istene törvénye az ő szívében, * és lépései nem fognak megtántoríttatni.
+36:32 A bűnös szemléli az igazat, * és halálra keresi őt;
+36:33 De az Úr nem hagyja őt annak kezeiben, * sem nem kárhoztatja őt, mikor amattól megítéltetik.
+36:34 Várjad az Urat és őrizd meg az ő útját, és fölmagasztal téged, hogy örökségül vedd a földet; * látni fogod, mikor elvesznek a bűnösök.
+36:35 Láttam az istentelent fölmagasztalva * és fölemelkedve, mint a Libanon cédrusait.
+36:36 És átmenék, és íme nem volt; * és kerestem őt, és helye sem találtatott.
+36:37 Őrizd meg az ártatlanságot, és nézd az igazságot: * mert vannak maradékai a békességes embernek.
+36:38 Az igazságtalanok pedig mindenestül elvesznek; * az istentelenek maradékai semmivé lesznek.
+36:39 De az igazak segedelme az Úrtól vagyon, * s ő azok oltalmazója a szorongatás idején.
+36:40 És megsegíti őket az Úr és megszabadítja; * és megmenti a bűnösöktől, és megtartja őket, mert benne bíztak.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm37.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm37.txt
@@ -1,0 +1,23 @@
+37:2 Uram, ne feddj meg engem búsulásodban, * és haragodban ne dorgálj meg engem;
+37:3 Mert a te nyilaid belém szegeztettek, * és megnehezítetted rajtam kezedet.
+37:4 Nincs épség testemben a te haragod színe miatt; * nincs nyugalma csontjaimnak bűneim színe miatt.
+37:5 Mert gonoszságaim fölülhaladták fejemet; * és rám súlyos teherként nehezültek.
+37:6 Megbűzhödtek és senyvedtek sebhelyeim * az én balgatagságom miatt.
+37:7 Nyomorulttá lettem és igen meggörbíttettem; * napestig szomorkodva járok vala.
+37:8 Mert ágyékaim telvék csalatkozásokkal, * és nincs épség testemben.
+37:9 Megsanyargattattam és igen megaláztattam; * jajgaték szívem fohászkodása miatt.
+37:10 Uram, előtted van minden kívánságom, * és fohászkodásom tőled nincs elrejtve.
+37:11 Szívem megháborodott, elhagyott engem erőm; * és szemem világa sincs velem.
+37:12 Barátaim és feleim * ellenem közeledtek és állottak;
+37:12 És akik mellettem voltak, távol állának; * és erőszakot cselekvének, kik lelkemet keresték;
+37:13 És kik romlásomra törekedtek, hiúságokat szólottak, * és egész nap álnokságokról gondolkodtak.
+37:14 Én pedig, mint a siket, nem hallám, * és mint a néma, ki nem nyitja föl száját.
+37:15 És levék, mint a nem halló ember, * és kinek szájában nincsenek ellenmondások.
+37:16 Mert, Uram, tebenned bíztam; * te meghallgatsz engem, Uram, Istenem.
+37:17 Azért mondottam: Ne örüljenek valaha rajtam ellenségeim; * midőn megtántorodnak lábaim, nagyokat ne szóljanak rólam.
+37:18 Mert én az ostorokra kész vagyok, * és fájdalmam előttem van mindenkoron.
+37:19 Mert én gonoszságomat megvallom, * és bűnömről gondolkodom.
+37:20 Ellenségeim pedig élnek, és erőt vettek rajtam; * és megsokasodtak, kik gonoszul gyűlölnek engem.
+37:21 Kik jóért rosszal fizetnek, rágalmaztak engem, * mivel a jót követtem.
+37:22 Ne hagyj el engem, Uram, Istenem, * ne távozzál tőlem.
+37:23 Figyelmezz az én segítségemre, * Uram, üdvösségem Istene!

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm38.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm38.txt
@@ -1,0 +1,18 @@
+38:2 Mondám: Megőrzöm utaimat, * hogy ne vétkezzem nyelvemmel;
+38:2 Őrizet alá vetettem számat, * mikor a bűnös ellenem állott.
+38:3 Elnémultam, és megalázódtam, és hallgattam a jókról: * és fájdalmam megújult.
+38:4 Szívem fölhevült bennem, * és elmélkedésemben fölgyullad a tűz.
+38:5 Szóltam nyelvemmel: * Add tudtomra nekem, Uram, az én végemet,
+38:5 És napjaim száma mennyi, * hogy tudjam, mi híjával vagyok.
+38:6 Íme mértékre tetted napjaimat, * és az én létem előtted, mint a semmi.
+38:6 Valóban merő hiúság * minden élő ember.
+38:7 Valóban elmúlik az ember, * mint az árnykép, és hiába nyugtalankodik;
+38:7 Kincseket gyűjt, * és nem tudja, kinek gyűjti azokat.
+38:8 És most mi az én várakozásom? Nem az Úr-e? * Mert az én létem nálad vagyon.
+38:9 Minden gonoszságomból szabadíts meg engem, * ki a balgatagnak gyalázatul adtál engem.
+38:10 Elnémultam, és nem nyitottam föl számat, mert te cselekedted. * Vedd el rólam csapásaidat.
+38:12 A te kezed erőssége miatt én elfogytam a fenyíték alatt. * A gonoszságért dorgálod az embert,
+38:12 És elepeszted az ő lelkét, mint a pókot; * valóban hiába aggódik minden ember.
+38:13 Hallgasd meg, Uram, imádságomat és könyörgésemet, * vedd figyelembe könnyhullatásaimat.
+38:13 Ne némulj el, mert jövevény vagyok én nálad és zarándok, * mint atyáim mindnyájan.
+38:14 Engedj nekem, hogy megenyhüljek, mielőtt elmenjek, * és többé nem leszek.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm39.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm39.txt
@@ -1,0 +1,24 @@
+39:2 Várva vártam az Urat, * és figyelt rám,
+39:3 És meghallgatta könyörgésemet, * és kivitt engem a nyomorúság verméből, és a mély sárból;
+39:3 És kősziklára állította lábaimat, * és igazgatta lépéseimet,
+39:4 És új éneket adott számba, * a mi Istenünk dicséretét.
+39:4 Meglátják ezt sokan, és félni fognak, * és az Úrban bíznak.
+39:5 Boldog ember, kinek reménye az Úr neve, * és nem néz hiúságokra és hamis balgaságokra.
+39:6 Sokat tettél, Uram Istenem, a te csodálatos dolgaidból, * és gondolataidban nincs, ki hasonló lenne hozzád.
+39:6 Hirdettem és beszéltem azt, * de számfölött sok.
+39:7 Áldozatot és ajándékot nem akartál, * füleimet pedig elkészítetted;
+39:7 Égő- és bűnáldozatot nem kívántál. * Akkor mondám: Íme, jövök!
+39:8 A könyvben főleg felőlem van írva, hogy a te akaratodat cselekedjem: * Istenem, én akartam, és a te törvényed szívem közepette van.
+39:10 Hirdettem igazságodat a nagy gyülekezetben, * íme ajkaimat nem tartóztatom, Uram, te tudod.
+39:11 Igazságodat nem rejtettem el szívemben; * igazmondásodról és szabadításodról szólottam.
+39:11 Nem rejtettem el irgalmadat és igazmondásodat * a nagy gyülekezettől.
+39:12 Te pedig, Uram, ne vidd távol könyörületedet tőlem; * a te irgalmad és igazmondásod mindenkor fönntartottak engem.
+39:13 Mert körülvettek engem a rosszak, melyeknek száma nincs; * gonoszságaim megfogtak engem, és nem láthattam.
+39:13 Megsokasodtak fejem hajszálai fölött, * és szívem elhagyott engem.
+39:14 Tessék neked, Uram, megmenteni engem; * Uram, tekints segítésemre.
+39:15 Piruljanak és szégyenüljenek meg mind, kik lelkemet keresik, * hogy elvegyék azt.
+39:15 Térjenek hátra és szégyenüljenek meg, * kik nekem rosszat akarnak.
+39:16 Viseljék mindjárt gyalázatukat, * kik azt mondják nekem: Ehe, ehe!
+39:17 Örvendezzenek és vigadjanak tebenned mindnyájan, kik téged keresnek; * és mondják mindenkor: Magasztaltassék az Úr, kik szeretik a te szabadításodat.
+39:18 Én pedig koldus vagyok és szegény; * az Úr gondoskodik felőlem.
+39:18 Te vagy segítőm és oltalmazóm, * én Istenem, ne késsél.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm4.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm4.txt
@@ -1,0 +1,10 @@
+4:2a Midőn segítségül hívtam, meghallgatott engem az én igazságom Istenem; * a szorongásban tágítottál rajtam.
+4:2b Könyörülj rajtam, * és hallgasd meg imádságomat.
+4:3 Emberek fiai, meddig lesztek nehéz szívvel? * Miért szeretitek a hiúságot, és keresitek a hazugságot?
+4:4 Tudjátok meg, hogy az Úr csodálatossá tette az ő szentjét; * az Úr meghallgat engem, mikor hozzá kiáltok.
+4:5 Haragudván, ne vétkezzetek; ‡ amit szívetekben mondotok, * nyughelyeiteken bánjátok meg.
+4:6 Áldozzátok az igazság áldozatát, † és bízzatok az Úrban. * Sokan mondják: Ki láttat velünk jókat?
+4:7 Ránk van jegyezve, Uram, orcád világossága; * örömet adtál szívembe.
+4:8 Gabonájuk, boruk és olajuk gyümölcsével * lettek ők gazdagok.
+4:9 De emiatt békességben * alszom, és megnyugszom;
+4:10 Mert te, Uram, kiváltképpen megerősítettél engem * a reménységben.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm40.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm40.txt
@@ -1,0 +1,14 @@
+40:2 Boldog, kinek gondja van a szűkölködőre és szegényre; * a rossz napon megszabadítja őt az Úr.
+40:3 Az Úr tartsa meg és éltesse őt, és tegye boldoggá a földön, * és ne adja őt ellenei kívánságára.
+40:4 Az Úr segítse meg őt fájdalma ágyán; * az ő egész ágyát megfordítod betegségében.
+40:5 Én mondám: Uram, könyörülj rajtam; * gyógyítsd meg lelkemet, mert vétkeztem ellened.
+40:6 Ellenségeim rosszat mondottak felőlem: * Mikor hal meg, és vész el az ő neve?
+40:7 És ha bejött egy, hogy meglátogasson, hiábavalókat beszélt, * szíve gonoszságot gyűjtött magának.
+40:7 Kiment * és beszélt ugyanarról.
+40:8 Ellenem suttogott minden ellenségem; * ellenem rosszat gondoltak.
+40:9 Istentelen szót végeztek ellenem. * Vajon aki alszik, nem kel-e föl többé?
+40:10 De még az ember is, kivel békességem volt, kiben bíztam, * ki kenyeremet ette, nagy csalárdságot tett rajtam.
+40:11 Te pedig, Uram, könyörülj rajtam, és emelj föl engem, * és megfizetek nekik.
+40:12 Ebből ismerem meg, hogy kedvelsz engem, * mert ellenségem nem fog örülni rajtam.
+40:13 Engem pedig az ártatlanságért fölvettél, * és megerősítettél engem színed előtt mindörökké.
+40:14 Áldott legyen Izrael Ura Istene öröktől és mindörökké. * Úgy legyen, úgy legyen!

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm41.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm41.txt
@@ -1,0 +1,16 @@
+41:2 Amint kívánkozik a szarvas a vízforrásokhoz, * úgy kívánkozik lelkem tehozzád, Isten!
+41:3 Szomjúhozik lelkem az erős élő Istenhez; * mikor jutok el s jelenek meg az Isten színe előtt?
+41:4 Az én könnyhullatásom kenyerem nekem éjjel s nappal, * midőn naponként mondják nekem: Hol vagyon a te Istened?
+41:5 Ezekről emlékezvén, kiöntöm magamba lelkemet; * mert átmennék a csodálatos hajlék helyéhez, az Isten házáig,
+41:5 Az öröm és hála szavával, * a vígan lakozók zengésével.
+41:6 Miért vagy szomorú, én lelkem? * És miért háborgatsz engem?
+41:6 Bízzál az Istenben, mert még hálát fogok adni neki; * ő orcám szabadítója, és az én Istenem.
+41:7 Lelkem megháborodott bennem, * azért emlékezem rólad a Jordán földjéről és Hermon hegyéről, a kis hegyről.
+41:8 Az örvény az örvénynek kiált * a te felhőszakadásaid zúgásában;
+41:8 Magas hullámaid és habjaid mind * átmennek rajtam.
+41:9 Nappal hozzám parancsolta az Úr irgalmát, * és éjjel az ő énekét,
+41:9 Az én imádságomat életem Istenéhez; * mondom Istennek: Én oltalmazóm vagy,
+41:10 Miért feledkeztél el rólam? * És miért járok szomorúan, midőn engem az ellenség sanyargat?
+41:11 Midőn összetöretnek csontjaim, * szidalmaznak engem az én szorongató ellenségeim,
+41:11 Midőn naponként mondják nekem: Hol vagyon a te Istened? * Miért vagy szomorú, én lelkem? És miért háborgatsz engem?
+41:12 Bízzál az Istenben, mert még hálát fogok adni neki; * ő orcám szabadítója és az én Istenem.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm42.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm42.txt
@@ -1,0 +1,6 @@
+42:1 Ítélj meg engem, Isten, és határozd el ügyemet az istentelen nemzetség ellen, * a gonosz és álnok embertől ments meg engem;
+42:2 Mert te vagy, Isten, az én erősségem. * Miért vetettél meg engem? És miért járok szomorúan, midőn engem az ellenség sanyargat?
+42:3 Bocsásd ki világosságodat és igazságodat, * azok elvezetnek engem és elvisznek a te szent hegyedre és hajlékodba.
+42:4 És bemegyek az Isten oltárához, * az Istenhez, ki megvidámítja ifjúságomat;
+42:5 Hálát adok neked citerán, ó Isten, én Istenem! * Miért vagy szomorú, én lelkem? És miért háborgatsz engem?
+42:6 Bízzál az Istenben, mert még hálát fogok adni neki, * ő orcám szabadítója és az én Istenem.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm43.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm43.txt
@@ -1,0 +1,28 @@
+43:2 Isten, füleinkkel hallottuk, * atyáink adták hírül nekünk
+43:2 A cselekvényt, melyet cselekedtél az ő napjaikban, * a régi napokban.
+43:3 A te kezed szórta szét a nemzeteket, és átültetted őket; * megsanyargattad a népeket, és kiűzted őket.
+43:4 Mert nem kardjuk által bírták a földet, * és nem karjuk szabadította meg őket,
+43:4 Hanem a te jobbod és karod és orcád világossága, * mert kedvelted őket.
+43:5 Te magad vagy az én királyom és Istenem, * ki Jákobnak segítséget küldesz.
+43:6 Teáltalad ellenségeinket szarvakkal ide s tova hányjuk, * és a te neved által megvetjük a ránk támadókat.
+43:7 Mert nem kézíjamban bízom, * és nem kardom szabadít meg engem:
+43:8 Hanem te szabadítasz meg minket sanyargatóinktól, * és megszégyeníted, kik minket gyűlölnek.
+43:9 Az Istenben dicsekedünk egész nap, * és a te nevednek hálát adunk mindörökké.
+43:10 Most pedig elvetettél és meggyaláztál minket; * és nem jössz ki, Isten, a mi seregeinkkel.
+43:11 Hátratérítettél minket ellenségeink előtt, * és akik gyűlöltek minket, zsákmányoltak maguknak.
+43:12 Mint az ennivaló juhokat, odaadtál minket, * és a nemzetek közé szórtál minket.
+43:13 Ár nélkül adtad el népedet, * és nem volt sokaság eladatásán.
+43:14 Gyalázatra adtál minket szomszédainknak, * csúfra és nevetségre azoknak, kik köröttünk vannak.
+43:15 Közmondássá tettél minket a pogányoknál, * főcsóválásra a népek közé.
+43:16 Naponként előttem van gyalázatom, * és orcám pirulása elborít engem,
+43:17 A szidalmazó és ellenmondó szava miatt, * az ellenség és üldöző színe előtt.
+43:18 Ezek mind ránk jöttek, és mi mégsem feledtünk el téged, * és nem cselekedtünk gonoszul szövetséged ellen.
+43:19 És nem tért hátra szívünk; * és te eltérítetted ösvényeinket utadról.
+43:20 Mert megaláztál minket a nyomorgatás helyén, * és a halál árnyéka borított be minket.
+43:21 Ha elfeledkezünk a mi Istenünk nevéről, * és ha kiterjesztjük kezeinket idegen istenhez:
+43:22 Nem veszi-e számon Isten ezeket? * Miután ő tudja a szívek titkait.
+43:22 Mert éretted öldököltetünk naponként, * és úgy tartatunk, mint a megölni való juhok.
+43:23 Kelj föl, miért alszol el, Uram? * Kelj föl és ne vess el mindvégig.
+43:24 Miért fordítod el orcádat, * elfeledkezel szegénységünkről és szorongattatásunkról?
+43:25 Mert lealáztatott lelkünk a porba; * és hasunk a földhöz ragadott.
+43:26 Kelj föl, Uram, segíts meg minket, * és szabadíts meg minket a te nevedért.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm44.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm44.txt
@@ -1,0 +1,20 @@
+44:2a Az én szívem jó beszédet önt ki; * a királynak ajánlom énekemet.
+44:2b Az én nyelvem az író tolla, * ki gyorsan ír.
+44:3 Ékes alakú vagy az emberek fiai fölött, † kedvesség van elöntve ajkaidon; * azért áldott meg téged az Isten mindörökké.
+44:4 Kösd fel oldaladra kardodat, * leghatalmasabb!
+44:5a A te ékességeddel és szépségeddel * indulj meg, járj szerencsésen és országolj
+44:5b a valóságért és szelídségért és igazságért; * és jobbod csodálatosan elvezet téged.
+44:6 Nyilaid élesek, népek esnek el alattad, * a király ellenségeinek szíveibe (hatolnak).
+44:7 A te széked, Isten, mindörökkön-örökké áll; * igazság pálcája a te országod pálcája.
+44:8 Szereted az igazságot, és gyűlölöd a gonoszságot; * azért kent föl téged az Isten, a te Istened vigasság olajával társaid fölött.
+44:9 Mirha és áloé és kasszia van ruházatodban az elefántcsont-házakból, * melyekkel gyönyörködtettek téged a királyok leányai (10a) a te dicsőségedben.
+44:10b A királyné jobbod felől áll aranyos ruházatban, * körülvétetve sokszínű ékességgel.
+44:11 Halljad, leányom, és lássad, és hajtsd ide füledet; * és feledd el népedet és atyád házát.
+44:12 És a király megkívánja ékességedet; * mert ő a te Urad Istened, és imádni fogják őt.
+44:13 És Tírusz leányai, * a község minden gazdagjai ajándékokkal könyörögni fognak színed előtt.
+44:14 A király leányának minden dicsősége belül vagyon, * arannyal szegélyezett (15a) sokszínű öltözetében.
+44:15b Utána szüzek vezettetnek a királyhoz, * az ő társai hozzád vitetnek;
+44:16 bevitetnek vigassággal és örvendezéssel, * behozatnak a király templomába.
+44:17 Atyáid helyett fiak születnek neked; * fejedelmekké rendeled azokat az egész földön.
+44:18a Megemlékeznek a te nevedről * minden nemzedékről nemzedékre;
+44:18b azért a népek dicsérni fognak téged örökké * és mindörökkön-örökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm45.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm45.txt
@@ -1,0 +1,11 @@
+45:2 A mi Istenünk oltalom és erő; * segítő a szorongatásokban, melyek igen elértek minket.
+45:3 Azért nem félünk, ha a föld megrendül is, * és a hegyek a tenger szívébe vitetnek.
+45:4 Zúgjanak bár és háborogjanak az ő vizei, * rengjenek a hegyek az ő erőssége miatt:
+45:5 A folyó rohama fölvidítja az Isten városát, * megszenteli hajlékát a Fölséges.
+45:6 Isten annak közepette van, s nem fog ingani; * megsegíti őt Isten korán reggel.
+45:7 Fölháborodtak a nemzetek, és hanyatlottak az országok; * ő szózatát adta, és megrendült a föld.
+45:8 Az erők Ura mivelünk; * oltalmazónk Jákob Istene.
+45:9 Jöjjetek elő, és lássátok az Úr cselekedeteit, minő csodákat tett a földön: * megszüntetvén a hadakat a föld végéig,
+45:10 Eltöri a kézíjat, és összezúzza a fegyvereket, * és a pajzsokat megégeti tűzzel.
+45:11 Szűnjetek meg, és lássátok, hogy én vagyok az Isten; * fölmagasztaltatom a nemzetek között, és fölmagasztaltatom a földön.
+45:12 Az erők Ura mivelünk; * oltalmazónk Jákob Istene.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm46.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm46.txt
@@ -1,0 +1,9 @@
+46:2 Minden nemzetek, tapsoljatok kézzel; * örvendezzetek az Úrnak vigasság szavával.
+46:3 Mert az Úr fölséges, rettenetes; * nagy király az egész földön.
+46:4 Alánk vetette a népeket, * és a pogányokat lábaink alá;
+46:5 Közöttünk választotta örökségét, * Jákob szépségét, melyet szeret.
+46:6 Fölment az Isten örvendezéssel, * az Úr harsonaszóval.
+46:7 Énekeljetek a mi Istenünknek, énekeljetek; * énekeljetek a mi királyunknak, énekeljetek.
+46:8 Mert az egész föld királya az Isten; * énekeljetek bölcsességgel.
+46:9 Isten országol a pogányokon; * Isten az ő szent székében ül.
+46:10 A föld népeinek fejedelmei Ábrahám Istenéhez gyűlnek; * mert a föld erős istenei igen fölemelkednek.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm47.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm47.txt
@@ -1,0 +1,13 @@
+47:2 Nagy az Úr és igen dicséretes * a mi Istenünknek városában, az ő szent hegyén.
+47:3 Az egész föld örömére van alapítva Sion hegye, * északi oldalán a nagy király városa.
+47:4 Házaiban az Isten ismeretes, * mint az ő oltalmuk.
+47:5 Mert íme a föld királyai összegyűltek, * egyesültek;
+47:6 Ők azt így látván, elcsodálkoztak, zavarba jöttek, megindultak; * reszketés fogta el őket;
+47:7 Oly fájdalom, mint a szülőé, * és amily rohanó a szélvész, mely összetöri Tarzisz hajóit.
+47:9 Amint hallottuk, úgy láttuk az erők Ura városában, a mi Istenünk városában; * Isten alapította azt mindörökre.
+47:10 Megemlékezünk, Isten, a te irgalmasságodról * templomodnak közepette.
+47:11 Valamint a te neved, Isten, úgy dicséreted is a föld határáig ér; * igazsággal teljes a te jobbod.
+47:12 Vigadjon Sion hegye, és örvendezzenek Júda leányai * ítéleteid miatt, Uram!
+47:13 Kerüljétek meg Siont és szemléljétek azt körül; * számláljátok meg tornyait.
+47:14 Függesszétek szíveiteket erősségére, * vegyétek számba házait, hogy elbeszéljétek a jövő nemzedéknek:
+47:15 Mert ez az Isten, a mi Istenünk örökké és mindörökkön-örökké; * ő igazgat minket mindörökké.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm48.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm48.txt
@@ -1,0 +1,21 @@
+48:2 Halljátok ezt, minden népek, * vegyétek ezt füleitekbe mindnyájan, kik a föld kerekségén laktok,
+48:3 Mindnyájan, föld lakói és emberek fiai, * egyetemben gazdag és szegény.
+48:4 Az én szám bölcsességet szól, * és szívem elmélkedése okosságot.
+48:5 Példabeszédre hajtom fülemet; * hárfán nyilatkoztatom ki talányomat.
+48:6 Miért féljek a gonosz napon, * midőn körülvesz engem incselkedőim gonoszsága,
+48:7 Kik erejükben bíznak, * és gazdagságuk sokaságában dicsekszenek?
+48:8 Az atyafi nem vált meg, megvált-e az ember? * Nem adhat ő engesztelést az Istennek,
+48:9 Sem váltságdíjat lelkéért, * ha örökké fáradna és vég nélkül élne is.
+48:11 Nem gondol enyészetére, midőn látja, hogy a bölcsek is meghalnak, * és elvesznek úgy, mint az esztelen és értetlen,
+48:11 Kik másoknak hagyják gazdagságukat, * míg sírjaik örök házaik lesznek,
+48:12 Bár lakhelyeik nemzedékről nemzedékre állanak, * és nevet szereztek maguknak földjeiken.
+48:13 De némely ember, midőn tiszteletben van, ezt figyelembe nem veszi, * olyan, mint az oktalan állatok, és hasonló azokhoz.
+48:14 Ezen útjuk megejti őket, * s ők mégis tetszést nyernek szájukkal.
+48:15 Mint a juhok az alvilágba tereltetnek, * hol a halál megemészti őket;
+48:15 És csakhamar uralkodnak rajtuk az igazak, * és segítségük elenyészik a sírban, miután dicsőségük eltűnt.
+48:16 De az én lelkemet megszabadítja Isten a pokol kezéből, * midőn elveszen engem.
+48:17 Ne félj, mikor gazdaggá lesz az ember, * és mikor gyarapodik az ő háza dicsősége:
+48:18 Mert midőn meghal, semmit sem visz el, * sem nem száll le vele az ő dicsősége;
+48:19 Lelke ugyan áldatik életében, * hálát ad neked, mikor jót teszel vele:
+48:20 De le fog menni atyái nemzetségéhez, * és nem fog látni világosságot mindörökké.
+48:21 De némely ember, midőn tiszteletben van, ezt figyelembe nem veszi, * olyan, mint az oktalan állatok, és hasonló azokhoz.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm49.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm49.txt
@@ -1,0 +1,24 @@
+49:1 Az istenek Istene, az Úr szól, * és szólítja a földet
+49:1 Napkelettől napnyugatig * Sionból ragyog az ő szépségének képe.
+49:3 Az Isten nyilván jő, * a mi Istenünk nem hallgat.
+49:3 Tűz gyullad színe előtt, * és körötte hatalmas förgeteg.
+49:4 Előszólítja az eget onnan felülről, * és a földet, hogy népét megítélje.
+49:5 Gyűjtsétek egybe neki az ő szentjeit, * kik szövetséget kötnek vele áldozat által.
+49:6 És az egek hirdetni fogják az ő igazságát; * mert Isten a bíró.
+49:7 Halljad, én népem, és szólani fogok; Izrael, és bizonyságot teszek neked: * Isten, a te Istened vagyok én.
+49:8 Nem az áldozatok miatt feddelek téged, * mert áldozataid szemem előtt vannak mindenkoron.
+49:9 Nem veszem el házadból a borjakat, * sem nyájaidból a bakokat;
+49:10 Mert enyém az erdők minden vadja, * a barmok a hegyeken és az ökrök.
+49:11 Ismerem mind az égi madarakat, * és a mező szépsége előttem vagyon.
+49:12 Ha éhezném, nem mondanám neked; * mert enyém a föld kereksége és annak teljessége.
+49:13 Vajon a tulkok húsát eszem-e? * Vagy a bakok vérét iszom-e?
+49:14 Áldozd Istennek a dicséret áldozatát, * és add meg fogadásaidat a Fölségesnek;
+49:15 És hívj segítségül engem a szorongatás napján: * megmentelek és tisztelni fogsz engem.
+49:16 A bűnösnek pedig mondja az Isten: * Miért hirdeted te igazságaimat, és veszed szádba szövetségemet?
+49:17 Holott te gyűlölted a fegyelmet, * és hátravetetted beszédeimet.
+49:18 Ha tolvajt láttál, vele futottál, * és a házasságtörőkkel volt részed.
+49:19 Szád bővelkedett gonoszsággal, * és nyelved álnokságot koholt.
+49:20 Leülvén, atyádfia ellen szólottál, és anyád fiának botrányára voltál. * Ezeket cselekedted, s én hallgattam.
+49:21 Azt vélted gonoszul, hogy hasonló vagyok hozzád; * de én megfeddelek téged és szemed elé rakom.
+49:22 Értsétek ezt, kik az Istent elfeleditek: * nehogy egykor elragadjon, és ne legyen, ki megmentsen.
+49:23 A dicséret áldozata tisztel engem; * és ez az út, melyen megmutatom neki az Isten szabadítását.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm5.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm5.txt
@@ -1,0 +1,15 @@
+5:2 Igéimet vedd füleidbe, Uram, * értsd meg kiáltásomat.
+5:3 Figyelmezz könyörgésem szavára, * én királyom és én Istenem!
+5:4 Mert neked könyörgök; * Uram, reggel meghallgatod az én szómat.
+5:5 Reggel eléd állok, és nézek; * mert nem vagy te gonoszságkedvelő Isten.
+5:6 Sem gonosztevő nem lakik melletted, * sem a gonoszok nem maradnak meg szemeid előtt.
+5:7a Gyűlölöd mind, kik gonoszságot cselekszenek, * elveszted mind, kik hazugságot szólnak.
+5:7b A vérszopó és álnok férfit utálja az Úr. * (8a) Én pedig irgalmad sokaságában
+5:8b Bemegyek a te házadba: * imádkozom szent templomodnál a te félelmedben.
+5:9 Uram, vezérelj engem igazságodban; * ellenségeim miatt igazgasd utamat színed előtt.
+5:10 Mert nincs igazság szájukban; * hiú az ő szívük.
+5:11a Nyílt sír az ő torkuk, † nyelvüket álnokul forgatják, * ítéld meg őket, Isten!
+5:11b Essenek el szándékaiktól, † istentelenségeik sokasága szerint űzd ki őket; * mert bosszantottak, Uram, téged.
+5:12a És örüljenek mindnyájan, kik benned bíznak, * örökké vigadni fognak; és bennük fogsz lakni.
+5:12b És dicsekedni fognak benned mindnyájan, kik szeretik a te nevedet, * (13a) mert te megáldod az igazat,
+5:13b Uram, jóvoltoddal, mint pajzzsal, * környékeztél meg minket.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm50.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm50.txt
@@ -1,0 +1,20 @@
+50:3a Könyörülj rajtam, Isten, * a te nagy irgalmasságod szerint;
+50:3b És könyörületed sokasága szerint, * töröld el gonoszságomat.
+50:4 Moss meg engem mindinkább gonoszságomból, * és bűnömből tisztíts meg engem.
+50:5 Mert elismerem gonoszságomat, * és bűnöm előttem vagyon mindenkoron.
+50:6 Egyedül neked vétettem, és gonoszt előtted cselekedtem; * hogy igaznak találtassál beszédeidben, és győzedelmes légy, midőn ítéltetel.
+50:7 Mert íme vétekben fogantattam; * és bűnökben fogant engem anyám.
+50:8 Mert íme az igazságot szereted; * a te bölcsességed titkos és elrejtett dolgait kinyilatkoztattad nekem.
+50:9 Hints meg engem izsóppal, és megtisztulok; * moss meg engem, és a hónál fehérebb leszek.
+50:10 Add, hogy örömet és vigasságot halljak, * és örvendezzenek megalázott csontjaim.
+50:11 Fordítsd el orcádat bűneimről; * és töröld el minden gonoszságomat.
+50:12 Tiszta szívet teremts bennem, Isten, * és az igaz lelket újítsd meg belső részeimben.
+50:13 Ne vess el engem színed elől; * és szent lelkedet ne vedd el tőlem.
+50:14 Add vissza nekem üdvözítésed örömét; * és jeles lélekkel erősíts meg engem.
+50:15 Megtanítom utaidra a gonoszakat; * és az istentelenek hozzád térnek.
+50:16 Szabadíts meg engem a vérbűntől, Isten, üdvösségem Istene, * és nyelvem magasztalni fogja a te igazságodat.
+50:17 Uram, nyisd meg ajkamat, * és szám a te dicséretedet fogja hirdetni.
+50:18 Mert ha kedvelnéd, bizonyára áldozatot adtam volna; * de az égőáldozatokban nem gyönyörködöl.
+50:19 Áldozat Istennek a kesergő lélek; * a töredelmes és alázatos szívet, Isten, nem veted meg.
+50:20 Cselekedjél kegyesen, Uram, jóakaratodból Sionnal, * hogy épüljenek Jeruzsálem kőfalai.
+50:21 Akkor veszed kedvesen az igazság áldozatát, az ajándékokat és égőáldozatokat; * akkor tesznek oltárodra borjakat.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm51.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm51.txt
@@ -1,0 +1,9 @@
+51:3 Mit dicsekszel a gonoszságban, * ki hatalmas vagy az igaztalanságban?
+51:4 Napestig hamisságot gondolt nyelved; * mint az éles borotva álnokságot cselekedtél.
+51:5 Inkább szeretted a gonoszságot, mint a kegyességet, * örömestebb szólottál hamisságot, mint igazat.
+51:6 Szerettél minden veszedelmes igét, * álnok nyelv!
+51:7 Azért Isten megront téged végképpen, * kigyomlál téged, és kiköltöztet hajlékodból, és gyökeredet az élők földjéből.
+51:8 Látni fogják az igazak és megfélemlenek, és nevetnek rajta, és majd mondják: * Íme az ember, ki az Istent nem választotta segítőjének,
+51:9 Hanem gazdagsága sokaságában bízott, * és hatalmaskodott hiúságában.
+51:10 Én pedig mint a gyümölcsöző olajfa Isten házában, * bízom Isten irgalmában örökké és mindörökkön-örökké.
+51:11 Hálát adok neked örökké, mert te cselekedted ezt, * és reménylek a te nevedben, mert jó az szentjeid színe előtt.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm52.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm52.txt
@@ -1,0 +1,8 @@
+52:1 Mondá szívében az esztelen: * Nincs Isten.
+52:2 Meg vannak vesztegetve és utálatosakká lettek gonoszságaikban; * nincs, ki jót cselekedjék.
+52:3 Isten letekint a mennyből az emberek fiaira, * hogy lássa, ha van-e értelmes és Istent kereső.
+52:4 De mind elhajlottak, mindnyájan hasztalanokká lettek gonoszságaikban; * nincs, ki jót cselekedjék, egyetlen egy sincs.
+52:5 Nem tudják-e ezt mindazok, kik gonoszságot cselekesznek, * kik megemésztik népemet, mint a kenyeret?
+52:6 Az Istent nem hívták segítségül, * ott remegtek félelemmel, hol nem volt félelem;
+52:6 Mert az Isten széthányja azok tetemeit, kik az embereknek tetszenek; * megszégyenülnek, mert Isten megvetette őket.
+52:7 Ki ad Sionból Izraelnek szabadulást? * Mikor visszatéríti Isten az ő fogolynépét, örvendeni fog Jákob és vigadni Izrael.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm53.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm53.txt
@@ -1,0 +1,7 @@
+53:3 Isten, a te nevedben szabadíts meg engem; * és a te erődben ítélj meg engem.
+53:4 Isten, hallgasd meg imádságomat; * vedd füleidbe az én szám igéit.
+53:5 Mert idegenek támadtak föl ellenem, és erősek keresték lelkemet, * és Istent nem tartották szemük előtt.
+53:6 Holott íme az Isten segít engem; * és az Úr oltalmazója lelkemnek.
+53:7 Fordítsd ellenségeimre a rosszakat; * és igazságod szerint veszítsd el őket.
+53:8 Szabad akaratomból fogok áldozni neked, * és hálát adni a te nevednek, Uram, mert jó az;
+53:9 Mert minden szorongatásból megmentettél engem; * és ellenségeimet le fogja nézni az én szemem.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm54.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm54.txt
@@ -1,0 +1,27 @@
+54:2 Hallgasd meg Isten, az én imádságomat, és ne vesd meg könyörgésemet; * figyelmezz rám, és hallgass meg engem.
+54:3 Elszomorodtam az én küzdelmemben * és megháborodtam az ellenség szava és a bűnös szorongatása miatt;
+54:4 Mert rosszakat hoznak rám, * és haraggal bántanak engem.
+54:5 Szívem megháborodott bennem, * és a halál félelme szállott rám.
+54:6 Félelem és reszketés jött rám; * és sötétség borított be engem.
+54:7 És mondám: Ki ad nekem szárnyakat, mint a galambnak, * hogy röpüljek és megnyugodjam?
+54:8 Íme elfutván eltávoztam, * és a pusztában laktam.
+54:9 Vártam azt, ki megszabadított engem * a lélek csüggedésétől és a szélvésztől.
+54:10 Buktasd meg, Uram, és oszd meg nyelvüket; * mert gonoszságot láttam és ellenmondást a városban.
+54:11 Éjjel-nappal körülveszi őt kőfalai fölött a gonoszság, * és közepette nyomor van és igaztalanság;
+54:12 És utcáiról nem fogy el * az uzsora és csalárdság.
+54:13 Mert ha ellenségem átkozott volna engem, * eltűrtem volna ugyan;
+54:13 És ha az, ki gyűlölt engem, nagyokat mondott volna rám, * talán elrejtettem volna magamat előtte.
+54:14 De te, velem egyakaratú ember, * én vezérem és ismerőm,
+54:15 Ki velem együtt édes étkeket ettél, * kik az Isten házába egyetértőleg jártunk.
+54:16 Jöjjön halál rájuk, * és elevenen szálljanak le a pokolba.
+54:16 Mert gonoszság van lakhelyükben, * közöttük.
+54:17 Én pedig az Istenhez kiáltok; * és az Úr megszabadít engem.
+54:18 Este, reggel és délben elbeszélem és hirdetem; * és meghallgatja az én szómat.
+54:19 Megmenti békességben lelkemet azoktól, kik hozzám közelednek; * noha sokan vannak.
+54:20 Meghallgat Isten, és megalázza őket, * ki minden idő előtt vagyon;
+54:20 Mert ők nem változnak meg, és nem félik az Istent. * Ő kinyújtja kezét a bosszúállásra.
+54:21 Azok megfertőztetik szövetségét; de orcájának haragja eloszlatja őket, * és szíve közel éri.
+54:22 Az ő beszédei lágyabbak az olajnál, * de azok nyilak.
+54:23 Vesd az Úrra gondodat, és ő eltáplál téged; * az igazat nem hagyja örökké ingani.
+54:24 És te, Isten, leviszed őket * a veszedelem vermébe.
+54:24 A vérszopó és csalárd férfiak nem érik el napjaik felét; * én pedig tebenned bízom, Uram.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm55.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm55.txt
@@ -1,0 +1,13 @@
+55:2 Könyörülj rajtam, Isten, mert összetipor engem az ember; * egész nap ostromolván, szorongat engem.
+55:3 Tipornak engem ellenségeim egész nap; * mert sokan hadakoznak ellenem.
+55:4 A nap magasságától félek; * mindazáltal én benned bízom.
+55:5 Istenben dicsekszem az én beszédeimmel, Istenben bízom; * nem félek, bármit tegyen nekem a test.
+55:6 Napestig káromolják szavaimat; * minden gondolatuk ellenem van gonoszra.
+55:7 Lakást vesznek és elrejtőznek; * ők sarkamra vigyáznak.
+55:8 De amint várják az én lelkemet, úgy ne szabadítsd meg őket semmiképpen; * haragban összezúzod a népeket.
+55:9 Isten, az én életemet elbeszéltem neked; * könnyhullatásomat színed elé tetted,
+55:9 Amint meg is ígérted. * Azért térnek hátra az én ellenségeim,
+55:10 Amely nap segítségül hívlak téged, * íme én tapasztaltam, hogy Istenem vagy.
+55:11 Istenben dicsekszem az igével, az Úrban dicsekszem a beszéddel; * Istenben bízom, nem félek, bármit tegyen nekem az ember.
+55:12 Rajtam vannak, Isten, neked tett fogadásaim, * melyeket megadok a te dicséretedre;
+55:13 Mert megmentetted lelkemet a haláltól, és lábaimat az eséstől, * hogy kedves legyek Isten előtt az élők világosságában.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm56.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm56.txt
@@ -1,0 +1,14 @@
+56:2 Könyörülj rajtam, Isten, könyörülj rajtam; * mert lelkem benned bízik;
+56:2 És szárnyaid árnyékában bízom, * míg átvonul a gonoszság.
+56:3 Kiáltok a fölséges Istenhez, * az Istenhez, ki jót tesz velem.
+56:4 Elküld a mennyből, és megszabadít engem, * gyalázatra adja az engem tapodókat;
+56:4 Elküldi Isten az ő irgalmát és igazságát, * és kiragadja lelkemet az oroszlánok kölykei közül, míg háborogva alszom;
+56:5 Az emberek fiai közül, kiknek fogai fegyverek és nyilak, * és nyelvük éles kard.
+56:6 Magasztaltassál föl az egek fölött, Isten, * és a te dicsőséged az egész földön.
+56:7 Tőrt vetettek lábaimnak, * és megalázták lelkemet;
+56:7 Vermet ástak szemem előtt, * és beestek abba.
+56:8 Kész az én szívem, Isten, kész az én szívem * énekelni, és dicséretet mondani.
+56:9 Serkenj föl, dicsőségem, serkenj föl, zsoltárom és hárfám! * Fölkelek korán reggel;
+56:10 Hálát adok neked, Uram, a népek között, * és dicséretet mondok neked a nemzetek között;
+56:11 Mert magasztos az égig a te irgalmad, * és a felhőkig a te igazságod.
+56:12 Magasztaltassál föl az egek fölött, Isten, * és a te dicsőséged az egész földön.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm57.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm57.txt
@@ -1,0 +1,11 @@
+57:2 Ha valóban igazságot szóltok, * igazat ítéljetek, emberek fiai.
+57:3 De ti szívben gonoszságot míveltek; * kezeitek igaztalanságokat szőnek a földön.
+57:4 Eltértek a bűnösök az anyaméhtől fogva, eltévedtek születés óta, * s hazugságokat szólanak.
+57:5 Mérgük hasonló a kígyóéhoz, * a siket áspiséhoz, mely bedugja füleit,
+57:6 Hogy ne hallja a bűvölők szavát * és a bűvöléshez értő varázslóét.
+57:7 Isten összetöri szájukban fogaikat; * az oroszlánok zápfogait összerontja az Úr.
+57:8 Elenyésznek, mint a lefolyó víz; * megvonja a kézíjat, és ők elvesztik erejüket.
+57:9 Mint az elolvadó viasz, szétfolynak, * tűz hull rájuk, és nem látják meg a napot.
+57:10 Mielőtt töviseitek bokorrá lennének, * haragjában mintegy elevenen elnyeli őket.
+57:11 Örvendeni fog az igaz, midőn látja a bosszúállást; * kezeit a bűnös vérében fogja mosni.
+57:12 És mondani fogja az ember: Van mégis gyümölcse az igaznak; * van mégis Isten, ki őket megítéli a földön.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm58.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm58.txt
@@ -1,0 +1,20 @@
+58:2 Ments meg engem ellenségeimtől, Istenem, * és a rám támadóktól szabadíts meg engem.
+58:3 Ments meg engem a gonosztevőktől; * és a vérszopó férfiaktól szabadíts meg engem.
+58:4 Mert íme megfogják lelkemet; * rám rohannak az erősek;
+58:5 És nincs gonoszságom, sem bűnöm, Uram, * gonoszság nélkül futottam, és eligazodtam.
+58:6 Kelj föl elém, és lásd ezt, * és te, Uram, erők Istene, Izrael Istene,
+58:6 Figyelj és látogass meg minden nemzetet; * és ne könyörülj senkin, ki gonoszságot cselekszik.
+58:7 Visszatérnek estére, és éhséget fognak szenvedni, mint az ebek, * és megkerülik a várost.
+58:8 Íme szájukkal szólnak, és kard van ajkaikon; * mert ki hallja?
+58:9 De te, Uram, kineveted őket; * semmivé teszel minden nemzetet.
+58:10 Én erősségemet benned helyezem; mert te, Isten, az én oltalmam vagy. * Az én Istenem irgalmassága megelőz engem;
+58:12 Az Isten megmutatja nekem ellenségeimet. Ne öld meg őket, * nehogy megfeledkezzenek népeim.
+58:12 Széleszd el őket a te erőddel, * és vesd le őket, én oltalmazó Uram.
+58:13 Amit szájuk mond, merő gonoszság. * Fogassanak meg kevélységükben;
+58:13 Kik az átkozódásban és hazugságban még kérkednek is. * Veszítsd el őket a te haragodban, veszítsd el őket, hogy többé ne legyenek.
+58:14 És tudva lesz, hogy Isten uralkodik Jákobon * és a föld határain.
+58:15 Visszatérnek estére, és éhséget fognak szenvedni, mint az ebek, * és megkerülik a várost.
+58:16 Ők elszélednek eledelért, * és ha jól nem laknak, morognak is.
+58:17 Én pedig a te erősségedet éneklem, * és fölmagasztalom irgalmadat reggel;
+58:17 Mert oltalmam lettél * és menedékem az én szorongásom napján.
+58:18 Én segítőm, neked éneklek, mert oltalmazó Istenem vagy; * én Istenem, én irgalmasságom.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm59.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm59.txt
@@ -1,0 +1,13 @@
+59:3 Isten, elvetettél és megrontottál minket; * megharagudtál, de könyörülsz is rajtunk.
+59:4 Megindítottad a földet és megrendítetted azt; * gyógyítsd meg romlásait, mert megmozdult.
+59:5 Kemény dolgokat mutattál a te népednek; * a keserűség borával itattál minket.
+59:6 De jelt adtál a téged félőknek, * hogy elfussanak a kézív elől,
+59:7 Hogy megszabaduljanak kedveltjeid. * Szabadíts meg a te jobb kezeddel és hallgass meg engem.
+59:8 Az Isten szólott az ő szent helyén: * Vigadni fogok és fölosztom Szikemet, és a sátorok völgyét fölmérem.
+59:9 Enyém Gálaád, és enyém Manasszesz, * és Efraim fejem erőssége,
+59:9 Júda az én királyom. * Moáb reményem fazeka;
+59:10 Idumeára kinyújtom sarumat; * az idegenek meghódolnak nekem.
+59:11 Ki visz engem az erős városba? * Ki visz engem Idumeáig?
+59:12 Nemde te, Isten, ki minket elvetettél? * És nem jössz-e ki, Isten, a mi seregeinkkel?
+59:13 Segíts ki minket a szorongásból; * mert hiábavaló az ember segedelme.
+59:14 Isten által fejtünk ki majd erőt, * és ő megsemmisíti szorongatóinkat.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm6.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm6.txt
@@ -1,0 +1,10 @@
+6:2 Uram, ne feddj meg engem búsulásodban, * és haragodban ne dorgálj meg engem.
+6:3 Könyörülj rajtam, Uram, mert erőtlen vagyok; * gyógyíts meg engem, Uram, mert reszketnek csontjaim,
+6:4 És lelkem igen megháboríttatott; * de te, Uram, meddig?
+6:5 Fordulj meg, Uram, és mentsd ki lelkemet; * szabadíts meg engem a te irgalmasságodért.
+6:6 Mert nincs, ki a halálban megemlékezzék rólad; * a pokolban pedig ki fog dicsérni téged?
+6:7 Elfáradtam fohászkodásomban, † megöntözöm minden éjjel ágyamat, * megáztatom fekvőhelyemet könnyhullatásaimmal.
+6:8 Meghomályosult szemem a búsulás miatt; * megaggottam sok ellenségem között.
+6:9 Távozzatok tőlem mindnyájan, kik gonoszságot cselekesztek; * mert meghallgatta az Úr sírásom szavát.
+6:10 Meghallgatta az Úr könyörgésemet, * az Úr bevette imádságomat.
+6:11 Piruljanak és fölötte zavarodjanak meg minden ellenségeim; * térjenek hátra és piruljanak meg hirtelen.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm60.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm60.txt
@@ -1,0 +1,8 @@
+60:2 Hallgasd meg, Isten, az én könyörgésemet; * figyelmezz imádságomra.
+60:3 A föld határairól kiáltok hozzád, * mivel szorongattatik szívem. Te fölemelsz engem a kősziklára,
+60:4 Vezérelsz engem; mert reményemmé lettél, * erősség tornyává az ellenség ellen.
+60:5 A te hajlékodban fogok lakni mindörökké, * oltalmam lesz szárnyaid árnyéka alatt.
+60:6 Mert te, Istenem, meghallgatod imádságomat; * örökséget adsz a te nevedet félőknek.
+60:7 A király napjaihoz napokat adsz, * esztendeit nemzedékről nemzedékre terjeszted;
+60:8 S ő megmarad örökké az Isten színe előtt. * Az ő irgalmát és igazságát ki veszi számba?
+60:9 Így dicséretet mondok a te nevednek mindörökkön-örökké: * hogy teljesítsem fogadásaimat napról napra.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm61.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm61.txt
@@ -1,0 +1,11 @@
+61:2 Nemde az Istennek lesz alávetve az én lelkem, * miután tőle vagyon szabadulásom?
+61:3 Mert ő Istenem és szabadítóm; * az én oltalmazóm, s nem fogok többé ingadozni.
+61:4 Meddig rohantok az emberre, * mint egy meghajlott falra és eldőlt kerítésre, hogy megöljétek őt mindnyájan?
+61:5 Meg akarnak fosztani becsületemtől, én szomjazva futok; * ők szájukkal áldanak, és szívükben átkoznak.
+61:6 Mindazáltal, én lelkem, engedelmeskedjél az Istennek; * mert tőle vagyon az én béketűrésem.
+61:7 Mert ő Istenem és üdvözítőm; * az én segítőm, nem fogok eltérni.
+61:8 Istenben az én szabadulásom és dicsőségem, * ő segítségem Istene; és reményem Istenben vagyon.
+61:9 Bízzatok benne, a nép minden gyülekezete, öntsétek ki előtte szíveteket; * Isten a mi segítőnk mindörökké.
+61:10 De hiúk az emberek fiai, hazugok az emberek fiai a mérlegben; * úgy hogy önmagukat csalják meg a hiúságban.
+61:11 Ne bízzatok a gonoszságban, és ne kívánjátok meg a ragadományokat; * ha bővelkedtek gazdagsággal, szíveteket ahhoz ne tegyétek.
+61:12 Egyszer szólott az Isten, s e kettőt hallottam: hogy a hatalom Istené, és tied, Uram, az irgalmasság; * mert te megfizetsz kinek-kinek az ő cselekedetei szerint.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm62.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm62.txt
@@ -1,0 +1,10 @@
+62:2a Isten, én Istenem, * tehozzád ébredek virradatkor;
+62:2b Utánad szomjúhozik az én lelkem, * szintoly nagyon vágyódik utánad az én testem is.
+62:3 A puszta és járatlan és vizetlen földön, ‡ úgy jelenek meg előtted, mint a szent helyen, * hogy lássam a te erődet és dicsőségedet.
+62:4 Mert jobb a te irgalmasságod az életnél; * az én ajkaim dicsérnek téged.
+62:5 Így áldani foglak téged életemben; * és a te nevedben fölemelem kezeimet.
+62:6 Mintegy zsírral és kövérséggel telik meg lelkem; * és vigadás ajkaival fog dicsérni az én szám.
+62:7 Ha rólad emlékezem ágyamon, † ha reggel felőled elmélkedem; * (8a) mert segítőm vagy.
+62:8b És a te szárnyaid árnyéka alatt vigadok, † (9) az én lelkem hozzád ragaszkodik; * jobbod fölvett engemet.
+62:10 Azok pedig hiába keresik lelkemet, † lemennek a föld alsó részeibe; * (11) a kard kezébe adatnak, a rókák martalékai lesznek.
+62:12 A király pedig vigadni fog az Istenben; dicsértetni fognak mindnyájan, * kik rája esküsznek; mert bezáratik a gonoszságot szólók szája.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm63.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm63.txt
@@ -1,0 +1,11 @@
+63:2 Hallgasd meg, Isten, az én imádságomat, mikor könyörgök; * az ellenség félelmétől mentsd meg lelkemet.
+63:3 Te oltalmazz engem a rosszalkodók gyülekezetétől, * a gonosztevők sokaságától.
+63:4 Mert megélesítik nyelveiket, mint a kardot; * megvonják a kézíjat, a keserű szert, hogy lövöldözzék titkon az ártatlant.
+63:6 Hirtelen meglövik őt, és nem félnek; * megerősítik magukat a gonosz dologban;
+63:6 Beszélnek, hogy tőröket vessenek, * és mondják: Ki látja azokat?
+63:7 Gonoszban törik fejüket, * a fondorkodók elfáradnak az ármánykodásban,
+63:7 S az ember szíve fölemelkedik; * de az Isten fölmagasztaltatik.
+63:8 Kisdedek nyilai az ő sebesítésük, * és nyelveik megerőtlenednek önmagok ellen.
+63:9 Eliszonyodnak mindnyájan, kik őket látják; * és minden ember fél,
+63:10 És hirdeti az Isten cselekedeteit, * és elismeri az ő tetteit.
+63:11 Az igaz örvendeni fog az Úrban, és benne bízni, * és dicsértetni fog minden igaz szívű.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm64.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm64.txt
@@ -1,0 +1,14 @@
+64:2 Téged illet a dicséret, Isten, Sionban; * és neked teljesítik a fogadást Jeruzsálemben.
+64:3 Mert te meghallgatod az imádságot; * tehozzád folyamodik minden ember.
+64:4 A gonosz cselekedetek hatalmat vettek rajtunk; * de te megkegyelmezel istentelenségeinknek.
+64:5 Boldog az, kit kiválasztasz és magadhoz fogadsz; * a te tornácaidban fog lakni;
+64:5 Eltelünk házad javaival; * szent a te templomod, csodálatos az igazságban.
+64:6 Hallgass meg minket, szabadító Istenünk, * te reménye a föld minden határának, és a messze tengernek.
+64:7 Te alapítád meg a hegyeket erőddel, ki fel vagy övezve hatalmassággal; * fölháborítod a tenger mélységét, az ő habjai zúgását.
+64:8 Zavarba jőnek a nemzetek, és félni fognak jeleidtől, kik a határokon laknak; * hol a nap felkeltét és lenyugtát örvendetessé teszed.
+64:10 Megtekinted a földet és elárasztod; * nagyon gazdaggá teszed azt.
+64:10 Isten folyója tele van vizekkel, te készíted el nekik az élelmet; * mert így van a föld elrendezve.
+64:11 Barázdáit megáztatod, termését megsokasítod; * az eső csorgásán örvendez a termő föld.
+64:12 Megáldod kegyességeddel az esztendő koszorúját; * és mezőid megtelnek bőséggel.
+64:13 Megkövérednek a puszták legelői, * és a halmok vigassággal övezkednek körül.
+64:14 A legelőt juhnyájak lepik el, és a völgyek bővelkednek gabonával; * minden örvend és éneket zengedez.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm65.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm65.txt
@@ -1,0 +1,19 @@
+65:1 Örvendezzetek az Úrnak, minden föld, mondjatok dicséretet az ő nevének; * tegyétek dicsőségessé dicséretét.
+65:3 Mondjátok az Istennek: Mely rettenetesek a te cselekedeteid, Uram, * a te erőd nagysága miatt hízelkedni fognak neked ellenségeid.
+65:4 Az egész föld imádjon téged és énekeljen neked; * mondjon dicséretet a te nevednek.
+65:5 Jöjjetek, és lássátok az Isten műveit; * rettenetes ő tanácsaiban az emberek fiai fölött.
+65:6 Ki a tengert szárazzá változtatta, a folyóvízen lábbal mentek át; * ott vigadtunk őbenne.
+65:7 Ki saját ereje által uralkodik mindörökké, az ő szemei a nemzetekre néznek. * Kik búsítják őt, föl ne fuvalkodjanak magukban.
+65:8 Áldjátok, nemzetek, a mi Istenünket, * és hallassátok az ő dicséretének szózatát.
+65:9 Ki engemet életben tartott, * és nem hagyta ingadozni lábaimat.
+65:10 Mert megkísértettél minket, Isten, * tűzzel próbáltál minket, mint próbáltatik az ezüst.
+65:11 Tőrbe vittél minket, nyomorúságokat tettél hátunkra, * embereket ültettél fejeinkre.
+65:12 Tűzön és vízen mentünk át, * de kivezettél minket enyhülésre.
+65:13 Bemegyek a te házadba égőáldozatokkal, * teljesítem neked fogadásaimat, melyeket ajkaim kifejeztek,
+65:14 És az én szám mondott * szorongásomban.
+65:15 Velős égőáldozatokat viszek neked a kosok jó illatszerével, * tulkokat áldozok neked bakokkal.
+65:16 Jöjjetek, halljátok mindnyájan, kik félitek az Urat, és elbeszélem, * mennyit cselekedett az én lelkemmel.
+65:17 Hozzá kiáltottam számmal, * és fölmagasztaltam őt nyelvemmel.
+65:18 Ha gonoszságra tekintettem volna szívemben, * nem hallgatott volna meg az Úr.
+65:19 De meghallgatott az Isten, * és könyörgésem szavára figyelmezett.
+65:20 Áldott legyen az Isten, * ki nem távoztatta el imádságomat és az ő irgalmát éntőlem.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm66.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm66.txt
@@ -1,0 +1,6 @@
+66:2 Könyörüljön rajtunk az Isten, és áldjon meg minket; * derítse föl ránk az ő orcáját, és könyörüljön rajtunk:
+66:3 Hogy megismerjük a földön utadat, * minden nép között a te szabadításodat.
+66:4 Adjanak hálát neked, Isten, a népek; * adjon hálát minden nép.
+66:5 Örüljenek és vigadjanak a nemzetek; * mert te ítéled a népeket igazságban, és a nemzeteket a földön kormányozod.
+66:6 Adjanak hálát neked, Isten, a népek; adjon hálát minden nép. * (7a) A föld megadja gyümölcsét.
+66:7b Áldjon meg minket Isten, a mi Istenünk, (8) áldjon meg minket Isten; * és félje őt a föld minden határa.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm67.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm67.txt
@@ -1,0 +1,38 @@
+67:2 Keljen föl az Isten, és széledjenek el az ő ellenségei, * és fussanak orcája elől, kik őt gyűlölik.
+67:3 Mint elenyészik a füst, enyésszenek el; * mint elolvad a viasz a tűz színe előtt, úgy vesszenek el a bűnösök Isten színe elől.
+67:4 És az igazak vendégeskedjenek és vigadjanak Isten színe előtt, * és gyönyörködjenek örömmel.
+67:5a Énekeljetek Istennek, mondjatok dicséretet az ő nevének, * készítsetek utat annak, ki fölmegyen napnyugatra, (fejet hajtunk) Úr az ő neve.
+67:5b Örvendezzetek színe előtt, * mely előtt amazok megrémülnek. (6a) Árvák atyja és özvegyek bírája
+67:6b Isten az ő szent helyén, * (7a) Isten, ki békés lakást ad a házban az egyértelműeknek,
+67:7b ki a foglyokat kivezeti erősséggel, * hasonlóképpen az ellenszegülőket, kik a sírokban laknak.
+67:8 Isten, midőn a te néped színe előtt jártál, * midőn átmentél a pusztán,
+67:9 a föld megrendült, és az egek csöpögtek a Sinai Istenének színe előtt, * Izrael Istenének színe előtt.
+67:10 Óhajtott esőt adtál, Isten, a te örökségednek; * mely elfáradott, de te megerősítetted őt.
+67:11 A te nyájad lakott abban; * elkészítetted azt, Isten, kegyességedből a szegénynek.
+67:12 Az Úr szót ad az örömhír vivőinek * nagy hatalommal.
+67:13 A seregek királyai futva futnak; * és a ház ékességének jut a ragadományok osztása.
+67:14 Ha osztályrészeitekben feküsztök, hasonlók lesztek a galambhoz, * melynek tollai ezüstösek, és háta vége felé aranysárga.
+67:15 Midőn a mennyben lakó ott a királyokat elszéleszti, fehérek lesznek mint a hótól Szelmon. * (16a) Az Isten hegye kövér hegy,
+67:16b erős hegy, termékeny hegy. * (17a) Miért nézitek gyanúsan az erős hegységet?
+67:17b E hegy az, melyen az Istennek lakni tetszik; * mert az Úr ott fog lakni mindörökké.
+67:18 Isten szekere több tízezernél, ezrek az örvendezők; * az Úr közöttük van, mint a Sinai hegyen a szentélyben.
+67:19a Fölmégy a magasba, fogva viszed a fogságot, * ajándékokat veszel az embereknek,
+67:19b a nem hívőknek is, * hogy az Úr Istennél lakjanak.
+67:20 Áldott legyen az Úr minden nap; * szerencsés utat készít nekünk a mi üdvösségünk Istene.
+67:21 A mi Istenünk a szabadító Isten; * és az Úré, az Úré a halálból való kivitel.
+67:22 Ellenben Isten összezúzza ellenségei fejeit, * a vétkeikben járók fejtetejét.
+67:23 Mondá az Úr: Bászánból visszatérítem őket, * a tenger mélységébe térítem;
+67:24 hogy lábad vérbe mártassék, * ebeid nyelve az ellenség vérébe.
+67:25 Látják bemeneteledet, Isten, * az én Istenem bemenetelét; az én királyomét, ki a szentélyben vagyon.
+67:26 Elől mennek a fejedelmek az éneklőkkel együtt * a doboló leányzók között.
+67:27 A gyülekezetekben áldjátok az Úr Istent, * Izrael törzséből valók.
+67:28a Ott van az ifjú Benjamin * lelki elragadtatásban,
+67:28b Júda fejedelmei, azok vezérei, * Zabulon fejedelmei, Neftali fejedelmei.
+67:29 Parancsolj, Isten, a te erődnek; * erősítsd meg azt, Isten, mit közöttünk cselekedtél,
+67:30 a te templomodból Jeruzsálemben. * A királyok ajándékokat hoznak neked.
+67:31a Dorgáld meg a nádas vadait; bikák gyülekezete van a népek tehenei között, * hogy kirekesszék azokat, kik megpróbáltattak, mint az ezüst.
+67:31b Széleszd el a nemzeteket, melyek hadakat kívánnak. (32) Követek jőnek Egyiptomból, * Etiópia megelőzve nyújtja kezeit az Istenhez.
+67:33a Föld országai, énekeljetek az Istennek; * zengjetek az Úrnak,
+67:33b zengjetek az Istennek, (34a) ki fölmegy az egek ege fölé * napkeletre.
+67:34b Íme szózatának az erő szavát adja. (35) Adjatok dicsőséget az Istennek, Izrael fölött, * az ő dicsősége és ereje a felhőkben.
+67:36 Csodálatos az Isten az ő szentjeiben; Izrael Istene ő ad hatalmat és erőt az ő népének. * Áldott legyen az Isten.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm68.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm68.txt
@@ -1,0 +1,42 @@
+68:2 Szabadíts meg engem, Isten, * mert behatottak a vizek lelkemig.
+68:3 Besüllyedtem a mélységes sárba, * és nincs megállapodás;
+68:3 A tenger mélységére jutottam, * és a szélvész elmerített engem.
+68:4 Elfáradtam a kiáltásban, torkom elrekedt, * szemeim elbágyadnak, míg az én Istenemben bízom.
+68:5 Megsokasodtak fejem hajszálai fölött, * kik engem ok nélkül gyűlölnek;
+68:5 Megerősödnek ellenségeim, kik igazságtalanul üldöznek engem; * amit nem ragadtam el, meg kell fizetnem.
+68:6 Isten, te tudod balgatagságomat; * és vétkeim nincsenek előtted elrejtve.
+68:7 Ne piruljanak meg miattam, kik téged várnak, Uram, * erők ura.
+68:7 Ne szégyenüljenek meg miattam, * kik téged keresnek, Izrael Istene.
+68:8 Mert éretted szenvedem a gyalázatot, * szégyen borítja el orcámat.
+68:9 Idegenné lettem atyámfiainál, * és jövevénnyé anyám fiainál.
+68:10 Mert a buzgóság házadért megemészt engem; * és a téged gyalázók szidalmai esnek rám.
+68:11 Böjtöléssel födöztem lelkemet: * és gyalázatomra lett nekem.
+68:12 Öltözetemmé tettem a zsákot: * és közmondássá lettem nekik.
+68:13 Ellenem szólának, kik a kapuban ültek; * és rólam éneklének, kik bort ittak.
+68:14 Én pedig tehozzád imádkozom, Uram, * legyen ez a tetszés ideje, Istenem,
+68:14 Irgalmad sokaságában hallgass meg engem, * a te szabadításod igazvolta szerint.
+68:15 Ragadj ki engem a sárból, hogy bele ne süllyedjek; * szabadíts meg engem azoktól, kik engem gyűlölnek, és a vizek mélységéből.
+68:16 Ne merítsen el engem a víz árja, és ne nyeljen el engem a mélység, * és ne zárja rám száját a kút.
+68:17 Hallgass meg engem, Uram, mert kegyes a te irgalmad; * könyörületed sokasága szerint tekints reám.
+68:18 És ne fordítsd el orcádat a te szolgádtól; * mert szorongattatom, gyorsan hallgass meg engem.
+68:19 Legyen gondod lelkemre, és szabadítsd meg azt; * ellenségeim miatt ments meg engem.
+68:20 Te tudod gyalázatomat és megszégyenülésemet * és pirulásomat.
+68:21 Színed előtt vannak mindnyájan, kik engem szorongatnak; * szidalmat és ínséget vár szívem.
+68:21 És vártam, ki szánakozzék, és nem volt; * és ki megvigasztaljon, és nem találtam.
+68:22 És epét adtak nekem eledelül; * és szomjúságomban ecettel itattak engem.
+68:23 Legyen az ő asztaluk tőrré előttük, * és visszafizetéssé és botránkozássá.
+68:24 Homályosodjanak meg szemeik, hogy ne lássanak, * és hátukat mindenkor görbítsd meg.
+68:25 Öntsd ki rájuk haragodat; * és haragod búsulása ragadja meg őket.
+68:26 Legyen puszta az ő lakhelyük, * és ne legyen, ki hajlékaikban lakjék.
+68:27 Mert akit te megvertél, azt üldözték; * és sebeim fájdalmát többé tették.
+68:28 Hagyd vétkezni vétkük felett, * és ne jussanak igazságodba.
+68:29 Töröltessenek ki az élők könyvéből, * és az igazakkal ne írassanak be.
+68:30 Én szegény vagyok és szenvedő, * a te szabadításod, Isten, fölemel engem.
+68:31 Dicsérem az Isten nevét énekkel, * és magasztalom őt dicsérettel.
+68:32 S ez kedvesebb lesz Istennek a gyenge borjúnál, * melynek szarvai és körmei kelnek.
+68:33 Lássák a szegények, és vigadjanak; * keressétek az Istent, és élni fog lelketek;
+68:34 Mert az Úr meghallgatja a szegényeket, * és foglyait nem veti meg.
+68:35 Dicsérjék őt az egek és a föld, * a tenger és minden, mi azokban mozog.
+68:36 Mert az Isten megszabadítja Siont, * és fölépíttetnek Júda városai,
+68:36 S ott fognak lakni, * és örökségül veszik azt.
+68:37 És szolgáinak ivadéka fogja bírni azt; * és kik szeretik az ő nevét, azok fognak lakni abban.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm69.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm69.txt
@@ -1,0 +1,7 @@
+69:2 Isten, figyelmezz segítségemre; * Uram, siess segítésemre.
+69:3 Szégyenüljenek meg, és valljanak gyalázatot, * kik lelkemet keresik.
+69:4 Térjenek hátra és piruljanak meg, * kik rosszat akarnak nekem;
+69:4 Térjenek hátra mindjárt megpirulva, * kik azt mondják nekem: Úgy kell, úgy kell!
+69:5 Örvendezzenek és vigadjanak tebenned mindnyájan, kik téged keresnek, * és mondják mindenkor, kik szeretik szabadításodat: Magasztaltassék az Úr!
+69:6 Én pedig szűkölködő és szegény vagyok; * Isten, segíts meg engem.
+69:6 Én segítőm és szabadítóm vagy te; * Uram, ne késsél.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm7.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm7.txt
@@ -1,0 +1,18 @@
+7:2 Uram, én Istenem, tebenned bíztam; * szabadíts meg engem minden üldözőmtől, és ments meg engem;
+7:3 Nehogy elragadja mint az oroszlán lelkemet, * midőn nincs, ki megváltson, sem ki megszabadítson.
+7:4 Uram, én Istenem, ha ezt cselekedtem, * ha gonoszság vagyon kezeimben,
+7:5 Ha hasonlóval fizettem a velem gonoszul cselekvőknek: * essem el méltán ellenségeim előtt üresen;
+7:6 Üldözze az ellenség lelkemet, † és fogja meg, és tiporja el a földön éltemet, * és tegye porrá dicsőségemet.
+7:7a Kelj föl, Uram, haragodban, * és emelkedjél föl ellenségeim határaiban;
+7:7b Kelj föl, Uram, én Istenem, a parancs szerint, melyet parancsoltál; * (8a) és a népek gyülekezete körülveszen téged;
+7:8b És emiatt térj vissza a magasra. * (9a) Az Úr ítéli a népeket.
+7:9b Ítélj meg engem, Uram, igazságom szerint, * és ártatlanságom szerint történjék velem.
+7:10 Szűnjék meg a bűnösök gonoszsága, és vezéreld az igazat, * szíveket és veséket vizsgáló Isten!
+7:11 Az én igaz segítségem az Úrtól vagyon, * ki megszabadítja az egyenes szívűeket.
+7:12 Az Isten igaz bíró, erős és tűrő; * haragszik-e minden nap?
+7:13 Ha nem tértek meg, kirántja fegyverét; * kézíját megvonta, és elkészítette azt.
+7:14 A halál eszközeit készíté abba; * nyilait égőkké tette.
+7:15 Íme igazságtalanságot fogant, * fájdalommal vajúdott, és csalárdságot szült.
+7:16 Vermet nyitott, és kiásta azt; * de a gödörbe esett, melyet csinált.
+7:17 Fejére tér vissza az ő hamissága; * és feje tetejére száll gonoszsága.
+7:18 Hálát adok az Úrnak az ő igazsága szerint; * és zengeni fogok a fölséges Úr nevének.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm70.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm70.txt
@@ -1,0 +1,26 @@
+70:1 Tebenned bízom, Uram, soha ne szégyenüljek meg; * a te igazságod által szabadíts meg engem, és ments meg engem.
+70:2 Hajtsd hozzám füledet, * és szabadíts meg engem.
+70:3 Légy nekem oltalmazó Istenem és erős helyem, * hogy megszabadíts engem;
+70:3 Mert erősségem * és oltalmam te vagy.
+70:4 Én Istenem, ments meg engem a bűnös kezéből, * és a törvény ellen cselekvő és a gonosz kezéből.
+70:5 Mert te vagy az én béketűrésem, Uram; * Uram, az én reményem ifjúságomtól.
+70:6 Teáltalad erősödtem meg anyám méhétől; * anyám méhétől fogva vagy az én oltalmazóm.
+70:7 Felőled van éneklésem mindenkoron, * mintegy csodája lettem soknak, és te erős segítő voltál.
+70:8 Teljék meg az én szám dicsérettel, hogy énekeljem dicsőségedet, * egész nap a te nagy voltodat.
+70:9 Ne vess el engem a vénség idején; * midőn megfogyatkozik erőm, ne hagyj el engem.
+70:10 Mert szólanak rólam ellenségeim; * és kik életemre leselkednek, együtt tartanak tanácsot,
+70:11 Mondván: Az Isten elhagyta őt, üldözzétek és fogjátok meg őt; * mert nincs, ki megmentse.
+70:12 Isten, ne légy távol tőlem; * én Istenem, tekints segítségemre.
+70:13 Szégyenüljenek meg és enyésszenek el az én lelkem rágalmazói; * boríttassanak be gyalázattal és szégyennel, kik nekem rosszat akarnak.
+70:14 Én pedig mindenkor bízom, * és még többet teszek minden dicséretedre.
+70:15 Az én szám hirdeti igazságodat, * egész nap a te szabadításodat,
+70:16 Melynek számát nem tudom. Bemegyek az Úr hatalmasságába; * Uram, egyedül a te igazságodról fogok emlékezni.
+70:17 Isten, te tanítottál engem ifjúságomtól; * és mind ez ideig beszélem csodáidat.
+70:18 És vénségemig és őszkoromig, * Isten, ne hagyj el engem,
+70:18 Míg hirdetem a te karodat * minden jövendő nemzedéknek,
+70:19 Hatalmadat, és igazságodat, mely a magasságig ér, Isten, mely nagyokat cselekedtél. * Isten, ki hasonló hozzád?
+70:20 Mily sok és gonosz szorongatást mutattál nekem! De megfordulván, fölélesztettél engem, * és a föld mélységeiből ismét visszahoztál engem.
+70:21 Megsokasítottad nagyvoltodat; * és megfordulván, megvigasztaltál engem.
+70:22 Én is dicsérni fogom hangszerekkel a te hűségedet, * Isten, énekelni fogok neked hárfával, Izrael Szentje.
+70:23 Örvendezni fognak ajkaim, midőn éneklek neked, * és lelkem, melyet megváltottál.
+70:24 De nyelvem is egész nap beszélni fogja igazságodat; * mert megszégyenülnek és megpirulnak, kik nekem rosszat akarnak.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm71.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm71.txt
@@ -1,0 +1,20 @@
+71:2 Isten, add jogodat a királynak, * és igazságodat a király fiának;
+71:2 Hogy igazságosan ítélje a te népedet, * és méltányosan a te szegényeidet.
+71:3 A hegyek hozzanak békességet a népnek, * és a halmok igazságot.
+71:4 Ő meg fogja ítélni a nép szegényeit, megszabadítja a szegények fiait, * és megalázza a rágalmazót.
+71:5 És megmarad, míg a nap és hold tart, * nemzedékről nemzedékre.
+71:6 Leszáll, mint az eső a gyapjúra, * és mint az esőcseppek a földre.
+71:7 Az ő napjaiban kivirágzik az igazság és a béke bősége, * míg elenyészik a hold.
+71:8 És a tengertől tengerig fog uralkodni, * és a folyóvíztől a földkerekség határáig.
+71:9 Leborulnak előtte az etiópok, * és ellenségei a földet nyalják.
+71:10 Tarzisz és a sziget királyai ajándékokat mutatnak be; * Arábia és Sába királyai ajándékokat hoznak.
+71:11 És imádni fogja őt a föld minden királya; * minden nemzet szolgálni fog neki.
+71:12 Mert megszabadítja a szegényt a hatalmastól; * a szegényt, kinek nem volt segítője;
+71:13 Megkíméli a szegényt és szűkölködőt, * és a szegények lelkeit megszabadítja.
+71:14 Az uzsorákból és hamisságból kiszabadítja azok lelkeit: * mert azok neve tiszteletes őelőtte.
+71:15 Élni fog, és Arábia aranyából adatik neki, és imádni fogják őt mindenkoron, * egész nap áldják őt.
+71:16 És bőség lesz a földön s a hegytetőkön is, gyümölcse meghaladja a Libanonét, * és a városokban virágzani fognak a lakosok, mint a föld füve.
+71:17 Legyen áldott az ő neve mindörökké; * mint a nap megmarad az ő neve,
+71:17 És megáldatik benne a föld minden nemzetsége; * minden nép magasztalni fogja őt.
+71:18 Áldott legyen Izrael Ura, Istene, * ki egyedül tesz csodálatos dolgokat.
+71:19 És áldott legyen az ő fölségének neve mindörökké; * és dicsőségével teljék be az egész föld. Úgy legyen, úgy legyen.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm72.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm72.txt
@@ -1,0 +1,28 @@
+72:1 Mily jó Izrael Istene * azoknak, kik igaz szívvel vannak.
+72:2 Az én lábaim pedig csaknem megtántorodtak; * csaknem elcsuszamodtak lépéseim.
+72:3 Mert bosszankodtam a gonoszokra, * látván a bűnösök békességét.
+72:4 Mert a fájdalomtól halálukig mentek, * és nincs tartósság csapásukban.
+72:5 Nincsenek az emberek bajaiban, * és az emberekkel nem ostoroztatnak.
+72:6 Azért fogta el őket a kevélység, * beboríttatnak gonoszságukkal és istentelenségükkel.
+72:7 Kiszivárog, mint a kövérségből, az ő gonoszságuk; * a szív indulata után mennek.
+72:8 Álnokságot gondolnak és szólanak, * gonoszságot szólanak magasságukban.
+72:9 Az ég káromlására nyitják föl szájukat, * és nyelvük az embereket szerte rágalmazza.
+72:10 Azért tér hozzájuk ez az én népem, * hogy náluk jó napokra találjon;
+72:11 Mondván: Hogyan tudná meg az Isten? * És van-e tudomány a Fölségesben?
+72:12 Íme ők bűnösök, és bővelkednek a világon, * gazdagságot nyertek.
+72:13 És mondám: Tehát hiába igazultam meg szívemben, * és mostam meg az ártatlanok között kezeimet?
+72:14 És ostoroztattam egész nap, * és fenyíték volt részem reggeltől.
+72:15 De ha ezt mondottam volna, úgy beszélvén, mint ők: * íme a te fiaid nemzetségétől elpártoltam volna.
+72:16 És gondolkodtam, hogy megértsem ezt; * de ez nehézség volt előttem,
+72:17 Mígnem bementem az Isten szentélyébe, * és megértém az ő végüket.
+72:18 Mert csalatkozásukra tettél így nekik; * letaszítottad őket, midőn fölemelkedtek.
+72:19 Mennyire elpusztultak, hirtelen elfogytak, * elvesztek gonoszságuk miatt.
+72:20 Mint a fölserkenők álmát, Uram, * semmivé teszed városodban az ő képüket.
+72:21 Ha azért fölhevülne szívem, és vesém fölháborodnék: * akkor én esztelennek tartanám magamat, ki mit sem tud,
+72:23 És oktalan barom volnék előtted. * Én mindazáltal mindenkor veled voltam.
+72:24 Azért te jobb kezemnél fogsz engem tartani, és akaratod szerint vezetni, * és a dicsőségbe fogadni.
+72:25 Mert mim vagyon az égben? * És tekívüled mit akartam a földön?
+72:26 Ha testem és szívem elfogyatkozik is, * szívem Istene és osztályrészem az Isten mindörökké.
+72:27 Mert íme, akik eltávoznak tőled, elvesznek; * elveszted mind, akik elhajlanak tőled.
+72:28 Nekem pedig jó az Istenhez ragaszkodnom, * az Úr Istenbe helyeznem reménységemet;
+72:28 Hogy hirdessen minden dicséretedet * Sion leányának kapuiban.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm73.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm73.txt
@@ -1,0 +1,24 @@
+73:1 Miért vetettél el minket, Isten, mindvégig, * fölindulván haragod a te legelőd juhaira?
+73:2 Emlékezzél meg gyülekezetedről, * melyet kezdettől bírtál,
+73:2 És megváltottál, mint örökséged osztályrészét; * ki Sion hegyén laktál.
+73:3 Emeld föl az ő kevélységük ellen kezeidet mindvégig. * Mennyi gonoszt tőn az ellenség a szent helyen!
+73:4 És dicsekedtek, akik gyűlöltek téged, * ünnepeid között.
+73:5 Az ő jeleiket jelekül tették * a magasokra, mint a kapukra, és nem értették.
+73:6 Mint a fák erdejében, fejszékkel vágták szét annak ajtajait mindegyütt, * fejszével és bárddal döntötték le azt,
+73:7 Felgyújtották tűzzel a te Szentélyedet, * a földön megfertőztették a te neved hajlékát.
+73:8 Mondák szívükben ők és nemzetségük együtt: * Szüntessük meg az Isten minden ünnepnapját a földön.
+73:9 Jeleinket nem látjuk, már nincs próféta; * s minket ő nem ismer többé.
+73:10 Isten, meddig szidalmaz az ellenség, * s bosszantja nevedet az ellenkező mindvégig?
+73:11 Miért tartod vissza kezedet és jobbodat? * Vond ki kebledből, és végezz.
+73:12 Isten a mi királyunk öröktől fogva, * szabadulást szerzett a föld közepette.
+73:13 Te tetted erősséggé erőddel a tengert, * összezúztad a sárkányfőket a vizekben.
+73:14 Te törted össze a sárkány fejeit, * eledelül adtad őt az etiópok népeinek.
+73:15 Te fakasztottál forrásokat és patakokat; * te szárasztottad meg Étán folyóvizeit.
+73:16 Tied a nap, és tied az éj; * te alkottad a hajnalt és a napot.
+73:17 Te rendezted a föld minden határát; * a nyarat és tavaszt te teremtetted.
+73:18 Emlékezzél meg erről: Az ellenség szidalmazta az Urat, * és az esztelen nép ingerelte a te nevedet.
+73:19 Ne add a vadaknak a téged dicsérő lelkeket; * és szegényeid lelkeit ne feledd el egészen.
+73:20 Tekints a te szövetségedre; * mert kik homályban voltak a földön, házakat bírnak tele igaztalansággal.
+73:21 Ne térjen vissza a megalázott szégyennel; * a szegény és szűkölködő dicsérni fogja a te nevedet.
+73:22 Kelj föl, Isten, ítélj a te ügyedben; * emlékezzél meg gyalázatodról, mellyel az esztelen téged egész nap illet.
+73:23 Ne feledkezzél el a te ellenségeid szavairól; * azok kevélysége, kik téged gyűlölnek, mindenkor növekedik.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm74.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm74.txt
@@ -1,0 +1,10 @@
+74:2 Hálát adunk neked, Isten, * hálát adunk, és segítségül hívjuk a te nevedet;
+74:3 Hirdetjük csodáidat. * Mikor az idő itt leend, én igazsággal fogok ítélni;
+74:4 Akkor megolvad a föld és mindnyájan, kik azon laknak; * mert én erősítettem meg annak oszlopait.
+74:5 Azért mondom a gonoszoknak: Ne cselekedjetek gonoszul; * és a vétkezőknek: Ne emeljétek föl szarvatokat.
+74:6 Ne emeljétek föl magasan szarvatokat; * ne szóljatok az Isten ellen hamisságot.
+74:7 Mert sem napkeletről, sem napnyugatról, sem a puszta hegyekről; * mivelhogy Isten a bíró.
+74:8 Ezt megalázza, és amazt fölmagasztalja; * mert kehely van az Úr kezében, tele vegyített színborral,
+74:9 És tölt egyfelé és másfelé, mindazáltal seprője nem fogyott el, * a föld minden bűnösei fogják inni.
+74:10 Én pedig hirdetni fogom ezt mindörökké, * énekelni fogok Jákob Istenének.
+74:11 A bűnösök minden szarvát letöröm, * és az igazak szarvai föl fognak emelkedni.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm75.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm75.txt
@@ -1,0 +1,12 @@
+75:2 Ismeretes az Isten Júdeában; * Izraelben nagy az ő neve.
+75:3 És békességben vagyon az ő helye, * és lakása Sionban.
+75:4 Ott törte össze a kézívek hatalmát, * a pajzsot, kardot és hadat.
+75:5 Midőn te csodálatosképpen világítottál az örök hegyekről, * a balgatag szívűek mind megháborodtak.
+75:6 Aludták álmukat, * és a gazdagság férfiai semmit sem találtak kezeikben
+75:7 A te feddésedtől, Jákob Istene, * elaludtak, kik lovon ültek.
+75:8 Te rettenetes vagy; és ki áll ellened, * mihelyst haragszol?
+75:9 Mennyből hallattad az ítéletet; * a föld megrendült és elcsendesedett,
+75:10 Midőn az Isten fölkelt ítéletre, * hogy megszabadítson a földön minden szelídet.
+75:11 Az ember bősz gondolata is dicsér téged, * és még fogytig tartó haragja is ünnepnapot szerez neked.
+75:12 Tegyetek fogadást és teljesítsétek azt a ti Uratoknak, Isteneteknek, * mindnyájan, kik köröskörül ajándékokat hoztok
+75:13 A rettenetesnek, ki elveszi a fejedelmek lelkét, * ki rettenetes a föld királyainál.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm76.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm76.txt
@@ -1,0 +1,20 @@
+76:2 Szómmal az Úrhoz kiáltok, * szómmal az Istenhez, hogy figyelmezzen reám.
+76:3 Szorongatásom napján az Istent keresem, kezeimet éjjel is feléje emelvén * szüntelenül;
+76:4 És nem akart megvigasztaltatni az én lelkem. * Megemlékezem az Istenről, és gyönyörködöm; és elmélkedem, de az én lelkem elbágyad.
+76:5 A hajnalt megelőzik szemeim, * meg vagyok háborodva, és nem szólhatok.
+76:6 Gondolkodom a régi napokról, * és az örök esztendők vannak elmémben,
+76:7 És elmélkedem éjjel szívemben, * és gondolkodom, és megvizsgálom lelkemet.
+76:8 Vajon az Isten örökre elvet-e? * És nem lesz már engedékenyebb?
+76:9 Vagy mindvégig megszünteti-e irgalmasságát, * nemzedékről nemzedékre?
+76:10 Vagy elfeledkezik-e könyörülni az Isten? * Vagy visszatartja-e haragjában az ő irgalmasságát?
+76:11 És mondom: Most felfogtam! * Ez a változás a Fölséges jobbja által vagyon.
+76:12 Megemlékezem az Úr cselekedeteiről; * mert eszemben vannak kezdettől a te csodatételeid;
+76:13 És elmélkedem minden cselekedetedről, * és a te végzéseiddel foglalkozom.
+76:14 Isten, a te utad szentség; kicsoda oly nagy Isten, mint a mi Istenünk? * Te vagy az Isten, ki csodákat mívelsz;
+76:15 Megismertetted erődet a népekkel, * megszabadítottad karoddal a te népedet, Jákob és József fiait.
+76:17 Láttak téged, Isten, a vizek, láttak téged a vizek, * és féltek, és remegtek a mélységek.
+76:18 Nagy volt a vizek zúgása. * Szózatot adtak a felhők,
+76:18 Mert nyilaid átmentek, * a te mennydörgésed szólt a forgatagban,
+76:19 Villámlásaid tündöklöttek a föld kerekségén; * a föld megmozdult és rengett.
+76:20 A tengeren volt utad, és ösvényeid a sok víz árján; * és nyomdokaid meg nem ismerhetők.
+76:21 Vezetted a te népedet, mint a juhokat, * Mózes és Áron keze által.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm77.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm77.txt
@@ -1,0 +1,78 @@
+77:1 Figyelmezzetek, én népem, az én törvényemre; * hajtsátok fületeket az én szám igéire.
+77:2 Megnyitom számat példabeszédekben, * titkos dolgokat szólok kezdettől.
+77:3 Amiket hallottunk és értettünk, * és atyáink beszélettek nekünk,
+77:4 Nincsenek eltitkolva azok fiaitól * a következő nemzedékben.
+77:4 Elbeszélték az Úr dicséretét, és az ő hatalmát; * és csodatetteit, melyeket cselekedett;
+77:5 Hogy bizonyságot támasztott Jákobban, * és törvényt adott Izraelben.
+77:5 Mennyit parancsolt atyáinknak tudtul adatni fiaik előtt, * hogy tudja a következő nemzedék,
+77:6 A fiak, kik születnek, és felnőnek, * és elbeszélik fiaiknak:
+77:7 Hogy az Istenbe helyezzék reménységüket, és el ne feledjék az Isten jótéteményeit, * és keressék az ő parancsait,
+77:8 És ne legyenek, mint atyáik, * gonosz és bosszantó nemzedék;
+77:8 Oly nemzedék, melynek szíve nem volt igaz, * és melynek lelke nem volt hű az Istenhez,
+77:9 Mint Efrem fiai, kik a kézíjat megvonták, megeresztették, * de visszafordultak a harc napján.
+77:10 Nem tartották meg az Isten szövetségét, * és nem akartak az ő törvényében járni,
+77:11 És elfeledkeztek az ő jótéteményeiről * és csodatetteiről, melyeket mutatott nekik.
+77:12 Atyáik előtt csodákat tett Egyiptom földjén, * Tánisz mezején.
+77:13 Áthasította a tengert, és átvitte őket, * és mintegy tömlőben, megállítá a vizeket.
+77:14 És nappal felhő által vezette őket, * és egész éjjel tűz világítása által.
+77:15 A kősziklát megrepesztette a pusztában, * és megitatta őket, mint nagy mélységből.
+77:16 És vizet fakasztott a kősziklából, * és mint a folyót, úgy árasztotta a vizet.
+77:17 És mégis folyvást vétkeztek ellene, * haragra indították a Fölségest a vizetlen pusztában.
+77:18 És kisértették az Istent szívükben, * midőn lelküknek ételt kértek;
+77:19 És gonoszul szólottak az Istenről, * mondván: Készíthet-e az Isten asztalt a pusztában?
+77:20 Mivelhogy megütötte a kősziklát, és vizek folytak, * és patakok áradtak:
+77:20 Vajon adhat-e kenyeret is, * vagy készíthet-e asztalt is az ő népének?
+77:21 Ezt meghallá az Úr, és elhalasztá; * és tűz gerjedett Jákobra, és harag szállt Izraelre;
+77:22 Mert nem hittek az Istenben, * és nem bíztak az ő szabadításában.
+77:23 És parancsolt onnan fentről a felhőknek, * és megnyitá az ég ajtajait,
+77:24 És mannát hullatott nekik eledelül, * és mennyei kenyeret adott nekik.
+77:25 Az angyalok kenyerét ette az ember; * eledelt küldött nekik bőséggel.
+77:26 Elvivé a napkeleti szelet az égről, * és elhozá erejével a délit.
+77:27 És mint a port, úgy hullatta nekik a húst, * és a tollas madarakat, mint a tenger fövenyét.
+77:28 És táboruk közepére estek * az ő sátoraik körül.
+77:29 És evének, és igen jóllakának, és kívánságukat teljesíté, * és nem csalatkoztak meg kívánságukban.
+77:30 De még szájukban volt étkük, * és már az Isten haragja rájuk szállott,
+77:31 És megölé azok kövéreit, * Izrael választottait megakadályozá.
+77:32 Mindezek mellett mégis vétkeztek, * és nem hittek az ő csodáinak.
+77:33 És elfogytak napjaik hiúságban, * és esztendeik sietséggel.
+77:34 Midőn ölte őket, keresték őt, * és megtértek, és korán reggel hozzája jöttek,
+77:35 És megemlékeztek, hogy Isten az ő segítőjük, * és a fölséges Isten az ő megváltójuk.
+77:36 De csak szájukkal szerették őt, * és nyelvükkel hazudtak neki.
+77:37 Mert szívük hozzája nem volt igaz, * és nem találtattak hűeknek az ő szövetségében.
+77:38 Ő pedig irgalmas, és megkegyelmez bűneiknek, * és nem veszti el őket.
+77:38 És gyakran volt azon, hogy elfordítsa haragját, * és nem gerjeszté föl egészen haragját,
+77:39 És megemlékezett, hogy nem egyebek, mint test, * elenyésző és vissza nem térő lehelet.
+77:40 Hányszor búsították őt a pusztában, * s indították őt haragra a vizetlen helyen?
+77:41 És újra meg újra kísértették az Istent, * és Izrael Szentjét bosszantották.
+77:42 Nem emlékeztek meg az ő kezéről, * ama napról, melyen megszabadította őket a nyomorgató kezéből,
+77:43 Mint vitte véghez Egyiptomban jeleit, * és csodáit Tánisz mezején,
+77:44 Midőn vérré változtatta azok folyóvizeit * és árjait, hogy nem ihattak;
+77:45 Mindenféle legyet bocsátott rájuk, mely megemészté őket; * és békát, mely elpusztítá őket;
+77:46 És a ragyának adá gyümölcsüket, * és termesztményeiket a sáskának;
+77:47 És elverte jégesővel szőlőiket, * és szederfáikat dérrel;
+77:48 És a jégesőnek adá barmaikat, * és jószágukat a tűznek;
+77:49 Midőn rájuk bocsátotta bosszankodása haragját, * a bosszankodást és haragot és szorongatást, csapásokat a gonosz angyalok által;
+77:50 Midőn utat csinált haragja ösvényének, s nem kímélte a haláltól lelküket, * és barmaikat a halálnak szánta;
+77:51 És megölt minden elsőszülöttet Egyiptom földjén, * minden munkájuk zsengéit Kám hajlékaiban;
+77:52 És elvitte népét, mint a juhokat, * és hordozta őket, mint nyájat a pusztában,
+77:53 És kivezette őket reménységben, és nem féltek; * és ellenségeiket a tenger elborította;
+77:54 És bevitte őket megszenteltetése hegyére, * a hegyre, melyet az ő jobbja szerzett;
+77:54 És kiűzte színük elől a nemzeteket, * és elosztá nekik a földet sors által az osztás kötelével;
+77:55 És megtelepíté azok hajlékaiban * Izrael nemzetségeit,
+77:56 És ők kísértették és bosszantották a fölséges Istent, * és nem őrzötték meg bizonyságait,
+77:57 És elfordultak, és nem tarták meg a kötést, * mint atyáik, csalárd kézívként hátrafordultak.
+77:58 Haragra indíták őt halmaikon, * és faragott képeikkel bosszúállásra ingerlék őt.
+77:59 Meghallotta ezt Isten, és megvetette * és igen megutálta Izraelt,
+77:60 És elhagyta Silóban hajlékát, * az ő hajlékát, hol az emberek között lakott,
+77:61 És fogságra adá azok erejét, * és azok szépségét az ellenség kezeibe,
+77:62 És fegyver alá juttatta népét, * és örökségét megvetette.
+77:63 Ifjait tűz emésztette meg; * és szüzeit senki sem siratta.
+77:64 Papjai fegyver által hullottak el; * és özvegyeiken senki sem siránkozott.
+77:65 Akkor mintegy álomból fölserkent az Úr, * mint a bortól megrészegült hatalmas.
+77:66 És megveré ellenségeit hátul; * örök gyalázatot tett rajtuk.
+77:67 És megvetette József hajlékát, * és nem választá Efraim nemzetségét;
+77:68 Hanem Júda nemzetségét választotta, * Sion hegyét, melyet szeretett.
+77:69 És fölépíté szent helyét, mint az egyszarvú szarvát, a földön, * melyet örökre alapított.
+77:70 És Dávidot, az ő szolgáját választotta, és elvevé őt a juhok nyájaitól, * a tejelők mögül hozta el őt,
+77:71 Hogy legeltesse szolgáját, Jákobot, * és örökségét, Izraelt.
+77:72 És legeltette őket szívének ártatlanságában, * és kezeinek okossága szerint vezérlette őket.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm78.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm78.txt
@@ -1,0 +1,15 @@
+78:1 Isten, pogányok jöttek örökségedbe, megfertőztették szent templomodat, * őrkunyhóvá tették Jeruzsálemet.
+78:2 Szolgáid holttestét eledelül adták az égi madaraknak, * szentjeid húsát a föld vadainak.
+78:3 Vérüket mint a vizet ontották Jeruzsálem körül, * és nem volt, ki eltemesse.
+78:4 Gyalázattá lettünk szomszédainknak, * nevetséggé és csúfsággá azoknak, kik körülöttünk vannak.
+78:5 Meddig haragszol, Uram, egészen? * Fölgerjed-e, mint a tűz, bosszankodásod?
+78:6 Öntsd ki haragodat a pogányokra, kik téged nem ismernek, * és az országokra, melyek a te nevedet nem hívták segítségül,
+78:7 Mert megemésztették Jákobot, * és az ő helyét elpusztították.
+78:8 Ne emlékezzél meg régi gonoszságainkról, hamar előzzön meg minket a te irgalmasságod: * mert igen szegények lettünk.
+78:9 Segíts meg minket, szabadító Istenünk, és a te neved dicsőségéért, Uram, szabadíts meg minket; * és légy kegyelmes bűneinknek a te nevedért,
+78:10 Nehogy azt mondják a pogányok között: Hol vagyon az ő Istenük? * Legyen nyilvános a nemzetek között szemeink előtt
+78:10 A bosszúállás szolgáid kiontott véréért. * Jusson színed elé a foglyok fohászkodása;
+78:11 A te karod nagyvolta szerint * tartsd meg a megöltek fiait,
+78:12 És fizesd vissza szomszédainknak keblükbe hétszerte * szidalmukat, mellyel, Uram, téged szidalmaztak.
+78:13 Mi pedig, a te néped, és a te legelőd juhai, * hálát adunk neked mindörökké,
+78:13 Nemzedékről nemzedékre * hirdetni fogjuk dicséretedet.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm79.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm79.txt
@@ -1,0 +1,20 @@
+79:2 Ki Izraelt legelteted, halljad; * ki Józsefet vezeted, mint a juhot,
+79:2 Ki a kerubok fölött ülsz, * jelenj meg Efraim, Benjamin és Manassze előtt;
+79:3 Ébreszd föl hatalmasságodat, és jöjj el, * hogy megszabadíts minket.
+79:4 Isten, téríts meg minket, * és mutasd meg a te orcádat, és megszabadulunk.
+79:5 Erők Ura, Istene, * meddig fogsz haragudni szolgád imádsága fölött?
+79:6 Könnyhullatás kenyerével etetsz-e minket, * és könnyeket adsz-e nekünk italul mértékkel?
+79:7 Ellenmondásul helyeztél minket szomszédainknak, * és ellenségeink gúnyolnak minket.
+79:8 Erők Istene, téríts meg minket, * és mutasd meg a te orcádat, és megszabadulunk.
+79:9 Szőlőt hoztál át Egyiptomból, * kiűzted a nemzeteket, és elültetted azt.
+79:10 Az út vezére voltál színe előtt, * és elültetted gyökereit, és betöltötte a földet,
+79:11 Árnyéka befödte a hegyeket, * és ágai az Isten cédrusait,
+79:12 Kiterjeszté vesszeit a tengerig, * és csemetéit a folyóig.
+79:13 Miért bontottad el sövényét, * hogy szaggassák azt mindnyájan, kik az úton átmennek?
+79:14 Földúlja azt az erdei kan, * és a magányos vad elpusztítja azt.
+79:15 Erők Istene, térj vissza; * tekints le a mennyből, és nézd, és látogasd meg e szőlőt,
+79:16 És végezd el azt, melyet a te jobbod ültetett, * az ember fiára nézve, kit magadnak megerősítettél.
+79:17 Ő tűzzel fölgyújtatott és aláásatott. * Orcád dorgálásától elvesznek.
+79:18 Legyen kezed a te jobbod férfián, * és az ember fián, kit magadnak megerősítettél.
+79:19 És nem távozunk el tőled, te megelevenítesz minket, * és nevedet segítségül fogjuk hívni.
+79:20 Erők Ura, Istene, téríts meg minket, * és mutasd meg a te orcádat, és megszabadulunk.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm8.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm8.txt
@@ -1,0 +1,9 @@
+8:2a Uram, mi Urunk, * mily csodálatos a te neved az egész földön!
+8:2b Mert a te dicsőséged fölmagasztaltatott * az egek fölött.
+8:3 A kisdedek és csecsemők szája által viszed véghez a dicséretet ellenségeid miatt, * hogy megrontsd az ellenséget és bosszúállót.
+8:4 Mert ha nézem egeidet, a te ujjaid alkotásait, * a holdat és csillagokat, melyeket te alapítottál:
+8:5 Mi az ember, hogy megemlékezel róla? * Vagy az ember fia, hogy meglátogatod őt?
+8:6 Kevéssel tetted őt kisebbé az angyaloknál, † dicsőséggel és tisztelettel koronáztad meg őt, * (7) és kezeid alkotmányai fölé rendelted őt.
+8:8 Mindent lábai alá vetettél, * a juhokat és ökröket mind, azon fölül a mezei vadakat is.
+8:9 Az égi madarakat és a tenger halait, * melyek eljárják a tenger ösvényeit.
+8:10 Uram, mi Urunk, * mily csodálatos a te neved az egész földön!

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm80.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm80.txt
@@ -1,0 +1,15 @@
+80:2 Örvendezzetek a mi segítő Istenünknek; * örüljetek Jákob Istenének.
+80:3 Kezdjetek éneket, és hozzatok dobot, * kellemes hárfát citerával.
+80:4 Fújjatok harsonát az újhold napján, * a ti ünnepetek jeles napján.
+80:5 Mert parancsolat ez Izraelben, * és törvény Jákob Istenétől.
+80:6 Bizonyságul rendelte ezt Józsefben, midőn kijött Egyiptom földjéről; * hol nyelvet hallott, melyet nem értett.
+80:7 Elfordította hátát a terhektől, * midőn kezei kosárral szolgáltak.
+80:8 A szorongatásban segítségül hívtál engem, és megszabadítottalak tégedet; * meghallgattalak a förgeteg homályából, megpróbáltalak az ellenmondás vizénél.
+80:9 Halljad, én népem, és bizonyságot teszek neked; * Izrael, ha engem hallgatsz, nem leszen nálad új Isten, sem idegen Istent nem fogsz imádni.
+80:11 Mert én vagyok a te Urad, Istened, ki téged kihoztalak Egyiptom földjéről; * tátsd föl szádat, és betöltöm azt.
+80:12 De az én népem nem hallgatott szavamra, * és nem figyelmezett rám Izrael.
+80:13 És az ő szívük kívánságaira hagytam őket, * és öntanácsaik szerint jártak.
+80:14 Ha az én népem rám hallgatott volna, * ha Izrael utaimon járt volna,
+80:15 Igen könnyen megaláztam volna az ő ellenségeit, * és szorongatóira vetettem volna kezemet.
+80:16 Az Úr ellenségei hízelegnének neki; * és jólétük ideje örökké tartana;
+80:17 És a gabona javával táplálná őket, * és a kősziklából mézzel elégítené meg őket.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm81.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm81.txt
@@ -1,0 +1,8 @@
+81:1 Isten az istenek gyülekezetében áll, * és ítéli abban az isteneket.
+81:2 Meddig ítéltek hamisságot, * és tekintitek a bűnös személyét?
+81:3 Tegyetek ítéletet a szűkölködőnek és árvának; * a megalázottnak és szegénynek szolgáltassatok igazságot.
+81:4 Mentsétek meg a szegényt, * és a szűkölködőt szabadítsátok ki a bűnös kezéből.
+81:5 De ők nem tudják ezt, és nem értik, sötétségben járnak; * azért ingadozik a föld minden alapja.
+81:6 Én mondottam: istenek vagytok, * és a Fölséges fiai mindnyájan.
+81:7 De azért mint emberek fogtok meghalni, * és mint egy a fejedelmek közül, elestek.
+81:8 Kelj föl, Isten, ítéld meg a földet, * mert te örökségül bírod mind a nemzeteket.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm82.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm82.txt
@@ -1,0 +1,17 @@
+82:2 Isten, ki hasonló hozzád? * Ne hallgass, és ne nyugodjál, Isten.
+82:3 Mert íme a te ellenségeid fölzendültek, * és akik gyűlölnek téged, fejüket fölemelték.
+82:4 A te néped fölött gonosz tanácsot tartanak, * és a te szentjeid ellen ármánykodnak.
+82:5 Mondják: Jertek és irtsuk ki őket a nemzetek közül, * és Izrael neve többé ne legyen emlékezetben.
+82:6 Mert egy akarattal tanácskoznak, * szövetséget kötnek együtt ellened az idumeusok hajlékai és az izmaeliták,
+82:8 Moáb és az agarénusok, Gebál és Ammon és Amalek, * az idegenek Tírusz lakóival.
+82:9 Asszúr is velük jő, * segítségül lettek Lót fiainak.
+82:10 Cselekedjél velük, mint Mádiánnal és Sisarával, * mint Jábinnal Cisszon patakjánál.
+82:11 Kik elvesztek Endorban, * s lettek mint a föld ganéja.
+82:12 Tégy az ő fejedelmeikkel, mint Órebbel és Zebbel * és Zebeével és Szalmanával;
+82:13 Minden fejedelmükkel, * kik azt mondják: Bírjuk örökségül az Isten Szentélyét.
+82:14 Én Istenem, tedd őket olyanokká, mint a forgatag, * és mint a pozdorja a szél színe előtt.
+82:15 Mint a tűz, mely fölégeti az erdőt, * és mint a hegyeket fölégető láng:
+82:16 Úgy üldözd őket a te viharod által, * és zavard össze haragod által.
+82:17 Töltsd be orcájukat gyalázattal, * hogy keressék, Uram, a te nevedet.
+82:18 Piruljanak és rémüljenek el örökkön-örökre; * és szégyenüljenek meg és vesszenek el.
+82:19 És ismerjék meg, hogy Úr a te neved, * te vagy egyedül Fölséges az egész földön.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm83.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm83.txt
@@ -1,0 +1,13 @@
+83:2 Mily kellemesek a te hajlékaid, erők Ura, * kívánkozik és eped lelkem az Úr tornácai után.
+83:3 Szívem és testem * örvendeznek az élő Istenben.
+83:4 Mert a veréb talál magának házat, * és a gerlice fészket, hova fiait helyezze,
+83:4 Én a te oltáraidat, erők Ura, * királyom és Istenem.
+83:5 Boldogok, kik a te házadban laknak, Uram, * örökkön-örökké dicsérnek tégedet.
+83:6 Boldog a férfiú, kinek tőled vagyon segítsége. * Fölmenetekről gondolkodik szívében, a könnyhullatások völgyén, ama helyre, melyet magának kitűzött.
+83:8 Mert áldást ad a törvényszerző, erényről erényre mennek, * míg meglátják az istenek Istenét Sionban.
+83:9 Erők Ura, Istene, hallgasd meg imádságomat; * vedd füleidbe, Jákob Istene.
+83:10 Mi oltalmazó Istenünk, * tekints és nézz a te fölkented orcájára;
+83:11 Mert jobb egy nap a te tornácaidban * ezereknél.
+83:11 Inkább akarok utolsó lenni az én Istenem házában, * mint lakni a bűnösök hajlékaiban.
+83:12 Mert Isten az irgalmasságot és igazságot szereti; * kegyelmet és dicsőséget ád az Úr;
+83:13 Nem vonja meg a jókat azoktól, kik ártatlanságban járnak. * Erők Ura, boldog ember az, ki benned bízik.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm84.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm84.txt
@@ -1,0 +1,14 @@
+84:2 Megáldottad, Uram, a te földedet; * elfordítottad Jákob fogságát,
+84:3 Megbocsátottad a te néped gonoszságát, * elfödözted minden vétküket,
+84:4 Megenyhítetted minden haragodat, * eltértél a te haragod hevétől.
+84:5 Téríts meg minket, szabadító Istenünk, * és fordítsd el rólunk haragodat.
+84:6 Vajon örökké fogsz-e ránk haragudni? * Vagy kiterjeszted-e haragodat nemzedékről nemzedékre?
+84:7 Isten, ha te hozzánk fordulsz, fölélesztesz minket; * és a te néped örvendeni fog benned.
+84:8 Mutasd meg, nekünk, Uram, irgalmasságodat; * és szabadításodat add meg nekünk.
+84:9 Meghallom, mit szól az Úr Isten: * békességet szól ő népének
+84:9 És az ő szentjeinek * és azoknak, kik szívükbe térnek.
+84:10 Valóban az őt félőkhöz közel van szabadítása, * hogy dicsőség lakjék a mi földünkön.
+84:11 Az irgalom és igazság találkoznak; * az igazság és béke megcsókolják egymást.
+84:12 A hűség a földből ered, * és az igazság a mennyből letekint.
+84:13 Mert az Úr jót ad, * és a mi földünk megadja gyümölcsét.
+84:14 Igazság jár előtte, * és annak útján lépdel.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm85.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm85.txt
@@ -1,0 +1,16 @@
+85:1 Hajtsd meg, Uram, füledet, és hallgass meg engem; * mert nyomorult és szegény vagyok én.
+85:2 Őrizd meg lelkemet, mert neked vagyok szentelve; * szabadítsd meg benned bízó szolgádat, én Istenem.
+85:3 Könyörülj rajtam, Uram, mert egész nap hozzád kiáltok. * Vidámítsd meg a te szolgád lelkét, mert, Uram, tehozzád emelem lelkemet.
+85:5 Mert te, Uram, jóságos vagy és kegyes, * és nagy irgalmú mindazokhoz, kik téged segítségül hívnak.
+85:6 Vedd füleidbe, Uram, imádságomat, * és figyelmezz az én könyörgésem szavára.
+85:7 Szorongásom napján hozzád kiáltok; * mert te meghallgatsz engem.
+85:8 Nincs, Uram, hasonló hozzád az istenek között, * és nincs a te cselekedeteidhez.
+85:9 A nemzetek, kiket alkottál, mind eljőnek és imádkozni fognak előtted, Uram, * és dicsőítik majd a te nevedet.
+85:10 Mert nagy vagy te, és csodákat mívelsz; * te vagy Isten egyedül.
+85:11 Vezess engem, Uram, a te utadon, és igazságodban fogok járni; * vigadjon az én szívem, hogy félje a te nevedet.
+85:12 Hálát adok neked, Uram, Istenem, teljes szívemből, * és dicsőítem a te nevedet mindörökké.
+85:13 Mert nagy a te irgalmasságod énrajtam, * és kimentetted lelkemet a legalsóbb mélységből.
+85:14 Isten, a gonoszok föltámadtak ellenem, és a hatalmasok gyülekezete keresi az én lelkemet; * és nem tart téged szemei előtt.
+85:15 De te, Uram, Isten, könyörülő vagy és irgalmas, * tűrő és nagy irgalmú és igazságos;
+85:16 Tekints rám, és könyörülj rajtam; * add hatalmadat szolgádnak, és szabadítsd meg szolgálód fiát.
+85:17 Add jelét irántam való jóságodnak, hogy lássák azt, kik engem gyűlölnek, és szégyenüljenek meg; * mert, Uram, te segítesz és megvigasztalsz engem.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm86.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm86.txt
@@ -1,0 +1,7 @@
+86:1 Az ő alapjai a szent hegyeken vannak; * szereti az Úr Sion kapuit Jákob minden hajléka fölött.
+86:3 Dicsőséges dolgok mondatnak felőled, * Isten városa.
+86:4 Megemlékezem Ráhábról és Babilonról, * hogy megismerjenek engem.
+86:4 Íme az idegenek, és Tírusz és az etiópok népe, * ezek is oda valók.
+86:5 Nemde Sionról fog mondatni: Ember és ember született benne; * és maga alapította azt a Fölséges?
+86:6 Az Úr fogja ezt elbeszélni a népek és fejedelmek írásaiban, * azokéban, kik benne vannak.
+86:7 Mindnyájan vigadni fognak, * kiknek lakásuk vagyon benned.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm87.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm87.txt
@@ -1,0 +1,19 @@
+87:2 Én szabadulásom Ura, Istene, * éjjel-nappal kiáltok teelőtted.
+87:3 Jusson színed elé az én imádságom; * hajtsd füledet könyörgésemre.
+87:4 Mert lelkem eltelt rosszakkal; * és életem közelget a pokolhoz.
+87:5 A sírgödörbe lemenőkhöz számláltatom; * olyan lettem, mint a segítség nélkül való ember, a halottak közé bocsátva,
+87:6 Mint a sírokban alvó megsebesültek, kikről többé meg nem emlékezel, * és kik a te kezedből kiszakasztattak.
+87:7 Mély verembe tettek engem, * sötétségbe és a halál árnyékába.
+87:8 Rám nehezült a te haragod, * és rám hoztad minden hullámodat.
+87:9 Eltávolítottad tőlem ismerőimet, * utálatosságul tettek engem maguknak.
+87:9 Kézbe adattam, és nincs menekvésem; * szemeim elbágyadnak az ínség miatt;
+87:10 Hozzád kiáltok, Uram, napestig, * hozzád terjesztem ki kezeimet.
+87:11 Vajon a holtakon mívelsz-e csodákat? * Vagy az orvosok fognak föltámasztani, hogy magasztaljanak tégedet?
+87:12 Beszéli-e valaki a sírban irgalmasságodat, * és igazságodat az enyészetben?
+87:13 Tudják-e a sötétségben csodatételeidet, * és igazságodat a feledés földjén?
+87:14 Én azért, Uram, hozzád kiáltok, * és reggel megelőz téged imádságom.
+87:15 Miért veted meg, Uram, imádságomat, * s fordítod el tőlem orcádat?
+87:16 Szegény vagyok és megterhelt ifjúságomtól fogva; * ha fölmagasztaltattam is, de megaláztattam és megszégyeníttettem.
+87:17 Keresztül megy rajtam a te haragod, * és rettentéseid megháborítanak engem.
+87:18 Körülvesznek engem, mint a víz egész nap, * körülvesznek engem egyetemben.
+87:19 Eltávolítottad tőlem barátomat és társamat, * és ismerőimet nyomorúságomtól.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm88.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm88.txt
@@ -1,0 +1,51 @@
+88:2 Az Úr irgalmasságait * mindörökké éneklem,
+88:2 Nemzedékről nemzedékre * hirdetni fogom igazságodat az én számmal.
+88:3 Mert azt mondottad: Az irgalmasság örökre megállapíttatik a mennyekben, * el van készítve igazságod azokban.
+88:4 Szövetséget kötöttem választottaimmal, megesküdtem Dávid szolgámnak: * Megalapítom a te ivadékodat
+88:5 És nemzedékről nemzedékre megerősítem * székedet.
+88:6 Hirdetni fogják, Uram, az egek csodatételeidet, * és igaz voltodat a szentek gyülekezetében.
+88:7 Mert ki hasonlítható a felhőkben az Úrhoz? * Ki lesz hasonló Isten fiai közt az Istenhez?
+88:8 Az Isten, ki a szentek tanácsában dicsőíttetik, * nagy és rettenetes mindazok fölött, kik körötte vannak.
+88:9 Erők Ura, Istene, ki hasonló hozzád? * Hatalmas vagy, Uram, és a te igazságod környezetedben.
+88:10 Te uralkodol a tenger hatalmasságán, * és habjai dagályát te csendesíted le.
+88:11 Te megalázod a kevélyt, mint a sebesültet, * a te erőd karjaival ide s tova hányod ellenségeidet.
+88:12 Tieid az egek, és tied a föld; a föld kerekségét, s ami azt betölti, te alapítottad; * az északot és a tengert te teremtetted;
+88:13 Tábor és Hermon a te nevedben örvendenek. * Hatalmas a te karod.
+88:14 Erősödjék meg kezed, és magasztaltassék föl a te jobbod. * Jog és igazság a te széked alapja;
+88:15 Irgalom és valóság járnak orcád előtt. * Boldog nép az, mely tud vigadozni;
+88:16 Uram, a te orcád világosságában járnak ők, és a te nevednek örvendeznek egész nap, * és igazságodban fölmagasztaltatnak.
+88:18 Mert erejük dicsősége te vagy, * és jóvoltodból emelkedik föl a mi szarvunk;
+88:19 Mert az Úr fölvett bennünket, * Izrael Szentje a mi királyunk.
+88:20 Akkor látomásban szólottál szentjeidnek, és mondád: * Segítséget adtam a hatalmasnak, és fölmagasztaltam a választottat népem közül.
+88:21 Találtam Dávidot az én szolgámat, * szent olajommal kentem fel őt.
+88:22 Mert az én kezem megsegíti őt, * és karom megerősíti őt.
+88:23 Semmire sem megy vele az ellenség, * és a gonoszság fia nem mer ártani neki.
+88:24 És összevágom orcája előtt ellenségeit, * és gyűlölőit megszalasztom.
+88:25 És az én valóságom és irgalmam vele lesz; * és nevemben föl fog emelkedni szarva.
+88:26 És a tengerre teszem az ő kezét, * és jobbját a folyóvizekre.
+88:27 Ő segítségül hív engem: Te Atyám vagy, * Istenem, és üdvöm oltalma.
+88:28 És én elsőszülötté teszem őt, * följebbvalóvá a föld királyainál.
+88:29 Örökké megtartom neki irgalmasságomat, * és szövetségemet hűen őneki.
+88:30 És ivadékát örökkévalóvá teszem, * és királyi székét, mint az ég napjait.
+88:31 De ha fiai elhagyják törvényemet, * és nem járnak ítéleteimben,
+88:32 Ha rendeléseimet megfertőztetik, * és parancsaimat nem tartják:
+88:33 Meglátogatom vesszővel gonoszságaikat, * és vereségekkel az ő bűneiket.
+88:34 Azonban irgalmasságomat nem veszem el tőle, * és nem szegem meg igazmondásomat,
+88:35 Sem nem hamisítom meg szövetségemet, * s ami ajkaimon kijő, nem teszem érvénytelenné.
+88:36 Egyszer megesküdtem az én szentségemre; hazudok-e Dávidnak? * Az ő ivadéka örökké megmarad,
+88:37 És királyi széke, mint a nap, az én szemem előtt, * és mint a teljes hold mindörökké; s ama hűséges tanú az égen.
+88:39 Te pedig megvetetted és megutáltad, * távol tartottad a te Fölkentedet,
+88:40 Fölforgattad a te szolgád szövetségét, * megfertőztetted a földön az ő Szentélyét,
+88:41 Lerontottad minden kerítését, * erősségébe félelmet helyeztél;
+88:42 Megrabolta őt minden útonjáró, * gyalázattá lett szomszédainak.
+88:43 Fölemelted az ő nyomorgatói jobbját, * örömet szerzettél minden ellenségének,
+88:44 Elvetted fegyverének segítségét, * és nem segítetted őt a hadban.
+88:45 Eltörlötted az ő tisztaságát, * és székét a földre vetetted,
+88:46 Megrövidítetted ideje napjait, * elborítottad őt gyalázattal.
+88:47 Meddig fordulsz el, Uram, egészen? * Fölgyullad-e mint a tűz a te haragod?
+88:48 Emlékezzél meg, mi az én mivoltom; * hiába alkottad-e mind az emberek fiait?
+88:49 Melyik ember az, ki él, és halált nem lát? * Megmenti-e lelkét a pokol kezéből?
+88:50 Hol vannak a te régi irgalmasságaid, Uram, * amint megesküdtél Dávidnak igaz voltodra?
+88:51 Emlékezzél meg, Uram, a te szolgáid gyalázatáról, * mit kebelemben hordozok annyi sok nemzettől,
+88:52 Hogy gúnyolnak, Uram, a te ellenségeid, * s kigúnyolják a te fölkented balsorsát.
+88:53 Áldassék az Úr mindörökké. * Úgy legyen, úgy legyen.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm89.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm89.txt
@@ -1,0 +1,19 @@
+89:1 Uram, oltalmunk lettél nekünk * nemzedékről nemzedékre.
+89:2 Mielőtt a hegyek lettek, vagy a föld alkottatott és a világ, * öröktől fogva és örökké vagy te, Isten.
+89:3 Ne taszítsd el az embert romlásra, * ki mondottad: Térjetek meg, emberek fiai.
+89:4 Mert ezer esztendő a te szemeid előtt, * mint a tegnapi nap, mely elmúlt,
+89:5 Mint egy éjjeli őrizet. * Mint amik semmiknek tartatnak, olyanok az ő esztendeik.
+89:6 Korán elhervad, mint a fű; reggel virágzik, hogy elhervadjon; * este lehull, elfonnyad és elszárad.
+89:7 Mert elenyészünk haragod miatt, * és búsulásod miatt folyvást rettegünk.
+89:8 Eléd raktad gonoszságainkat, * és életidőnket orcád világossága elé.
+89:9 Mert napjaink mind elenyésznek, * és haragod miatt elfogyunk;
+89:9 A mi esztendeink pókhálók gyanánt tekinthetők; * a mi éveink napjai hetven esztendő,
+89:10 Jó erőben, nyolcvan esztendő, * s mi azok fölött van, fáradság és fájdalom;
+89:10 Mert eljő az ernyedés, * és elragadtatunk.
+89:11 Ki ismeri a te haragod erejét? * S a tőled való félelem miatt, ki mérheti meg haragodat?
+89:12 Taníts meg jobbodtól függő napjainkat számba venni, * hogy bölcs szívet nyerhessünk.
+89:13 Térj hozzánk, Uram, valahára, * és légy könyörületes a te szolgáidhoz.
+89:14 És megtelünk reggel irgalmasságoddal, * és örvendezünk és gyönyörködünk minden napjainkban,
+89:15 Vigadunk a napokért, melyekben minket megaláztál; * az esztendőkért, melyekben nyomorúságokat láttunk.
+89:16 Tekints a te szolgáidra és alkotásodra, * és igazgasd azok fiait.
+89:17 És legyen rajtunk a mi Urunk, Istenünk fényessége, és kezeink munkáit te igazgasd fölöttünk, * kezeink munkáját igazgassad.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm9.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm9.txt
@@ -1,0 +1,42 @@
+9:2 Hálát adok neked Uram, teljes szívemből; * elbeszélem minden csodádat,
+9:3 Vigadok és örvendezek benned; * dicséretet mondok a te nevednek, Fölséges.
+9:4 Hátratérvén ellenségeim, * elgyengülnek és elvesznek színed elől;
+9:5 Mert végrehajtottad ítéletemet és ügyemet; * a királyi széken ültél, ki igazsággal ítélsz.
+9:6 Megdorgáltad a pogányokat, és elveszett az istentelen; * nevüket eltörlötted örökre és mindörökkön-örökre.
+9:7a Az ellenség kardjai végképp ellankadtak; * az ő városaikat lerontottad.
+9:7b Elveszett emlékezetük, mint a hang. * (8a) De az Úr örökké megmarad;
+9:8b Királyi székét elkészítette ítéletre; * (9) és ő ítéli meg a föld kerekségét igazán, megítéli a népeket igazsággal.
+9:10 Az Úr menedéke lőn a szegénynek, * segítője alkalmas időben, a szorongatásban.
+9:11 És bíznak benned, kik ismerik a te nevedet, * mert nem hagyod el, akik keresnek téged, Uram.
+9:12 Zengjetek az Úrnak, ki Sionban lakik; * hirdessétek a pogányok között végzéseit;
+9:13 Mert a vér bosszulója megemlékezett róluk; * nem feledte el a szegények kiáltását.
+9:14 Könyörülj rajtam, Uram, * lásd ellenségeimtől való megaláztatásomat;
+9:15 Ki fölemelsz engem a halál kapuiból, * hogy hirdessem minden dicséretedet Sion leánya kapuiban.
+9:16a Örvendezni fogok szabadításodon; * a pogányok elsüllyedtek a veszedelemben, melyet készítettek.
+9:16b E tőrben, melyet elrejtettek, * fogatott meg az ő lábuk.
+9:17 Majd megismertetik az Úr, hogy ítéletet teszen; * kezei cselekedeteiben fogatott meg a bűnös.
+9:18 Pokolba térjenek a bűnösök, * mind a népek, kik elfeledik az Istent.
+9:19 Mert nem leszen mindvégig elfeledve a szegény; * a szegények tűrése nem vesz el mindvégig.
+9:20 Kelj föl, Uram, ne erősödjék meg az ember; * ítéltessenek meg a népek színed előtt.
+9:21 Rendelj, Uram, törvényhozót föléjük: * tudják meg a nemzetek, hogy emberek.
+9:22 Miért távoztál, Uram, messze, * elfordulsz az alkalmas időben, a szorongatásban?
+9:23 Míg az istentelen kevélykedik, ég a szegény; * de amaz megfogatik tanácsaiban, melyeket forralt;
+9:24 Mert a bűnös dicsekszik lelke kívánságaiban, * és a gonosz áldja magát.
+9:25 A bűnös megkeseríti az Urat, * haragja nagysága szerint nem néz semmit.
+9:26a Nincs Isten az ő színe előtt; * utai meg vannak fertőztetve minden időben.
+9:26b Eltávolíttatnak ítéleteid az ő orcája elől, * minden ellenségén uralkodni akar.
+9:27 Mert mondá szívében: * Nem fogok ingadozni, nemzedékről nemzedékre, baj nélkül leszek.
+9:28 Szája telve átokkal és keserűséggel és álnoksággal; * nyelve alatt nyomorgatás vagyon és fájdalom.
+9:29 Lesben ül a gazdagokkal, rejtekben, * hogy megölje az ártatlant.
+9:30a Szemei a szegényre néznek; * leselkedik a rejtekben, mint barlangjában az oroszlán.
+9:30b Leselkedik, hogy elragadja a szegényt; * elragadja a szegényt, magához vonván őt.
+9:31 Tőrében lenyomja őt, * meghajol és rohan, midőn hatalmába ejti a szegényeket.
+9:32 Mert mondá szívében: Elfelejtkezett az Isten, * elfordította orcáját, hogy mindvégig ne lásson.
+9:33 Kelj föl, Uram, Isten, emeld föl kezedet; * ne feledkezzél el a szegényekről.
+9:34 A gonosz miért ingerlette az Istent? * Mert mondá szívében: Nem fog számra venni.
+9:35a Te pedig látod ezt, mert te nézed a nyomorgatást és fájdalmat, * hogy kezedbe ejtsd őket.
+9:35b Rád van hagyva a szegény; * te leszel az árva segítője.
+9:36 Törd el a bűnös és gonosztevő karját; * keresni fogják az ő bűnét, és nem találják.
+9:37 Az Úr országlani fog örökké és mindörökkön-örökké; * ti pogányok, elvesztek az ő földjéről.
+9:38 A szegények kívánságát meghallgatta az Úr; * szívük készületeit meghallotta a te füled:
+9:39 Hogy ítéletet tégy az árvának és alázatosnak, * hogy az ember többé ne magasztalja föl magát a földön.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm90.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm90.txt
@@ -1,0 +1,16 @@
+90:1 Aki a Fölséges segítségében lakik, * a menny Istenének oltalmában marad.
+90:2 Mondhatja az Úrnak: Oltalmazóm vagy te és segítségem; * én Istenem, őbenne bízom.
+90:3 Valóban ő megszabadított engem a vadászok tőréből * és a súlyos veszélytől.
+90:4 Vállaival megárnyékoz téged, * és az ő szárnyai alatt biztos vagy.
+90:5 Pajzs gyanánt vesz téged körül az ő igazsága; * nem fogsz félni az éjjeli rémtől,
+90:6 A nappal repülő nyíltól, † a sötétben járó vésztől, * és a déli gonosz támadásától.
+90:7 Ezren hullanak el oldalad mellől, † és tízezren jobbod felől: * tehozzád pedig nem fog közeledni;
+90:8 Hanem szemeiddel nézed, * és a bűnösök díját meglátod.
+90:9 Mert te vagy, Uram, az én reményem; * ha a Fölségest választottad magadnak menedékül,
+90:10 Nem járul hozzád veszedelem, * és csapás nem közeledik hajlékodhoz.
+90:11 Mert angyalainak parancsolt felőled, * hogy megőrizzenek téged minden utadban.
+90:12 Kezeikben hordoznak téged, * hogy kőbe ne üssed lábadat.
+90:13 Áspison és baziliszkuszon fogsz járni, * s az oroszlánt és sárkányt tapodod.
+90:14 Mivelhogy bennem bízott, megszabadítom őt, * mert megismerte az én nevemet.
+90:15 Hozzám kiált, és én meghallgatom őt; ‡ vele vagyok a szorongatásban; * megmentem és megdicsőítem őt.
+90:16 Betöltöm őt hosszú élettel, * és megmutatom neki az én szabadításomat.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm91.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm91.txt
@@ -1,0 +1,15 @@
+91:2 Jó az Urat dicsérni, * és éneket mondani a te nevednek, Fölséges.
+91:3 Hogy reggel hirdettessék irgalmasságod, * és igaz voltod éjjel,
+91:4 Tízhúrú lanton, hárfán, * énekkel, citerával.
+91:5 Mert örömet szereztél nekem, Uram, a te alkotásodban; * és kezeid műveiben örvendezek.
+91:6 Mily nagyok, Uram, a te munkáid! * Igen mélységesek a te gondolataid.
+91:7 Az esztelen ember nem veszi észre, * és a bolond nem érti ezeket:
+91:8 Hogy midőn kikelnek a bűnösök, mint a fű, * és kitűnnek mindnyájan, kik gonoszt mívelnek,
+91:9 Örökkön-örökre elvesznek. * Te pedig, Uram, fölséges vagy mindörökké.
+91:10 Mert íme, Uram, a te ellenségeid, mert íme a te ellenségeid elvesznek; * és széthányatnak mindnyájan, kik gonoszságot cselekszenek.
+91:11 De az én szarvam föl fog emelkedni, mint az egyszarvúé, * és bőséges irgalomban lesz öregségem.
+91:12 És szemem lenéz majd ellenségeimre; * és a rám támadó gonosztevőkről hallani fog fülem.
+91:13 Az igaz, mint a pálmafa, virágzik, * növekedni fog, mint a Libanon cédrusa.
+91:14 Kik az Úr házában vannak ültetve, * a mi Istenünk háza tornácaiban virágzani fognak.
+91:15 Még öregségükben is hajtani fognak, * és jó állapotban lesznek, hogy hirdessék:
+91:16 Mily igaz a mi Urunk, Istenünk, * és igaztalanság nincs őbenne.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm92.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm92.txt
@@ -1,0 +1,7 @@
+92:1a Az Úr országol, ékességbe öltözött, * erősségbe öltözött az Úr, és felövezte magát;
+92:1b Mert ő erősítette meg a föld kerekségét, * mely nem fog inogni.
+92:2 Alapítva van a te széked kezdet óta, * öröktől fogva vagy te.
+92:3a Fölemelik, Uram, a folyók, * fölemelik a folyók szavukat,
+92:3b Fölemelik a folyók habjaikat, * (4a) de a sok vizek zúgásainál,
+92:4b A tenger csodálatos dagályánál is * csodálatosabb az Úr a magasságban.
+92:5 A te bizonyságtételeid igen hitelesek lettek; * a te házadat szentség illeti, Uram, örök időkre.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm93.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm93.txt
@@ -1,0 +1,23 @@
+93:1 Isten a bosszúállás Ura, * a bosszúállás Istene szabadon cselekszik.
+93:2 Emelkedjél föl, ki a földet ítéled; * fizesd meg a díjt a kevélyeknek.
+93:3 Meddig fognak, Uram, a bűnösök, * meddig fognak a bűnösök örvendezni,
+93:4 Beszélni és gonoszságot szólani, * szólani mind, kik igaztalanságot mívelnek?
+93:5 A te népedet, Uram, megalázzák, * és örökségedet nyomorgatják;
+93:6 Az özvegyet és jövevényt megölik, * és az árvákat meggyilkolják,
+93:7 És azt mondják: Nem látja az Úr, * és nem veszi észre Jákob Istene.
+93:8 Értsétek meg, esztelenek, a nép között, * és bolondok, valahára okuljatok.
+93:9 Ki a fület plántálta, nem hall-e? * Vagy ki a szemet alkotta, nem lát-e?
+93:10 Ki megdorgálja a népeket, nem fedd-e meg? * Ki tudományra tanítja az embert?
+93:11 Az Úr tudja az emberek gondolatait, * hogy hiábavalók.
+93:12 Boldog ember az, kit te oktatsz, Uram, * és törvényedre tanítasz.
+93:13 Hogy megnyugtasd őt a rossz napokon, * míg a bűnösnek verem ásatik.
+93:14 Mert az Úr nem veti meg népét, * és örökségét nem hagyja el,
+93:15 Mígnem az igazság ítéletté változik, * és mellette lesznek mind, kik igaz szívűek.
+93:16 Ki kel föl érettem a gonoszok ellen? * Vagy ki áll mellém a gonosztevők ellen?
+93:17 Ha akkor az Úr nem segít engem, * csakhamar pokolban lakott volna az én lelkem.
+93:18 Ha mondottam: Lábam ingadoz, * a te irgalmasságod, Uram, megsegített engem.
+93:19 Szívem fájdalmainak sokasága között * a te vigasztalásaid örvendeztették az én lelkemet.
+93:20 Vajon a gonoszság székével tartasz-e? * S a törvény örve alatt nyomorgatás-e a te szándékod?
+93:21 Ők kapkodnak az igaz lelkén, * és az ártatlan vért elkárhoztatják;
+93:22 De az Úr nekem oltalmam lett, * és az én Istenem reményem segítsége;
+93:23 És megfizeti nekik gonoszságukat, és rosszaságukban elveszti őket, * elveszti őket a mi Urunk, Istenünk.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm94.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm94.txt
@@ -1,0 +1,14 @@
+94:1 Jertek, örvendezzünk az Úrnak, * vigadjunk a mi szabadító Istenünknek:
+94:2 Járuljunk orcája elé hálaadással, * és zsoltárokkal vigadjunk neki.
+$ant
+94:3 Mert nagy Isten az Úr, * és nagy király minden istenek fölött:
+94:4 Mert kezében vagyon a föld minden határa, * és övéi a hegyek magasságai.
+$ant
+94:5 Mert övé a tenger, és ő alkotta azt, * és az ő kezei alakították a szárazat.
+$ant
+94:7 És mi az ő legelőjének népe, és kezeinek juhai vagyunk. * Ma, ha az ő szavát halljátok, meg ne keményítsétek szíveteket,
+94:8 Mint ama bosszantással a kísértés napján a pusztában: * hol megkísértettek engem atyáitok, próbára tettek engem, bár látták cselekedeteimet.
+$ant
+94:9 Negyven esztendeig bosszantott engem e nemzedék, * és mondám; Ezek szívükben mindenkor tévelyegnek:
+94:10 És nem ismerték meg az én utaimat, úgy hogy megesküdtem haragomban; * Nem mennek be az én nyugodalmamba.
+$ant

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm95.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm95.txt
@@ -1,0 +1,13 @@
+95:1 Énekeljetek az Úrnak új éneket; * énekeljetek az Úrnak, minden föld.
+95:2 Énekeljetek az Úrnak, és áldjátok az ő nevét; * hirdessétek napról napra szabadítását.
+95:3 Hirdessétek a nemzetek között dicsőségét, * minden nép között az ő csodáit.
+95:4 Mert nagy az Úr, és igen dicsérendő; * rettenetes minden istenek fölött.
+95:5 Mert a pogányok minden istenei gonosz lelkek; * az Úr pedig alkotta az egeket.
+95:6 Hálaadás és szépség vagyon színe előtt, * szentség és fönség az ő szentélyében.
+95:7 Adjatok az Úrnak népek hazái, adjatok az Úrnak dicsőséget és tiszteletet. * Adjatok az Úr nevének dicsőséget;
+95:8 Vigyetek áldozatokat, és menjetek az ő tornácaiba. * Imádjátok az Urat szent tornácában;
+95:9 Rendüljön meg orcája előtt az egész föld. * Mondjátok a pogányok között, hogy az Úr országol;
+95:10 Ki összeszerkeszté a föld kerekségét, mely nem fog inogni; * igazságban ítéli meg a népeket.
+95:11 Vigadjanak az egek, és örvendezzen a föld; induljon meg a tenger, és ami azt betölti; * örüljenek a mezők, és mind ami azokon vagyon;
+95:12 Örvendezzen az erdők minden fája az Úr színe előtt, mert eljő *; eljő a földet ítélni.
+95:13 Megítéli a föld kerekségét igazságban, * és a népeket igaz volta szerint.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm96.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm96.txt
@@ -1,0 +1,13 @@
+96:1 Az Úr országol, örvendezzen a föld; * vigadjon a sok sziget.
+96:2 Felhő és homály van körötte, * igazság és ítélet az ő székének alapja.
+96:3 Tűz jár előtte, * és megemészti köröskörül ellenségeit.
+96:4 Villámai megvilágítják a föld kerekségét; * látja és megrendül a föld.
+96:5 A hegyek mint a viasz megolvadnak az Úr színe előtt, * az Úr színe előtt az egész föld.
+96:6 Az egek hirdetik az ő igazságát; * és minden nép az ő dicsőségét.
+96:7 Szégyenüljenek meg mindnyájan, kik faragott képeket imádnak, * és kik bálványaikban dicsekszenek.
+96:7 Imádjátok őt, minden angyalai. * * Hallja ezt Sion, és örül;
+96:8 És Júda leányai örvendeznek * a te ítéleteidben, Uram.
+96:9 Mert te, Uram, legfölségesebb vagy az egész földön, * igen fölmagasztaltattál minden istenek fölött.
+96:10 Kik szeretitek az Urat, gyűlöljétek a gonoszt; * az Úr megőrzi az ő szentjei lelkeit, a bűnös kezéből megszabadítja őket.
+96:11 Világosság támadott az igaznak, * és vigasság az egyenesszívűeknek.
+96:12 Vigadjatok, igazak, az Úrban, * és dicsérjétek az ő szentségének emlékezetét.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm97.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm97.txt
@@ -1,0 +1,10 @@
+97:1 Énekeljetek az Úrnak új éneket; * mert csoda dolgokat cselekedett.
+97:1 Megsegítette őt jobbja * és az ő szent karja.
+97:2 Az Úr kijelentette szabadítását, * a nemzetek színe előtt kinyilatkoztatta igazságát.
+97:3 Megemlékezett irgalmasságáról * és igazmondásáról Izrael háza iránt.
+97:3 A föld minden határa látja * a mi Istenünk szabadítását.
+97:4 Örvendezzetek az Istennek, minden föld, * énekeljetek és vigadjatok, és zengjetek dicséretet.
+97:5 Zengjetek az Úrnak citerán, citerával, és zsoltárszóval * harsonazengés és kürthangok között.
+97:6 Örvendezzetek az Úr, a király színe előtt. * Induljon meg a tenger, és mi azt betölti; a föld kereksége, és a kik azon laknak.
+97:8 Tapsoljanak kézzel a folyók, egyetemben örvendezzenek a hegyek az Úr színe előtt; * mert eljő a földet ítélni.
+97:9 Megítéli a föld kerekségét igazságban, * és a népeket egyenességgel.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm98.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm98.txt
@@ -1,0 +1,10 @@
+98:1 Az Úr országol, reszkessenek a népek; * a kerubokon ül, rémüljön meg a föld.
+98:2 Nagy az Úr Sionban, * és fölséges minden nép fölött.
+98:3 Adjanak hálát a te nagy nevednek; mert rettenetes és szent, * és az igazságot szerető király hatalmának.
+98:4 Te szerzel törvényt, * ítéletet és igazságot Jákobban te szolgáltatsz.
+98:5 Magasztaljátok a mi Urunkat, Istenünket, és boruljatok le lábai zsámolya előtt, * mert ő szent.
+98:6 Mózes és Áron az ő papjai között, * és Sámuel azok között, kik segítségül hívják az ő nevét,
+98:6 Segítségül hívták az Urat, és meghallgatta őket, * a felhőoszlopból szólt hozzájuk;
+98:7 Ők megtartották bizonyságait * és a parancsot, melyet nekik adott.
+98:8 Urunk, Istenünk, te meghallgattad őket; * Isten, te kegyelmes voltál hozzájuk, és megbosszultál minden törekvést ellenük.
+98:9 Magasztaljátok a mi Urunkat, Istenünket, és imádjátok az ő szent hegyén; * mert szent a mi Urunk, Istenünk.

--- a/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm99.txt
+++ b/web/www/horas/Magyar-Kaldi/Psalterium/Psalmorum/Psalm99.txt
@@ -1,0 +1,5 @@
+99:2a Örvendezzetek az Istennek, minden föld; * szolgáljatok az Úrnak vigassággal,
+99:2b Járuljatok színe elé * örvendezéssel.
+99:3a Tudjátok meg, hogy ő az Úr, ő az Isten. * Ő alkotott minket, és nem mi magunkat;
+99:3b Az ő népe és legelőjének juhai vagyunk. ‡ (4a) Menjetek be az ő kapuin hálaadással, * tornácaiba dicséretekkel; adjatok hálát neki.
+99:4b Dicsérjétek az ő nevét, (5) mert jóságos az Úr, † örökké tart irgalmassága, * és nemzedékről nemzedékre az ő igazsága.

--- a/web/www/horas/horas.dialog
+++ b/web/www/horas/horas.dialog
@@ -43,7 +43,7 @@ Votive~>$votive~>Optionmenu~>votives;;
 tota,psalteria,propria,lineamenta
 
 [languages]
-Latin,Cantilenæ/Latin-gabc,English,Čeština/Bohemice,Čeština - Schaller/Cesky-Schaller,Dansk,Deutsch,Español/Espanol,Français/Francais,Italiano,Magyar,Nederlands,Polski,Português/Portugues,Tiếng Việt/Vietnamice,Latin-Bea,Polski-Newer,עברית/Hebrew
+Latin,Cantilenæ/Latin-gabc,English,Čeština/Bohemice,Čeština - Schaller/Cesky-Schaller,Dansk,Deutsch,Español/Espanol,Français/Francais,Italiano,Magyar,Magyar-Káldi/Magyar-Kaldi,Nederlands,Polski,Português/Portugues,Tiếng Việt/Vietnamice,Latin-Bea,Polski-Newer,עברית/Hebrew
 
 [versions]
 Tridentine - 1570,Tridentine - 1888,Tridentine - 1906,Divino Afflatu - 1939,Divino Afflatu - 1954,Reduced - 1955,Rubrics 1960 - 1960,Rubrics 1960 - 2020 USA,Monastic - 1617/Monastic Tridentinum 1617,Monastic - 1930/Monastic Divino 1930,Monastic - 1963,Monastic - 1963 - Barroux,Ordo Cisterciensis - 1951/Monastic Tridentinum Cisterciensis 1951,Ordo Cisterciensis - Abbatia B.M.V. de Altovado/Monastic Tridentinum Cisterciensis Altovadensis,Ordo Praedicatorum - 1962


### PR DESCRIPTION
Restore the previously included Psalms using Káldi György's translation, from his Hungarian Bible completed between 1605 and 1607, as requested in #5369.