### PR TITLE
Make webdia.pl resilient to blank rubric lines

### DIFF
--- a/web/cgi-bin/horas/webdia.pl
+++ b/web/cgi-bin/horas/webdia.pl
@@ -357,6 +357,7 @@ sub clean_setupsave {
 # returns <FONT ...>$text</FONT> string
 sub setfont {
   my $istr = shift;
+  my $tag_only = shift;
   my $text = shift;
   return $text unless $istr;
 
@@ -368,7 +369,8 @@ sub setfont {
   if ($size) { $font .= "SIZE='$size' "; }
   if ($color && $color !~ /black/i) { $font .= "COLOR=\"$color\""; }    # black not explictly for dark mode
   $font .= ">";
-  if (!$text) { return $font; }
+  if ($tag_only) { return $font; }
+  return '' unless defined $text && length $text;
   my $bold = '';
   my $bolde = '';
   my $italic = '';


### PR DESCRIPTION
Before this commit, there was a bug where a blank rubric line like `!  ` would cause a <font> tag to be emitted without any closing </font> tag, making all the following text in the section red.

For example, in the old Assumption Mass (rubrica 1939 or earlier), when displaying English, `missa.pl` outputs the introit without the citation `!Sedulius` and the entire introit text in red. `missa/English/Sancti/08-15t.txt` (old Assumption Mass) does not have give a proper `[Intoitus]`, so it falls back to the Latin `missa/Latin/Sancti/08-15t.txt`, which in turn pulls the introit from `@Sancti/07-16`. However, the English `web/www/missa/English/Sancti/07-16.txt` includes an exclamation mark followed by two spaces and a newline (`!  `), tripping up the `webdia.pl`, which output a `<font>` tag without a closing `</font>`.