### PR TITLE
Add missing/incomplete German canticles in the Psalter

### DIFF
--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm212.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm212.txt
@@ -1,12 +1,12 @@
-(Canticum Tobiae * Tob. 13:1-11)
-13:1 Magnus es, Dómine, in ætérnum, * et in ómnia sæcula regnum tuum:
-13:2 Quóniam tu flagéllas, et salvas: dedúcis ad ínferos, et redúcis: * et non est qui effúgiat manum tuam.
-13:3 Confitémini Dómino, fílii Israël, * et in conspéctu géntium laudáte eum:
-13:4 Quóniam ídeo dispérsit vos inter gentes, quæ ignórant eum, * ut vos enarrétis mirabília ejus,
-13:5 Et faciátis scire eos, * quia non est álius Deus omnípotens præter eum.
-13:6 Ipse castigávit nos propter iniquitátes nostras: * et ipse salvábit nos propter misericórdiam suam.
-13:7 Aspícite ergo quæ fecit nobíscum, et cum timóre et tremóre confitémini illi: * Regémque sæculórum exaltáte in opéribus vestris.
-13:8 Ego autem in terra captivitátis meæ confitébor illi: * quóniam osténdit majestátem suam in gentem peccatrícem.
-13:9 Convertímini ítaque, peccatóres, et fácite justítiam coram Deo, * credéntes quod fáciat vobíscum misericórdiam suam:
-13:10 Ego autem, et ánima mea * in eo lætábimur.
-13:11 Benedícite Dóminum, omnes elécti ejus: * ágite dies lætítiæ, et confitémini illi.
+(Canticum Tobiæ * Tob. 13:1-11)
+13:1 Groß bist du, o Herr, in Ewigkeit, * und in alle Ewigkeit währt deine Herrschaft.
+13:2 Denn du schlägst und heilst, du führst zur Unterwelt hinab und wieder herauf: * und niemand kann deiner Hand entfliehen.
+13:3 Preiset den Herrn, ihr Kinder Israels, * und lobet ihn vor dem Angesichte der Völker:
+13:4 Denn darum hat er euch unter die Völker zerstreut, welche ihn nicht kennen, * damit ihr seine Wundertaten verkündet,
+13:5 Und jenen zu wissen tuet, * dass kein anderer der allmächtige Gott ist außer ihm.
+13:6 Er hat uns um unserer Missetaten willen gezüchtigt: * und er wird uns um seiner Barmherzigkeit willen erlösen.
+13:7 Sehet also, was er an uns getan, und preiset ihn mit Furcht und Zittern: * und erhebet den König der Ewigkeit durch euer Tun.
+13:8 Ich aber will ihn preisen im Lande meiner Gefangenschaft: * denn er hat seine Herrlichkeit an einem sündigen Volke erwiesen.
+13:9 Bekehret euch daher, ihr Sünder, und übet Gerechtigkeit vor Gott, * glaubend, dass er euch seine Barmherzigkeit erweisen wird:
+13:10 Ich aber und meine Seele, * wir wollen uns in ihm freuen.
+13:11 Preiset den Herrn, ihr alle seine Auserwählten: * feiert Freudentage und danket ihm.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm213.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm213.txt
@@ -1,9 +1,9 @@
 (Canticum Judith * Judith 16:15-22)
-16:15 Hymnum cantémus Dómino, * hymnum novum cantémus Deo nostro.
-16:16 Adonái, Dómine, magnus es tu, et præclárus in virtúte tua, * et quem superáre nemo potest.
-16:17 Tibi sérviat omnis creatúra tua: * quia dixísti, et facta sunt:
-16:18 Misísti spíritum tuum, et creáta sunt, * et non est qui resístat voci tuæ.
-16:19 Montes a fundaméntis movebúntur cum aquis: * petræ, sicut cera, liquéscent ante fáciem tuam.
-16:20 Qui autem timent te, * magni erunt apud te per ómnia.
-16:21 Væ genti insurgénti super genus meum: Dóminus enim omnípotens vindicábit in eis, * in die judícii visitábit illos.
-16:22 Dabit enim ignem, et vermes in carnes eórum, * ut urántur, et séntiant usque in sempitérnum.
+16:15 Lasset uns dem Herrn ein Lied singen, * ein neues Loblied lasset uns unserm Gott singen!
+16:16 Adonai, Herr, du bist groß und herrlich in deiner Kraft, * und niemand kann dich übertreffen.
+16:17 Dir sollen alle deine Geschöpfe dienen: * denn du sprachst, und es ward:
+16:18 Du sandtest deinen Geist, und es ward erschaffen, * und niemand vermag deiner Stimme zu widerstehen.
+16:19 Die Berge wanken in ihren Gründen mit den Wassern: * die Felsen zerschmelzen wie Wachs vor deinem Antlitz.
+16:20 Aber die, welche dich fürchten, * werden bei dir in allem groß sein.
+16:21 Wehe dem Volke, das sich über mein Volk erhebt; denn der Herr, der Allmächtige, wird sich an ihnen rächen, * wird sie heimsuchen am Tage des Gerichtes.
+16:22 Denn er wird ihr Fleisch dem Feuer und den Würmern preisgeben, * dass sie brennen und es fühlen in Ewigkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm215.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm215.txt
@@ -1,17 +1,17 @@
-(Canticum Isaiae * Isa 45:15-30)
-45:15 Vere tu es Deus abscónditus, * Deus Israël, Salvátor.
-45:16 Confúsi sunt, et erubuérunt omnes: * simul abiérunt in confusiónem fabricatóres errórum.
-45:17 Israël salvátus est in Dómino salúte ætérna: * non confundémini, et non erubescétis usque in sæculum sæculi.
-45:18 Quia hæc dicit Dóminus creans cælos, * ipse Deus formans terram, et fáciens eam, ipse plastes ejus:
-45:19 Non in vanum creávit eam, ut habitarétur, formávit eam: * Ego Dóminus, et non est álius.
-45:20 Non in abscóndito locútus sum, * in loco terræ tenebróso:
-45:21 Non dixi sémini Jacob frustra: Quærite me: * ego Dóminus loquens justítiam, annúntians recta.
-45:22 Congregámini, et veníte, et accédite simul * qui salváti estis ex géntibus:
-45:23 Nesciérunt qui levant lignum sculptúræ suæ, * et rogant deum non salvántem.
-45:24 Annuntiáte, et veníte, et consiliámini simul: * Quis audítum fecit hoc ab inítio, ex tunc prædíxit illud?
-45:25 Numquid non ego Dóminus, et non est ultra Deus absque me? * Deus justus, et salvans non est præter me.
-45:26 Convertímini ad me, et salvi éritis, omnes fines terræ: * quia ego Deus, et non est álius.
-45:27 In memetípso jurávi, egrediétur de ore meo justítiæ verbum, * et non revertétur:
-45:28 Quia mihi curvábitur omne genu, * et jurábit omnis lingua.
-45:29 Ergo in Dómino, dicet, meæ sunt justítiæ et impérium: * ad eum vénient, et confundéntur omnes qui repúgnant ei.
-45:30 In Dómino justificábitur, et laudábitur * omne semen Israël.
+(Canticum Isaiæ * Isa 45:15-30)
+45:15 Wahrlich, du bist ein verborgener Gott, * du Gott Israels, Heiland!
+45:16 Beschämt werden alle und stehen schamrot da; * mit Schanden weichen die Schmiede der Irrtümer allzumal zurück.
+45:17 Israel ist gerettet in dem Herrn durch ewiges Heil; * ihr werdet nicht zuschanden noch schamrot werden in alle Ewigkeit.
+45:18 Denn also spricht der Herr, der die Himmel schuf, * der Gott, der die Erde bildete und formte, ihr Bildner:
+45:19 Nicht zur Einöde schuf er sie, sondern damit sie bewohnt würde, bildete er sie: * Ich bin der Herr, und es ist keiner sonst.
+45:20 Nicht im Verborgenen habe ich geredet, * an dunkler Stätte der Erde:
+45:21 Nicht sprach ich zur Nachkommenschaft Jakobs: Ohne Erfolg suchet mich! * Ich bin der Herr, der Gerechtigkeit redet und verkündet, was recht ist.
+45:22 Versammelt euch und kommet und tretet herzu insgesamt, * die ihr gerettet seid aus den Heiden!
+45:23 Töricht sind, die das Holz ihres Schnitzbildes schleppen, * und einen Gott anflehen, der nicht helfen kann.
+45:24 Verkündiget und kommet und beratet euch zumal! * Wer hat dies von Anbeginn an kundgetan, vorlängst es vorhergesagt?
+45:25 Nicht ich, der Herr, und ist etwa ein Gott außer mir? * Ein gerechter und ein helfender Gott ist nicht außer mir!
+45:26 Bekehret euch zu mir, so werdet ihr gerettet werden, alle Enden der Erde! * denn ich bin Gott und es ist sonst keiner.
+45:27 Ich habe bei mir selbst geschworen, das Wort der Gerechtigkeit geht aus meinem Munde aus, * und wird nicht rückgängig:
+45:28 Dass sich mir jedes Knie beugen soll, * und jede Zunge mir schwören!
+45:29 Also bei dem Herrn, wird man sprechen, ist Gerechtigkeit für mich und Macht; * zu ihm kommt man, und beschämt werden alle, die sich ihm widersetzen.
+45:30 Im Herrn wird gerechtfertigt * und verherrlicht werden alle Nachkommenschaft Israels.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm216.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm216.txt
@@ -1,17 +1,17 @@
 (Canticum Ecclesiastici * Sir 36:1-16)
