### PR TITLE
Migrate unit tests from Test::Simple to Test2::V0

### DIFF
--- a/t/DivinumOfficium/Date.t
+++ b/t/DivinumOfficium/Date.t
@@ -1,8 +1,8 @@
 use strict;
 use warnings;
 use DivinumOfficium::Date
-   qw(getweek leapyear geteaster get_sday nextday day_of_week monthday prevnext ydays_to_date date_to_ydays);
-use Test::Simple tests => 75;
+  qw(getweek leapyear geteaster get_sday nextday day_of_week monthday prevnext ydays_to_date date_to_ydays);
+use Test2::V0;
 
 ### leapyear
 # Given the purpose of this application, we only need to test the Gregorian leap year rules, not the Julian ones,
@@ -28,96 +28,96 @@ ok(!leapyear(2026), '2026 is not a leap year');
 # Reference dates cross-checked against published Easter tables.
 # TODO: Add robustness & input validation tests (e.g., invalid years)
 
-ok(join(',', geteaster(2024)) eq '31,3,2024', 'Easter 2024 is March 31');
-ok(join(',', geteaster(2025)) eq '20,4,2025', 'Easter 2025 is April 20');
-ok(join(',', geteaster(2000)) eq '23,4,2000', 'Easter 2000 is April 23');
+is(join(',', geteaster(2024)), '31,3,2024', 'Easter 2024 is March 31');
+is(join(',', geteaster(2025)), '20,4,2025', 'Easter 2025 is April 20');
+is(join(',', geteaster(2000)), '23,4,2000', 'Easter 2000 is April 23');
 
 ### date_to_ydays / ydays_to_date round-trip
 # TODO: Add robustness & input validation tests (e.g., invalid dates)
 
-ok(date_to_ydays(1, 1, 2024) == 1, '1 Jan is day 1 of the year');
-ok(date_to_ydays(31, 12, 2023) == 365, '31 Dec of non-leap year is day 365');
-ok(date_to_ydays(31, 12, 2024) == 366, '31 Dec of leap year is day 366');
-ok(date_to_ydays(29, 2, 2024) == 60, '29 Feb is day 60 in a leap year');
+is(date_to_ydays(1, 1, 2024), 1, '1 Jan is day 1 of the year');
+is(date_to_ydays(31, 12, 2023), 365, '31 Dec of non-leap year is day 365');
+is(date_to_ydays(31, 12, 2024), 366, '31 Dec of leap year is day 366');
+is(date_to_ydays(29, 2, 2024), 60, '29 Feb is day 60 in a leap year');
 
-ok(join(',', ydays_to_date(1, 2024)) eq '1,1,2024', 'Day 1 round-trips to 1 Jan');
-ok(join(',', ydays_to_date(60, 2024)) eq '29,2,2024', 'Day 60 round-trips to 29 Feb in a leap year');
-ok(join(',', ydays_to_date(366, 2024)) eq '31,12,2024', 'Day 366 round-trips to 31 Dec in a leap year');
+is(join(',', ydays_to_date(1, 2024)), '1,1,2024', 'Day 1 round-trips to 1 Jan');
+is(join(',', ydays_to_date(60, 2024)), '29,2,2024', 'Day 60 round-trips to 29 Feb in a leap year');
+is(join(',', ydays_to_date(366, 2024)), '31,12,2024', 'Day 366 round-trips to 31 Dec in a leap year');
 
 ### day_of_week
 # 0 = Sunday .. 6 = Saturday (Monday 1 Jan 2024 confirmed against a real calendar).
 # TODO: Add robustness & input validation tests (e.g., invalid dates)
 
-ok(day_of_week(1, 1, 2024) == 1, '1 Jan 2024 was a Monday');
-ok(day_of_week(7, 1, 2024) == 0, '7 Jan 2024 was a Sunday');
-ok(!defined(day_of_week(0, 1, 2024)), 'Falsy day returns undef');
+is(day_of_week(1, 1, 2024), 1, '1 Jan 2024 was a Monday');
+is(day_of_week(7, 1, 2024), 0, '7 Jan 2024 was a Sunday');
+is(day_of_week(0, 1, 2024), undef, 'Falsy day returns undef');
 
 ### get_sday
 # In leap years the internal folder day is shifted: 24 Feb is kept as the
 # 'leap day' (29), and 25-29 Feb are each renumbered back by one.
 # TODO: Add robustness & input validation tests (e.g., invalid dates)
 
-ok(get_sday(2, 24, 2024) eq '02-29', 'Leap year: 24 Feb maps to folder 02-29');
-ok(get_sday(2, 25, 2024) eq '02-24', 'Leap year: 25 Feb maps to folder 02-24');
-ok(get_sday(2, 29, 2024) eq '02-28', 'Leap year: 29 Feb maps to folder 02-28');
-ok(get_sday(2, 23, 2024) eq '02-23', 'Leap year: days before 24 Feb are unaffected');
-ok(get_sday(2, 24, 2023) eq '02-24', 'Non-leap year: 24 Feb is unaffected');
-ok(get_sday(3, 1, 2024) eq '03-01', 'Months other than Feb are unaffected');
+is(get_sday(2, 24, 2024), '02-29', 'Leap year: 24 Feb maps to folder 02-29');
+is(get_sday(2, 25, 2024), '02-24', 'Leap year: 25 Feb maps to folder 02-24');
+is(get_sday(2, 29, 2024), '02-28', 'Leap year: 29 Feb maps to folder 02-28');
+is(get_sday(2, 23, 2024), '02-23', 'Leap year: days before 24 Feb are unaffected');
+is(get_sday(2, 24, 2023), '02-24', 'Non-leap year: 24 Feb is unaffected');
+is(get_sday(3, 1, 2024), '03-01', 'Months other than Feb are unaffected');
 
 ### nextday
 
-ok(nextday(12, 31, 2023) eq '01-01', '31 Dec rolls over into 1 Jan of next year');
-ok(nextday(1, 1, 2024) eq '01-02', '1 Jan advances to 2 Jan');
-ok(nextday(2, 23, 2024) eq '02-29', 'In a leap year, the day after 23 Feb is folder 02-29 (the leap day)');
-ok(nextday(2, 24, 2024) eq '02-24', 'In a leap year, the day after 24 Feb is folder 02-24 (real 25 Feb)');
-ok(nextday(2, 28, 2024) eq '02-28', 'In a leap year, the day after 28 Feb is folder 02-28 (real 29 Feb)');
-ok(nextday(2, 29, 2024) eq '03-01', 'In a leap year, the day after 29 Feb is folder 03-01');
-ok(nextday(2, 28, 2023) eq '03-01', 'In a non-leap year, the day after 28 Feb is 1 Mar');
+is(nextday(12, 31, 2023), '01-01', '31 Dec rolls over into 1 Jan of next year');
+is(nextday(1, 1, 2024), '01-02', '1 Jan advances to 2 Jan');
+is(nextday(2, 23, 2024), '02-29', 'In a leap year, the day after 23 Feb is folder 02-29 (the leap day)');
+is(nextday(2, 24, 2024), '02-24', 'In a leap year, the day after 24 Feb is folder 02-24 (real 25 Feb)');
+is(nextday(2, 28, 2024), '02-28', 'In a leap year, the day after 28 Feb is folder 02-28 (real 29 Feb)');
+is(nextday(2, 29, 2024), '03-01', 'In a leap year, the day after 29 Feb is folder 03-01');
+is(nextday(2, 28, 2023), '03-01', 'In a non-leap year, the day after 28 Feb is 1 Mar');
 
 ### prevnext
 
