### PR TITLE
Fix EofficiumXhtml.pl crash from removed Date::date_to_days/days_to_date

### DIFF
--- a/standalone/tools/epubgen2/EofficiumXhtml.pl
+++ b/standalone/tools/epubgen2/EofficiumXhtml.pl
@@ -90,6 +90,7 @@ require "$Bin/horasjs.pl";
 use lib "$Bin/../../../web/cgi-bin";
 use DivinumOfficium::LanguageTextTools qw(load_languages_data);
 use DivinumOfficium::RunTimeOptions qw(check_version check_language);
+use DivinumOfficium::Date qw(prevnext);
 
 binmode(STDOUT, ':encoding(utf-8)');
 
@@ -412,18 +413,3 @@ PrintTag
 
 }
 
-sub prevnext {
-  my $date1 = shift;
-  my $inc = shift;
-
-  $date1 =~ s/\//\-/g;
-  my ($month, $day, $year) = split('-', $date1);
-
-  my $d = date_to_days($day, $month - 1, $year);
-
-  my @d = days_to_date($d + $inc);
-  $month = $d[4] + 1;
-  $day = $d[3];
-  $year = $d[5] + 1900;
-  return sprintf("%02i-%02i-%04i", $month, $day, $year);
-}

--- a/web/cgi-bin/DivinumOfficium/Directorium.pm
+++ b/web/cgi-bin/DivinumOfficium/Directorium.pm
@@ -308,6 +308,7 @@ sub dirge {
 # Rule XX.3
 sub hymnmerge {
   my ($version, $day, $month, $year, $dioecesis) = @_;
+  $dioecesis //= '';
 
   get_from_directorium("transfer", $version, sprintf("Hy%s", get_sday($month, $day, $year)), $year, $dioecesis) =~
     /1(\;\;$dioecesis)?/;
@@ -318,6 +319,7 @@ sub hymnmerge {
 # Rule XX.3
 sub hymnshift {
   my ($version, $day, $month, $year, $dioecesis) = @_;
+  $dioecesis //= '';
 
   get_from_directorium("transfer", $version, sprintf("Hy%s", get_sday($month, $day, $year)), $year, $dioecesis) =~
     /2(\;\;$dioecesis)?/;
@@ -328,6 +330,7 @@ sub hymnshift {
 # Rule XX.3
 sub hymnshiftmerge {
   my ($version, $day, $month, $year, $dioecesis) = @_;
+  $dioecesis //= '';
 
   get_from_directorium("transfer", $version, sprintf("Hy%s", get_sday($month, $day, $year)), $year, $dioecesis) =~
     /3(\;\;$dioecesis)?/;


### PR DESCRIPTION
Fixes #5493

- EofficiumXhtml.pl: drop stale local prevnext(), use
  DivinumOfficium::Date::prevnext (same one officium.pl already uses).
- Directorium.pm: default $dioecesis to '' to silence uninitialized-value
  warning in hymnmerge/hymnshift/hymnshiftmerge. No behavior change.