-36:1 Miserére nostri, Deus ómnium, et réspice nos, * et osténde nobis lucem miseratiónum tuárum:
-36:2 Et immítte timórem tuum super gentes, * quæ non exquisiérunt te,
-36:3 Ut cognóscant quia non est Deus nisi tu, * et enárrent magnália tua.
-36:4 Álleva manum tuam super gentes aliénas, * ut vídeant poténtiam tuam.
-36:5 Sicut enim in conspéctu eórum sanctificátus es in nobis, * sic in conspéctu nostro magnificáberis in eis,
-36:6 Ut cognóscant te, sicut et nos cognóvimus, * quóniam non est Deus præter te, Dómine.
-36:7 Ínnova signa, et immúta mirabília. * Glorífica manum, et bráchium dextrum.
-36:8 Éxcita furórem, et effúnde iram. * Tolle adversárium, et afflíge inimícum.
-36:9 Festína tempus, et meménto finis, * ut enárrent mirabília tua.
-36:10 In ira flammæ devorétur qui salvátur: * et qui péssimant plebem tuam, invéniant perditiónem.
-36:11 Cóntere caput príncipum inimicórum, * dicéntium: Non est álius præter nos.
-36:12 Cóngrega omnes tribus Jacob: ut cognóscant quia non est Deus nisi tu, * et enárrent magnália tua:
-36:13 Et hereditábis eos, * sicut ab inítio.
-36:14 Miserére plebi tuæ, super quam invocátum est nomen tuum: * et Israël, quem coæquásti primogénito tuo.
-36:15 Miserére civitáti sanctificatiónis tuæ Jerúsalem, * civitáti requiéi tuæ.
-36:16 Reple Sion inenarrabílibus verbis  tuis, * et glória tua pópulum tuum.
+36:1 Erbarme dich unser, du Gott über alles, und schau auf uns, * und zeige uns das Licht deiner Erbarmungen:
+36:2 Und sende Furcht über die Völker, * welche dich nicht suchen,
+36:3 Damit sie erkennen, dass kein Gott ist außer dir, * und deine großen Taten verkünden.
+36:4 Erhebe deine Hand über die fremden Völker, * dass sie deine Macht erfahren.
+36:5 Denn wie du vor ihren Augen dich an uns heilig erwiesen hast, * so mögest du vor unsern Augen dich an ihnen verherrlichen,
+36:6 Damit sie dich erkennen, wie auch wir erkannt haben, * dass kein Gott ist außer dir, o Herr.
+36:7 Erneuere die Zeichen und wiederhole die Wunder. * Verherrliche deine Hand und deinen rechten Arm.
+36:8 Entfache deinen Grimm und gieße deinen Zorn aus. * Vertilge den Widersacher und züchtige den Feind.
+36:9 Beschleunige die Zeit und gedenke des Endes, * damit sie deine Wundertaten verkünden.
+36:10 Wer sich gerettet hat, werde vom Feuer des Zornes verzehrt: * und wer dein Volk bedrückt, möge zugrunde gehen.
+36:11 Zerschmettere die Häupter der feindlichen Fürsten, * die da sprechen: Außer uns ist niemand etwas!
+36:12 Sammle alle Stämme Jakobs: damit sie erkennen, dass kein Gott ist außer dir, * und sie deine Wunder verkünden:
+36:13 Und nimm sie wieder als dein Eigentum an, * wie vom Anfange her.
+36:14 Erbarme dich deines Volkes, über das dein Name angerufen ist, * und Israels, das du einem Erstgebornen gleichgehalten.
+36:15 Erbarme dich der Stadt deines Heiligtums, Jerusalems, * der Stadt deiner Ruhe.
+36:16 Erfülle Sion mit deiner unaussprechlichen Verheißung, * und dein Volk mit deiner Herrlichkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm220.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm220.txt
@@ -1,8 +1,8 @@
-(Canticum Trium_puerorum * Dan 3:52-57)
-3:52 Benedictus es, Dómine, Deus patrum nostrórum: * et laudábilis, et gloriósus, et superexaltátus in sæcula.
-3:53 Et benedíctum nomen glóriæ tuæ sanctum: * et laudábile, et superexaltátum in ómnibus sæculis.
-3:54 Benedíctus es in templo sancto glóriæ tuæ: * et superlaudábilis, et supergloriósus in sæcula.
-3:55 Benedíctus es in throno regni tui: * et superlaudábilis, et superexaltátus in sæcula.
-3:56 Benedíctus es, qui intúeris abýssos, et sedes super Chérubim: * et laudábilis, et superexaltátus in sæcula.
-3:57 Benedíctus es in firmaménto cæli: * et laudábilis, et gloriósus in sæcula.
-3:58 Benedícite, ómnia ópera Dómini, Dómino: * laudáte, et superexaltáte eum in sæcula.
+(Canticum Trium Puerorum * Dan 3:52-57)
+3:52 Gepriesen seist du, Herr, Gott unserer Väter: * preiswürdig und herrlich und hochgerühmt in Ewigkeit.
+3:53 Und gepriesen sei dein heiliger, herrlicher Name: * lobwürdig und hochgerühmt in alle Ewigkeit.
+3:54 Gepriesen seist du in dem heiligen Tempel deiner Herrlichkeit: * überaus preiswürdig und überaus verherrlicht in Ewigkeit.
+3:55 Gepriesen seist du auf dem Throne deines Reiches: * überaus preiswürdig und hochgerühmt in Ewigkeit.
+3:56 Gepriesen seist du, der du die Tiefen schaust und über den Cherubim thronst: * preiswürdig und hochgerühmt in Ewigkeit.
+3:57 Gepriesen seist du an der Feste des Himmels: * preiswürdig und verherrlicht in Ewigkeit.
+3:58 Preiset den Herrn, alle ihr Werke des Herrn: * lobet und rühmet ihn hoch in Ewigkeit.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm221.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm221.txt
@@ -1,8 +1,8 @@
-(Canticum Isaiae * Isa 12:1-7)
-12:1 Confitébor tibi, Dómine, quóniam irátus es mihi: * convérsus est furor tuus, et consolátus es me.
-12:2 Ecce Deus salvátor meus, * fiduciáliter agam, et non timébo:
-12:3 Quia fortitúdo mea, et laus mea Dóminus, * et factus est mihi in salútem.
-12:4 Hauriétis aquas in gáudio de fóntibus Salvatóris: * et dicétis in die illa: Confitémini Dómino, et invocáte nomen ejus:
-12:5 Notas fácite in pópulis adinventiónes ejus: * mementóte quóniam excélsum est nomen ejus.
-12:6 Cantáte Dómino quóniam magnífice fecit: * annuntiáte hoc in univérsa terra.
-12:7 Exsúlta, et lauda, habitátio Sion: * quia magnus in médio tui Sanctus Israel.
+(Canticum Isaiæ * Isa 12:1-7)
+12:1 Ich preise dich, Herr, denn du zürntest mir: * aber dein Zorn hat sich gewendet, und du hast mich getröstet.
+12:2 Siehe, Gott ist mein Heiland: * ich will vertrauensvoll handeln und mich nicht fürchten:
+12:3 Denn meine Stärke und mein Preis ist der Herr, * und er ist mir zum Heil geworden.
+12:4 Ihr werdet in Freuden Wasser schöpfen aus den Quellen des Heilands: * und werdet an jenem Tage sprechen: Preiset den Herrn und rufet seinen Namen an:
+12:5 Machet unter den Völkern seine Taten kund: * verkündiget, dass sein Name erhaben ist.
+12:6 Lobsinget dem Herrn, denn er hat Herrliches getan: * verkündiget es auf der ganzen Erde.
+12:7 Frohlocket und jauchzet, ihr Bewohner Sions: * denn groß ist in eurer Mitte der Heilige Israels.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm222.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm222.txt
@@ -1,16 +1,16 @@
-(Canticum Ezechiae * Isa 38:10-24)
-38:10 Ego dixi: In dimídio diérum meórum * vadam ad portas ínferi.
-38:11 Quæsívi resíduum annórum meórum. * Dixi: Non vidébo Dóminum Deum in terra vivéntium.
-38:12 Non aspíciam hóminem ultra, * et habitatórem quiétis.
-38:13 Generátio mea abláta est, et convolúta est a me, * quasi tabernáculum pastórum.
-38:14 Præcísa est velut a texénte, vita mea: dum adhuc ordírer, succídit me: * de mane usque ad vésperam fínies me.
-38:15 Sperábam usque ad mane, * quasi leo sic contrívit ómnia ossa mea:
-38:16 De mane usque ad vésperam fínies me: * sicut pullus hirúndinis sic clamábo, meditábor ut colúmba:
-38:17 Attenuáti sunt óculi mei, * suspiciéntes in excélsum.
-38:18 Dómine, vim pátior, respónde pro me. * Quid dicam, aut quid respondébit mihi, cum ipse fécerit?
-38:19 Recogitábo tibi omnes annos meos * in amaritúdine ánimæ meæ.
-38:20 Dómine, si sic vívitur, et in tálibus vita spíritus mei, corrípies me, et vivificábis me. * Ecce, in pace amaritúdo mea amaríssima:
-38:21 Tu autem eruísti ánimam meam ut non períret: * projecísti post tergum tuum ómnia peccáta mea.
-38:22 Quia non inférnus confitébitur tibi, neque mors laudábit te: * non exspectábunt qui descéndunt in lacum, veritátem tuam.
-38:23 Vivens vivens ipse confitébitur tibi, sicut et ego hódie: * pater fíliis notam fáciet veritátem tuam.
-38:24 Domine, salvum me fac * et psalmos nostros cantábimus cunctis diébus vitae nostrae in domo Dómini.
+(Canticum Ezechiæ * Isa 38:10-24)
+38:10 Ich sprach: In der Mitte meiner Tage * soll ich zu des Totenreiches Pforten gehen.
+38:11 Ich misse den Rest meiner Jahre. * Ich sprach: Nicht schauen soll ich den Herrn, Gott, im Lande der Lebendigen.
+38:12 Nicht ferner erblicken Menschen, * und Bewohner der Ruhe.
+38:13 Meine Lebenszeit wird hinweggenommen und zusammengerollt vor mir, * wie ein Hirtenzelt.
+38:14 Abgeschnitten wie vom Weber wird mein Leben: da ich noch am Weben bin, schneidet er mich ab: * vom Morgen bis zum Abend bringst du mich zu Ende.
+38:15 Ich hoffte bis zum Morgen, * aber wie ein Löwe, so zermalmt er alle meine Gebeine:
+38:16 Vom Morgen bis zum Abend bringst du mich zu Ende: * wie eine junge Schwalbe seufze ich, girre wie eine Taube:
+38:17 Meine Augen sind ermattet, * aufblickend zur Höhe.
+38:18 Herr, ich leide Gewalt, tritt für mich ein! * Was soll ich sagen? oder was wird er mir entgegnen, hat er es doch selbst getan?
+38:19 Ich will vor dir alle meine Jahre überdenken * in der Bitterkeit meiner Seele.
+38:20 Herr, lebt man so und ist darin meines Geistes Leben? du mögest mich züchtigen und mich neu beleben. * Siehe, im Frieden ward mir meine bitterste Bitterkeit:
+38:21 Du aber hast meine Seele errettet, dass sie nicht umkomme: * hast alle meine Sünden hinter dich geworfen.
+38:22 Denn nicht die Unterwelt preist dich, noch lobsingt dir der Tod: * und die in die Grube hinabsteigen, harren nicht auf deine Treue.
+38:23 Wer lebt, wer lebt, der preist dich, wie ich heute: * der Vater tut den Kindern deine Treue kund.
+38:24 Herr, schaffe mir Heil, * so wollen wir unsere Danklieder singen alle Tage unseres Lebens im Hause des Herrn.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm223.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm223.txt
@@ -1,17 +1,17 @@
-(Canticum Annae * 1 Sam 2:1-16)
-2:1 Exsultávit cor meum in Dómino, * et exaltátum est cornu meum in Deo meo.
-2:2 Dilatátum est os meum super inimícos meos: * quia lætáta sum in salutári tuo.
-2:3 Non est sanctus, ut est Dóminus: neque enim est álius extra te, * et non est fortis sicut Deus noster.
-2:4 Nolíte multiplicáre loqui sublímia, * gloriántes:
-2:5 Recédant vétera de ore vestro: quia Deus scientiárum, Dóminus est, * et ipsi præparántur cogitatiónes.
-2:6 Arcus fórtium superátus est, * et infírmi accíncti sunt róbore.
-2:7 Repléti prius, pro pánibus se locavérunt: * et famélici saturáti sunt.
-2:8 Donec stérilis péperit plúrimos: * et quæ multos habébat fílios, infirmáta est.
-2:9 Dóminus mortíficat et vivíficat, * dedúcit ad ínferos et redúcit.
-2:10 Dóminus páuperem facit et ditat, * humíliat et súblevat.
-2:11 Súscitat de púlvere egénum, * et de stércore élevat páuperem:
-2:12 Ut sédeat cum princípibus, * et sólium glóriæ téneat.
-2:13 Dómini enim sunt cárdines terræ, * et pósuit super eos orbem.
-2:14 Pedes sanctórum suórum servábit, et ímpii in ténebris conticéscent: * quia non in fortitúdine sua roborábitur vir.
-2:15 Dóminum formidábunt adversárii ejus: * et super ipsos in cælis tonábit:
-2:16 Dóminus judicábit fines terræ, et dabit impérium regi suo, * et sublimábit cornu Christi sui.
+(Canticum Annæ * 1 Reg 2:1-16)
+2:1 Es frohlockt mein Herz in dem Herrn, * hoch erhoben ist mein Horn in meinem Gott.
+2:2 Es tut sich mein Mund auf gegen meine Feinde: * denn ich freue mich deines Heiles.
+2:3 Niemand ist heilig wie der Herr; denn es ist kein anderer außer dir, * und niemand ist stark wie unser Gott.
+2:4 Führet nicht, euch rühmend, * immer von neuem hohe Reden;
+2:5 Es weiche das Alte von euerm Munde; denn ein Gott des Wissens ist der Herr, * und vor ihm liegen offen die Gedanken.
+2:6 Der Bogen der Helden ist überwunden, * und die Schwachen sind mit Kraft umgürtet.
+2:7 Die zuvor satt waren, haben sich um Brot verdungen: * und die Hungrigen sind gesättigt;
+2:8 Ja, die Unfruchtbare hat sehr viele Kinder geboren: * und die viele Söhne hatte, ist schwach geworden.
+2:9 Der Herr gibt Tod und Leben, * er führt in das Totenreich und wieder zurück.
+2:10 Der Herr macht arm und macht reich, * erniedrigt und erhöht.
+2:11 Er erhebt aus dem Staube den Dürftigen, * und hebt aus der Niedrigkeit den Armen empor,
+2:12 Dass er sitze neben den Fürsten, * und den Thron der Herrlichkeit einnehme.
+2:13 Denn des Herrn sind die Grundsäulen der Erde, * und er hat den Erdkreis auf sie gesetzt.
+2:14 Er wird die Füße seiner Heiligen behüten, und die Gottlosen werden verstummen in Finsternis: * denn nicht durch eigene Kraft wird der Mensch stark sein.
+2:15 Den Herrn werden seine Feinde fürchten: * er wird über sie seinen Donner rollen lassen im Himmel:
+2:16 Der Herr wird die Grenzen der Erde richten und die Herrschaft seinem Könige geben, * und das Horn seines Gesalbten erhöhen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm224.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm224.txt
@@ -1,23 +1,23 @@
 (Canticum Moysis * Exod. 15:1-22)