-ok(prevnext('12-31-2023', 1) eq '01-01-2024', 'prevnext steps forward across a year boundary');
-ok(prevnext('01-01-2024', -1) eq '12-31-2023', 'prevnext steps backward across a year boundary');
-ok(prevnext('06-15-2024', 5) eq '06-20-2024', 'prevnext steps forward within a month');
-ok(prevnext('02-28-2024', 1) eq '02-29-2024', 'prevnext steps forward a day in leap year');
-ok(prevnext('02-29-2024', 1) eq '03-01-2024', 'prevnext steps forward a day in leap year');
-ok(prevnext('02-28-2025', 1) eq '03-01-2025', 'prevnext steps forward a day in non leap year');
-ok(prevnext('02-29-2024', -1) eq '02-28-2024', 'prevnext steps backward a day in leap year');
-ok(prevnext('03-01-2024', -1) eq '02-29-2024', 'prevnext steps backward a day in leap year');
-ok(prevnext('03-01-2025', -1) eq '02-28-2025', 'prevnext steps backward a day in non leap year');
+is(prevnext('12-31-2023', 1), '01-01-2024', 'prevnext steps forward across a year boundary');
+is(prevnext('01-01-2024', -1), '12-31-2023', 'prevnext steps backward across a year boundary');
+is(prevnext('06-15-2024', 5), '06-20-2024', 'prevnext steps forward within a month');
+is(prevnext('02-28-2024', 1), '02-29-2024', 'prevnext steps forward a day in leap year');
+is(prevnext('02-29-2024', 1), '03-01-2024', 'prevnext steps forward a day in leap year');
+is(prevnext('02-28-2025', 1), '03-01-2025', 'prevnext steps forward a day in non leap year');
+is(prevnext('02-29-2024', -1), '02-28-2024', 'prevnext steps backward a day in leap year');
+is(prevnext('03-01-2024', -1), '02-29-2024', 'prevnext steps backward a day in leap year');
+is(prevnext('03-01-2025', -1), '02-28-2025', 'prevnext steps backward a day in non leap year');
 
 ### getweek
 # Spot checks at the season boundaries, cross-checked against the
 # liturgical calendar for the given years (Easter 2024 = 31 March).
 
-ok(getweek(1, 1, 2024) eq 'Nat01', '1 Jan (before Epiphany octave ends) is in the Nativity season');
-ok(getweek(7, 1, 2024) eq 'Epi1', '7 Jan 2024 is the first week after Epiphany');
-ok(getweek(28, 1, 2024) eq 'Quadp1', '28 Jan 2024 is Septuagesima week (Quadp1)');
-ok(getweek(11, 2, 2024) eq 'Quadp3', '11 Feb 2024 is Quinquagesima week (Quadp3)');
-ok(getweek(18, 2, 2024) eq 'Quad1', '18 Feb 2024 is the first week of Lent');
-ok(getweek(31, 3, 2024) eq 'Pasc0', 'Easter Sunday itself is Pasc0');
-ok(getweek(19, 5, 2024) eq 'Pasc7', '19 May 2024 (Whit Sunday) is the seventh Sunday after Easter (Pasc7)');
-ok(getweek(1, 12, 2024) eq 'Adv1', '1 Dec 2024 is the first Sunday of Advent');
-ok(getweek(25, 12, 2024) eq 'Nat25', 'Christmas Day is Nat25');
-ok(getweek(14,1,2016) eq 'Epi1', '14 Jan 2016 is in the first week after Epiphany');
-ok(getweek(7,2,2016) eq 'Quadp3', '7 Feb 2016 is Quinquagesima Sunday (Quadp3)');
-ok(getweek(20,2,2016) eq 'Quad1', '20 Feb 2016 is the first week of Lent (Ember Saturday)');
-ok(getweek(12,3,2016) eq 'Quad4', '12 Mar 2016 is the fourth week of Lent');
-ok(getweek(4,4,2016) eq 'Pasc1', '4 Apr 2016 is the week of the first Sunday after Easter (Pasc1)');
-ok(getweek(5,5,2016) eq 'Pasc5', '5 May 2016 is Ascension Thursday week (Pasc5)');
-ok(getweek(23,5,2016) eq 'Pent01', '23 May 2016 is Monday of first week after the octave of Pentecost (Pent01)');
-ok(getweek(11,9,2016) eq 'Pent17', '11 Sept 2016 is week 17 after the octave of Pentecost');
-ok(getweek(24,9,2016) eq 'Pent18', '24 Sept 2016 is week 18 after the octave of Pentecost; ember week');
-ok(getweek(11,12,2016) eq 'Adv3', '11 Dec 2016 is the third Sunday of Advent (Gaudete Sunday)');
-ok(getweek(17,12,2016) eq 'Adv3', '18 Dec 2016 is the Saturday after the third Sunday of Advent');
+is(getweek(1, 1, 2024), 'Nat01', '1 Jan (before Epiphany octave ends) is in the Nativity season');
+is(getweek(7, 1, 2024), 'Epi1', '7 Jan 2024 is the first week after Epiphany');
+is(getweek(28, 1, 2024), 'Quadp1', '28 Jan 2024 is Septuagesima week (Quadp1)');
+is(getweek(11, 2, 2024), 'Quadp3', '11 Feb 2024 is Quinquagesima week (Quadp3)');
+is(getweek(18, 2, 2024), 'Quad1', '18 Feb 2024 is the first week of Lent');
+is(getweek(31, 3, 2024), 'Pasc0', 'Easter Sunday itself is Pasc0');
+is(getweek(19, 5, 2024), 'Pasc7', '19 May 2024 (Whit Sunday) is the seventh Sunday after Easter (Pasc7)');
+is(getweek(1, 12, 2024), 'Adv1', '1 Dec 2024 is the first Sunday of Advent');
+is(getweek(25, 12, 2024), 'Nat25', 'Christmas Day is Nat25');
+is(getweek(14, 1, 2016), 'Epi1', '14 Jan 2016 is in the first week after Epiphany');
+is(getweek(7, 2, 2016), 'Quadp3', '7 Feb 2016 is Quinquagesima Sunday (Quadp3)');
+is(getweek(20, 2, 2016), 'Quad1', '20 Feb 2016 is the first week of Lent (Ember Saturday)');
+is(getweek(12, 3, 2016), 'Quad4', '12 Mar 2016 is the fourth week of Lent');
+is(getweek(4, 4, 2016), 'Pasc1', '4 Apr 2016 is the week of the first Sunday after Easter (Pasc1)');
+is(getweek(5, 5, 2016), 'Pasc5', '5 May 2016 is Ascension Thursday week (Pasc5)');
+is(getweek(23, 5, 2016), 'Pent01', '23 May 2016 is Monday of first week after the octave of Pentecost (Pent01)');
+is(getweek(11, 9, 2016), 'Pent17', '11 Sept 2016 is week 17 after the octave of Pentecost');
+is(getweek(24, 9, 2016), 'Pent18', '24 Sept 2016 is week 18 after the octave of Pentecost; ember week');
+is(getweek(11, 12, 2016), 'Adv3', '11 Dec 2016 is the third Sunday of Advent (Gaudete Sunday)');
+is(getweek(17, 12, 2016), 'Adv3', '18 Dec 2016 is the Saturday after the third Sunday of Advent');
 
 # "Resumed Epiphany" weeks and the Pent23/Pent24 boundary near the end of the
 # liturgical year, verified for 2024 (Easter 31 March).