-15:1 Cantémus Dómino: glorióse enim magnificátus est, * equum et ascensórem dejécit in mare.
-15:2 Fortitúdo mea, et laus mea Dóminus, * et factus est mihi in salútem.
-15:3 Iste Deus meus, et glorificábo eum: * Deus patris mei, et exaltábo eum.
-15:4 Dóminus quasi vir pugnátor, Omnípotens nomen ejus. * Currus Pharaónis et exércitum ejus projécit in mare.
-15:5 Elécti príncipes ejus submérsi sunt in Mari Rubro: * abýssi operuérunt eos, descendérunt in profúndum quasi lapis.
-15:6 Déxtera tua, Dómine, magnificáta est in fortitúdine: déxtera tua, Dómine, percússit inimícum. * Et in multitúdine glóriæ tuæ deposuísti adversários tuos:
-15:7 Misísti iram tuam, quæ devorávit eos sicut stípulam. * Et in spíritu furóris tui congregátæ sunt aquæ:
-15:8 Stetit unda fluens, * congregátæ sunt abýssi in médio mari.
-15:9 Dixit inimícus: Pérsequar et comprehéndam, * dívidam spólia, implébitur ánima mea:
-15:10 Evaginábo gládium meum, * interfíciet eos manus mea.
-15:11 Flavit spíritus tuus, et opéruit eos mare: * submérsi sunt quasi plumbum in aquis veheméntibus.
-15:12 Quis símilis tui in fórtibus, Dómine? * quis símilis tui, magníficus in sanctitáte, terríbilis atque laudábilis, fáciens mirabília?
-15:13 Extendísti manum tuam, et devorávit eos terra. * Dux fuísti in misericórdia tua pópulo quem redemísti:
-15:14 Et portásti eum in fortitúdine tua, * ad habitáculum sanctum tuum.
-15:15 Ascendérunt pópuli, et iráti sunt: * dolóres obtinuérunt habitatóres Philísthiim.
-15:16 Tunc conturbáti sunt príncipes Edom, robústos Moab obtínuit tremor: * obriguérunt omnes habitatóres Chánaan.
-15:17 Irruat super eos formído et pavor, * in magnitúdine bráchii tui:
-15:18 Fiant immóbiles quasi lapis, donec pertránseat pópulus tuus, Dómine, * donec pertránseat pópulus tuus iste, quem possedísti.
-15:19 Introdúces eos, et plantábis in monte hereditátis tuæ, * firmíssimo habitáculo tuo quod operátus es, Dómine:
-15:20 Sanctuárium tuum, Dómine, quod firmavérunt manus tuæ. * Dóminus regnábit in ætérnum et ultra.
-15:21 Ingréssus est enim eques Phárao cum cúrribus et equítibus ejus in mare: * et redúxit super eos Dóminus aquas maris:
-15:22 Fílii autem Israël ambulavérunt per siccum * in médio ejus.
+15:1 Lasset uns dem Herrn lobsingen: denn glorreich hat er sich herrlich erwiesen, * Rosse und Reiter hat er in's Meer gestürzt.
+15:2 Meine Stärke und mein Lobpreis ist der Herr, * denn er ward mir zum Heile.
+15:3 Er ist mein Gott, ihn will ich preisen: * der Gott meines Vaters, ihn will ich hocherheben.
+15:4 Der Herr ist wie ein Kriegsheld, Allmächtiger ist sein Name. * Die Wagen Pharaos und sein Heer hat er in das Meer gestürzt,
+15:5 Seine auserlesenen Fürsten sind versunken im roten Meere: * Abgründe bedeckten sie, sie sanken in die Tiefe wie ein Stein.
+15:6 Deine Rechte, o Herr, ward verherrlicht in Macht; deine Rechte, o Herr, schlug den Feind. * In der Fülle deiner Herrlichkeit stürztest du deine Widersacher:
+15:7 Du entsandtest deinen Grimm, der sie verzehrte wie Stoppeln. * Durch den Hauch deines Grimmes türmten sich auf die Gewässer:
+15:8 Es stand die flüssige Welle aufrecht, * es türmten sich die Fluten mitten im Meere.
+15:9 Es sprach der Feind: Ich will nachsetzen und sie ergreifen, * will Beute austeilen und des Herzens Begier erfüllen:
+15:10 Ich will mein Schwert ziehen, * sie töten mit meiner Hand.
+15:11 Da wehte dein Hauch, und es bedeckte sie das Meer: * sie versanken wie Blei in den mächtigen Fluten.
+15:12 Wer ist dir gleich unter den Starken, o Herr? * Wer dir gleich, so herrlich in Heiligkeit, so furchtbar und preiswürdig, Wunder verrichtend?
+15:13 Du strecktest deine Hand aus, und die Erde verschlang sie. * Du führtest in Erbarmen das Volk, das du erlöst hast:
+15:14 Und geleitetest es mit deiner Macht, * zu deiner heiligen Wohnung.
+15:15 Es erhoben sich die Völker und sind ergrimmt: * Wehe ergriff die Bewohner Philistäas.
+15:16 Da wurden die Fürsten Edoms bestürzt, die Starken Moabs erfasste Schrecken: * es erstarrten alle Bewohner Chanaans.
+15:17 Es falle auf sie Furcht und Grauen, * ob der Kraft deines Armes:
+15:18 Sie mögen erstarren wie Stein, bis hindurchgezogen dein Volk, o Herr, * bis hindurchgezogen dies dein Volk, das du erworben.
+15:19 Du wirst sie hinführen und pflanzen auf den Berg deines Erbes, * in deine feste Wohnung, die du, o Herr, bereitet,
+15:20 Als dein Heiligtum, o Herr, das deine Hände gefestigt haben. * Der Herr wird herrschen ewig und immerdar.
+15:21 Denn es zogen die Reisigen Pharaos und seine Wagen und Reiter in's Meer: * und der Herr führte über sie die Wasser des Meeres:
+15:22 Die Söhne Israels aber zogen im Trockenen * mitten durch das Meer hindurch.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm226.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm226.txt
@@ -1,66 +1,66 @@
 (Canticum Moysis * Deut 32:1-65)
-32:1 Audíte, cæli, quæ loquor: * áudiat terra verba oris mei.
-32:2 Concréscat ut plúvia doctrína mea, * fluat ut ros elóquium meum.
-32:3 Quasi imber super herbam, et quasi stillæ super grámina. * Quia nomen Dómini invocábo.
-32:4 Date magnificéntiam Deo nostro. * Dei perfécta sunt ópera, et omnes viæ ejus judícia:
-32:5 Deus fidélis, et absque ulla iniquitáte, justus et rectus. * Peccavérunt ei, et non fílii ejus in sórdibus:
-32:6 Generátio prava atque pervérsa. * Hæccine reddis Dómino, pópule stulte et insípiens?
-32:7 Numquid non ipse est pater tuus, * qui possédit te, et fecit, et creávit te?
-32:8 Meménto diérum antiquórum, * cógita generatiónes síngulas:
-32:9 Intérroga patrem tuum, et annuntiábit tibi: * majóres tuos, et dicent tibi.
-32:10 Quando dividébat Altíssimus Gentes: * quando separábat fílios Adam.
-32:11 Constítuit términos populórum * juxta númerum filiórum Israël.
-32:12 Pars autem Dómini, pópulus ejus: * Jacob funículus hereditátis ejus.
-32:13 Invénit eum in terra desérta, * in loco horróris et vastæ solitúdinis:
-32:14 Circumdúxit eum, et dócuit: * et custodívit quasi pupíllam óculi sui.
-32:15 Sicut áquila próvocans ad volándum pullos suos, * et super eos vólitans,
-32:16 Expándit alas suas, et assúmpsit eum, * atque portávit in húmeris suis.
-32:17 Dóminus solus dux ejus fuit: * et non erat cum eo deus aliénus.
-32:18 Constítuit eum super excélsam terram: * ut coméderet fructus agrórum,
-32:19 Ut súgeret mel de petra, * oleúmque de saxo duríssimo.
-32:20 Butýrum de arménto, et lac de óvibus * cum ádipe agnórum, et aríetum filiórum Basan:
-32:21 Et hircos cum medúlla trítici, * et sánguinem uvæ bíberet meracíssimum.
-32:22 Incrassátus est diléctus, et recalcitrávit: * incrassátus, impinguátus, dilatátus,
-32:23 Derelíquit Deum, factórem suum, * et recéssit a Deo, salutári suo.
-32:24 Provocavérunt eum in diis aliénis, * et in abominatiónibus ad iracúndiam concitavérunt.
-32:25 Immolavérunt dæmóniis, et non Deo, * diis, quos ignorábant:
-32:26 Novi recentésque venérunt, * quos non coluérunt patres eórum.
-32:27 Deum qui te génuit dereliquísti, * et oblítus es Dómini, creatóris tui.
-32:28 Vidit Dóminus, et ad iracúndiam concitátus est: * quia provocavérunt eum fílii sui et fíliæ.
-32:29 Et ait: Abscóndam fáciem meam ab eis, * et considerábo novíssima eórum:
-32:30 Generátio enim pervérsa est, * et infidéles fílii.
-32:31 Ipsi me provocavérunt in eo, qui non erat Deus, * et irritavérunt in vanitátibus suis:
-32:32 Et ego provocábo eos in eo, qui non est pópulus, * et in gente stulta irritábo illos.
-32:33 Ignis succénsus est in furóre meo, * et ardébit usque ad inférni novíssima:
-32:34 Devorabítque terram cum gérmine suo, * et móntium fundaménta combúret.
-32:35 Congregábo super eos mala, * et sagíttas meas complébo in eis.
-32:36 Consuméntur fame, * et devorábunt eos aves morsu amaríssimo:
-32:37 Dentes bestiárum immíttam in eos, * cum furóre trahéntium super terram, atque serpéntium.
-32:38 Foris vastábit eos gládius, et intus pavor, * júvenem simul ac vírginem, lactántem cum hómine sene.
-32:39 Dixi: Ubinam sunt? * cessáre fáciam ex homínibus memóriam eórum.
-32:40 Sed propter iram inimicórum dístuli: * ne forte superbírent hostes eórum,
-32:41 Et dícerent: Manus nostra excélsa, et non Dóminus, * fecit hæc ómnia.
-32:42 Gens absque consílio est, et sine prudéntia. * Utinam sáperent, et intellígerent, ac novíssima providérent.
-32:43 Quómodo persequátur unus mille, * et duo fugent decem míllia?
-32:44 Nonne ídeo, quia Deus suus véndidit eos, * et Dóminus conclúsit illos?
-32:45 Non enim est Deus noster ut dii eórum: * et inimíci nostri sunt júdices.
-32:46 De vínea Sodomórum vínea eórum, * et de suburbánis Gomórrhæ:
-32:47 Uva eórum uva fellis, * et botri amaríssimi.
-32:48 Fel dracónum vinum eórum, * et venénum áspidum insanábile.
-32:49 Nonne hæc cóndita sunt apud me, * et signáta in thesáuris meis?
-32:50 Mea est últio, et ego retríbuam in témpore, * ut labátur pes eórum:
-32:51 Juxta est dies perditiónis, * et adésse festínant témpora.
-32:52 Judicábit Dóminus pópulum suum, * et in servis suis miserébitur:
-32:53 Vidébit quod infirmáta sit manus, * et clausi quoque defecérunt, residuíque consúmpti sunt.
-32:54 Et dicet: Ubi sunt dii eórum, * in quibus habébant fidúciam?
-32:55 De quorum víctimis comedébant ádipes, * et bibébant vinum libáminum:
-32:56 Surgant, et opituléntur vobis, * et in necessitáte vos prótegant.
-32:57 Vidéte quod ego sim solus, * et non sit álius Deus præter me:
-32:58 Ego occídam, et ego vívere fáciam: percútiam, et ego sanábo, * et non est qui de manu mea possit erúere.
-32:59 Levábo ad cælum manum meam, et dicam: * Vivo ego in ætérnum.
-32:60 Si acúero ut fulgur gládium meum, * et arripúerit judícium manus mea:
-32:61 Reddam ultiónem hóstibus meis, * et his qui odérunt me retríbuam.
-32:62 Inebriábo sagíttas meas sánguine, * et gládius meus devorábit carnes,
-32:63 De cruóre occisórum, * et de captivitáte, nudáti inimicórum cápitis.
-32:64 Laudáte, Gentes, pópulum ejus, * quia sánguinem servórum suórum ulciscétur:
-32:65 Et vindíctam retríbuet in hostes eórum, * et propítius erit terræ pópuli sui.
+32:1 Höret, ihr Himmel, was ich rede: * es höre die Erde die Worte meines Mundes!
+32:2 Meine Lehre ströme zusammen wie Regen, * wie Tau fließe meine Rede,
+32:3 Wie milder Regenguss auf das Grün, wie Regentropfen auf die Gräser. * Denn den Namen des Herrn will ich preisen.
+32:4 Gebet unserm Gott die Ehre! * Gottes Werke sind vollkommen, und alle seine Wege sind gerecht:
+32:5 Getreu ist Gott, und ohne allen Trug, gerecht und gerade. * Sie sündigten gegen ihn in Schmach, sie, nicht mehr seine Söhne:
+32:6 Ein verderbtes und verkehrtes Geschlecht! * Vergiltst du so dem Herrn, du törichtes und unverständiges Volk?
+32:7 Ist er denn nicht dein Vater, * der dich erworben, der dich gemacht und erschaffen hat?
+32:8 Gedenke der weit zurückliegenden Tage, * betrachte alle Geschlechter:
+32:9 Frage deinen Vater, er wird es dir kundtun: * deine Vorfahren, sie werden es dir sagen.
+32:10 Als der Höchste die Völker schied: * als er die Söhne Adams sonderte,
+32:11 Bestimmte er die Grenzen der Völker * nach der Zahl der Söhne Israels.
+32:12 Des Herrn Anteil aber ist sein Volk: * Jakob das ihm zugemessene Erbe.
+32:13 Er fand es im wüsten Lande, * am Orte des Grauens, der weiten Einöde:
+32:14 Er führte es, und lehrte es: * und hütete es wie seinen Augapfel.
+32:15 Gleichwie der Adler seine Jungen zum Fluge lockt und über ihnen schwebt, * so breitete er seine Flügel aus,
+32:16 Und nahm es, * und trug es auf seinen Schultern.
+32:17 Der Herr allein war sein Führer: * und kein fremder Gott war mit ihm.
+32:18 Er setzte es auf ein hohes Land, dass es die Früchte des Feldes esse, * dass es Honig aus dem Felsen sauge,
+32:19 Und Öl aus dem harten Gesteine, * Butter esse von den Kühen und Milch von den Schafen,
+32:20 Samt dem Fette der Lämmer und Widder der Söhne Basans, und Böcke, samt dem Marke des Weizens: * dass es trinke das Blut der Trauben, den lautersten Wein.
+32:21 Aber der Liebling ward fett und schlug aus: * er ward feist und breit,
+32:22 Da verließ er Gott, seinen Schöpfer, * und wich von Gott, seinem Heile.
+32:23 Sie erzürnten ihn durch fremde Götter, * sie reizten ihn durch Greuel zum Zorne.
+32:24 Sie brachten den bösen Geistern Opfer dar, und nicht Gott, Göttern, die sie nicht kannten, * neuen, die jüngst aufgekommen waren,
+32:25 Die ihre Väter nicht verehrten. * Den Gott, der dich gezeugt, hast du verlassen,
+32:26 Und des Herrn, deines Schöpfers, * hast du vergessen.
+32:27 Der Herr sah es und ward zum Zorne erregt: * denn seine Söhne und Töchter reizten ihn.
+32:28 Und er sprach: Ich will mein Angesicht vor ihnen verbergen, * und schauen, welches ihr Ende sein wird:
+32:29 Denn sie sind ein verkehrtes Geschlecht, * und Kinder ohne Treue.
+32:30 Sie haben mich durch das, was nicht Gott war, gereizt, mich mit ihren Eitelkeiten erbittert: * so will auch ich sie reizen mit dem, was kein Volk ist,
+32:31 Und sie durch ein törichtes Volk erbittern. * Das Feuer meines Zornes ist entflammt,
+32:32 Und wird brennen bis in die tiefste Tiefe der Hölle: * und wird die Erde mit ihrem Gewächs verzehren,
+32:33 Und die Grundfesten der Berge verbrennen. * Ich will des Unglücks Fülle über sie häufen,
+32:34 Und alle meine Pfeile gegen sie schleudern. * Sie werden vom Hunger aufgezehrt werden,
+32:35 Und Raubvögel werden sie mit bitterm Bisse verschlingen: * den Zahn wilder Tiere werde ich über sie senden,
+32:36 Die Wut der am Boden dahinschleichenden Schlangen. * Von außen wird sie das Schwert dahinraffen, von innen der Schrecken,
+32:37 Den Jüngling wie die Jungfrau, * den Säugling wie den Greis.
+32:38 Ich sprach: Wo sind sie? * Vernichten werde ich ihr Andenken unter den Menschen.
+32:39 Doch wegen des Grimmes der Widersacher habe ich verzogen, * dass ihre Feinde nicht etwa im Übermute sagen möchten:
+32:40 Unsere mächtige Hand und nicht der Herr, * hat dies alles getan.
+32:41 Es ist ein Volk ohne Rat und ohne Einsicht. * O wären sie weise, und hätten sie Einsicht,
+32:42 Und bedächten, * welches ihr Ende sein wird!
+32:43 Wie könnte ein einziger tausend verfolgen, * und zwei zehntausend in die Flucht jagen?
+32:44 Nicht darum, weil ihr Gott sie verkauft, * und der Herr sie preisgegeben hat?
+32:45 Denn unser Gott ist nicht wie ihre Götter: * und des sind unsere Feinde selbst Richter.
+32:46 Vom Weinstocke Sodoms stammt ihr Weinstock, * und von den Gefilden Gomorrhas:
+32:47 Ihre Trauben sind Trauben von Galle, * und ihre Beeren bitter.
+32:48 Drachengalle ist ihr Wein, * und unheilbares Natterngift.
+32:49 Ist dies nicht bei mir verborgen, * und versiegelt in meinen Schätzen?
+32:50 Mein ist die Rache, und ich will vergelten zu seiner Zeit, * auf dass ihr Fuß wanke:
+32:51 Schon nahet der Tag des Verderbens, * und die Zeiten eilen schnell heran.
+32:52 Der Herr wird sein Volk richten, * und sich über seine Diener erbarmen:
+32:53 Wenn er sieht, dass ihre Hand entkräftet ist, * dass die Eingeschlossenen schwach und die übriggebliebenen aufgerieben sind.
+32:54 Und er wird sprechen: Wo sind ihre Götter, * auf welche sie ihr Vertrauen setzten?
+32:55 Von deren Schlachtopfer sie das Fett aßen, * von deren Trankopfern sie den Wein tranken?
+32:56 Sie mögen sich erheben, und euch Hilfe bringen, * und euch in der Not beschirmen.
+32:57 Erkennet denn, dass ich der einzige bin, * und dass kein anderer Gott ist außer mir:
+32:58 Ich töte, und ich mache lebendig; ich schlage, und ich heile, * und niemand kann aus meiner Hand erretten.
+32:59 Ich erhebe meine Hand zum Himmel und spreche: * So wahr ich lebe in Ewigkeit!
+32:60 Wenn ich mein Schwert wie den Blitz schärfe, * und meine Hand das Gericht ergreifet:
+32:61 So werde ich Rache an meinen Feinden nehmen, * und denen vergelten, die mich hassen.
+32:62 Ich will meine Pfeile trunken machen vom Blut, * und mein Schwert soll Fleisch fressen von dem Blute der Erschlagenen,
+32:63 Und von den Gefangenen, * das Fleisch der Feinde, deren Haupt entblößt ist.
+32:64 Preiset, ihr Völker, sein Volk! * Denn er rächt das Blut seiner Knechte,
+32:65 Und nimmt Rache an ihren Feinden, * und ist gnädig dem Lande seines Volkes.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm234.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm234.txt
@@ -1,41 +1,41 @@
 (Canticum Quicumque * Symbolum Athanasium)