-ok(getweek(1, 11, 2024) eq 'Pent23', '1 Nov 2024 is still Pent23');
-ok(getweek(8, 11, 2024) eq 'Epi4', '8 Nov 2024 falls back to a resumed Epiphany week (Epi4)');
-ok(getweek(22, 11, 2024) eq 'Epi6', '22 Nov 2024 is the last resumed Epiphany week (Epi6)');
-ok(getweek(29, 11, 2024) eq 'Pent24', '29 Nov 2024 is the last week of the liturgical year (Pent24)');
-ok(getweek(01, 12, 2024) eq 'Adv1', '1 Dec 2024 is the first week of Advent (Adv1)');
+is(getweek(1, 11, 2024), 'Pent23', '1 Nov 2024 is still Pent23');
+is(getweek(8, 11, 2024), 'Epi4', '8 Nov 2024 falls back to a resumed Epiphany week (Epi4)');
+is(getweek(22, 11, 2024), 'Epi6', '22 Nov 2024 is the last resumed Epiphany week (Epi6)');
+is(getweek(29, 11, 2024), 'Pent24', '29 Nov 2024 is the last week of the liturgical year (Pent24)');
+is(getweek(01, 12, 2024), 'Adv1', '1 Dec 2024 is the first week of Advent (Adv1)');
 
 ### monthday
 # 1960-rubrics-specific week-skip logic in Aug-Nov.