-Quicúmque vult salvus esse, * ante ómnia opus est, ut téneat cathólicam fidem:
-Quam nisi quisque íntegram inviolatámque serváverit, * absque dúbio in ætérnum períbit.
-Fides autem cathólica hæc est: * ut unum Deum in Trinitáte, et Trinitátem in unitáte venerémur.
-Neque confundéntes persónas, * neque substántiam separántes.
-Alia est enim persóna Patris, ália Fílii, * ália Spíritus Sancti:
-Sed Patris, et Fílii, et Spíritus Sancti una est divínitas, * æquális glória, coætérna majéstas.
-Qualis Pater, talis Fílius, * talis Spíritus Sanctus.
-Increátus Pater, increátus Fílius, * increátus Spíritus Sanctus.
-Imménsus Pater, imménsus Fílius, * imménsus Spíritus Sanctus.
-Ætérnus Pater, ætérnus Fílius, * ætérnus Spíritus Sanctus.
-Et tamen non tres ætérni, * sed unus ætérnus.
-Sicut non tres increáti, nec tres imménsi, * sed unus increátus, et unus imménsus.
-Simíliter omnípotens Pater, omnípotens Fílius, * omnípotens Spíritus Sanctus.
-Et tamen non tres omnipoténtes, * sed unus omnípotens.
-Ita Deus Pater, Deus Fílius, * Deus Spíritus Sanctus.
-Ut tamen non tres Dii, * sed unus est Deus.
-Ita Dóminus Pater, Dóminus Fílius, * Dóminus Spíritus Sanctus.
-Et tamen non tres Dómini, * sed unus est Dóminus.
-Quia, sicut singillátim unamquámque persónam Deum ac Dóminum confitéri christiána veritáte compéllimur: * ita tres Deos aut Dóminos dícere cathólica religióne prohibémur.
-Pater a nullo est factus: * nec creátus, nec génitus.
-Fílius a Patre solo est: * non factus, nec creátus, sed génitus.
-Spíritus Sanctus a Patre et Fílio: * non factus, nec creátus, nec génitus, sed procédens.
-Unus ergo Pater, non tres Patres: unus Fílius, non tres Fílii: * unus Spíritus Sanctus, non tres Spíritus Sancti.
-Et in hac Trinitáte nihil prius aut postérius, nihil majus aut minus: * sed totæ tres persónæ coætérnæ sibi sunt et coæquáles.
-Ita ut per ómnia, sicut jam supra dictum est, * et únitas in Trinitáte, et Trínitas in unitáte veneránda sit.
-Qui vult ergo salvus esse, * ita de Trinitáte séntiat.
-Sed necessárium est ad ætérnam salútem, * ut Incarnatiónem quoque Dómini nostri Jesu Christi fidéliter credat.
-Est ergo fides recta ut credámus et confiteámur, * quia Dóminus noster Jesus Christus, Dei Fílius, Deus et homo est.
-Deus est ex substántia Patris ante sæcula génitus: * et homo est ex substántia matris in sæculo natus.
-Perféctus Deus, perféctus homo: * ex ánima rationáli et humána carne subsístens.
-Æquális Patri secúndum divinitátem: * minor Patre secúndum humanitátem.
-Qui licet Deus sit et homo, * non duo tamen, sed unus est Christus.
-Unus autem non conversióne divinitátis in carnem, * sed assumptióne humanitátis in Deum.
-Unus omníno, non confusióne substántiæ, * sed unitáte persónæ.
-Nam sicut ánima rationális et caro unus est homo: * ita Deus et homo unus est Christus.
-Qui passus est pro salúte nostra: descéndit ad ínferos: * tértia die resurréxit a mórtuis.
-Ascéndit ad cælos, sedet ad déxteram Dei Patris omnipoténtis: * inde ventúrus est judicáre vivos et mórtuos.
-Ad cujus advéntum omnes hómines resúrgere habent cum corpóribus suis; * et redditúri sunt de factis própriis ratiónem.
-Et qui bona egérunt, ibunt in vitam ætérnam: * qui vero mala, in ignem ætérnum.
-Hæc est fides cathólica, * quam nisi quisque fidéliter firmitérque credíderit, salvus esse non póterit.
+Wer immer selig werden will, * der muß vor allem den katholischen Glauben festhalten.
+Wer diesen nicht in seinem ganzen Umfange und unverletzt bewahrt, * wird ohne Zweifel ewig zugrunde gehen.
+Es ist aber katholischer Glaube, * daß wir einen Gott in der Dreifaltigkeit und die Dreifaltigkeit in der Einheit anbeten.
+Ohne Vermengung der Personen * und ohne Trennung der Wesenheit.
+Denn verschieden ist die Person des Vaters, die des Sohnes * und die des Heiligen Geistes.
+Aber nur eine Gottheit ist im Vater und im Sohne und im Heiligen Geiste, * gleich ist Ihre Herrlichkeit, gleich ewig Ihre Majestät.
+Wie der Vater, so der Sohn, * so der Heilige Geist.
+Unerschaffen ist der Vater, unerschaffen der Sohn, * unerschaffen der Heilige Geist.
+Unermeßlich ist der Vater, unermeßlich der Sohn, * unermeßlich der Heilige Geist.
+Ewig ist der Vater, ewig der Sohn, * ewig der Heilige Geist.
+Und doch sind es nicht drei Ewige, * sondern nur ein Ewiger.
+Wie auch nicht drei Unerschaffene und nicht drei Unermeßliche, * sondern ein Unerschaffener und ein Unermeßlicher.
+In gleicher Weise ist allmächtig der Vater, allmächtig der Sohn, * allmächtig der Heilige Geist.
+Und doch sind es nicht drei Allmächtige, * sondern ein Allmächtiger.
+Ebenso ist der Vater Gott, der Sohn Gott, * der Heilige Geist Gott.
+Und doch sind es nicht drei Götter, * sondern es ist nur ein Gott.
+Ebenso ist der Vater Herr, der Sohn Herr, * der Heilige Geist Herr.
+Und doch sind es nicht drei Herren, * sondern nur ein Herr.
+Denn wie wir nach Vorschrift der christlichen Lehre jede Person einzeln für sich als Gott und Herrn bekennen, * so verbietet uns anderseits der katholische Glaube, drei Götter oder Herren anzunehmen.
+Der Vater ist von niemand gemacht, * auch nicht geschaffen, auch nicht gezeugt.
+Der Sohn ist vom Vater allein, * nicht gemacht, nicht geschaffen, sondern gezeugt.
+Der Heilige Geist ist vom Vater und Sohn, * nicht gemacht, nicht geschaffen, nicht gezeugt, sondern hervorgehend.
+Es ist also ein Vater, nicht drei Väter; ein Sohn, nicht drei Söhne; * ein Heiliger Geist, nicht drei Heilige Geister.
+Und in dieser Dreieinigkeit ist nichts früher oder später, nichts größer oder kleiner, * sondern alle drei Personen sind sich gleich ewig und vollkommen gleich.
+So ist in allem, wie schon vorhin gesagt, * die Einheit in der Dreifaltigkeit und die Dreifaltigkeit in der Einheit anzubeten.
+Wer daher selig werden will, * muß in dieser Weise an die heiligste Dreifaltigkeit glauben.
+Zum ewigen Heile ist es weiterhin notwendig, * daß man auch an die Menschwerdung unseres Herrn Jesus Christus aufrichtig glaube.
+Der wahre Glaube fordert also, daß wir glauben und bekennen: * daß Jesus Christus, der Sohn Gottes, Gott und Mensch zugleich ist.
+Gott ist Er, weil Er aus der Wesenheit des Vaters von Ewigkeit her gezeugt, * und Mensch ist Er, weil Er aus dem Leibe der Mutter in der Zeit geboren ist.
+Vollkommener Gott und vollkommener Mensch, * der aus einer vernünftigen Seele und einem menschlichen Leibe besteht.
+Er ist dem Vater gleich der Gottheit nach, * Er ist geringer als der Vater der Menschheit nach.
+Obgleich Er Gott und Mensch zugleich ist, * so sind doch nicht zwei, sondern nur ein Christus.
+Einer aber, nicht als ob die Gottheit in Fleisch verwandelt wäre, * sondern weil Gott die Menschheit angenommen hat.
+Einer ganz und gar, nicht durch Vermischung der Wesenheit, * sondern durch Einheit der Person.
+Denn wie die vernünftige Seele und das Fleisch nur einen Menschen ausmachen, * so ist auch Gott und Mensch nur ein Christus.
+Um unseres Heiles willen hat Er gelitten, ist zur Hölle abgestiegen * und am dritten Tage wieder von den Toten auferstanden;
+Er ist in den Himmel aufgefahren, sitzet zur rechten Hand Gottes, des allmächtigen Vaters, * von dannen Er kommen wird, zu richten die Lebendigen und die Toten.
+Bei Seiner Ankunft werden alle Menschen auferstehen mit ihren Leibern * und Rechenschaft ablegen über ihre eigenen Handlungen.
+Und die, welche Gutes getan, werden hingehen zum ewigen Leben; * die aber Böses getan, werden eingehen ins ewige Feuer.
+Das ist der katholische Glaube; * wer diesen nicht getreulich und fest bekennt, kann nicht selig werden.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm240.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm240.txt
@@ -1,9 +1,11 @@
-(Canticum Isaiae * Isa 40:10-17)
-40:10 Ecce Dominus Deus in fortitudine veniet, et brachium ejus dominabitur: ecce merces ejus cum eo, et opus illius coram illo.
-40:11 Sicut pastor gregem suum pascet, in brachio suo congregabit agnos, et in sinu suo levabit; fœtas ipse portabit.
-40:12 Quis mensus est pugillo aquas, et caelos palmo ponderavit? quis appendit tribus digitis molem terrae, et liberavit in pondere montes, et colles in statera?
-40:13 Quis adjuvit spiritum Domini? aut quis consiliarius ejus fuit, et ostendit illi?
-40:14 cum quo iniit consilium, et instruxit eum, et docuit eum semitam justitiae, et erudivit eum scientiam, et viam prudentiae ostendit illi?
-40:15 Ecce gentes quasi stilla situlae, et quasi momentum staterae reputatae sunt; ecce insulae quasi pulvis exiguus.
-40:16 Et Libanus non sufficiet ad succendendum, et animalia ejus non sufficient ad holocaustum.
-40:17 Omnes gentes quasi non sint, sic sunt coram eo, et quasi nihilum et inane reputatae sunt ei.
+(Canticum Isaiæ * Isa 40:10-17)
+40:10 Sehet, der Herr, Gott, kommt mit Macht, * sein Arm übt Herrschaft:
+40:10 Sehet, sein Lohn ist mit ihm, * und sein Werk geht vor ihm her.
+40:11 Wie ein Hirt wird er seine Herde weiden: in seinen Arm die Lämmer sammeln, * und sie auf seinen Schoß heben, die säugenden Mütter selber tragen.
+40:12 Wer maß in hohler Hand die Wasser, * und schätzte die Himmel ab mit seiner Spanne?
+40:12 Wer fasste mit drei Fingern der Erde Last, * und wog nach dem Gewichte die Berge und die Hügel auf der Waage?
+40:13 Wer hat dem Geiste des Herrn geholfen? * oder wer war sein Ratgeber und unterwies ihn?
+40:14 Mit wem beriet er sich, dass dieser ihn unterwies, ihn den Weg des Rechtes lehrte, * und ihm Einsicht mitteilte und ihm den Weg der Klugheit zeigte?
+40:15 Siehe, Völker sind wie ein Tropfen am Eimer, * und wie ein Stäubchen an der Waage geachtet:
+40:16 Siehe, Inseln sind wie winziger Staub. Der Libanon reicht nicht zum Feuer hin, * und seine Tiere reichen nicht hin zum Brandopfer.
+40:17 Alle Völker sind vor ihm, wie wenn sie nicht wären, * und wie ein Nichts und eine Leere gelten sie bei ihm.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm242.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm242.txt
@@ -1,8 +1,11 @@
-(Canticum Isaiae * Isa 49:7-13)
-49:7 Haec dicit Dominus, redemptor Israël, Sanctus ejus, ad contemptibilem animam, ad abominatam gentem, ad servum dominorum: Reges videbunt, et consurgent principes, et adorabunt propter Dominum, quia fidelis est, et Sanctum Israël qui elegit te.
-49:8 Haec dicit Dominus: In tempore placito exaudivi te, et in die salutis auxiliatus sum tui: et servavi te, et dedi te in fœdus populi, ut suscitares terram, et possideres haereditates dissipatas;
-49:9 ut diceres his qui vincti sunt: Exite, et his qui in tenebris: Revelamini. Super vias pascentur, et in omnibus planis pascua eorum.
-49:10 Non esurient neque sitient, et non percutiet eos aestus et sol, quia miserator eorum reget eos, et ad fontes aquarum potabit eos.
-49:11 Et ponam omnes montes meos in viam, et semitae meae exaltabuntur.
-49:12 Ecce isti de longe venient, et ecce illi ab aquilone et mari, et isti de terra australi.
-49:13 Laudate, caeli, et exsulta, terra; jubilate, montes, laudem, quia consolatus est Dominus populum suum, et pauperum suorum miserebitur.
+(Canticum ejusdem * Isa 49:7-13)
+49:7 So spricht der Herr, der Erlöser Israels, sein Heiliger, zu der verachteten Seele, * zu dem verabscheuten Sprössling, zu dem Knechte der Herrscher.
+49:7 Könige werden sehen und Fürsten sich erheben und anbeten um des Herrn willen, denn er ist treu, * und um des Heiligen Israels willen, der dich erkoren hat.
+49:8 So spricht der Herr: Zur Zeit der Huld erhörte ich dich, * und am Tage des Heiles half ich dir.
+49:8 Und ich rettete dich, und setzte dich ein zum Bunde des Volkes, * um aufzurichten das Land, und in Besitz zu nehmen die verödeten Erbteile:
+49:9 Dass du sprächest zu den Gefangenen: Gehet heraus! * und zu denen in der Finsternis: Kommet ans Licht!
+49:9 Sie werden weiden an den Wegen, * und auf allen Ebenen werden ihre Triften sein.
+49:10 Sie werden nicht Hunger noch Durst leiden, noch wird Hitze und Sonne sie treffen: * denn ihr Erbarmer leitet sie, und tränkt sie an Wasserquellen.
+49:11 Und ich werde alle meine Berge zum Wege machen, * und meine Straßen werden erhöht werden.
+49:12 Sehet, diese kommen von ferne her, und sehet, jene von Mitternacht und vom Meere her, * und diese aus dem Lande gegen Mittag.
+49:13 Lobsinget, ihr Himmel, und frohlocke, Erde, und jubelt, ihr Berge, im Lobe: * denn der Herr hat sein Volk getröstet, und seiner Armen sich erbarmt.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm243.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm243.txt
@@ -1,6 +1,11 @@
-(Canticum Isaiae * Isa 63:1-5)
-63:1 Quis est iste, qui venit de Edom, tinctis vestibus de Bosra? iste formosus in stola sua, gradiens in multitudine fortitudinis suae? Ego qui loquor justitiam, et propugnator sum ad salvandum.
-63:2 Quare ergo rubrum est indumentum tuum, et vestimenta tua sicut calcantium in torculari?
-63:3 Torcular calcavi solus, et de gentibus non est vir mecum; calcavi eos in furore meo, et conculcavi eos in ira mea: et aspersus est sanguis eorum super vestimenta mea, et omnia indumenta mea inquinavi.
-63:4 Dies enim ultionis in corde meo; annus redemptionis meae venit.
-63:5 Circumspexi, et non erat auxiliator; quaesivi, et non fuit qui adjuvaret: et salvavit mihi brachium meum, et indignatio mea ipsa auxiliata est mihi.
+(Canticum Isaiæ * Isa 63:1-5)
+63:1 Wer ist dieser, der von Edom kommt, * in geröteten Kleidern von Bosra?
+63:1 Dieser, prangend in seinem Gewande, * einherschreitend in der Fülle seiner Kraft?
+63:1 Ich bin es, der ich Gerechtigkeit rede, * und Vorkämpfer bin zum Heile.
+63:2 Warum aber ist dein Gewand rot, * und sind deine Kleider wie die der Keltertreter?
+63:3 Die Kelter habe ich allein getreten, * und von den Völkern war niemand bei mir:
+63:3 Ich trat sie in meinem Grimm, * und zerstampfte sie in meinem Zorne:
+63:3 Und ihr Blut spritzte über meine Kleider, * und ich befleckte alle meine Gewänder.
+63:4 Denn ein Tag der Rache ist in meinem Herzen; * das Jahr meiner Erlösung ist gekommen.
+63:5 Ich blickte umher, und da war kein Helfer; * ich suchte, und da war niemand, der mir beistand:
+63:5 Da brachte mein Arm mir Heil zuwege, * und meine Eifersglut, diese ward mir Stütze.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm245.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm245.txt
@@ -1,7 +1,11 @@
-(Canticum Sophonee * Soph 3:8-13)
-3:8 Quapropter exspecta me, dicit Dominus, in die resurrectionis meae in futurum: quia judicium meum ut congregem gentes, et colligam regna, et effundam super eos indignationem meam, omnem iram furoris mei: in igne enim zeli mei devorabitur omnis terra.
-3:9 Quia tunc reddam populis labium electum, ut invocent omnes in nomine Domini, et serviant ei humero uno.
-3:10 Ultra flumina Æthiopiae, inde supplices mei; filii dispersorum meorum deferent munus mihi.
-3:11 In die illa non confunderis super cunctis adinventionibus tuis, quibus praevaricata es in me, quia tunc auferam de medio tui magniloquos superbiae tuae, et non adjicies exaltari amplius in monte sancto meo.
-3:12 Et derelinquam in medio tui populum pauperem et egenum: et sperabunt in nomine Domini.
-3:13 Reliquiae Israël non facient iniquitatem, nec loquentur mendacium, et non invenietur in ore eorum lingua dolosa, quoniam ipsi pascentur, et accubabunt, et non erit qui exterreat.
+(Canticum Sophoniæ * Soph 3:8-13)
+3:8 Darum harre mein, spricht der Herr, am Tage, da ich mich erhebe für die Zukunft: * denn mein Rechtsspruch ist es, dass ich die Völker versammle und die Reiche zusammenraffe,
+3:8 Und ich will über sie meinen Unwillen ausgießen, * all meine Zornesglut:
+3:8 Denn im Feuer meines Zorneifers * soll die ganze Erde verzehrt werden.
+3:9 Denn alsdann werde ich den Völkern wieder reine Lippen geben, † dass alle den Namen des Herrn anrufen, * und ihm dienen Schulter an Schulter.
+3:10 Von jenseits der Ströme Äthiopiens werden meine Anbeter kommen; * die Söhne meiner Zerstreuten werden mir Opfergaben darbringen.
+3:11 An jenem Tage darfst du nicht mehr erröten ob all deiner Bestrebungen, * mit denen du wider mich gesündigt:
+3:11 Denn alsdann werde ich aus deiner Mitte die über deine Hoheit Großsprechenden hinwegnehmen, * und du wirst dich nicht ferner ob meines heiligen Berges überheben.
+3:12 Und ich werde dir ein geringes und dürftiges Volk übriglassen: * das auf den Namen des Herrn vertraut.
+3:13 Israels Überrest wird kein Unrecht mehr begehen, † und nicht Lügen reden, * und in ihrem Munde wird keine trügerische Zunge gefunden werden:
+3:13 Denn sie werden weiden und sich lagern, * und niemand wird sie aufschrecken.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm247.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm247.txt
@@ -1,7 +1,9 @@
-(Canticum Habacuc * Hab 3:7-12)
-3:7 Pro iniquitate vidi tentoria Æthiopiae; turbabuntur pelles terrae Madian.
-3:8 Numquid in fluminibus iratus es, Domine? aut in fluminibus furor tuus? vel in mari indignatio tua? Qui ascendes super equos tuos, et quadrigae tuae salvatio.
-3:9 Suscitans suscitabis arcum tuum, juramenta tribubus quae locutus es; fluvios scindes terrae.
-3:10 Viderunt te, et doluerunt montes; gurges aquarum transiit: dedit abyssus vocem suam; altitudo manus suas levavit.
-3:11 Sol et luna steterunt in habitaculo suo: in luce sagittarum tuarum ibunt, in splendore fulgurantis hastae tuae.
-3:12 In fremitu conculcabis terram; in furore obstupefacies gentes.
+(Canticum * Habacuc 3:7-12)
+3:7 Unter Unheil sehe ich die Zelte Äthiopiens: * es schwanken die Zelte des Landes Madian.
+3:8 Bist du denn wider die Ströme ergrimmt, o Herr? † oder gilt den Strömen dein Zorn? * oder dem Meere dein Grimm?
+3:8 Du steigst auf deine Rosse: * und deine Wagen sind Heil.
+3:9 Du spannst mit Kraft deinen Bogen: * wie du den Stämmen geschworen:
+3:9 Ströme lässest du aus der Erde hervorbrechen: † da sie dich sehen, erbeben die Berge: * die Wasserflut bricht herein.
+3:10 Der Abgrund lässt seine Stimme erschallen: * die Tiefe erhebt ihre Hände.
+3:11 Sonne und Mond bleiben in ihrer Behausung: † bei dem Leuchten deiner Pfeile treten sie zurück, * vor dem Glanze deines blitzenden Speeres.
+3:12 Im Grimme zertrittst du die Erde: * im Zorne machst du die Völker erstarren.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm249.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm249.txt
@@ -1,6 +1,6 @@
-(Canticum Ecclesiasticae * Eccli 39:17-21)
-39:17 In voce dicit: Obaudite me, divini fructus, et quasi rosa plantata super rivos aquarum fructificate.
-39:18 Quasi Libanus odorem suavitatis habete.
-39:19 Florete flores quasi lilium: et date odorem, et frondete in gratiam: et collaudate canticum, et benedicite Dominum in operibus suis.
-39:20 Date nomini ejus magnificentiam, et confitemini illi in voce labiorum vestrorum, et in canticis labiorum, et citharis: et sic dicetis in confessione:
-39:21 Opera Domini universa bona valde.
+(Canticum Ecclesiasticæ * Eccli 39:17-21)
+39:17 Höret auf mich, ihr Kinder Gottes, * und bringet Frucht gleich der Rose, die an Wasserbächen gepflanzt ist.
+39:18 Duftet Wohlgeruch, * wie der Weihrauch.
+39:19 Treibet Blüten wie die Lilie, und duftet Wohlgeruch, † und grünet zum Ergötzen; stimmet ein Loblied an, * und preiset den Herrn ob seiner Werke.
+39:20 Verherrlichet seinen Namen, † und preiset ihn mit der Stimme eurer Lippen, * mit Lobgesängen der Lippen und mit Zithern;
+39:21 Und sprechet also im Lobpreise: * Alle Werke des Herrn sind sehr gut.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm250.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm250.txt
@@ -1,6 +1,9 @@
-(Canticum Isaiae * Isa 61:10-11; 62:1-3)
-61:10 Gaudens gaudebo in Domino, et exsultabit anima mea in Deo meo, quia induit me vestimentis salutis, et indumento justitiae circumdedit me, quasi sponsum decoratum corona, et quasi sponsam ornatam monilibus suis.
-61:11 Sicut enim terra profert germen suum, et sicut hortus semen suum germinat, sic Dominus Deus germinabit justitiam et laudem coram universis gentibus.
-62:1 Propter Sion non tacebo, et propter Jerusalem non quiescam, donec egrediatur ut splendor justus ejus, et salvator ejus ut lampas accendatur.
-62:2 Et videbunt gentes justum tuum, et cuncti reges inclytum tuum; et vocabitur tibi nomen novum, quod os Domini nominabit.
-62:3 Et eris corona gloriae in manu Domini, et diadema regni in manu Dei tui.
+(Canticum Isaiæ * Isa 61:10-11; 62:1-3)
+61:10 Ich freue mich und bin fröhlich in dem Herrn, * und meine Seele frohlockt in meinem Gott:
+61:10 Denn er hat mich mit den Gewändern des Heiles bekleidet, * und mich angetan mit dem Gewande der Gerechtigkeit,
+61:10 Wie einen Bräutigam mit der Krone geziert, * wie eine Braut mit Geschmeide geschmückt.
+61:11 Denn wie die Erde ihre Keime hervorbringt, † und der Garten seinen Samen aufgehen lässt, * so wird Gott, der Herr, Gerechtigkeit und Lobpreisung vor allen Völkern hervorsprossen lassen.
+62:1 Um Sions willen will ich nicht schweigen, und um Jerusalems willen nicht rasten, † bis wie Sonnenglanz sein Gerechter aufgeht, * und sein Heiland wie eine Fackel leuchtet.
+62:2 Dann werden die Völker deinen Gerechten sehen, * und alle Könige deinen Herrlichen;
+62:2 Und man wird dich mit einem neuen Namen nennen, * welchen des Herrn Mund aussprechen wird.
+62:3 Und du wirst eine Ehrenkrone sein in der Hand des Herrn, * und ein Diadem des Königtums in der Hand deines Gottes.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm251.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm251.txt
@@ -1,5 +1,8 @@
-(Canticum Isaiae * Isa 62:4-7)
-62:4 Non vocaberis ultra Derelicta, et terra tua non vocabitur amplius Desolata; sed vocaberis, Voluntas mea in ea, et terra tua Inhabitata, quia complacuit Domino in te, et terra tua inhabitabitur.
-62:5 Habitabit enim juvenis cum virgine, et habitabunt in te filii tui; et gaudebit sponsus super sponsam, et gaudebit super te Deus tuus
-62:6 Super muros tuos, Jerusalem, constitui custodes; tota die et tota nocte in perpetuum non tacebunt. Qui reminiscimini Domini, ne taceatis,
-62:7 et ne detis silentium ei, donec stabiliat et donec ponat Jerusalem laudem in terra.
+(Canticum Isaiæ * Isa 62:4-7)
+62:4 Du wirst nicht mehr Verlassene heißen, * und dein Land nicht mehr Verwüstetes heißen:
+62:4 Sondern man wird dich nennen: Meine Wonne an ihr, * und dein Land: Das bewohnte:
+62:4 Denn der Herr hat sein Wohlgefallen an dir: * und dein Land wird bewohnt sein.
+62:5 Denn wie der Jüngling mit der Jungfrau wohnt, * so werden deine Kinder in dir wohnen:
+62:5 Und wie sich der Bräutigam freut über die Braut, * so wird sich dein Gott über dich freuen.
+62:6 Über deine Mauern, Jerusalem, habe ich Wächter bestellt; * den ganzen Tag und die ganze Nacht werden sie nimmer schweigen.
+62:6 Die ihr des Herrn gedenket, schweiget nicht, † und gönnet ihm keine Ruhe, * bis er Jerusalem festgründe und zum Lobpreise mache auf Erden.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm253.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm253.txt
@@ -1,5 +1,9 @@
-(Canticum Isaiae * Isa 61:6-9)
-61:6 Vos autem sacerdotes Domini vocabimini: Ministri Dei nostri, dicetur vobis, fortitudinem gentium comedetis, et in gloria earum superbietis.
-61:7 Pro confusione vestra duplici et rubore, laudabunt partem suam; propter hoc in terra sua duplicia possidebunt, laetitia sempiterna erit eis.
-61:8 Quia ego Dominus diligens judicium, et odio habens rapinam in holocausto; et dabo opus eorum in veritate, et fœdus perpetuum feriam eis.
-61:9 Et scient in gentibus semen eorum, et germen eorum in medio populorum; omnes qui viderint eos cognoscent illos, quia isti sunt semen cui benedixit Dominus.
+(Canticum Isaiæ * Isa 61:6-9)
+61:6 Ihr aber werdet Priester des Herrn heißen: * Diener unseres Gottes, wird man euch nennen:
+61:6 Den Reichtum der Heiden werdet ihr genießen, * und in ihrer Herrlichkeit prangen.
+61:7 Für eure zweifache Schande und Schmach * preisen sie ihren Anteil;
+61:7 Darum sollen sie in ihrem Lande Doppeltes besitzen, * ewige Freude soll ihr Teil werden.
+61:8 Denn ich, der Herr, liebe das Recht, * und hasse den Raub am Brandopfer:
+61:8 Und ich gründe ihr Werk in der Wahrheit, * und schließe einen ewigen Bund mit ihnen.
+61:9 Man wird unter den Völkern ihr Geschlecht erkennen, * und ihre Sprossen in der Mitte der Nationen:
+61:9 Alle, die sie sehen, werden sie kennen, * denn sie sind das Geschlecht, das der Herr gesegnet hat.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm254.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm254.txt
@@ -1,4 +1,5 @@
-(Canticum Sapientiae * Sap 3:7-9)
-3:7 Fulgebunt justi et tamquam scintillae in arundineto discurrent.
-3:8 Judicabunt nationes, et dominabuntur populis, et regnabit Dominus illorum in perpetuum.
-3:9 Qui confidunt in illo intelligent veritatem, et fideles in dilectione acquiescent illi, quoniam donum et pax est electis ejus.
+(Canticum * Sap 3:7-9)
+3:7 Die Gerechten werden glänzen, * und wie Funken im Geröhre sich ausbreiten.
+3:8 Sie werden zu Gericht sitzen über die Völker und über die Nationen herrschen, * und der Herr wird ihr König sein in Ewigkeit.
+3:9 Die auf ihn vertrauen, werden die Wahrheit erkennen, * und die in der Liebe treu sind, werden bei ihm weilen:
+3:9 Denn Gnade * und Friede erlangen seine Auserwählten.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm257.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm257.txt
@@ -1,3 +1,4 @@
-(Canticum Jeremiae * Jer 17:7-8)
-17:7 Benedictus vir qui confidit in Domino, et erit Dominus fiducia ejus.
-17:8 Et erit quasi lignum quod transplantatur super aquas, quod ad humorem mittit radices suas, et non timebit cum venerit aestus: et erit folium ejus viride, et in tempore siccitatis non erit sollicitum, nec aliquando desinet facere fructum.
+(Canticum Jeremiæ * Jer 17:7-8)
+17:7 Gesegnet der Mann, der sein Vertrauen auf den Herrn setzt, * und dessen Zuversicht der Herr ist!
+17:8 Er ist wie ein Baum, der am Wasser gepflanzt ist, † der nach dem Bache hin seine Wurzeln ausstreckt: * nicht darf er fürchten, wenn die Hitze kommt.
+17:8 Sein Laub bleibt grün, † und zur Zeit der Dürre hat er keine Sorge, * und nimmer lässt er ab, Frucht zu tragen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm259.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm259.txt
@@ -1,7 +1,7 @@
-(Canticum Sapientiae * Sap 3:1-6)
-3:1 Justorum autem animae in manu Dei sunt, et non tangent illos tormentum mortis.
-3:2 Visi sunt oculis insipientium mori, et aestimata est afflictio exitus illorum,
-3:3 et quod a nobis est iter exterminium; illi autem sunt in pace:
-3:4 etsi coram hominibus tormenta passi sunt, spes illorum immortalitate plena est.
-3:5 In paucis vexati sunt, in multis bene disponentur, quoniam Deus tentavit eos, et invenit illos dignos se.
-3:6 Tamquam aurum in fornace probavit illos, et quasi holocausti hostiam accepit illos, et in tempore erit respectus illorum.
+(Canticum Sapientiæ * Sap 3:1-6)
+3:1 Die Seelen der Gerechten aber sind in der Hand Gottes, * und nicht berührt sie des Todes Pein.
+3:2 Den Augen der Unweisen scheinen sie zu sterben, * und ihr Hingang wird für Leid geachtet,
+3:3 Und ihr Scheiden von uns für Vernichtung gehalten; * sie aber sind im Frieden:
+3:4 Wenn sie auch vor den Menschen Qual erduldet haben, * so ist doch ihre Hoffnung voll der Unsterblichkeit.
+3:5 Nachdem sie ein wenig gelitten, wird ihnen viel Gutes zuteil; * denn Gott hat sie geprüft, und seiner würdig erfunden.
+3:6 Wie Gold im Ofen hat er sie erprobt, † und wie ein Brandopfer hat er sie angenommen, * und zu seiner Zeit wird er sie heimsuchen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm260.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm260.txt
@@ -1,9 +1,10 @@
-(Canticum Tobiae * Tob 13:10-17)
-13:10 Benedicite Dominum omnes electi ejus: agite dies laetitiae, et confitemini illi.
-13:11 Jerusalem civitas Dei, castigavit te Dominus in operibus manuum tuarum.
-13:12 Confitere Domino in bonis tuis, et benedic Deum saeculorum: ut reaedificet in te tabernaculum suum, et revocet ad te omnes captivos, et gaudeas in omnia saecula saeculorum.
-13:13 Luce splendida fulgebis, et omnes fines terrae adorabunt te.
-13:14 Nationes ex longinquo ad te venient, et munera deferentes adorabunt in te Dominum, et terram tuam in sanctificationem habebunt:
-13:15 nomen enim magnum invocabunt in te.
-13:16 Maledicti erunt qui contempserint te, et condemnati erunt omnes qui blasphemaverint te: benedictique erunt qui aedificaverint te.
-13:17 Tu autem laetaberis in filiis tuis, quoniam omnes benedicentur, et congregabuntur ad Dominum.
+(Canticum Tobiæ * Tob 13:10-17)
+13:10 Preiset den Herrn, ihr alle seine Auserwählten: * feiert Freudentage und danket ihm.
+13:11 Jerusalem, du Stadt Gottes, * dich hat der Herr wegen der Werke deiner Hände gezüchtigt.
+13:12 Lobsinge dem Herrn wegen deiner Güter, * und preise den ewigen Gott, dass er seine Wohnung wieder in dir aufbaue,
+13:12 Und alle Gefangenen zu dir zurückrufe, * und du dich freuest in alle Ewigkeit.
+13:13 Du wirst in glänzendem Lichte erstrahlen, * und alle Grenzen der Erde werden dich verehren.
+13:14 Die Völker werden aus der Ferne zu dir kommen, * und, Geschenke darbringend, den Herrn in dir anbeten,
+13:15 Und dein Land heilig halten: * denn sie werden den großen Namen in dir anrufen.
+13:16 Verflucht werden sein, die dich verachten, und verdammt alle, die dich lästern: * gesegnet aber werden sein, die dich aufbauen.
+13:17 Du aber wirst dich deiner Kinder freuen, * denn alle werden gesegnet und zu dem Herrn versammelt werden.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm261.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm261.txt
@@ -1,3 +1,6 @@
-(Canticum Isaiae * Isa 2:2-3)
-2:2 Et erit in novissimis diebus: praeparatus mons domus Domini in vertice montium, et elevabitur super colles; et fluent ad eum omnes gentes,
-2:3 et ibunt populi multi, et dicent: Venite, et ascendamus ad montem Domini, et ad domum Dei Jacob; et docebit nos vias suas, et ambulabimus in semitis ejus, quia de Sion exibit lex, et verbum Domini de Jerusalem.
+(Canticum Isaiæ * Isa 2:2-3)
+2:2 Und in den letzten Tagen wird der Berg des Hauses des Herrn festgegründet sein * auf dem Gipfel der Berge,
+2:2 Und erhöht sein über die Hügel: * und alle Völker werden zu ihm strömen.
+2:3 Und viele Völker werden hinwallen und sprechen: * Kommet, lasset uns hinaufziehen zum Berge des Herrn und zum Hause des Gottes Jakobs,
+2:3 Dass er uns seine Wege lehre, * und dass wir auf seinen Pfaden wandeln:
+2:3 Denn von Sion wird das Gesetz ausgehen, * und das Wort des Herrn von Jerusalem.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm262.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm262.txt
@@ -1,7 +1,9 @@
-(Canticum Jeremiae * Jer 7:2-7)
-7:2 Sta in porta domus Domini, et praedica ibi verbum istud, et dic: Audite verbum Domini, omnis Juda, qui ingredimini per portas has ut adoretis Dominum.
-7:3 Haec dicit Dominus exercituum, Deus Israël: Bonas facite vias vestras, et studia vestra, et habitabo vobiscum in loco isto.
-7:4 Nolite confidere in verbis mendacii, dicentes: Templum Domini, templum Domini, templum Domini est!
-7:5 Quoniam si bene direxeritis vias vestras, et studia vestra; si feceritis judicium inter virum et proximum ejus;
-7:6 advenae, et pupillo, et viduae non feceritis calumniam, nec sanguinem innocentem effuderitis in loco hoc, et post deos alienos non ambulaveritis in malum vobismetipsis:
-7:7 habitabo vobiscum in loco isto, in terra quam dedi patribus vestris a saeculo et usque in saeculum.
+(Canticum Jeremiæ * Jer 7:2-7)
+7:2 Höret das Wort des Herrn, ganz Juda, * die ihr durch diese Tore eintretet, um den Herrn anzubeten!
+7:3 So spricht der Herr der Heerscharen, * der Gott Israels:
+7:3 Machet euren Wandel und eure Bestrebungen gut, * so will ich bei euch an dieser Stätte wohnen.
+7:4 Setzet euer Vertrauen nicht auf Lügenworte, und saget nicht: * Der Tempel des Herrn, der Tempel des Herrn, der Tempel des Herrn ist dies.
+7:5 Denn wenn ihr euch bemüht, einen guten Wandel zu führen, * und recht zu handeln:
+7:6 Wenn ihr Gerecht übt untereinander, * Fremdlinge, Waisen und Witwen nicht bedrückt,
+7:6 Noch unschuldiges Blut an dieser Stätte vergießt, * noch fremden Göttern nachwandelt zu euerm eigenen Schaden:
+7:7 So will ich bei euch wohnen an dieser Stätte, * im Lande, welches ich euern Vätern gegeben, für und für.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm263.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm263.txt
@@ -1,7 +1,13 @@
-(Canticum Isaiae * Isa 9:2-7)
-9:2 Populus qui ambulabat in tenebris, vidit lucem magnam; habitantibus in regione umbrae mortis, lux orta est eis.
-9:3 Multiplicasti gentem, et non magnificasti laetitiam. Laetabuntur coram te, sicut qui laetantur in messe; sicut exsultant victores capta praeda, quando dividunt spolia.
-9:4 Jugum enim oneris ejus, et virgam humeri ejus, et sceptrum exactoris ejus superasti, sicut in die Madian.
-9:5 Quia omnis violentia praedatio cum tumultu, et vestimentum mistum sanguine, erit in combustionem, et cibus ignis.
-9:6 Parvulus enim natus est nobis, et filius datus est nobis, et factus est principatus super humerum ejus: et vocabitur nomen ejus, Admirabilis, Consiliarius, Deus, Fortis, Pater futuri saeculi, Princeps pacis.
-9:7 Multiplicabitur ejus imperium, et pacis non erit finis; super solium David, et super regnum ejus sedebit, ut confirmet illud et corroboret in judicio et justitia, amodo usque in sempiternum: zelus Domini exercituum faciet hoc.
+(Canticum Isaiæ * Isa 9:2-7)
+9:2 Das Volk, das in Finsternis wandelte, * sah ein großes Licht:
+9:2 Über den Bewohnern der Landschaft des Todesschattens * strahlte ein Licht auf.
+9:3 Du hast das Volk vermehrt, * und nicht die Freude erhöht:
+9:3 Doch jetzt werden sie sich vor dir freuen, wie man sich in der Ernte freut: * wie Sieger frohlocken über die gewonnene Beute, wenn sie die Beute austeilen.
+9:4 Denn das Joch seiner Bürde und die Rute seines Rückens, * und den Herrscherstab seines Bedrängers zerbrichst du wie am Tage Madians.
+9:5 Denn jede gewaltsame und im Getümmel eroberte Beute, * und jedes blutgetränkte Gewand wird dann verbrannt und dem Feuer als Speise überliefert.
+9:6 Denn ein Kind ist uns geboren, * und ein Sohn ist uns gegeben,
+9:6 Und die Herrschaft ist auf seine Schulter gelegt: * und sein Name wird genannt werden: Wunderbarer, Ratgeber,
+9:6 Starker Gott, Vater der Zukunft, * Friedensfürst.
+9:7 Seine Herrschaft wird sich mehren, * und Friede wird ohne Ende sein:
+9:7 Auf dem Throne Davids und über dessen Reich wird er herrschen, * dass er es festige und stütze durch Recht und Gerechtigkeit,
+9:7 Von nun an bis in Ewigkeit: * der Eifer des Herrn der Heerscharen wird dies vollbringen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm264.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm264.txt
@@ -1,13 +1,15 @@
-(Canticum Isaiae * Isa 26:1-12)
-26:1 Urbs fortitudinis nostrae Sion; salvator ponetur in ea murus et antemurale.
-26:2 Aperite portas, et ingrediatur gens justa, custodiens veritatem.
-26:3 Vetus error abiit: servabis pacem; pacem, quia in te speravimus.
-26:4 Sperastis in Domino in saeculis aeternis; in Domino Deo forti in perpetuum.
-26:5 Quia incurvabit habitantes in excelso; civitatem sublimem humiliabit: humiliabit eam usque ad terram, detrahet eam usque ad pulverem.
-26:6 Conculcabit eam pes, pedes pauperis, gressus egenorum.
-26:7 Semita justi recta est, rectus callis justi ad ambulandum.
-26:8 Et in semita judiciorum tuorum, Domine, sustinuimus te: nomen tuum et memoriale tuum in desiderio animae.
-26:9 Anima mea desideravit te in nocte, sed et spiritu meo in praecordiis meis de mane vigilabo ad te. Cum feceris judicia tua in terra, justitiam discent habitatores orbis.
-26:10 Misereamur impio, et non discet justitiam; in terra sanctorum iniqua gessit, et non videbit gloriam Domini.
-26:11 Domine, exaltetur manus tua, et non videant; videant, et confundantur zelantes populi; et ignis hostes tuos devoret.
-26:12 Domine, dabis pacem nobis: omnia enim opera nostra operatus es nobis.
+(Canticum Isaiæ * Isa 26:1-12)
+26:1 Die Stadt unserer Stärke ist Sion, der Heiland: * er steht in ihr da als Mauer und Vormauer.
+26:2 Öffnet die Tore, dass ein gerechtes Volk einziehe, * das an der Treue festhält!
+26:3 Der alte Irrtum ist geschwunden: du wirst Frieden wahren: * Frieden, weil wir auf dich gehofft.
+26:4 Ihr hofftet auf den Herrn ewiglich: * auf den Herrn, den starken Gott, zu aller Zeit.
+26:5 Denn er hat niedergebeugt, die in der Höhe wohnen: * die hochragende Stadt erniedrigt er.
+26:5 Er erniedrigt sie bis zum Boden, * stößt sie herab bis in den Staub.
+26:6 Es zertritt sie der Fuß, die Füße des Armen, * die Tritte der Dürftigen.
+26:7 Der Pfad des Gerechten ist gerade, * gerade zum Wandeln der Pfad des Gerechten.
+26:8 Und auf dem Wege deiner Gerichte, Herr, haben wir auf dich geharrt: * nach deinem Namen und deinem Andenken verlangte die Seele.
+26:9 Meine Seele sehnte sich nach dir in der Nacht, * ja auch mit meinem Geiste wache ich in meinem Innern am frühen Morgen zu dir.
+26:9 Wenn du auf Erden Gericht hältst, * werden die Bewohner des Erdkreises Gerechtigkeit lernen.
+26:10 Erweist man dem Gottlosen Nachsicht, so lernt er nicht Gerechtigkeit: * im Lande der Heiligen tut er Böses, und achtet nicht auf die Herrlichkeit des Herrn.
+26:11 Herr, deine Hand werde erhöht, und sie mögen es nicht achten: * achten sollen sie es und zuschanden werden, die Eiferer gegen dein Volk, und Feuer möge deine Feinde verzehren!
+26:12 Herr, du wirst uns Frieden gewähren: * denn all unser Tun hast du für uns vollbracht.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm265.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm265.txt
@@ -1,8 +1,11 @@
-(Canticum Isaiae * Isa 66:10-16)
-66:10 Laetamini cum Jerusalem et exsultate in ea, omnes qui diligitis eam; gaudete cum ea gaudio, universi qui lugetis super eam:
-66:11 ut sugatis et repleamini ab ubere consolationis ejus; ut mulgeatis et deliciis affluatis ab omnimoda gloria ejus.
-66:12 Quia haec dicit Dominus: Ecce ego declinabo super eam quasi fluvium pacis, et quasi torrentem inundantem gloriam gentium, quam sugetis: ad ubera portabimini, et super genua blandientur vobis.
-66:13 Quomodo si cui mater blandiatur, ita ego consolabor vos, et in Jerusalem consolabimini.
-66:14 Videbitis, et gaudebit cor vestrum, et ossa vestra quasi herba germinabunt: et cognoscetur manus Domini servis ejus, et indignabitur inimicis suis.
-66:15 Quia ecce Dominus in igne veniet, et quasi turbo quadrigae ejus, reddere in indignatione furorem suum et increpationem suam in flamma ignis:
-66:16 quia in igne Dominus dijudicabit, et in gladio suo ad omnem carnem; et multiplicabuntur interfecti a Domino,
+(Canticum Isaiæ * Isa 66:10-16)
+66:10 Freuet euch mit Jerusalem und jubelt in ihm, * alle, die ihr es liebt:
+66:10 Frohlocket mit ihm in Freuden, alle, die ihr über dasselbe trauert: * auf dass ihr sauget und gesättigt werdet an der Brust seiner Tröstung:
+66:11 Auf dass ihr trinket und in Wonne überfließet * von dem Übermaße seiner Herrlichkeit.
+66:12 Denn so spricht der Herr: Siehe, ich lenke zu ihr einem Strome gleich den Frieden hin, * und wie einen überflutenden Gießbach die Herrlichkeit der Völker,
+66:12 Die ihr genießen sollt: an der Brust wird man euch tragen, * und auf den Knien euch liebkosen.
+66:13 Wie wenn eine Mutter liebkost, so will ich euch trösten: * und in Jerusalem werdet ihr getröstet werden.
+66:14 Ihr werdet es sehen, und euer Herz wird sich freuen, * und eure Gebeine werden gleich dem Grün erblühen:
+66:14 Und erkannt werden wird die Hand des Herrn an seinen Dienern, * aber seinen Feinden wird er zürnen.
+66:15 Denn sehet, der Herr wird im Feuer kommen, und wie der Sturmwind sind seine Wagen: * um im Grimm seinen Zorn auszuführen, und seine Drohung in Feuerflamme:
+66:16 Denn mit Feuer wird der Herr richten, und mit seinem Schwerte alles Fleisch: * und groß wird die Zahl sein der vom Herrn Getöteten.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm266.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm266.txt
@@ -1,10 +1,11 @@
-(Canticum Isaiae * Isa 33:2-10)
-33:2 Domine, miserere nostri, te enim exspectavimus; esto brachium nostrum in mane, et salus nostra in tempore tribulationis.
-33:3 A voce angeli fugerunt populi, et ab exaltatione tua dispersae sunt gentes.
-33:4 Et congregabuntur spolia vestra sicut colligitur bruchus, velut cum fossae plenae fuerint de eo.
-33:5 Magnificatus est Dominus, quoniam habitavit in excelso; implevit Sion judicio et justitia.
-33:6 Et erit fides in temporibus tuis: divitiae salutis sapientia et scientia; timor Domini ipse est thesaurus ejus.
-33:7 Ecce videntes clamabunt foris; angeli pacis amare flebunt.
-33:8 Dissipatae sunt viae, cessavit transiens per semitam: irritum factum est pactum, projecit civitates, non reputavit homines.
-33:9 Luxit et elanguit terra; confusus est Libanus, et obsorduit: et factus est Saron sicut desertum, et concussa est Basan, et Carmelus.
-33:10 Nunc consurgam, dicit Dominus; nunc exaltabor, nunc sublevabor.
+(Canticum Isaiæ * Isa 33:2-10)
+33:2 Herr, erbarme dich unser, denn auf dich harren wir; † sei unser Arm früh morgens, * und unser Heil zur Zeit der Drangsal.
+33:3 Vor der Stimme des Engels fliehen die Völker, * und wenn du dich erhebst, zerstreuen sich die Nationen.
+33:4 Und eure Beute wird gesammelt werden, wie man Heuschrecken sammelt, * wie wenn die Gräben mit ihnen angefüllt wären.
+33:5 Erhöht ist der Herr, denn er wohnt in der Höhe; * er hat Sion mit Recht und Gerechtigkeit erfüllt.
+33:6 Und es wird Treue herrschen zu deiner Zeit: † Schätze des Heils, der Weisheit * und Erkenntnis; die Furcht des Herrn, dies ist sein Schatz.
+33:7 Siehe, die Sehenden jammern draußen; * die Friedensboten weinen bitterlich.
+33:8 Öde liegen die Straßen, der Wanderer zieht nicht mehr des Weges: † man bricht den Bund, * er hat die Städte niedergeworfen, der Menschen nicht geachtet.
+33:9 Es trauert und schmachtet das Land dahin; * beschämt steht der Libanon da und ist befleckt.
+33:9 Und der Saron ist wie eine Wüste geworden, * und Basan und Karmel sind entlaubt.
+33:10 Nun werde ich aufstehen, spricht der Herr; * nun mich erheben, nun mich aufrichten!

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm268.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm268.txt
@@ -1,7 +1,8 @@
-(Canticum Ecclesiasticae * Eccli 36:14-19)
-36:14 Miserere plebi tuae, super quam invocatum est nomen tuum, et Israël quem coaequasti primogenito tuo.
-36:15 Miserere civitati sanctificationis tuae, Jerusalem, civitati requiei tuae.
-36:16 Reple Sion inenarrabilibus verbis tuis, et gloria tua populum tuum.
-36:17 Da testimonium his qui ab initio creaturae tuae sunt, et suscita praedicationes quas locuti sunt in nomine tuo prophetae priores.
-36:18 Da mercedem sustinentibus te, ut prophetae tui fideles inveniantur: et exaudi orationes servorum tuorum,
-36:19 secundum benedictionem Aaron de populo tuo: et dirige nos in viam justitiae, et sciant omnes qui habitant terram quia tu es Deus conspector saeculorum.
+(Canticum * Eccli 36:14-19)
+36:14 Erbarme dich deines Volkes, über das dein Name angerufen ist: * und Israels, das du einem Erstgebornen gleichgehalten.
+36:15 Erbarme dich der Stadt deines Heiligtums, Jerusalems, * der Stadt deiner Ruhe.
+36:16 Erfülle Sion mit deiner unaussprechlichen Verheißung, * und dein Volk mit deiner Herrlichkeit.
+36:17 Gib Zeugnis für die, welche von Anbeginn deine Geschöpfe sind, * und erfülle die Weissagungen, welche die Propheten in deinem Namen verkündet haben.
+36:18 Belohne diejenigen, die auf dich harren, * damit deine Propheten wahrhaftig erfunden werden:
+36:18 Und erhöre das Gebet deiner Diener, nach dem Segen Aarons über dein Volk: * und leite uns auf den Weg der Gerechtigkeit.
+36:19 Und lass alle Bewohner der Erde erkennen, * dass du Gott bist, der die Ewigkeit durchschaut.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm269.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm269.txt
@@ -1,0 +1,11 @@
+(Canticum Jeremiæ * Jer 14:17-21)
+14:17 Meine Augen strömen von Tränen Tag und Nacht, * und hören nicht auf,
+14:17 Denn mit furchtbarer Verwüstung wird die Tochter meines Volkes geschlagen werden, * mit unheilbaren Schlägen schwer verwundet.
+14:18 Wenn ich auf das Feld hinausgehe, siehe da vom Schwerte Erschlagene! * wenn ich in die Stadt komme, siehe da vor Hunger Verschmachtete!
+14:18 Auch Propheten und Priester werden in ein Land ziehen, * das sie nicht kennen.
+14:19 Hast du denn Juda gänzlich verworfen? * oder ist Sion deiner Seele zum Abscheu geworden?
+14:19 Warum hast du uns denn so geschlagen, * dass es keine Heilung mehr gibt?
+14:19 Wir harrten auf Frieden, aber es kommt nichts Gutes: * auf eine Zeit der Heilung, und siehe, es kommt Schrecknis.
+14:20 Herr, wir erkennen unsere Freveltaten, * das Unrecht unserer Väter, dass wir wider dich gesündigt haben.
+14:21 Überliefere uns nicht der Beschimpfung, um deines Namens willen, * und entehre uns nicht, den Thron deiner Herrlichkeit:
+14:21 Gedenke doch, * und hebe deinen Bund mit uns nicht auf.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm270.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm270.txt
@@ -1,0 +1,14 @@
+(Canticum * Thren. 5:1-7,15-17,19-21)
+5:1 Gedenke, Herr, was uns widerfahren: * schau und siehe unsere Schmach.
+5:2 Unser Erbe ist Fremden zuteil geworden, * unsere Häuser Ausländern.
+5:3 Wir sind Waisen geworden ohne Vater, * unsere Mütter Witwen gleich.
+5:4 Unser Wasser tranken wir um Geld: * unser Holz müssen wir um Zahlung erwerben.
+5:5 Mit Ketten auf unserm Nacken werden wir dahingetrieben, * sind wir müde, so gönnt man uns keine Ruhe.
+5:6 Ägypten reichen wir die Hand und den Assyriern, * um uns mit Brot zu sättigen.
+5:7 Unsere Väter haben gesündigt und sind nicht mehr: * und wir tragen ihre Verschuldungen.
+5:15 Geschwunden ist die Freude unseres Herzens: * in Trauer verwandelt ist unser Reigen.
+5:16 Entfallen ist die Krone unserm Haupte: * wehe uns, denn wir haben gesündigt.
+5:17 Darüber ist unser Herz gramvoll geworden: * darum sind unsere Augen verdunkelt.
+5:19 Du aber, Herr, bleibst in Ewigkeit, * dein Thron von Geschlecht zu Geschlecht.
+5:20 Warum willst du uns auf ewig vergessen, * uns verlassen die Länge der Tage?
+5:21 Bekehre uns zu dir, Herr, und wir werden uns bekehren: * erneuere unsere Tage wie vor alters.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm271.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm271.txt
@@ -1,0 +1,7 @@
+(Canticum Ezechielis * Ez 36:24-28)
+36:24 Denn ich werde euch aus den Völkern wegnehmen und euch sammeln aus allen Ländern, * und euch in euer Land führen.
+36:25 Und ich werde reines Wasser über euch ausgießen, dass ihr von allen euern Befleckungen gereinigt werdet, * und von allen euern Götzenbildern werde ich euch reinigen.
+36:26 Und ich werde euch ein neues Herz geben, * und einen neuen Geist in euer Inneres einführen:
+36:26 Und ich werde das Herz von Stein aus euerm Leibe nehmen, * und euch ein Herz von Fleisch geben.
+36:27 Und ich werde meinen Geist in euer Inneres geben: * und machen, dass ihr nach meinen Geboten wandelt, meine Rechte beobachtet und sie übt.
+36:28 Dann sollt ihr im Lande wohnen, das ich euern Vätern gegeben habe: * und sollt mein Volk sein, und ich werde euer Gott sein.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm272.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm272.txt
@@ -1,0 +1,10 @@
+(Canticum Proverb * Prov. 9:1-6, 10-12)
+9:1 Die Weisheit hat sich ein Haus gebaut: * sich sieben Säulen ausgehauen.
+9:2 Sie hat ihre Opfertiere geschlachtet, * den Wein gemischt und ihren Tisch zugerichtet.
+9:3 Sie sendet ihre Dienerinnen aus, dass sie rufen bei der Burg, * und bei den Mauern der Stadt:
+9:4 Ist jemand einfältig, er komme zu mir! * Und den Unweisen ließ sie sagen:
+9:5 Kommet, esset mein Brot, * und trinket den Wein, den ich für euch gemischt habe.
+9:6 Lasset von der Einfalt und lebet, * und wandelt auf den Wegen der Klugheit.
+9:10 Die Furcht des Herrn ist der Weisheit Anfang, * und den Heiligen erkennen ist Einsicht.
+9:11 Denn durch mich werden deiner Tage viele werden, * und die Jahre des Lebens sich dir mehren.
+9:12 Wenn du weise bist, bist du für dich selbst weise; * bist du aber ein Spötter, so wirst du das Unheil allein tragen.

--- a/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm273.txt
+++ b/web/www/horas/Deutsch/Psalterium/Psalmorum/Psalm273.txt
@@ -1,0 +1,8 @@
+(Canticum Sapientiæ * Sap 16:20-21, 26, 29; 17:1)
+16:20 Du nährtest dein Volk mit Engelspeise, * und verliehest ihnen Brot vom Himmel, bereitet ohne Arbeit,
+16:20 Das jegliche Annehmlichkeit in sich enthielt, * und die Lieblichkeit jedes Geschmackes.
+16:21 Denn dein Wesen machte offenbar, * wie gütig du gegen deine Kinder bist:
+16:21 Und eines jeden Begehren sich fügend, * wandelte sie sich in das, was jeder wollte.
+16:26 Damit deine Söhne, die du, Herr, lieb hast, inne würden, † dass nicht nur die erzeugten Früchte den Menschen nähren, * sondern dass dein Wort diejenigen erhält, welche an dich glauben.
+16:29 Denn die Hoffnung des Undankbaren zerschmilzt wie winterliches Eis, * und verrinnt gleich unbrauchbarem Wasser.
+17:1 Denn groß sind deine Gerichte, Herr, † und unaussprechlich deine Ratschlüsse: * darum fielen ungelehrige Seelen in Irrtum.


### PR DESCRIPTION
Adds 5 completely missing canticles ("Psalm"269–273) and fixes 31 
canticles that were present in the German folder but still contained 
Latin or English text instead of an actual translation (including 
Psalm212–226, the Quicumque/Athanasian Creed, and Psalm240–268).

Translation based on the Allioli-Arndt Bible (1914, public domain), 
following Vulgate verse numbering. 

Also found two minor reference errors along the way:
- Psalm223: source was listed as "3 Reg 2:1-16", should be "1 Reg 2:1-16" (Canticum Annae)
- Psalm247: source was listed as "Zef 3", should be "Hab 3" (Canticum Habacuc)