@@ -125,9 +125,11 @@ ok(getweek(01, 12, 2024) eq 'Adv1', '1 Dec 2024 is the first week of Advent (Adv
 # October: with the 1960 rubrics, the III week of October vanishes when the
 # first Sunday of October falls on the 4th-7th (as it does in 2024, when 1
 # Oct is a Tuesday).
-ok(monthday(13, 10, 2024, 1) eq '102-0', '1960 rubrics skip the III week of October in 2024');
-ok(monthday(13, 10, 2024, 0) eq '103-0', 'Traditional rubrics keep the III week of October in 2024');
+is(monthday(13, 10, 2024, 1), '102-0', '1960 rubrics skip the III week of October in 2024');
+is(monthday(13, 10, 2024, 0), '103-0', 'Traditional rubrics keep the III week of October in 2024');
 
 # November: with the 1960 rubrics, the II week of November always vanishes.
-ok(monthday(8, 11, 2023, 1) eq '111-3', '1960 rubrics skip the II week of November (2023)');
-ok(monthday(8, 11, 2023, 0) eq '112-3', 'Traditional rubrics keep the II week of November (2023)');
+is(monthday(8, 11, 2023, 1), '111-3', '1960 rubrics skip the II week of November (2023)');
+is(monthday(8, 11, 2023, 0), '112-3', 'Traditional rubrics keep the II week of November (2023)');
+
+done_testing;

--- a/t/DivinumOfficium/Directorium.t
+++ b/t/DivinumOfficium/Directorium.t
@@ -12,7 +12,7 @@ BEGIN {
 
 use lib 'web/cgi-bin';
 use DivinumOfficium::Directorium qw(get_from_directorium transfered check_coronatio dirge hymnmerge hymnshift);
-use Test::Simple tests => 32;
+use Test2::V0;
 
 # TODO: Not covered here (documented gap, no fixture data set up for these):
 #   - get_from_directorium() for the 'tempora'/'stransfer' subjects directly
@@ -24,8 +24,8 @@ use Test::Simple tests => 32;
 
 ### check_coronatio - pure function, no I/O.
 
-ok(check_coronatio(18, 5) eq 'Commune/Coronatio', '18 May is Coronatio');
-ok(check_coronatio(19, 5) eq '', 'Other dates are not Coronatio');
+is(check_coronatio(18, 5), 'Commune/Coronatio', '18 May is Coronatio');
+is(check_coronatio(19, 5), '', 'Other dates are not Coronatio');
 
 ### get_from_directorium('kalendar', ...)
 # t/fixtures/directorium/data.txt defines three fictional versions: 'Fixture
@@ -34,16 +34,16 @@ ok(check_coronatio(19, 5) eq '', 'Other dates are not Coronatio');
 # 'tbase', fallback).
 
 # Kalendaria/derived.txt directly overrides 02-02.
-ok(get_from_directorium('kalendar', 'Fixture Derived', '02-02') eq '02-02-derived', 'Direct override in derived.txt');
+is(get_from_directorium('kalendar', 'Fixture Derived', '02-02'), '02-02-derived', 'Direct override in derived.txt');
 
 # 01-01 isn't in derived.txt; it's inherited from the base version's
 # Kalendaria/base.txt via the 'base' column in data.txt.
-ok(
-  get_from_directorium('kalendar', 'Fixture Derived', '01-01') eq '01-01-base',
-  "Falls back to the base version's kalendar",
+is(
+  get_from_directorium('kalendar', 'Fixture Derived', '01-01'),
+  '01-01-base', "Falls back to the base version's kalendar",
 );
 
-ok(get_from_directorium('kalendar', 'Fixture Derived', '99-99') eq '', 'Unknown key returns an empty string');
+is(get_from_directorium('kalendar', 'Fixture Derived', '99-99'), '', 'Unknown key returns an empty string');
 
 ### transfered
 # Transfer/409.txt contains '09-09=01-15;;derived', tagged for the
@@ -52,52 +52,51 @@ ok(get_from_directorium('kalendar', 'Fixture Derived', '99-99') eq '', 'Unknown 
 # leap-year file-splitting logic in Directorium::load_transfers) has Easter
 # on 9 April.
 
-ok(
-  transfered('Sancti/01-15', 2023, 'Fixture Derived') eq '09-09',
-  '15 Jan is transferred to 09-09 per the fixture data',
-);
-ok(transfered('Sancti/01-16', 2023, 'Fixture Derived') eq '', 'Untransferred dates return an empty string');
+is(transfered('Sancti/01-15', 2023, 'Fixture Derived'), '09-09',
+  '15 Jan is transferred to 09-09 per the fixture data',);
+is(transfered('Sancti/01-16', 2023, 'Fixture Derived'), '', 'Untransferred dates return an empty string');
 
 # The 'Sancti(M|Cist|OP)?/' prefix is stripped regardless of which variant is
 # used, and a bare/unprefixed date string works the same way.
-ok(transfered('SanctiM/01-15', 2023, 'Fixture Derived') eq '09-09', 'SanctiM/ prefix is stripped like Sancti/');
-ok(transfered('SanctiCist/01-15', 2023, 'Fixture Derived') eq '09-09', 'SanctiCist/ prefix is stripped like Sancti/');
-ok(transfered('SanctiOP/01-15', 2023, 'Fixture Derived') eq '09-09', 'SanctiOP/ prefix is stripped like Sancti/');
-ok(transfered('01-15', 2023, 'Fixture Derived') eq '09-09', 'A bare, unprefixed date string works the same way');
-ok(transfered('Sancti/', 2023, 'Fixture Derived') eq '', 'A string that strips down to empty returns empty');
+is(transfered('SanctiM/01-15', 2023, 'Fixture Derived'), '09-09', 'SanctiM/ prefix is stripped like Sancti/');
+is(transfered('SanctiCist/01-15', 2023, 'Fixture Derived'), '09-09', 'SanctiCist/ prefix is stripped like Sancti/');
+is(transfered('SanctiOP/01-15', 2023, 'Fixture Derived'), '09-09', 'SanctiOP/ prefix is stripped like Sancti/');
+is(transfered('01-15', 2023, 'Fixture Derived'), '09-09', 'A bare, unprefixed date string works the same way');
+is(transfered('Sancti/', 2023, 'Fixture Derived'), '', 'A string that strips down to empty returns empty');
 
 # '01-30=01-30;;derived': the value starts with its own key, so the
 # self-referential guard ($val !~ /^$key/) must prevent this from ever being
 # reported as a transfer, even though the value otherwise matches.
-ok(
-  transfered('Sancti/01-30', 2023, 'Fixture Derived') eq '',
-  'Self-referential entries are never reported as transfers'
-);
+is(transfered('Sancti/01-30', 2023, 'Fixture Derived'), '',
+  'Self-referential entries are never reported as transfers',);
 
 # '05-06=01-21v;;derived': the trailing 'v' marks this as a votive entry,
 # which the ($transfer{$key} !~ /v\s*$/i) guard must exclude.
-ok(transfered('Sancti/01-21', 2023, 'Fixture Derived') eq '', 'Votive-suffixed entries are excluded');
+is(transfered('Sancti/01-21', 2023, 'Fixture Derived'), '', 'Votive-suffixed entries are excluded');
 
 # 'dirge1=03-03;;derived' would otherwise match a query for 03-03, but keys
 # matching /(dirge|Hy)/i must be skipped entirely when scanning for
 # transfers.
-ok(transfered('Sancti/03-03', 2023, 'Fixture Derived') eq '',
-  'dirge/Hy-named keys are excluded from transfer matching');
+is(transfered('Sancti/03-03', 2023, 'Fixture Derived'), '', 'dirge/Hy-named keys are excluded from transfer matching',);
 
 # '05-07=Tempora/Epi3;;derived' points at a Tempora season without the
 # 'Epi1-0' exception, so it must be skipped; '05-08=Tempora/Epi1-0;;derived'
 # has the exception and so must NOT be skipped.
-ok(transfered('Epi3', 2023, 'Fixture Derived') eq '',
-  'Entries pointing at Tempora (without the Epi1-0 exception) are skipped');
-ok(transfered('Epi1-0', 2023, 'Fixture Derived') eq '05-08',
-  'Entries pointing at Tempora with the Epi1-0 exception are not skipped');
+is(
+  transfered('Epi3', 2023, 'Fixture Derived'),
+  '', 'Entries pointing at Tempora (without the Epi1-0 exception) are skipped',
+);
+is(
+  transfered('Epi1-0', 2023, 'Fixture Derived'),
+  '05-08', 'Entries pointing at Tempora with the Epi1-0 exception are not skipped',
+);
 
 # '10-10=02-25;;tbaseversion' only exists tagged for 'Fixture TBase', which is
 # only reachable via the recursive 'tbase' (transferbase) fallback once
 # 'Fixture Derived' itself has no matching entry.
-ok(
-  transfered('Sancti/02-25', 2023, 'Fixture Derived') eq '10-10',
-  'Falls back through the transferbase chain to Fixture TBase'
+is(
+  transfered('Sancti/02-25', 2023, 'Fixture Derived'),
+  '10-10', 'Falls back through the transferbase chain to Fixture TBase',
 );
 
 ### dirge
@@ -128,9 +127,9 @@ ok(dirge('Fixture Derived', 'Laudes', 3, 3, 2023), "Generale's own dirge date is
 ### get_from_directorium('transfer', ...) with a $dioecesis
 # Transfer/TestDioc/409.txt also has '11-11=05-20;;derived'.
 
-ok(
-  get_from_directorium('transfer', 'Fixture Derived', '11-11', 2023, 'TestDioc') eq '05-20;;TestDioc',
-  'Diocese-specific transfer entries are found, tagged with the diocese name',
+is(
+  get_from_directorium('transfer', 'Fixture Derived', '11-11', 2023, 'TestDioc'),
+  '05-20;;TestDioc', 'Diocese-specific transfer entries are found, tagged with the diocese name',
 );
 
 # NB: the equivalent diocese-override lookup for the 'kalendar' subject does
@@ -149,3 +148,5 @@ ok(!hymnshift('Fixture Derived', 5, 5, 2023, ''), 'Hymnshift does not apply when
 
 ok(hymnshift('Fixture Derived', 9, 5, 2023, ''), 'Hymnshift applies on its own recorded date');
 ok(!hymnmerge('Fixture Derived', 9, 5, 2023, ''), 'Hymnmerge does not apply when hymnshift does instead');
+
+done_testing;

--- a/t/DivinumOfficium/Lexicon.t
+++ b/t/DivinumOfficium/Lexicon.t
@@ -2,18 +2,20 @@ use strict;
 use warnings;
 use lib 'web/cgi-bin';
 use DivinumOfficium::Lexicon qw(apply_interlinear);
-use Test::Simple tests => 6;
+use Test2::V0;
 
 $ENV{LEXICON_PATH} = 't/fixtures/latin_lexicon_test.json';
 
 my $result = apply_interlinear('Dominus');
-ok($result =~ /class="lw"/,    'Known word gets lw span');
-ok($result =~ /class="gloss"/, 'Known word gets gloss span');
-ok($result =~ /\(Lord\)/,      'Correct gloss for Dominus');
+like($result, qr/class="lw"/, 'Known word gets lw span');
+like($result, qr/class="gloss"/, 'Known word gets gloss span');
+like($result, qr/\(Lord\)/, 'Correct gloss for Dominus');
 
 my $unknown = apply_interlinear('xyz123');
-ok($unknown eq 'xyz123', 'Unknown word passes through');
+is($unknown, 'xyz123', 'Unknown word passes through');
 
 my $html = apply_interlinear('<b>Deus</b>');
-ok($html =~ m{<b><span class="lw">Deus}, 'HTML tag before word preserved');
-ok($html !~ m{<span.*?<b},                'HTML tag not wrapped in span');
+like($html, qr{<b><span class="lw">Deus}, 'HTML tag before word preserved');
+unlike($html, qr{<span.*?<b}, 'HTML tag not wrapped in span');
+
+done_testing;

--- a/t/DivinumOfficium/LiturgicalColor.t
+++ b/t/DivinumOfficium/LiturgicalColor.t
@@ -3,7 +3,7 @@ use warnings;
 
 use DivinumOfficium::Main qw(liturgical_color);
 
-use Test::Simple tests => 57;
+use Test2::V0;
 
 # These tests check liturgical_color() against real day titles pulled from
 # the actual data shipped in web/www/horas/Latin/ (the [Officium]/[Rank]
@@ -29,33 +29,33 @@ use Test::Simple tests => 57;
 
 ### Tempus Adventus (Advent) - violet
 
-ok(liturgical_color('Dominica I Adventus') eq 'purple', 'Advent Sunday is violet');
+is(liturgical_color('Dominica I Adventus'), 'purple', 'Advent Sunday is violet');
 
 ### Tempus Nativitatis (Christmastide) - white, except martyrs within it
 
-ok(liturgical_color('In Nativitate Domini') eq 'black', 'Christmas Day is white');
-ok(liturgical_color('Dominica infra Octavam Nativitatis') eq 'black', 'Christmastide is white');
+is(liturgical_color('In Nativitate Domini'), 'black', 'Christmas Day is white');
+is(liturgical_color('Dominica infra Octavam Nativitatis'), 'black', 'Christmastide is white');
 
 # 26 Dec, within the Octave of Christmas, but a martyr's feast overrides the
 # season's own white and is red instead.
-ok(liturgical_color('S. Stephani Protomartyris') eq 'red', 'St Stephen (26 Dec) is red, overriding the white octave');
+is(liturgical_color('S. Stephani Protomartyris'), 'red', 'St Stephen (26 Dec) is red, overriding the white octave');
 
 # 1 Jan has two real historical titles for the same day.
-ok(liturgical_color('In Circumcisione Domini') eq 'black', '1 Jan, pre-1960 title ("Circumcision"), is white');
-ok(
-  liturgical_color("Die Octav\x{e6} Nativitatis Domini") eq 'black',
-  '1 Jan, 1960-rubrics title ("Octave Day of the Nativity"), is white',
+is(liturgical_color('In Circumcisione Domini'), 'black', '1 Jan, pre-1960 title ("Circumcision"), is white');
+is(
+  liturgical_color("Die Octav\x{e6} Nativitatis Domini"),
+  'black', '1 Jan, 1960-rubrics title ("Octave Day of the Nativity"), is white',
 );
 
 # The Vigil of the Epiphany (5 Jan) is white, reached via the anchored
 # ^In Vigilia Epiphaniae branch.
-ok(liturgical_color("In Vigilia Epiphani\x{e6}") eq 'black', 'Vigil of the Epiphany is white');
+is(liturgical_color("In Vigilia Epiphani\x{e6}"), 'black', 'Vigil of the Epiphany is white');
 
 # The Feast of the Holy Family (Sunday within the Octave of the Epiphany) is
 # white; despite mentioning Mary, it is not a Marian feast, and this is a
 # real-data near-miss for the blue Marian pattern (Sanct + ae/ae is not
 # immediately followed by " Mari" here).
-ok(liturgical_color("Sanct\x{e6} Famili\x{e6} Jesu Mari\x{e6} Joseph") eq 'black', 'Feast of the Holy Family is white');
+is(liturgical_color("Sanct\x{e6} Famili\x{e6} Jesu Mari\x{e6} Joseph"), 'black', 'Feast of the Holy Family is white');
 
 ### Tempus post Epiphaniam (Time after Epiphany)
 
@@ -63,137 +63,134 @@ ok(liturgical_color("Sanct\x{e6} Famili\x{e6} Jesu Mari\x{e6} Joseph") eq 'black
 # white color; the ordinary green season does not begin until after the
 # octave ends, even though this title doesn't match any "white" keyword
 # either - it's white purely via the default fallback.
-ok(liturgical_color("In Octava Epiphani\x{e6}") eq 'black', 'Octave Day of the Epiphany is still white, not yet green');
+is(liturgical_color("In Octava Epiphani\x{e6}"), 'black', 'Octave Day of the Epiphany is still white, not yet green');
 
 # Once the octave has ended, ordinary Sundays "post Epiphaniam" are green.
-ok(liturgical_color('Dominica II post Epiphaniam') eq 'green', 'An ordinary Sunday after Epiphany is green');
+is(liturgical_color('Dominica II post Epiphaniam'), 'green', 'An ordinary Sunday after Epiphany is green');
 
 ### Septuagesima, Lent, Ember Days - violet
 
-ok(liturgical_color('Dominica in Septuagesima') eq 'purple', 'Septuagesima Sunday is violet');
-ok(liturgical_color('Dominica I in Quadragesima') eq 'purple', 'The first Sunday of Lent is violet');
-ok(
-  liturgical_color('Feria Quarta Quattuor Temporum Septembris') eq 'purple',
-  'The September Ember Wednesday is violet',
-);
+is(liturgical_color('Dominica in Septuagesima'), 'purple', 'Septuagesima Sunday is violet');
+is(liturgical_color('Dominica I in Quadragesima'), 'purple', 'The first Sunday of Lent is violet');
+is(liturgical_color('Feria Quarta Quattuor Temporum Septembris'), 'purple', 'The September Ember Wednesday is violet',);
 
 ### Passiontide and Holy Week
 
-ok(liturgical_color('Dominica de Passione') eq 'purple', 'Passion Sunday is violet');
-ok(liturgical_color('Dominica I Passionis') eq 'purple', 'Passion Sunday is violet');
-ok(liturgical_color('Dominica in Palmis') eq 'purple', 'Palm Sunday is violet');
-ok(liturgical_color('Dominica II Passionis seu in Palmis') eq 'purple', 'Palm Sunday is violet');
-ok(liturgical_color('Feria Secunda in Rogationibus') eq 'purple', 'Rogation Monday is violet');
+is(liturgical_color('Dominica de Passione'), 'purple', 'Passion Sunday is violet');
+is(liturgical_color('Dominica I Passionis'), 'purple', 'Passion Sunday is violet');
+is(liturgical_color('Dominica in Palmis'), 'purple', 'Palm Sunday is violet');
+is(liturgical_color('Dominica II Passionis seu in Palmis'), 'purple', 'Palm Sunday is violet');
+is(liturgical_color('Feria Secunda in Rogationibus'), 'purple', 'Rogation Monday is violet');
 
 # The eve of the Ascension (Wednesday of Rogation week) has two real titles:
 # the older one keeps the Rogation Days' own violet, while the 1960-rubrics
 # title drops the Rogation reference and is the Ascension Vigil proper
 # (white) - see the comment on the anchored branch in Main.pm.
-ok(
-  liturgical_color('Feria Quarta in Rogationibus in Vigilia Ascensionis') eq 'purple',
-  'Eve of the Ascension, pre-1960 title (still a Rogation Day), is violet',
+is(
+  liturgical_color('Feria Quarta in Rogationibus in Vigilia Ascensionis'),
+  'purple', 'Eve of the Ascension, pre-1960 title (still a Rogation Day), is violet',
 );
-ok(
-  liturgical_color('In Vigilia Ascensionis') eq 'black',
-  'Eve of the Ascension, 1960-rubrics title (Ascension Vigil proper), is white',
+is(
+  liturgical_color('In Vigilia Ascensionis'),
+  'black', 'Eve of the Ascension, 1960-rubrics title (Ascension Vigil proper), is white',
 );
 
-ok(liturgical_color('Feria Quinta in Cena Domini') eq 'black', 'Holy Thursday (Mass "in Cena Domini") is white');
+is(liturgical_color('Feria Quinta in Cena Domini'), 'black', 'Holy Thursday (Mass "in Cena Domini") is white');
 
 # Good Friday also has two real titles, both correctly grey (the app's
 # stand-in for black vestments) since the grey pattern recognizes both the
 # older "Parasceve" and the 1955/1960-rubrics "Morte" wording.
-ok(liturgical_color('Feria Sexta in Parasceve') eq 'grey', 'Good Friday, pre-1960/1955 title, is black (grey here)');
-ok(
-  liturgical_color('Feria Sexta in Passione et Morte Domini') eq 'grey',
-  'Good Friday, 1955/1960-rubrics title, is still black (grey here) despite also containing "Passione"',
+is(liturgical_color('Feria Sexta in Parasceve'), 'grey', 'Good Friday, pre-1960/1955 title, is black (grey here)');
+is(
+  liturgical_color('Feria Sexta in Passione et Morte Domini'),
+  'grey', 'Good Friday, 1955/1960-rubrics title, is still black (grey here) despite also containing "Passione"',
 );
 
-ok(liturgical_color('Sabbato Sancto') eq 'purple', 'Holy Saturday (before the Vigil) is violet');
+is(liturgical_color('Sabbato Sancto'), 'purple', 'Holy Saturday (before the Vigil) is violet');
 
 ### Tempus Paschale (Eastertide) - white
 
-ok(liturgical_color("Die II infra octavam Pasch\x{e6}") eq 'black', 'Easter Monday is white');
+is(liturgical_color("Die II infra octavam Pasch\x{e6}"), 'black', 'Easter Monday is white');
 
 # Easter Sunday's real title doesn't actually contain "Pascha" at all (it
 # says "Resurrectionis"), so unlike most of the Easter octave, this reaches
 # white via the default fallback rather than the black2 "Pasch" keyword.
-ok(liturgical_color('Dominica Resurrectionis') eq 'black', 'Easter Sunday itself is white, via the default fallback');
-ok(liturgical_color("Dominica in Albis in Octava Pasch\x{e6}") eq 'black', 'Sundays after Easter are white');
-ok(liturgical_color('Dominica III post Pascha') eq 'black', 'Sundays after Easter are white');
-ok(liturgical_color('Dominica infra Octavam Ascensionis') eq 'black', 'Sundays after Ascension is white');
+is(liturgical_color('Dominica Resurrectionis'), 'black', 'Easter Sunday itself is white, via the default fallback');
+is(liturgical_color("Dominica in Albis in Octava Pasch\x{e6}"), 'black', 'Sundays after Easter are white');
+is(liturgical_color('Dominica III post Pascha'), 'black', 'Sundays after Easter are white');
+is(liturgical_color('Dominica infra Octavam Ascensionis'), 'black', 'Sundays after Ascension is white');
 
 ### Pentecost - red
 
-ok(liturgical_color('Sabbato in Vigilia Pentecostes') eq 'red', 'The Vigil of Pentecost is red');
-ok(liturgical_color('Dominica Pentecostes') eq 'red', 'Pentecost Sunday is red');
+is(liturgical_color('Sabbato in Vigilia Pentecostes'), 'red', 'The Vigil of Pentecost is red');
+is(liturgical_color('Dominica Pentecostes'), 'red', 'Pentecost Sunday is red');
 
 ### Tempus post Pentecosten (Time after Pentecost)
 
-ok(
-  liturgical_color("Dominica Sanctissim\x{e6} Trinitatis") eq 'black',
-  'Trinity Sunday is white (also a real-data near-miss for the blue Marian pattern)',
+is(
+  liturgical_color("Dominica Sanctissim\x{e6} Trinitatis"),
+  'black', 'Trinity Sunday is white (also a real-data near-miss for the blue Marian pattern)',
 );
-ok(liturgical_color('Festum Sanctissimi Corporis Christi') eq 'black', 'Corpus Christi is white');
+is(liturgical_color('Festum Sanctissimi Corporis Christi'), 'black', 'Corpus Christi is white');
 
 # A Sunday falling within the Octave of Corpus Christi keeps that white
 # octave rather than the ordinary green of Time after Pentecost - this is
 # exactly the real-world case the green pattern's negative lookahead exists
 # for ("Pentecosten" followed later by "infra octavam" is excluded).
-ok(
-  liturgical_color('Dominica II Post Pentecosten infra Octavam Corporis Christi') eq 'black',
-  'A Sunday within the Corpus Christi octave stays white, not green',
+is(
+  liturgical_color('Dominica II Post Pentecosten infra Octavam Corporis Christi'),
+  'black', 'A Sunday within the Corpus Christi octave stays white, not green',
 );
 
-ok(liturgical_color('Sacratissimi Cordis Domini Nostri Jesu Christi') eq 'black', 'The Sacred Heart is white');
-ok(liturgical_color('Domini Nostri Jesu Christi Regis') eq 'black', 'Christ the King is white');
+is(liturgical_color('Sacratissimi Cordis Domini Nostri Jesu Christi'), 'black', 'The Sacred Heart is white');
+is(liturgical_color('Domini Nostri Jesu Christi Regis'), 'black', 'Christ the King is white');
 
 # Ordinary Sundays after Pentecost, including the last one of the liturgical
 # year, are green.
-ok(liturgical_color('Dominica X Post Pentecosten') eq 'green', 'An ordinary Sunday after Pentecost is green');
-ok(
-  liturgical_color('Dominica XXIV et Ultima Post Pentecosten') eq 'green',
-  'The last Sunday after Pentecost is also green',
+is(liturgical_color('Dominica X Post Pentecosten'), 'green', 'An ordinary Sunday after Pentecost is green');
+is(
+  liturgical_color('Dominica XXIV et Ultima Post Pentecosten'),
+  'green', 'The last Sunday after Pentecost is also green',
 );
 
 ### Sanctorale: Marian feasts - blue
 # The actual liturgical color for Marian feasts is white, but the app renders them as blue
 # to distinguish them from other white feasts (Christmastide, Eastertide, Confessors, etc.) that are not Marian.
 
-ok(liturgical_color("In Purificatione Beat\x{e6} Mari\x{e6} Virginis") eq 'blue', 'Candlemas is blue');
-ok(liturgical_color("In Annuntiatione Beat\x{e6} Mari\x{e6} Virginis") eq 'blue', 'The Annunciation is blue');
-ok(liturgical_color("In Assumptione Beat\x{e6} Mari\x{e6} Virginis") eq 'blue', 'The Assumption is blue');
-ok(liturgical_color("Assumptio BeatBeat\x{e6} Mari\x{e6} Mari\x{e6} Virginis") eq 'blue', 'The Assumption is blue');
-ok(
-  liturgical_color("In Conceptione Immaculata Beat\x{e6} Mari\x{e6} Virginis") eq 'blue',
-  'The Immaculate Conception is blue',
+is(liturgical_color("In Purificatione Beat\x{e6} Mari\x{e6} Virginis"), 'blue', 'Candlemas is blue');
+is(liturgical_color("In Annuntiatione Beat\x{e6} Mari\x{e6} Virginis"), 'blue', 'The Annunciation is blue');
+is(liturgical_color("In Assumptione Beat\x{e6} Mari\x{e6} Virginis"), 'blue', 'The Assumption is blue');
+is(liturgical_color("Assumptio BeatBeat\x{e6} Mari\x{e6} Mari\x{e6} Virginis"), 'blue', 'The Assumption is blue');
+is(
+  liturgical_color("In Conceptione Immaculata Beat\x{e6} Mari\x{e6} Virginis"),
+  'blue', 'The Immaculate Conception is blue',
 );
-ok(liturgical_color("In Nativitate Beat\x{e6} Mari\x{e6} Virginis") eq 'blue', 'The Nativity of Mary is blue');
-ok(liturgical_color("Beat\x{e6} Mari\x{e6} Virginis a Rosario") eq 'blue', 'Our Lady of the Rosary is blue');
+is(liturgical_color("In Nativitate Beat\x{e6} Mari\x{e6} Virginis"), 'blue', 'The Nativity of Mary is blue');
+is(liturgical_color("Beat\x{e6} Mari\x{e6} Virginis a Rosario"), 'blue', 'Our Lady of the Rosary is blue');
 
 ### Sanctorale: red feasts (martyrs, apostles, the Holy Cross)
 
-ok(liturgical_color("In Exaltatione Sanct\x{e6} Crucis") eq 'red', 'The Exaltation of the Holy Cross is red');
-ok(liturgical_color('SS. Apostolorum Petri et Pauli') eq 'red', 'Ss Peter and Paul (apostles and martyrs) is red');
-ok(liturgical_color('S. Laurentii Martyris') eq 'red', 'St Lawrence (martyr) is red');
-ok(liturgical_color('Ss. Fabiani et Sebastiani Martyrum') eq 'red', 'Ss Fabian and Sebastian (martyrs) is red');
-ok(liturgical_color("S. Marci Evangelist\x{e6}") eq 'red', 'St Mark Evangelist is red');
+is(liturgical_color("In Exaltatione Sanct\x{e6} Crucis"), 'red', 'The Exaltation of the Holy Cross is red');
+is(liturgical_color('SS. Apostolorum Petri et Pauli'), 'red', 'Ss Peter and Paul (apostles and martyrs) is red');
+is(liturgical_color('S. Laurentii Martyris'), 'red', 'St Lawrence (martyr) is red');
+is(liturgical_color('Ss. Fabiani et Sebastiani Martyrum'), 'red', 'Ss Fabian and Sebastian (martyrs) is red');
+is(liturgical_color("S. Marci Evangelist\x{e6}"), 'red', 'St Mark Evangelist is red');
 
 ### Sanctorale: white feasts, several of them real-data near-misses for blue
 
-ok(
-  liturgical_color("In Nativitate S. Joannis Baptist\x{e6}") eq 'black',
-  'The Nativity of St John the Baptist is white',
+is(liturgical_color("In Nativitate S. Joannis Baptist\x{e6}"), 'black',
+  'The Nativity of St John the Baptist is white',);
+is(
+  liturgical_color('S. Joseph Sponsi B.M.V. Confessoris'),
+  'black', 'St Joseph, Spouse of the BVM (a confessor), is white despite mentioning the BVM',
 );
-ok(
-  liturgical_color('S. Joseph Sponsi B.M.V. Confessoris') eq 'black',
-  'St Joseph, Spouse of the BVM (a confessor), is white despite mentioning the BVM',
-);
-ok(liturgical_color('S. Francisci Confessoris') eq 'black', 'St Francis (a confessor) is white');
-ok(liturgical_color('S. Joseph Opificis') eq 'black', 'St Joseph the Worker (a 1960-rubrics-specific feast) is white');
-ok(liturgical_color('Sanctissimi Nominis Jesu') eq 'black', 'The Holy Name of Jesus is white');
-ok(liturgical_color('Omnium Sanctorum') eq 'black', 'All Saints is white');
+is(liturgical_color('S. Francisci Confessoris'), 'black', 'St Francis (a confessor) is white');
+is(liturgical_color('S. Joseph Opificis'), 'black', 'St Joseph the Worker (a 1960-rubrics-specific feast) is white');
+is(liturgical_color('Sanctissimi Nominis Jesu'), 'black', 'The Holy Name of Jesus is white');
+is(liturgical_color('Omnium Sanctorum'), 'black', 'All Saints is white');
 
 ### All Souls - black (grey here)
 
-ok(liturgical_color('In Commemoratione Omnium Fidelium Defunctorum') eq 'grey', 'All Souls is black (grey here)');
+is(liturgical_color('In Commemoratione Omnium Fidelium Defunctorum'), 'grey', 'All Souls is black (grey here)');
+
+done_testing;

--- a/t/DivinumOfficium/Main.t
+++ b/t/DivinumOfficium/Main.t
@@ -3,7 +3,7 @@ use warnings;
 
 use DivinumOfficium::Main qw(vernaculars liturgical_color);
 
-use Test::Simple tests => 31;
+use Test2::V0;
 
 # We're assuming here that the test is invoked from the parent of the t/
 # directory.
@@ -20,18 +20,13 @@ my %vernaculars;
 @vernaculars{@vernaculars} = ();
 
 # Sanity checks on the available languages.
-ok(scalar(@vernaculars) == scalar(keys(%vernaculars)), 'No dups');
+is(scalar(@vernaculars), scalar(keys(%vernaculars)), 'No dups');
 ok(exists($vernaculars{'English'}), 'Has English');
 ok(exists($vernaculars{'Italiano'}), 'Has Italian');
 ok(!exists($vernaculars{'Latin'}), 'No Latin');
 
 # Make sure failing to load the file is fatal.
-{
-
-  package DivinumOfficium::Main;
-  use Test::Carp;
-  does_croak(\&::vernaculars, 'non/est/hic');
-}
+like(dies { vernaculars('non/est/hic') }, qr/Couldn't load language list/, 'croaks on a bad path');
 
 ### liturgical_color
 # liturgical_color() sets $_ = shift and then runs a fixed sequence of
@@ -48,129 +43,132 @@ ok(!exists($vernaculars{'Latin'}), 'No Latin');
 ## Group A: one representative match per branch/color, chosen to avoid
 ## incidentally tripping an earlier branch.
 
-ok(liturgical_color('In Nativitate Domini') eq 'black', 'No keywords matched falls through to the default black');
+is(liturgical_color('In Nativitate Domini'), 'black', 'No keywords matched falls through to the default black');
 
-ok(liturgical_color("Beatae Mariae") eq 'blue', 'Blue: "Beatae Mariae"');
-ok(liturgical_color("Sanct\x{e6} Mari\x{e6}") eq 'blue', 'Blue: the ae-ligature spelling is also recognized');
+is(liturgical_color("Beatae Mariae"), 'blue', 'Blue: "Beatae Mariae"');
+is(liturgical_color("Sanct\x{e6} Mari\x{e6}"), 'blue', 'Blue: the ae-ligature spelling is also recognized');
 
-ok(liturgical_color('Officium Defunctorum') eq 'grey', 'Grey: "Defunctorum"');
+is(liturgical_color('Officium Defunctorum'), 'grey', 'Grey: "Defunctorum"');
 
-ok(liturgical_color('In Vigilia Ascensionis Domini') eq 'black', 'Black (anchored): "^In Vigilia Ascensionis"');
+is(liturgical_color('In Vigilia Ascensionis Domini'), 'black', 'Black (anchored): "^In Vigilia Ascensionis"');
 
-ok(liturgical_color('Dominica Septuagesima') eq 'purple', 'Purple: "gesim" (Septuagesima/Sexagesima/Quinquagesima)');
+is(liturgical_color('Dominica Septuagesima'), 'purple', 'Purple: "gesim" (Septuagesima/Sexagesima/Quinquagesima)');
 
-ok(liturgical_color('In Dedicatione Ecclesiae') eq 'black', 'Black: "Dedicatione"');
+is(liturgical_color('In Dedicatione Ecclesiae'), 'black', 'Black: "Dedicatione"');
 
-ok(liturgical_color('In Festo Pentecosten') eq 'green', 'Green: bare "Pentecosten"');
+is(liturgical_color('In Festo Pentecosten'), 'green', 'Green: bare "Pentecosten"');
 
 # Isolated from every earlier branch (no Mari/Vigilia/Martyr/etc.), so this
 # can only be reached via the final red branch's "Innocentium" alternative.
-ok(liturgical_color('In Festo Sanctorum Innocentium') eq 'red', 'Red: "Innocentium", reached only via the last branch');
+is(liturgical_color('In Festo Sanctorum Innocentium'), 'red', 'Red: "Innocentium", reached only via the last branch');
 
 ## Group B: guards/exceptions on individual branches.
 
 # Blue's Marian pattern is explicitly suppressed for a Vigil; this falls all
 # the way through to purple's (case-insensitive, unguarded) "Vigilia".
-ok(
-  liturgical_color('In Vigilia Assumptionis Beatae Mariae Virginis') eq 'purple',
-  'Blue\'s Vigil exception sends a Marian vigil to purple instead',
+is(
+  liturgical_color('In Vigilia Assumptionis Beatae Mariae Virginis'),
+  'purple', 'Blue\'s Vigil exception sends a Marian vigil to purple instead',
 );
 
 # Purple's Advent keyword is suppressed by the "commemoratione" exception.
-ok(
-  liturgical_color('In Commemoratione Adventus Domini') eq 'black',
-  'Purple\'s commemoratione exception excludes "Adventus" here',
+is(
+  liturgical_color('In Commemoratione Adventus Domini'),
+  'black', 'Purple\'s commemoratione exception excludes "Adventus" here',
 );
 
 # Purple's Rogation keyword is suppressed by the "votivum" exception.
-ok(liturgical_color('In festo Rogationis votivum') eq 'black', 'Purple\'s votivum exception excludes "Rogatio" here');
+is(liturgical_color('In festo Rogationis votivum'), 'black', 'Purple\'s votivum exception excludes "Rogatio" here');
 
 # Green's negative lookahead only looks *forward* from the match position:
 # "Pentecosten" followed later by "infra octavam" is excluded from green...
-ok(
-  liturgical_color('In Pentecosten infra octavam') eq 'black',
-  'Green\'s lookahead excludes "Pentecosten" when "infra octavam" follows it',
+is(
+  liturgical_color('In Pentecosten infra octavam'),
+  'black', 'Green\'s lookahead excludes "Pentecosten" when "infra octavam" follows it',
 );
 
 # ...but if "infra octavam" precedes "Pentecosten" instead, the lookahead
 # (which only checks what comes after) does not exclude it.
-ok(
-  liturgical_color('Dominica infra octavam Pentecosten') eq 'green',
-  'Green\'s lookahead does not look backwards, so preceding text does not exclude it',
+is(
+  liturgical_color('Dominica infra octavam Pentecosten'),
+  'green', 'Green\'s lookahead does not look backwards, so preceding text does not exclude it',
 );
 
 ## Group C: case-sensitivity and orthography quirks worth pinning down.
 
 # Blue's pattern has no /i flag, so it is case-sensitive.
-ok(liturgical_color('beatae mariae') eq 'black',
-  'Blue\'s pattern is case-sensitive; an all-lowercase match falls through');
+is(
+  liturgical_color('beatae mariae'),
+  'black', 'Blue\'s pattern is case-sensitive; an all-lowercase match falls through',
+);
 
 # Black's anchored Vigil pattern has no /i flag either; a lowercase variant
 # instead falls through to purple's case-insensitive "Vigilia".
-ok(
-  liturgical_color('in vigilia ascensionis') eq 'purple',
-  'The anchored black Vigil pattern is case-sensitive; lowercase falls through to purple',
+is(
+  liturgical_color('in vigilia ascensionis'),
+  'purple', 'The anchored black Vigil pattern is case-sensitive; lowercase falls through to purple',
 );
 
 # Purple's Holy Week pattern only recognizes the ae-ligature
 # spelling ("Hebdomadae Sanctae" with ae-ligature characters), unlike blue's
 # Marian pattern which accepts both the ligature and the plain "ae" digraph.
-ok(
-  liturgical_color("Feria II Hebdomad\x{e6} Sanct\x{e6}") eq 'purple',
-  'Purple: the ae-ligature spelling of "Hebdomadae Sanctae" is recognized',
+is(
+  liturgical_color("Feria II Hebdomad\x{e6} Sanct\x{e6}"),
+  'purple', 'Purple: the ae-ligature spelling of "Hebdomadae Sanctae" is recognized',
 );
-ok(
-  liturgical_color('Feria II Hebdomadae Sanctae') eq 'black',
-  'Purple\'s Holy Week pattern does not recognize the plain "ae" digraph spelling',
+is(
+  liturgical_color('Feria II Hebdomadae Sanctae'),
+  'black', 'Purple\'s Holy Week pattern does not recognize the plain "ae" digraph spelling',
 );
 
 ## Group D: priority between branches that could both match the same input.
 
 # A Marian feast that is also a martyr is blue, not red: blue is checked
 # first.
-ok(liturgical_color('In Festo Sanctae Mariae Martyris') eq 'blue', 'Blue takes priority over red\'s "Martyr"');
+is(liturgical_color('In Festo Sanctae Mariae Martyris'), 'blue', 'Blue takes priority over red\'s "Martyr"');
 
 # Our Lady of Sorrows ("Dolorum") is a purple keyword, but a Marian feast
 # titled with it is still blue: blue is checked before purple.
-ok(liturgical_color('Septem Dolorum Beatae Mariae Virginis') eq 'blue', 'Blue takes priority over purple\'s "Dolorum"');
+is(liturgical_color('Septem Dolorum Beatae Mariae Virginis'), 'blue', 'Blue takes priority over purple\'s "Dolorum"');
 
 # Red's specific compound "Quattuor Temporum Pentecostes" is checked before
 # purple's bare "Quattuor", so the more specific Pentecost Ember Days phrase
 # wins; a bare "Quattuor" with no "Pentecostes" correctly falls through to
 # purple instead.
-ok(
-  liturgical_color('Feria IV Quattuor Temporum Pentecostes') eq 'red',
-  'Red\'s specific "Quattuor Temporum Pentecostes" takes priority over purple\'s bare "Quattuor"',
+is(
+  liturgical_color('Feria IV Quattuor Temporum Pentecostes'),
+  'red', 'Red\'s specific "Quattuor Temporum Pentecostes" takes priority over purple\'s bare "Quattuor"',
 );
-ok(
-  liturgical_color('Quattuor Temporum Septembris') eq 'purple',
-  'A bare "Quattuor" (no "Pentecostes") falls through to purple as expected',
+is(
+  liturgical_color('Quattuor Temporum Septembris'),
+  'purple', 'A bare "Quattuor" (no "Pentecostes") falls through to purple as expected',
 );
 
 # Red's "Decollatione" is checked before black's "oann", even though a
 # beheading-of-St-John feast name would match both.
-ok(
-  liturgical_color('In Decollatione S. Ioannis Baptistae') eq 'red',
-  'Red\'s "Decollatione" takes priority over black\'s "oann"'
+is(
+  liturgical_color('In Decollatione S. Ioannis Baptistae'),
+  'red', 'Red\'s "Decollatione" takes priority over black\'s "oann"',
 );
 
 # Grey's "Parasceve" is checked before purple's "Passion".
-ok(
-  liturgical_color('Passionis tempore in Parasceve') eq 'grey',
-  'Grey\'s "Parasceve" takes priority over purple\'s "Passion"'
+is(
+  liturgical_color('Passionis tempore in Parasceve'),
+  'grey', 'Grey\'s "Parasceve" takes priority over purple\'s "Passion"',
 );
 
 # Black's "Cathedra"/"Conversione" are checked before red's "Apostol", even
 # though feasts of an Apostle's Chair/Conversion would match both.
-ok(
-  liturgical_color('In Cathedra S. Petri Apostoli') eq 'black',
-  'Black\'s "Cathedra" takes priority over red\'s "Apostol"'
+is(
+  liturgical_color('In Cathedra S. Petri Apostoli'),
+  'black', 'Black\'s "Cathedra" takes priority over red\'s "Apostol"',
 );
 
 # Green's "Pentecosten" (accusative, n-ending) and red's "Pentecostes"
 # (s-ending) are distinct substrings that never overlap.
-ok(
-  liturgical_color('Dominica infra octavam Pentecostes') eq 'red',
-  'Red\'s "Pentecostes" (s-ending) is a distinct match from green\'s "Pentecosten" (n-ending)',
+is(
+  liturgical_color('Dominica infra octavam Pentecostes'),
+  'red', 'Red\'s "Pentecostes" (s-ending) is a distinct match from green\'s "Pentecosten" (n-ending)',
 );
 
+done_testing;

--- a/t/README
+++ b/t/README
@@ -1,5 +1,5 @@
 To run tests, run the following from the parent of this directory:
 
-	prove -r -I web/cgi-bin/ t
+    prove -r -I web/cgi-bin/ t
 
 The working directory really does matter as some tests depend on it.


### PR DESCRIPTION
Replace `use Test::Simple tests => N` with `use Test2::V0` and `done_testing` in all five `t/DivinumOfficium/*.t` files, so the assertion count no longer needs to be kept in sync by hand.

Convert eq/== comparisons to is($got, $expected, $desc) for structured failure diagnostics, and =~ /re/ checks in Lexicon.t to like()/unlike(). Plain boolean checks (leapyear, dirge, hymnmerge, exists, etc.) are left as ok().

Replace the `Test::Carp/does_croak` block in Main.t with Test2::V0's built-in `dies { ... }`, removing the only non-core test dependency.

Also fix a stray tab in t/README.